### PR TITLE
Store host toggle, directory browser, and store-first downloads

### DIFF
--- a/src/exo/store/model_store.py
+++ b/src/exo/store/model_store.py
@@ -274,8 +274,13 @@ class ModelStore:
         existing status.  If already in the store, returns "complete".
         """
         async with self._download_lock:
-            if model_id in self._active_downloads:
-                return self._active_downloads[model_id]
+            existing = self._active_downloads.get(model_id)
+            if existing is not None:
+                # Allow retrying failed downloads
+                if existing.status == "failed":
+                    del self._active_downloads[model_id]
+                else:
+                    return existing
             if self.is_in_store(model_id):
                 return StoreDownloadStatus(model_id=model_id, status="complete", progress=1.0)
             status = StoreDownloadStatus(model_id=model_id, status="pending")

--- a/src/exo/store/model_store.py
+++ b/src/exo/store/model_store.py
@@ -58,11 +58,14 @@ when a new model is registered, so this is not a hot path.
 """
 from __future__ import annotations
 
+import asyncio
 import json
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import final
+from typing import Literal, final
 
+import aiofiles.os as aios
 from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
@@ -96,6 +99,15 @@ class StoreModelEntry(BaseModel):
     total_bytes: int
 
 
+@dataclass
+class StoreDownloadStatus:
+    """Tracks the progress of a store-side HuggingFace download."""
+    model_id: str
+    status: Literal["pending", "downloading", "complete", "failed"] = "pending"
+    progress: float = 0.0
+    error: str | None = None
+
+
 @final
 class ModelStore:
     """Manages the model registry on the store host node.
@@ -127,6 +139,8 @@ class ModelStore:
         """
         self._store_path = store_path
         self._registry_path = store_path / "registry.json"
+        self._active_downloads: dict[str, StoreDownloadStatus] = {}
+        self._download_lock = asyncio.Lock()
 
     @property
     def store_path(self) -> Path:
@@ -248,3 +262,86 @@ class ModelStore:
                 indent=2,
             )
         )
+
+    # ------------------------------------------------------------------
+    # Store-side HuggingFace downloads
+    # ------------------------------------------------------------------
+
+    async def request_download(self, model_id: str) -> StoreDownloadStatus:
+        """Request that the store download a model from HuggingFace.
+
+        Deduplicates: if the model is already downloading, returns the
+        existing status.  If already in the store, returns "complete".
+        """
+        async with self._download_lock:
+            if model_id in self._active_downloads:
+                return self._active_downloads[model_id]
+            if self.is_in_store(model_id):
+                return StoreDownloadStatus(model_id=model_id, status="complete", progress=1.0)
+            status = StoreDownloadStatus(model_id=model_id, status="pending")
+            self._active_downloads[model_id] = status
+        asyncio.create_task(self._do_download(model_id))
+        return status
+
+    def get_download_status(self, model_id: str) -> StoreDownloadStatus | None:
+        """Return the download status for *model_id*, or None."""
+        if model_id in self._active_downloads:
+            return self._active_downloads[model_id]
+        if self.is_in_store(model_id):
+            return StoreDownloadStatus(model_id=model_id, status="complete", progress=1.0)
+        return None
+
+    async def _do_download(self, model_id: str) -> None:
+        """Download a model from HuggingFace into the store and register it."""
+        from exo.download.download_utils import (
+            download_file_with_retry,
+            fetch_file_list_with_cache,
+        )
+        from exo.shared.models.model_cards import ModelId
+
+        status = self._active_downloads[model_id]
+        status.status = "downloading"
+        sanitized = model_id.replace("/", "--")
+        target_dir = self._store_path / sanitized
+
+        try:
+            await aios.makedirs(str(target_dir), exist_ok=True)
+
+            file_list = await fetch_file_list_with_cache(
+                ModelId(model_id), "main", recursive=True
+            )
+            total_bytes = sum(f.size or 0 for f in file_list)
+            downloaded_bytes = 0
+
+            for f in file_list:
+                file_size = f.size or 0
+
+                def make_progress_cb(fsize: int):
+                    def cb(curr: int, total: int, is_renamed: bool) -> None:
+                        nonlocal downloaded_bytes
+                        status.progress = (downloaded_bytes + curr) / max(total_bytes, 1)
+                    return cb
+
+                await download_file_with_retry(
+                    ModelId(model_id),
+                    "main",
+                    f.path,
+                    target_dir,
+                    make_progress_cb(file_size),
+                )
+                downloaded_bytes += file_size
+                status.progress = downloaded_bytes / max(total_bytes, 1)
+
+            # Register in the store
+            files = [str(p.relative_to(target_dir)) for p in target_dir.rglob("*") if p.is_file()]
+            total = sum(p.stat().st_size for p in target_dir.rglob("*") if p.is_file())
+            self.register_model(model_id, target_dir, files, total)
+
+            status.status = "complete"
+            status.progress = 1.0
+            logger.info(f"ModelStore: downloaded {model_id} from HuggingFace ({total:,} bytes)")
+
+        except Exception as exc:
+            status.status = "failed"
+            status.error = str(exc)
+            logger.error(f"ModelStore: download of {model_id} failed: {exc}")

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -326,6 +326,82 @@ class ModelStoreClient:
             logger.debug(f"ModelStoreClient: fetch_registry failed: {exc}")
             return []
 
