### PR TITLE
feat: add cluster-wide purge staging cache command

### DIFF
--- a/dashboard/src/lib/stores/app.svelte.ts
+++ b/dashboard/src/lib/stores/app.svelte.ts
@@ -3496,3 +3496,19 @@ export const deleteStoreModel = async (modelId: string): Promise<boolean> => {
   });
   return resp.ok;
 };
+
+export const purgeStagingCaches = async (
+  modelId?: string,
+): Promise<{ commandId: string; message: string } | null> => {
+  try {
+    const resp = await fetch("/store/purge-staging", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ modelId: modelId ?? null }),
+    });
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch {
+    return null;
+  }
+};

--- a/dashboard/src/routes/downloads/+page.svelte
+++ b/dashboard/src/routes/downloads/+page.svelte
@@ -15,6 +15,7 @@
     fetchStoreDownloads,
     deleteStoreModel,
     requestStoreDownload,
+    purgeStagingCaches,
     instances,
     type StoreRegistryEntry,
     type StoreDownloadProgress,
@@ -365,6 +366,8 @@
   let downloadPollInterval: ReturnType<typeof setInterval> | null = null;
   let deleteConfirmEntry = $state<{ entry: StoreRegistryEntry; isActive: boolean } | null>(null);
   let deleting = $state(false);
+  let purgeConfirm = $state(false);
+  let purging = $state(false);
 
   // Model picker for "Find Models" — download to store
   let isModelPickerOpen = $state(false);
@@ -493,6 +496,16 @@
     }
   }
 
