### PR TITLE
Settings slide-over panel

### DIFF
--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dashboard-react",
       "version": "0.0.0",
       "dependencies": {
+        "@floating-ui/react": "^0.27.19",
         "@tolgee/react": "^6.6.0",
         "@tolgee/web": "^6.6.0",
         "d3": "^7.9.0",
@@ -999,6 +1000,59 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -6156,6 +6210,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@floating-ui/react": "^0.27.19",
     "@tolgee/react": "^6.6.0",
     "@tolgee/web": "^6.6.0",
     "d3": "^7.9.0",
@@ -25,7 +26,13 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@chromatic-com/storybook": "^5.0.2",
     "@eslint/js": "^9.39.4",
+    "@storybook/addon-a11y": "^10.3.3",
+    "@storybook/addon-docs": "^10.3.3",
+    "@storybook/addon-onboarding": "^10.3.3",
+    "@storybook/addon-vitest": "^10.3.3",
+    "@storybook/react-vite": "^10.3.3",
     "@types/d3": "^7.4.3",
     "@types/katex": "^0.16.8",
     "@types/node": "^24.12.0",
@@ -33,24 +40,18 @@
     "@types/react-dom": "^19.2.3",
     "@types/styled-components": "^5.1.36",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/browser-playwright": "^4.1.1",
+    "@vitest/coverage-v8": "^4.1.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-storybook": "^10.3.3",
     "globals": "^17.4.0",
+    "playwright": "^1.58.2",
+    "storybook": "^10.3.3",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",
-    "storybook": "^10.3.3",
-    "@storybook/react-vite": "^10.3.3",
-    "@chromatic-com/storybook": "^5.0.2",
-    "@storybook/addon-vitest": "^10.3.3",
-    "@storybook/addon-a11y": "^10.3.3",
-    "@storybook/addon-docs": "^10.3.3",
-    "@storybook/addon-onboarding": "^10.3.3",
-    "eslint-plugin-storybook": "^10.3.3",
-    "vitest": "^4.1.1",
-    "playwright": "^1.58.2",
-    "@vitest/browser-playwright": "^4.1.1",
-    "@vitest/coverage-v8": "^4.1.1"
+    "vitest": "^4.1.1"
   }
 }

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import { ThemeProvider } from 'styled-components';
 import { theme, GlobalStyle } from './theme';
@@ -7,6 +8,7 @@ import { TopologyGraph } from './components/topology/TopologyGraph';
 import { ConnectionBanner } from './components/status/ConnectionBanner';
 import { ToastContainer } from './components/status/ToastContainer';
 import { NetworkMesh } from './components/common/NetworkMesh';