+    async def request_and_wait_for_download(
+        self,
+        model_id: str,
+        on_progress: Callable[[float], Awaitable[None]] | None = None,
+        timeout: float = 7200,
+        poll_interval: float = 5.0,
+    ) -> bool:
+        """Request the store host download a model from HuggingFace, then wait.
+
+        Posts to ``/models/{id}/download`` to start the download, then polls
+        ``/models/{id}/download/status`` until complete or failed.
+
+        Args:
+            model_id: HuggingFace model ID.
+            on_progress: Called with progress (0.0-1.0) on each poll.
+            timeout: Maximum wait time in seconds.
+            poll_interval: Seconds between status polls.
+
+        Returns:
+            ``True`` if download completed successfully.
+
+        Raises:
+            RuntimeError: If the download failed on the store host.
+            TimeoutError: If the download didn't complete within *timeout*.
+        """
+        import asyncio as _asyncio
+
+        encoded_id = quote(model_id, safe="")
+
+        # Request download
+        url = _make_store_url(self._store_host, self._store_port, f"/models/{encoded_id}/download")
+        async with (
+            create_http_session(timeout_profile="short") as session,
+            session.post(url) as resp,
+        ):
+            if resp.status not in (200, 201):
+                raise RuntimeError(f"Store download request failed: HTTP {resp.status}")
+            data: object = await resp.json()
+            if isinstance(data, dict) and data.get("status") == "complete":
+                return True
+
+        # Poll for completion
+        status_url = _make_store_url(
+            self._store_host, self._store_port, f"/models/{encoded_id}/download/status"
+        )
+        elapsed = 0.0
+        while elapsed < timeout:
+            await _asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+            try:
+                async with (
+                    create_http_session(timeout_profile="short") as session,
+                    session.get(status_url) as resp,
+                ):
+                    if resp.status != 200:
+                        continue
+                    data = await resp.json()
+                    if not isinstance(data, dict):
+                        continue
+                    status = data.get("status", "")
+                    progress = float(data.get("progress", 0.0))
+                    if on_progress is not None:
+                        await on_progress(progress)
+                    if status == "complete":
+                        return True
+                    if status == "failed":
+                        raise RuntimeError(
+                            f"Store download of {model_id} failed: {data.get('error', 'unknown')}"
+                        )
+            except RuntimeError:
+                raise
+            except Exception as exc:
+                logger.debug(f"ModelStoreClient: download status poll failed: {exc}")
+
+        raise TimeoutError(f"Store download of {model_id} timed out after {timeout}s")
+
     # ------------------------------------------------------------------
     # Local copy path (store host → same filesystem)
     # ------------------------------------------------------------------
