### PR TITLE
fix: purge must reset read-only entries to prevent runner crash

### DIFF
--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -235,10 +235,9 @@ class DownloadCoordinator:
                 )
                 await asyncio.to_thread(shutil.rmtree, hf_cache, True)
 
-            # Reset all download statuses
+            # Reset all download statuses (including read-only entries —
+            # their files have been deleted so they are no longer valid)
             for mid, status in list(self.download_status.items()):
-                if isinstance(status, DownloadCompleted) and status.read_only:
-                    continue  # Don't reset EXO_MODELS_PATH entries
                 pending = DownloadPending(
                     shard_metadata=status.shard_metadata,
                     node_id=self.node_id,


### PR DESCRIPTION
## Summary
- Read-only `DownloadCompleted` entries (from `EXO_MODELS_PATH`) were being skipped during purge reset
- But the purge deletes those files, leaving stale "completed" entries in `State.downloads`
- `_load_model` sees these stale entries and tells runners to load from deleted paths
- Runners crash with `FileNotFoundError: config.json`
- Fix: reset ALL download status entries during purge, including read-only ones

## Test plan
- [ ] Purge all node caches
- [ ] Verify no runner crashes after purge
- [ ] Verify models can be re-downloaded and launched after purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)