+import { SettingsPanel } from './components/layout/SettingsPanel';
 
 const Shell = styled.div`
   position: relative;
@@ -23,6 +25,7 @@ const Main = styled.main`
 
 export function App() {
   const { topology, connected } = useClusterState();
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   return (
     <ThemeProvider theme={theme}>
@@ -34,6 +37,7 @@ export function App() {
           showHome
           showSidebarToggle
           sidebarVisible={false}
+          onOpenSettings={() => setSettingsOpen(true)}
         />
         <Main>
           {topology ? (
@@ -45,6 +49,7 @@ export function App() {
           )}
         </Main>
         <ToastContainer />
+        <SettingsPanel open={settingsOpen} onClose={() => setSettingsOpen(false)} />
       </Shell>
     </ThemeProvider>
   );

--- a/dashboard-react/src/components/common/InfoTooltip.stories.tsx
+++ b/dashboard-react/src/components/common/InfoTooltip.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { InfoTooltip } from './InfoTooltip';
+
+const meta: Meta<typeof InfoTooltip> = {
+  title: 'Common/InfoTooltip',
+  component: InfoTooltip,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: 100, background: '#111', display: 'flex', gap: 40, alignItems: 'center' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof InfoTooltip>;
+
+export const Default: Story = {
+  args: {
+    content: 'Pipeline splits the model into sequential stages across devices. Lower network overhead.',
+  },
+};
+
+export const Placements: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 40, alignItems: 'center' }}>
+      <InfoTooltip content="Top placement (default)" placement="top" />
+      <InfoTooltip content="Right placement" placement="right" />
+      <InfoTooltip content="Bottom placement" placement="bottom" />
+      <InfoTooltip content="Left placement" placement="left" />
+    </div>
+  ),
+};
+
+export const RichContent: Story = {
+  args: {
+    content: (
+      <div>
+        <strong style={{ color: '#FFD700' }}>Tensor Parallelism</strong>
+        <br />
+        Splits each layer across devices. Best with high-bandwidth connections like Thunderbolt.
+        <br /><br />
+        <span style={{ color: '#666' }}>Requires RDMA-capable interfaces.</span>
+      </div>
+    ),
+  },
+};
+
+export const CustomTrigger: Story = {
+  render: () => (
+    <InfoTooltip content="This is a custom trigger element">
+      <span style={{ color: '#FFD700', fontSize: 13, fontFamily: 'monospace', cursor: 'help', textDecoration: 'underline dotted' }}>
+        What is this?
+      </span>
+    </InfoTooltip>
+  ),
+};
+
+export const InContext: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontFamily: 'monospace', fontSize: 12, color: '#999' }}>
+      <span style={{ color: '#FFD700' }}>Pipeline</span>
+      <InfoTooltip content="Pipeline splits the model into sequential stages across devices. Lower network overhead." />
+      <span style={{ margin: '0 8px', color: '#333' }}>|</span>
+      <span style={{ color: '#FFD700' }}>MLX Ring</span>
+      <InfoTooltip content="Ring: standard networking. Works over any connection (Wi-Fi, Ethernet, Thunderbolt)." />
+    </div>
+  ),
+  name: 'In context (next to badges)',
+};

--- a/dashboard-react/src/components/common/InfoTooltip.tsx
+++ b/dashboard-react/src/components/common/InfoTooltip.tsx
@@ -1,0 +1,137 @@
+import { useState, useRef } from 'react';
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  arrow,
+  useHover,
+  useFocus,
+  useDismiss,
+  useRole,
+  useInteractions,
+  FloatingPortal,
+  FloatingArrow,
+  type Placement,
+} from '@floating-ui/react';
+import styled from 'styled-components';
+
+export interface InfoTooltipProps {
+  /** Tooltip content — string or JSX. */
+  content: React.ReactNode;
+  /** Preferred placement. Default 'top'. */
+  placement?: Placement;
+  /** Hover delay in ms before showing. Default 200. */
+  delay?: number;
+  /** Custom trigger element. Defaults to info icon. */
+  children?: React.ReactNode;
+  className?: string;
+}
+
+const Trigger = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: help;
+  color: ${({ theme }) => theme.colors.textMuted};
+  transition: color 0.15s;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.textSecondary};
+  }
+`;
+
+const TooltipBox = styled.div`
+  max-width: 280px;
+  padding: 8px 12px;
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: ${({ theme }) => theme.radii.md};
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  font-size: 12px;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  line-height: 1.5;
+  z-index: 9999;
+`;
+
+const ARROW_SIZE = 8;
+
+const InfoIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 16v-4" />
+    <path d="M12 8h.01" />
+  </svg>
+);
+
+export function InfoTooltip({
+  content,
+  placement = 'top',
+  delay = 200,
+  children,
+  className,
+}: InfoTooltipProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const arrowRef = useRef(null);
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement,
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(ARROW_SIZE + 4),
+      flip(),
+      shift({ padding: 8 }),
+      arrow({ element: arrowRef }),
+    ],
+  });
+
+  const hover = useHover(context, { delay: { open: delay, close: 0 } });
+  const focus = useFocus(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context, { role: 'tooltip' });
+
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    hover,
+    focus,
+    dismiss,
+    role,
+  ]);
+
+  return (
+    <>
+      <Trigger
+        ref={refs.setReference}
+        {...getReferenceProps()}
+        className={className}
+        tabIndex={0}
+      >
+        {children ?? <InfoIcon />}
+      </Trigger>
+
+      {isOpen && (
+        <FloatingPortal>
+          <TooltipBox
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+          >
+            <FloatingArrow
+              ref={arrowRef}
+              context={context}
+              width={ARROW_SIZE * 2}
+              height={ARROW_SIZE}
+              fill="#1a1a1a"
+              stroke="rgba(255, 255, 255, 0.1)"
+              strokeWidth={1}
+            />
+            {content}
+          </TooltipBox>
+        </FloatingPortal>
+      )}
+    </>
+  );
+}

--- a/dashboard-react/src/components/common/InfoTooltip.tsx
+++ b/dashboard-react/src/components/common/InfoTooltip.tsx
@@ -24,6 +24,8 @@ export interface InfoTooltipProps {
   placement?: Placement;
   /** Hover delay in ms before showing. Default 200. */
   delay?: number;
+  /** Fill the default info icon. Default false (outline only). */
+  filled?: boolean;
   /** Custom trigger element. Defaults to info icon. */
   children?: React.ReactNode;
   className?: string;
@@ -58,11 +60,11 @@ const TooltipBox = styled.div`
 
 const ARROW_SIZE = 8;
 