+  async function confirmPurge() {
+    purging = true;
+    try {
+      await purgeStagingCaches();
+    } finally {
+      purging = false;
+      purgeConfirm = false;
+    }
+  }
+
   onDestroy(() => {
     if (downloadPollInterval) {
       clearInterval(downloadPollInterval);
@@ -571,20 +584,33 @@
     {#if activeTab === "store" && storeAvailable}
       <div class="flex items-center justify-between">
         <div></div>
-        <button
-          type="button"
-          class="px-4 py-1.5 text-xs font-mono uppercase tracking-wider bg-exo-yellow text-exo-black rounded hover:bg-exo-yellow/90 transition-colors flex items-center gap-2"
-          onclick={() => {
-            fetchPickerModels();
-            isModelPickerOpen = true;
-          }}
-        >
-          <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="11" cy="11" r="8" />
-            <line x1="21" y1="21" x2="16.65" y2="16.65" />
-          </svg>
-          Find Models
-        </button>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="px-4 py-1.5 text-xs font-mono uppercase tracking-wider bg-red-500/20 text-red-300 border border-red-500/30 rounded hover:bg-red-500/30 transition-colors flex items-center gap-2"
+            onclick={() => (purgeConfirm = true)}
+          >
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+            </svg>
+            Purge All Node Caches
+          </button>
+          <button
+            type="button"
+            class="px-4 py-1.5 text-xs font-mono uppercase tracking-wider bg-exo-yellow text-exo-black rounded hover:bg-exo-yellow/90 transition-colors flex items-center gap-2"
+            onclick={() => {
+              fetchPickerModels();
+              isModelPickerOpen = true;
+            }}
+          >
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+            Find Models
+          </button>
+        </div>
       </div>
       <StoreRegistryTable
         entries={registryEntries}
@@ -1099,6 +1125,51 @@
       >
         {deleting ? "Deleting..." : "Delete"}
       </button>
+    </div>
+  </div>
+{/if}
+
+<!-- Purge staging confirmation modal -->
+{#if purgeConfirm}
+  <div
+    class="fixed inset-0 z-[60] bg-black/60"
+    transition:fade={{ duration: 150 }}
+    onclick={() => (purgeConfirm = false)}
+    role="presentation"
+  ></div>
+  <div
+    class="fixed inset-0 z-[61] flex items-center justify-center pointer-events-none"
+  >
+    <div
+      class="bg-exo-dark-gray border border-exo-medium-gray/40 rounded-lg p-6 w-[420px] pointer-events-auto"
+      transition:fly={{ y: 20, duration: 200, easing: cubicOut }}
+    >
+      <h3 class="text-sm font-mono uppercase tracking-wider text-red-400 mb-3">
+        Purge all node caches
+      </h3>
+      <p class="text-sm text-exo-light-gray mb-4 font-mono">
+        This will remove all staged model files from every node in the cluster. Models will need to be re-staged from the store before they can run again.
+      </p>
+      <p class="text-xs text-white/40 mb-4 font-mono">
+        Nodes that are currently offline will not receive this command.
+      </p>
+      <div class="flex justify-end gap-3">
+        <button
+          type="button"
+          class="px-4 py-1.5 text-xs font-mono uppercase tracking-wider text-white/70 hover:text-white border border-exo-medium-gray/40 rounded transition-colors"
+          onclick={() => (purgeConfirm = false)}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          disabled={purging}
+          class="px-4 py-1.5 text-xs font-mono uppercase tracking-wider bg-red-500/80 text-white rounded hover:bg-red-500 disabled:opacity-50 transition-colors"
+          onclick={confirmPurge}
+        >
+          {purging ? "Purging..." : "Purge All"}
+        </button>
+      </div>
     </div>
   </div>
 {/if}

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -83,6 +83,8 @@ from exo.api.types import (
     PlaceInstanceParams,
     PlacementPreview,
     PlacementPreviewResponse,
+    PurgeStagingRequest,
+    PurgeStagingResponse,
     StartDownloadParams,
     StartDownloadResponse,
     ToolCall,
@@ -371,8 +373,13 @@ class API:
         self.app.get("/store/registry")(self.get_store_registry)
         self.app.get("/store/downloads")(self.get_store_downloads)
         self.app.delete("/store/models/{model_id:path}")(self.delete_store_model)
-        self.app.post("/store/models/{model_id:path}/download")(self.request_store_download)
-        self.app.get("/store/models/{model_id:path}/download/status")(self.get_store_download_status)
+        self.app.post("/store/models/{model_id:path}/download")(
+            self.request_store_download
+        )
+        self.app.get("/store/models/{model_id:path}/download/status")(
+            self.get_store_download_status
+        )
+        self.app.post("/store/purge-staging")(self.purge_staging_caches)
         self.app.get("/filesystem/browse")(self.browse_filesystem)
         self.app.get("/node/identity")(self.get_node_identity)
 
@@ -1786,6 +1793,21 @@ class API:
         await self._send_download(command)
         return DeleteDownloadResponse(command_id=command.command_id)
 
+    async def purge_staging_caches(
+        self, payload: PurgeStagingRequest
+    ) -> PurgeStagingResponse:
+        from exo.shared.types.commands import PurgeStagingCache
+
+        command = PurgeStagingCache(
+            model_id=ModelId(payload.model_id) if payload.model_id else None,
+        )
+        await self._send_download(command)
+        model_suffix = f" for model {payload.model_id}" if payload.model_id else ""
+        return PurgeStagingResponse(
+            command_id=command.command_id,
+            message=f"Purge staging command broadcast to all nodes{model_suffix}",
+        )
+
     @staticmethod
     def _get_trace_path(task_id: str) -> Path:
         trace_path = EXO_TRACING_CACHE_DIR / f"trace_{task_id}.json"
@@ -1916,34 +1938,48 @@ class API:
 
     async def get_config(self) -> JSONResponse:
         if not self._config_path.exists():
-            return JSONResponse({"config": {}, "configPath": str(self._config_path), "fileExists": False})
+            return JSONResponse(
+                {
+                    "config": {},
+                    "configPath": str(self._config_path),
+                    "fileExists": False,
+                }
+            )
         with self._config_path.open() as f:
             raw = yaml.safe_load(f)
         if raw is None:
             raw = {}
-        return JSONResponse({"config": raw, "configPath": str(self._config_path), "fileExists": True})
+        return JSONResponse(
+            {"config": raw, "configPath": str(self._config_path), "fileExists": True}
+        )
 
     async def update_config(self, request: Request) -> JSONResponse:
         body = await request.json()
         config_data = body.get("config", body)
         # Validate by attempting to parse with Pydantic
         from exo.store.config import ExoConfig
+
         try:
             ExoConfig.model_validate(config_data)
         except Exception as exc:
             raise HTTPException(status_code=422, detail=str(exc))
-        config_yaml = yaml.safe_dump(config_data, default_flow_style=False, sort_keys=False)
+        config_yaml = yaml.safe_dump(
+            config_data, default_flow_style=False, sort_keys=False
+        )
         # Write locally
         with self._config_path.open("w") as f:
             f.write(config_yaml)
         # Broadcast to all nodes via the download commands topic (gossipsub)
         from exo.shared.types.commands import SyncConfig
+
         await self._send_download(SyncConfig(config_yaml=config_yaml))
-        return JSONResponse({
-            "success": True,
-            "message": "Config saved and synced to cluster. Restart exo for changes to take effect.",
-            "requiresRestart": True,
-        })
+        return JSONResponse(
+            {
+                "success": True,
+                "message": "Config saved and synced to cluster. Restart exo for changes to take effect.",
+                "requiresRestart": True,
+            }
+        )
 
     async def get_store_health(self) -> JSONResponse:
         if self._store_client is None:
@@ -1951,12 +1987,14 @@ class API:
         health = await self._store_client.health_check()
         if health is None:
             raise HTTPException(status_code=503, detail="Store unreachable")
-        return JSONResponse({
-            "storePath": health.store_path,
-            "freeBytes": health.free_bytes,
-            "totalBytes": health.total_bytes,
-            "usedBytes": health.used_bytes,
-        })
+        return JSONResponse(
+            {
+                "storePath": health.store_path,
+                "freeBytes": health.free_bytes,
+                "totalBytes": health.total_bytes,
+                "usedBytes": health.used_bytes,
+            }
+        )
 
     async def get_store_registry(self) -> JSONResponse:
         if self._store_client is None:
@@ -1968,7 +2006,9 @@ class API:
 
     async def browse_filesystem(self, path: str = "/Volumes") -> JSONResponse:
         resolved = Path(path).resolve()
-        if not any(resolved.is_relative_to(root) for root in self._ALLOWED_BROWSE_ROOTS):
+        if not any(
+            resolved.is_relative_to(root) for root in self._ALLOWED_BROWSE_ROOTS
+        ):
             raise HTTPException(status_code=400, detail="Path outside allowed roots")
         if not resolved.is_dir():
             raise HTTPException(status_code=400, detail="Path is not a directory")
@@ -2001,11 +2041,13 @@ class API:
                 ):
                     ip = addr
                     break
-        return JSONResponse({
-            "nodeId": str(self.node_id),
-            "hostname": hostname,
-            "ipAddress": ip,
-        })
+        return JSONResponse(
+            {
+                "nodeId": str(self.node_id),
+                "hostname": hostname,
+                "ipAddress": ip,
+            }
+        )
 
     async def get_store_downloads(self) -> JSONResponse:
         if self._store_client is None:
@@ -2030,5 +2072,7 @@ class API:
             raise HTTPException(status_code=503, detail="Store not configured")
         deleted = await self._store_client.delete_store_model(model_id)
         if not deleted:
-            raise HTTPException(status_code=404, detail=f"Model {model_id} not in store")
+            raise HTTPException(
+                status_code=404, detail=f"Model {model_id} not in store"
+            )
         return JSONResponse({"modelId": model_id, "deleted": True})

--- a/src/exo/api/types/__init__.py
+++ b/src/exo/api/types/__init__.py
@@ -40,6 +40,8 @@ from .api import PlacementPreview as PlacementPreview
 from .api import PlacementPreviewResponse as PlacementPreviewResponse
 from .api import PowerUsage as PowerUsage
 from .api import PromptTokensDetails as PromptTokensDetails
+from .api import PurgeStagingRequest as PurgeStagingRequest
+from .api import PurgeStagingResponse as PurgeStagingResponse
 from .api import StartDownloadParams as StartDownloadParams
 from .api import StartDownloadResponse as StartDownloadResponse
 from .api import StreamingChoiceResponse as StreamingChoiceResponse

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -422,6 +422,15 @@ class DeleteDownloadResponse(CamelCaseModel):
     command_id: CommandId
 
 
+class PurgeStagingRequest(CamelCaseModel):
+    model_id: str | None = None
+
+
+class PurgeStagingResponse(CamelCaseModel):
+    command_id: CommandId
+    message: str
+
+
 class TraceEventResponse(CamelCaseModel):
     name: str
     start_us: int

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -20,6 +20,7 @@ from exo.shared.types.commands import (
     CancelDownload,
     DeleteDownload,
     ForwarderDownloadCommand,
+    PurgeStagingCache,
     StartDownload,
     SyncConfig,
 )
@@ -47,6 +48,7 @@ class DownloadCoordinator:
     download_command_receiver: Receiver[ForwarderDownloadCommand]
     event_sender: Sender[Event]
     offline: bool = False
+    staging_cache_path: Path | None = None
 
     # Local state
     download_status: dict[ModelId, DownloadProgress] = field(default_factory=dict)
@@ -114,11 +116,16 @@ class DownloadCoordinator:
     async def _command_processor(self) -> None:
         with self.download_command_receiver as commands:
             async for cmd in commands:
-                # SyncConfig is cluster-wide — every node handles it
+                # Cluster-wide commands — every node handles these
                 match cmd.command:
                     case SyncConfig(config_yaml=config_yaml):
                         await self._sync_config(config_yaml)
                         continue
+                    case PurgeStagingCache(model_id=purge_model_id):
+                        await self._purge_staging_cache(purge_model_id)
+                        continue
+                    case _:
+                        pass  # Targeted commands handled below
 
                 # Only process targeted commands for this node
                 if cmd.command.target_node_id != self.node_id:
@@ -152,9 +159,80 @@ class DownloadCoordinator:
         config_path = Path("exo.yaml")
         try:
             config_path.write_text(config_yaml)
-            logger.info(f"DownloadCoordinator: synced exo.yaml from cluster ({len(config_yaml)} bytes)")
+            logger.info(
+                f"DownloadCoordinator: synced exo.yaml from cluster ({len(config_yaml)} bytes)"
+            )
         except Exception as exc:
             logger.warning(f"DownloadCoordinator: failed to sync exo.yaml: {exc}")
+
+    async def _purge_staging_cache(self, model_id: ModelId | None) -> None:
+        """Remove staged model files from the local node cache."""
+        if self.staging_cache_path is None:
+            logger.warning(
+                "PurgeStagingCache: no staging_cache_path configured, skipping"
+            )
+            return
+
+        cache_path = self.staging_cache_path.expanduser()
+        if not cache_path.exists():
+            logger.info(
+                f"PurgeStagingCache: staging path {cache_path} does not exist, nothing to purge"
+            )
+            return
+
+        if model_id is not None:
+            # Purge a specific model
+            sanitized = str(model_id).replace("/", "--")
+            model_dir = cache_path / sanitized
+            if model_dir.exists():
+                # Cancel active download if any
+                if model_id in self.active_downloads:
+                    self.active_downloads[model_id].cancel()
+                logger.info(f"PurgeStagingCache: removing {model_dir}")
+                await asyncio.to_thread(shutil.rmtree, model_dir, True)
+                if model_id in self.download_status:
+                    current = self.download_status[model_id]
+                    pending = DownloadPending(
+                        shard_metadata=current.shard_metadata,
+                        node_id=self.node_id,
+                        model_directory=self._model_dir(model_id),
+                    )
+                    await self.event_sender.send(
+                        NodeDownloadProgress(download_progress=pending)
+                    )
+                    del self.download_status[model_id]
+            else:
+                logger.info(f"PurgeStagingCache: model {model_id} not found in staging")
+        else:
+            # Purge all staged models
+            # Cancel all active downloads first
+            for _mid, scope in list(self.active_downloads.items()):
+                scope.cancel()
+
+            purged = 0
+            for entry in cache_path.iterdir():
+                if entry.is_dir():
+                    logger.info(f"PurgeStagingCache: removing {entry}")
+                    await asyncio.to_thread(shutil.rmtree, entry, True)
+                    purged += 1
+
+            # Reset all download statuses
+            for mid, status in list(self.download_status.items()):
+                if isinstance(status, DownloadCompleted) and status.read_only:
+                    continue  # Don't reset EXO_MODELS_PATH entries
+                pending = DownloadPending(
+                    shard_metadata=status.shard_metadata,
+                    node_id=self.node_id,
+                    model_directory=self._model_dir(mid),
+                )
+                await self.event_sender.send(
+                    NodeDownloadProgress(download_progress=pending)
+                )
+                del self.download_status[mid]
+
+            logger.info(
+                f"PurgeStagingCache: purged {purged} model directories from {cache_path}"
+            )
 
     async def _start_download(self, shard: ShardMetadata) -> None:
         model_id = shard.model_card.model_id

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -79,7 +79,11 @@ class Node:
         store_client: ModelStoreClient | None = None
         store_server: ModelStoreServer | None = None
 
-        if exo_config is not None and exo_config.model_store is not None and exo_config.model_store.enabled:
+        if (
+            exo_config is not None
+            and exo_config.model_store is not None
+            and exo_config.model_store.enabled
+        ):
             ms = exo_config.model_store
             local_hostname = socket.gethostname()
             is_store_host = ms.store_host in (str(node_id), local_hostname)
@@ -87,7 +91,9 @@ class Node:
             # Store host gets a local path so the client uses shutil instead of HTTP.
             # Use store_http_host (when set) as the HTTP hostname so that a PeerId
             # in store_host does not get used as a DNS name by worker nodes.
-            local_store_path: Path | None = Path(ms.store_path) if is_store_host else None
+            local_store_path: Path | None = (
+                Path(ms.store_path) if is_store_host else None
+            )
             store_client = ModelStoreClient(
                 store_host=ms.store_http_host or ms.store_host,
                 store_port=ms.store_port,
@@ -115,13 +121,21 @@ class Node:
             os.environ["EXO_MODELS_PATH"] = ":".join(paths)
             # Also update the in-process constants for the main process
             from exo.shared.constants import add_model_search_path
+
             add_model_search_path(Path(staging_cfg.node_cache_path))
-            logger.info(f"ModelStore: added staging path {staging_path} to EXO_MODELS_PATH")
+            logger.info(
+                f"ModelStore: added staging path {staging_path} to EXO_MODELS_PATH"
+            )
 
         # Create DownloadCoordinator (unless --no-downloads)
         if not args.no_downloads:
             base_downloader = exo_shard_downloader(offline=args.offline)
-            if exo_config is not None and exo_config.model_store is not None and exo_config.model_store.enabled and store_client is not None:
+            if (
+                exo_config is not None
+                and exo_config.model_store is not None
+                and exo_config.model_store.enabled
+                and store_client is not None
+            ):
                 ms = exo_config.model_store
                 staging_cfg = resolve_node_staging(ms, str(node_id))
                 shard_downloader = ModelStoreDownloader(
@@ -133,12 +147,24 @@ class Node:
             else:
                 shard_downloader = base_downloader
 
+            coordinator_staging_path = (
+                Path(
+                    resolve_node_staging(
+                        exo_config.model_store, str(node_id)
+                    ).node_cache_path
+                )
+                if exo_config is not None
+                and exo_config.model_store is not None
+                and exo_config.model_store.enabled
+                else None
+            )
             download_coordinator = DownloadCoordinator(
                 node_id,
                 shard_downloader,
                 event_sender=event_router.sender(),
                 download_command_receiver=router.receiver(topics.DOWNLOAD_COMMANDS),
                 offline=args.offline,
+                staging_cache_path=coordinator_staging_path,
             )
         else:
             download_coordinator = None
@@ -159,7 +185,11 @@ class Node:
 
         if not args.no_worker:
             worker_store_client: ModelStoreClient | None = store_client
-            if exo_config is not None and exo_config.model_store is not None and exo_config.model_store.enabled:
+            if (
+                exo_config is not None
+                and exo_config.model_store is not None
+                and exo_config.model_store.enabled
+            ):
                 worker_staging_cfg = resolve_node_staging(
                     exo_config.model_store, str(node_id)
                 )
@@ -310,8 +340,16 @@ class Node:
                     if self.download_coordinator:
                         self.download_coordinator.shutdown()
                         base_dl = exo_shard_downloader(offline=self.offline)
-                        ms = self.exo_config.model_store if self.exo_config is not None else None
-                        if ms is not None and ms.enabled and self.store_client is not None:
+                        ms = (
+                            self.exo_config.model_store
+                            if self.exo_config is not None
+                            else None
+                        )
+                        if (
+                            ms is not None
+                            and ms.enabled
+                            and self.store_client is not None
+                        ):
                             elect_staging = resolve_node_staging(ms, str(self.node_id))
                             elect_downloader = ModelStoreDownloader(
                                 inner=base_dl,
@@ -321,6 +359,15 @@ class Node:
                             )
                         else:
                             elect_downloader = base_dl
+                        elect_staging_path = (
+                            Path(
+                                resolve_node_staging(
+                                    ms, str(self.node_id)
+                                ).node_cache_path
+                            )
+                            if ms is not None and ms.enabled
+                            else None
+                        )
                         self.download_coordinator = DownloadCoordinator(
                             self.node_id,
                             elect_downloader,
@@ -329,11 +376,16 @@ class Node:
                                 topics.DOWNLOAD_COMMANDS
                             ),
                             offline=self.offline,
+                            staging_cache_path=elect_staging_path,
                         )
                         self._tg.start_soon(self.download_coordinator.run)
                     if self.worker:
                         self.worker.shutdown()
-                        ms2 = self.exo_config.model_store if self.exo_config is not None else None
+                        ms2 = (
+                            self.exo_config.model_store
+                            if self.exo_config is not None
+                            else None
+                        )
                         elect_staging2 = (
                             resolve_node_staging(ms2, str(self.node_id))
                             if ms2 is not None and ms2.enabled

--- a/src/exo/shared/types/commands.py
+++ b/src/exo/shared/types/commands.py
@@ -83,10 +83,19 @@ class CancelDownload(BaseCommand):
 
 class SyncConfig(BaseCommand):
     """Broadcast updated exo.yaml content to all nodes in the cluster."""
+
     config_yaml: str
 
 
-DownloadCommand = StartDownload | DeleteDownload | CancelDownload | SyncConfig
+class PurgeStagingCache(BaseCommand):
+    """Broadcast command to purge staged model caches on all nodes."""
+
+    model_id: ModelId | None = None
+
+
+DownloadCommand = (
+    StartDownload | DeleteDownload | CancelDownload | SyncConfig | PurgeStagingCache
+)
 
 
 Command = (


### PR DESCRIPTION
## Summary
- Adds `PurgeStagingCache` command type broadcast on the `DOWNLOAD_COMMANDS` gossipsub topic (same pattern as `SyncConfig`)
- Each node's `DownloadCoordinator` handles the command by deleting staged model directories, cancelling active downloads, and resetting download status
- New `POST /store/purge-staging` API endpoint (optional `modelId` field to purge a specific model, or omit for all)
- Dashboard "Purge All Node Caches" button on the Downloads page with confirmation modal

## Test plan
- [ ] Start multi-node cluster with model store enabled
- [ ] Download a model and verify it stages to nodes
- [ ] Click "Purge All Node Caches" on downloads page
- [ ] Verify staging directories are cleared on all nodes
- [ ] Verify download list resets in the dashboard
- [ ] Verify read-only models from `EXO_MODELS_PATH` are preserved
- [ ] Run `uv run basedpyright` — no new type errors
- [ ] Run `uv run pytest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)