@@ -656,11 +732,29 @@ class ModelStoreDownloader(ShardDownloader):
                 )
 
         if self._allow_hf_fallback:
+            # Ask the store host to download from HuggingFace on our behalf.
+            # Workers never download from HF directly — the store is the
+            # single source of truth for model files.
             logger.info(
-                f"ModelStoreDownloader: {model_id} not in store, "
-                "falling back to HuggingFace"
+                f"ModelStoreDownloader: {model_id} not in store — "
+                "requesting store host to download from HuggingFace"
             )
-            return await self._inner.ensure_shard(shard, config_only)
+            await self._emit_progress(shard, status="in_progress")
+            try:
+                await self._store_client.request_and_wait_for_download(
+                    model_id,
+                    on_progress=lambda _p: self._emit_progress(shard, status="in_progress"),
+                )
+            except (RuntimeError, TimeoutError) as exc:
+                raise ModelNotInStoreError(
+                    f"Store host failed to download {model_id}: {exc}"
+                )
+            # Model now in store — stage it
+            path = await self._store_client.stage_shard(
+                model_id, dest_path, on_progress=None,
+            )
+            await self._emit_progress(shard, status="complete")
+            return path
 
         raise ModelNotInStoreError(
             f"Model {model_id} is not in the store and HuggingFace fallback is disabled"

--- a/src/exo/store/model_store_server.py
+++ b/src/exo/store/model_store_server.py
@@ -128,6 +128,8 @@ class ModelStoreServer:
         self._app.router.add_get("/registry", self._handle_registry)
         self._app.router.add_get("/models", self._handle_models)
         self._app.router.add_get("/models/{model_id}/files", self._handle_model_files)
+        self._app.router.add_post("/models/{model_id}/download", self._handle_download_request)
+        self._app.router.add_get("/models/{model_id}/download/status", self._handle_download_status)
         self._app.router.add_get("/models/{model_id}/{path:.*}", self._handle_file)
 
     async def start(self) -> None:
@@ -258,3 +260,26 @@ class ModelStoreServer:
 
         await response.write_eof()
         return response
+
+    async def _handle_download_request(self, request: web.Request) -> web.Response:
+        """``POST /models/{model_id}/download`` — request store-side HF download."""
+        model_id = _sanitize_model_id(request.match_info["model_id"])
+        status = await self._store.request_download(model_id)
+        return web.json_response({
+            "modelId": status.model_id,
+            "status": status.status,
+            "progress": status.progress,
+        })
+
+    async def _handle_download_status(self, request: web.Request) -> web.Response:
+        """``GET /models/{model_id}/download/status`` — poll download progress."""
+        model_id = _sanitize_model_id(request.match_info["model_id"])
+        status = self._store.get_download_status(model_id)
+        if status is None:
+            raise web.HTTPNotFound(reason=f"No download in progress for {model_id}")
+        return web.json_response({
+            "modelId": status.model_id,
+            "status": status.status,
+            "progress": status.progress,
+            "error": status.error,
+        })


### PR DESCRIPTION
## Summary
Follow-up to PR #2 (merged with initial settings page). This adds:

- **Store host toggle**: "This node is the store host" checkbox auto-populates hostname + LAN IP
- **Directory browser**: Browse `/Volumes` to pick store path and cache paths visually
- **Store-first downloads**: Workers never download from HuggingFace — store host downloads on behalf of the cluster with deduplication
- **Config cluster sync**: `PUT /config` broadcasts via gossipsub to all nodes
- **Codex review fixes**: Browse root boundary check, blank field validation, staging.enabled preservation
- **Documentation**: Updated model-store.md with dashboard setup, new API endpoints, Phase 3 marked done

## Test plan
- [ ] Toggle "This node is the store host" → verify hostname/IP auto-fill
- [ ] Browse filesystem for store path → verify directory navigation works
- [ ] Launch a model not in store → verify store host downloads from HF, workers wait and stage
- [ ] Launch same model on second worker → verify deduplication (1 HF download, not 2)
- [ ] Save config → verify synced to all nodes via gossipsub
- [ ] Verify docs reflect all new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)