-const InfoIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+const InfoIcon = ({ filled = false }: { filled?: boolean }) => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill={filled ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="12" cy="12" r="10" />
-    <path d="M12 16v-4" />
-    <path d="M12 8h.01" />
+    <path d="M12 16v-4" stroke={filled ? '#000' : 'currentColor'} />
+    <path d="M12 8h.01" stroke={filled ? '#000' : 'currentColor'} />
   </svg>
 );
 
@@ -70,6 +72,7 @@ export function InfoTooltip({
   content,
   placement = 'top',
   delay = 200,
+  filled = false,
   children,
   className,
 }: InfoTooltipProps) {
@@ -109,7 +112,7 @@ export function InfoTooltip({
         className={className}
         tabIndex={0}
       >
-        {children ?? <InfoIcon />}
+        {children ?? <InfoIcon filled={filled} />}
       </Trigger>
 
       {isOpen && (

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -14,6 +14,7 @@ export interface HeaderNavProps {
   mobileRightOpen?: boolean;
   onToggleMobileRight?: () => void;
   downloadProgress?: { count: number; percentage: number } | null;
+  onOpenSettings?: () => void;
   className?: string;
 }
 
@@ -183,6 +184,7 @@ export function HeaderNav({
   mobileRightOpen = false,
   onToggleMobileRight,
   downloadProgress = null,
+  onOpenSettings,
   className,
 }: HeaderNavProps) {
   return (
@@ -210,9 +212,9 @@ export function HeaderNav({
           <DownloadIcon /> Downloads
         </NavLink>
 
-        <NavLink href="/#/settings">
-          <SettingsIcon /> Settings
-        </NavLink>
+        <Button variant="ghost" size="lg" icon onClick={onOpenSettings} aria-label="Settings">
+          <SettingsIcon />
+        </Button>
 
         {showMobileRightToggle && (
           <ToggleBtn variant="outline" size="lg" icon $active={mobileRightOpen} onClick={onToggleMobileRight} aria-label="Toggle right panel" aria-pressed={mobileRightOpen}>

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import styled, { css, keyframes } from 'styled-components';
 import { useConfig, type StoreConfig } from '../../hooks/useConfig';
 import { Button } from '../common/Button';
 import { Field } from '../common/Field';
+import { InfoTooltip } from '../common/InfoTooltip';
 import { addToast } from '../../hooks/useToast';
 
 export interface SettingsPanelProps {
@@ -109,6 +110,9 @@ const Row = styled.label`
 `;
 
 const FieldLabel = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: 12px;
   font-family: ${({ theme }) => theme.fonts.mono};
   color: ${({ theme }) => theme.colors.textSecondary};
@@ -248,7 +252,13 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
               <Fieldset>
                 <Legend>Model Store</Legend>
                 <Row>
-                  <FieldLabel>Enabled</FieldLabel>
+                  <FieldLabel>
+                    Enabled
+                    <InfoTooltip
+                      filled
+                      content="When enabled, model store allows specification of a single cluster attached storage device where downloaded models will be saved."
+                    />
+                  </FieldLabel>
                   <Toggle $on={draft.enabled} onClick={() => update({ enabled: !draft.enabled })} />
                 </Row>
                 {draft.enabled && (
@@ -298,7 +308,13 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
               <Fieldset>
                 <Legend>Download</Legend>
                 <Row>
-                  <FieldLabel>Allow HuggingFace fallback</FieldLabel>
+                  <FieldLabel>
+                    Allow HuggingFace fallback
+                    <InfoTooltip
+                      filled
+                      content="When enabled, nodes can download models directly from HuggingFace if the model is not in the store. Disable for air-gapped clusters where all models must be pre-loaded into the store."
+                    />
+                  </FieldLabel>
                   <Toggle
                     $on={draft.download.allow_hf_fallback}
                     onClick={() => updateDownload({ allow_hf_fallback: !draft.download.allow_hf_fallback })}
@@ -310,7 +326,13 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
               <Fieldset>
                 <Legend>Staging</Legend>
                 <Row>
-                  <FieldLabel>Enabled</FieldLabel>
+                  <FieldLabel>
+                    Enabled
+                    <InfoTooltip
+                      filled
+                      content="When enabled, worker nodes copy model files from the store to a local cache directory before loading. This gives MLX a local filesystem path for fast access. Disable only on the store host to load directly from the store path."
+                    />
+                  </FieldLabel>
                   <Toggle
                     $on={draft.staging.enabled}
                     onClick={() => updateStaging({ enabled: !draft.staging.enabled })}
@@ -328,7 +350,13 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
                       />
                     </Row>
                     <Row>
-                      <FieldLabel>Cleanup on deactivate</FieldLabel>
+                      <FieldLabel>
+                        Cleanup on deactivate
+                        <InfoTooltip
+                          filled
+                          content="When enabled, on deactivate staged models will be removed from cluster nodes to prevent storage bloat on cluster nodes."
+                        />
+                      </FieldLabel>
                       <Toggle
                         $on={draft.staging.cleanup_on_deactivate}
                         onClick={() => updateStaging({ cleanup_on_deactivate: !draft.staging.cleanup_on_deactivate })}

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -1,0 +1,356 @@
+import { useCallback, useEffect, useState } from 'react';
+import styled, { css, keyframes } from 'styled-components';
+import { useConfig, type StoreConfig } from '../../hooks/useConfig';
+import { Button } from '../common/Button';
+import { Field } from '../common/Field';
+import { addToast } from '../../hooks/useToast';
+
+export interface SettingsPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/* ---- animations ---- */
+
+const fadeIn = keyframes`
+  from { opacity: 0; }
+  to   { opacity: 1; }
+`;
+
+const slideIn = keyframes`
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+`;
+
+/* ---- styles ---- */
+
+const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+  animation: ${fadeIn} 0.2s ease-out;
+`;
+
+const Drawer = styled.aside`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 50;
+  width: 380px;
+  max-width: 100vw;
+  background: ${({ theme }) => theme.colors.surface};
+  border-left: 1px solid ${({ theme }) => theme.colors.border};
+  display: flex;
+  flex-direction: column;
+  animation: ${slideIn} 0.25s cubic-bezier(0.33, 1, 0.68, 1);
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+const Title = styled.h2`
+  font-size: 14px;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: #FFD700;
+`;
+
+const Body = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const Footer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 20px;
+  border-top: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+const Fieldset = styled.fieldset`
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.radii.md};
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const Legend = styled.legend`
+  font-size: 11px;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  padding: 0 6px;
+`;
+
+const Row = styled.label`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+`;
+
+const FieldLabel = styled.span`
+  font-size: 12px;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  white-space: nowrap;
+`;
+
+const Toggle = styled.button<{ $on: boolean }>`
+  all: unset;
+  cursor: pointer;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  position: relative;
+  flex-shrink: 0;
+  transition: background 0.2s;
+
+  ${({ $on }) =>
+    $on
+      ? css`background: #FFD700;`
+      : css`background: rgba(80, 80, 80, 0.5);`}
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: ${({ $on }) => ($on ? '18px' : '2px')};
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: ${({ $on }) => ($on ? '#000' : '#999')};
+    transition: left 0.2s;
+  }
+`;
+
+const StyledField = styled(Field)`
+  flex: 1;
+  min-width: 0;
+`;
+
+const ConfigPath = styled.div`
+  font-size: 10px;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const ErrorText = styled.div`
+  font-size: 12px;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: #ef4444;
+`;
+
+const LoadingText = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  font-size: 12px;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.textMuted};
+  text-transform: uppercase;
+  letter-spacing: 1px;
+`;
+
+const Spacer = styled.span`
+  flex: 1;
+`;
+
+/* ---- component ---- */
+
+export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
+  const { config, configPath, loading, saving, error, fetchConfig, saveConfig } = useConfig();
+  const [draft, setDraft] = useState<StoreConfig | null>(null);
+
+  // Fetch config when panel opens
+  useEffect(() => {
+    if (open) fetchConfig();
+  }, [open, fetchConfig]);
+
+  // Seed draft from fetched config
+  useEffect(() => {
+    if (config) setDraft({ ...config });
+  }, [config]);
+
+  const update = useCallback((patch: Partial<StoreConfig>) => {
+    setDraft((prev) => prev ? { ...prev, ...patch } : prev);
+  }, []);
+
+  const updateDownload = useCallback((patch: Partial<StoreConfig['download']>) => {
+    setDraft((prev) => prev ? { ...prev, download: { ...prev.download, ...patch } } : prev);
+  }, []);
+
+  const updateStaging = useCallback((patch: Partial<StoreConfig['staging']>) => {
+    setDraft((prev) => prev ? { ...prev, staging: { ...prev.staging, ...patch } } : prev);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!draft) return;
+    const ok = await saveConfig(draft);
+    if (ok) {
+      addToast({ type: 'success', message: 'Settings saved' });
+      onClose();
+    } else {
+      addToast({ type: 'error', message: 'Failed to save settings' });
+    }
+  }, [draft, saveConfig, onClose]);
+
+  // ESC to close
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <Backdrop onClick={onClose} />
+      <Drawer>
+        <Header>
+          <Title>Settings</Title>
+          <Button variant="ghost" size="sm" icon onClick={onClose} aria-label="Close settings">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </Button>
+        </Header>
+
+        <Body>
+          {loading && <LoadingText>Loading config…</LoadingText>}
+          {error && <ErrorText>{error}</ErrorText>}
+
+          {draft && (
+            <>
+              {/* Model Store */}
+              <Fieldset>
+                <Legend>Model Store</Legend>
+                <Row>
+                  <FieldLabel>Enabled</FieldLabel>
+                  <Toggle $on={draft.enabled} onClick={() => update({ enabled: !draft.enabled })} />
+                </Row>
+                {draft.enabled && (
+                  <>
+                    <Row>
+                      <FieldLabel>Store host</FieldLabel>
+                      <StyledField
+                        size="sm"
+                        value={draft.store_host}
+                        onChange={(e) => update({ store_host: (e.target as HTMLInputElement).value })}
+                        placeholder="hostname or node_id"
+                      />
+                    </Row>
+                    <Row>
+                      <FieldLabel>HTTP host</FieldLabel>
+                      <StyledField
+                        size="sm"
+                        value={draft.store_http_host}
+                        onChange={(e) => update({ store_http_host: (e.target as HTMLInputElement).value })}
+                        placeholder="defaults to store host"
+                      />
+                    </Row>
+                    <Row>
+                      <FieldLabel>Port</FieldLabel>
+                      <StyledField
+                        size="sm"
+                        type="number"
+                        value={String(draft.store_port)}
+                        onChange={(e) => update({ store_port: parseInt((e.target as HTMLInputElement).value) || 58080 })}
+                        style={{ maxWidth: 80 }}
+                      />
+                    </Row>
+                    <Row>
+                      <FieldLabel>Store path</FieldLabel>
+                      <StyledField
+                        size="sm"
+                        value={draft.store_path}
+                        onChange={(e) => update({ store_path: (e.target as HTMLInputElement).value })}
+                        placeholder="/path/to/models"
+                      />
+                    </Row>
+                  </>
+                )}
+              </Fieldset>
+
+              {/* Download */}
+              <Fieldset>
+                <Legend>Download</Legend>
+                <Row>
+                  <FieldLabel>Allow HuggingFace fallback</FieldLabel>
+                  <Toggle
+                    $on={draft.download.allow_hf_fallback}
+                    onClick={() => updateDownload({ allow_hf_fallback: !draft.download.allow_hf_fallback })}
+                  />
+                </Row>
+              </Fieldset>
+
+              {/* Staging */}
+              <Fieldset>
+                <Legend>Staging</Legend>
+                <Row>
+                  <FieldLabel>Enabled</FieldLabel>
+                  <Toggle
+                    $on={draft.staging.enabled}
+                    onClick={() => updateStaging({ enabled: !draft.staging.enabled })}
+                  />
+                </Row>
+                {draft.staging.enabled && (
+                  <>
+                    <Row>
+                      <FieldLabel>Cache path</FieldLabel>
+                      <StyledField
+                        size="sm"
+                        value={draft.staging.node_cache_path}
+                        onChange={(e) => updateStaging({ node_cache_path: (e.target as HTMLInputElement).value })}
+                        placeholder="~/.exo/staging"
+                      />
+                    </Row>
+                    <Row>
+                      <FieldLabel>Cleanup on deactivate</FieldLabel>
+                      <Toggle
+                        $on={draft.staging.cleanup_on_deactivate}
+                        onClick={() => updateStaging({ cleanup_on_deactivate: !draft.staging.cleanup_on_deactivate })}
+                      />
+                    </Row>
+                  </>
+                )}
+              </Fieldset>
+
+              {configPath && <ConfigPath>Config: {configPath}</ConfigPath>}
+            </>
+          )}
+        </Body>
+
+        <Footer>
+          <Spacer />
+          <Button variant="outline" size="md" onClick={onClose}>Cancel</Button>
+          <Button variant="primary" size="md" loading={saving} onClick={handleSave} disabled={!draft}>
+            Save
+          </Button>
+        </Footer>
+      </Drawer>
+    </>
+  );
+}

--- a/dashboard-react/src/hooks/useConfig.ts
+++ b/dashboard-react/src/hooks/useConfig.ts
@@ -1,0 +1,81 @@
+import { useCallback, useState } from 'react';
+
+export interface StoreConfig {
+  enabled: boolean;
+  store_host: string;
+  store_http_host: string;
+  store_port: number;
+  store_path: string;
+  download: {
+    allow_hf_fallback: boolean;
+  };
+  staging: {
+    enabled: boolean;
+    node_cache_path: string;
+    cleanup_on_deactivate: boolean;
+  };
+}
+
+export interface ConfigResponse {
+  config: {
+    model_store: StoreConfig;
+  };
+  configPath: string;
+  fileExists: boolean;
+}
+
+export interface UseConfigReturn {
+  config: StoreConfig | null;
+  configPath: string | null;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+  fetchConfig: () => Promise<void>;
+  saveConfig: (config: StoreConfig) => Promise<boolean>;
+}
+
+export function useConfig(): UseConfigReturn {
+  const [config, setConfig] = useState<StoreConfig | null>(null);
+  const [configPath, setConfigPath] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchConfig = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/config');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: ConfigResponse = await res.json();
+      setConfig(data.config.model_store);
+      setConfigPath(data.configPath);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch config');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const saveConfig = useCallback(async (updated: StoreConfig): Promise<boolean> => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model_store: updated }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setConfig(updated);
+      return true;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save config');
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  return { config, configPath, loading, saving, error, fetchConfig, saveConfig };
+}

--- a/dashboard-react/vite.config.ts
+++ b/dashboard-react/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/state': 'http://localhost:52415',
+      '/config': 'http://localhost:52415',
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Replace the Settings route/page with a slide-over drawer triggered by a gear icon in the header.

- Gear icon button replaces "Settings" nav link in HeaderNav
- Right-side drawer slides in with backdrop blur
- Fetches `GET /config` on open, saves `PUT /config` on save
- Controls: model store (enabled, host, HTTP host, port, path), download (HF fallback), staging (enabled, cache path, cleanup)
- Config file path shown at bottom
- Toast notifications on save success/failure
- ESC key and backdrop click to close

## Test plan
- [ ] Click gear icon — drawer slides in from right
- [ ] Verify settings load from cluster config
- [ ] Toggle settings, click Save — verify toast and config persisted
- [ ] Click Cancel or ESC or backdrop — drawer closes without saving
- [ ] Verify disabled sections collapse when toggled off

🤖 Generated with [Claude Code](https://claude.com/claude-code)