### PR TITLE
feat: broadcast node version/commit and fix build_model_path crash

### DIFF
--- a/dashboard/src/lib/stores/app.svelte.ts
+++ b/dashboard/src/lib/stores/app.svelte.ts
@@ -50,6 +50,8 @@ export interface NodeInfo {
   last_macmon_update: number;
   friendly_name?: string;
   os_version?: string;
+  exo_version?: string;
+  exo_commit?: string;
 }
 
 export interface TopologyEdge {
@@ -81,6 +83,8 @@ interface RawNodeIdentity {
   friendlyName?: string;
   osVersion?: string;
   osBuildVersion?: string;
+  exoVersion?: string;
+  exoCommit?: string;
 }
 
 interface RawMemoryUsage {
@@ -457,6 +461,8 @@ function transformTopology(
       last_macmon_update: Date.now() / 1000,
       friendly_name: identity?.friendlyName,
       os_version: identity?.osVersion,
+      exo_version: identity?.exoVersion,
+      exo_commit: identity?.exoCommit,
     };
   }
 

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -140,6 +140,24 @@
     }));
   });
 
+  // Detect exo version/commit mismatches across cluster nodes
+  const exoVersionMismatch = $derived.by(() => {
+    if (!identitiesData) return null;
+    const entries = Object.entries(identitiesData);
+    const nodesWithCommit = entries.filter(
+      ([_, id]) => id.exoCommit && id.exoCommit !== "Unknown" && id.exoCommit !== "unknown",
+    );
+    if (nodesWithCommit.length < 2) return null;
+    const commits = new Set(nodesWithCommit.map(([_, id]) => id.exoCommit));
+    if (commits.size <= 1) return null;
+    return nodesWithCommit.map(([nodeId, id]) => ({
+      nodeId,
+      friendlyName: getNodeName(nodeId),
+      version: id.exoVersion ?? "Unknown",
+      commit: id.exoCommit!,
+    }));
+  });
+
   // Detect TB5 nodes where RDMA is not enabled
   const tb5WithoutRdma = $derived.by(() => {
     const rdmaCtl = rdmaCtlData;
@@ -3225,7 +3243,7 @@
 </script>
 
 {#snippet clusterWarnings()}
-  {#if tbBridgeCycles.length > 0 || macosVersionMismatch || (tb5WithoutRdma && !tb5InfoDismissed) || (macStudioEn2RdmaWarning && !macStudioEn2Dismissed)}
+  {#if tbBridgeCycles.length > 0 || macosVersionMismatch || exoVersionMismatch || (tb5WithoutRdma && !tb5InfoDismissed) || (macStudioEn2RdmaWarning && !macStudioEn2Dismissed)}
     <div class="absolute top-4 left-4 flex flex-col gap-2 z-40">
       {#if tbBridgeCycles.length > 0}
         {@const cycle = tbBridgeCycles[0]}
@@ -3344,6 +3362,53 @@
             <p class="text-xs text-white/60">
               <span class="text-yellow-300">Suggested action:</span> Update all nodes
               to the same macOS version for best compatibility.
+            </p>
+          </div>
+        </div>
+      {/if}
+
+      {#if exoVersionMismatch}
+        <div class="group relative" role="alert">
+          <div
+            class="flex items-center gap-2 px-3 py-2 rounded border border-red-500/50 bg-red-500/10 backdrop-blur-sm cursor-help"
+          >
+            <svg
+              class="w-5 h-5 text-red-400 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d={warningIconPath}
+              />
+            </svg>
+            <span class="text-sm font-mono text-red-200">
+              EXO VERSION MISMATCH
+            </span>
+          </div>
+
+          <!-- Tooltip on hover -->
+          <div
+            class="absolute top-full left-0 mt-2 w-80 p-3 rounded border border-red-500/30 bg-exo-dark-gray/95 backdrop-blur-sm opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50 shadow-lg"
+          >
+            <p class="text-xs text-white/80 mb-2">
+              Nodes in this cluster are running different versions of exo. This
+              will cause inference failures and unexpected behavior.
+            </p>
+            <div class="text-xs text-white/60 mb-2">
+              <span class="text-red-300">Node versions:</span>
+              {#each exoVersionMismatch as node}
+                <div class="ml-2">
+                  {node.friendlyName} — v{node.version} ({node.commit})
+                </div>
+              {/each}
+            </div>
+            <p class="text-xs text-white/60">
+              <span class="text-red-300">Action required:</span> Update all nodes
+              to the same version with <code class="text-red-200">git pull && uv sync</code>.
             </p>
           </div>
         </div>
@@ -3674,7 +3739,7 @@
 {/snippet}
 
 {#snippet clusterWarningsCompact()}
-  {#if tbBridgeCycles.length > 0 || macosVersionMismatch || (tb5WithoutRdma && !tb5InfoDismissed) || (macStudioEn2RdmaWarning && !macStudioEn2Dismissed)}
+  {#if tbBridgeCycles.length > 0 || macosVersionMismatch || exoVersionMismatch || (tb5WithoutRdma && !tb5InfoDismissed) || (macStudioEn2RdmaWarning && !macStudioEn2Dismissed)}
     <div class="absolute top-2 left-2 flex flex-col gap-1">
       {#if tbBridgeCycles.length > 0}
         <div

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -121,6 +121,7 @@ def resolve_model_in_path(model_id: ModelId) -> Path | None:
     paths added at runtime (e.g. by the model store) are picked up.
     """
     import exo.shared.constants as _constants
+
     search_path = _constants.EXO_MODELS_PATH
     if search_path is None:
         return None
@@ -133,10 +134,24 @@ def resolve_model_in_path(model_id: ModelId) -> Path | None:
 
 
 def build_model_path(model_id: ModelId) -> Path:
+    """Resolve a local filesystem path for *model_id*.
+
+    Checks ``EXO_MODELS_PATH`` (staging, store, etc.) first, then falls
+    back to the standard ``EXO_MODELS_DIR``.  Raises ``FileNotFoundError``
+    if no valid model directory is found — this prevents the runner from
+    attempting to load from a path that doesn't exist.
+    """
     found = resolve_model_in_path(model_id)
     if found is not None:
         return found
-    return EXO_MODELS_DIR / model_id.normalize()
+    default = EXO_MODELS_DIR / model_id.normalize()
+    if default.is_dir() and (default / "config.json").exists():
+        return default
+    raise FileNotFoundError(
+        f"Model {model_id} not found on disk. "
+        f"Checked EXO_MODELS_PATH and {default}. "
+        f"Ensure the model is downloaded before loading."
+    )
 
 
 async def resolve_model_path_for_repo(model_id: ModelId) -> Path:

--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -312,6 +312,8 @@ def apply_node_gathered_info(event: NodeGatheredInfo, state: State) -> State:
                     "chip_id": info.chip,
                     "os_version": info.os_version,
                     "os_build_version": info.os_build_version,
+                    "exo_version": info.exo_version,
+                    "exo_commit": info.exo_commit,
                 }
             )
             update["node_identities"] = {

--- a/src/exo/shared/types/profiling.py
+++ b/src/exo/shared/types/profiling.py
@@ -83,6 +83,8 @@ class NodeIdentity(CamelCaseModel):
     friendly_name: str = "Unknown"
     os_version: str = "Unknown"
     os_build_version: str = "Unknown"
+    exo_version: str = "Unknown"
+    exo_commit: str = "Unknown"
 
 
 class NodeNetworkInfo(CamelCaseModel):

--- a/src/exo/utils/info_gatherer/info_gatherer.py
+++ b/src/exo/utils/info_gatherer/info_gatherer.py
@@ -186,6 +186,8 @@ class StaticNodeInformation(TaggedModel):
     chip: str
     os_version: str
     os_build_version: str
+    exo_version: str
+    exo_commit: str
 
     @classmethod
     async def gather(cls) -> Self:
@@ -195,7 +197,37 @@ class StaticNodeInformation(TaggedModel):
             chip=chip,
             os_version=get_os_version(),
             os_build_version=await get_os_build_version(),
+            exo_version=_get_exo_version(),
+            exo_commit=_get_git_commit(),
         )
+
+
+def _get_exo_version() -> str:
+    """Get exo version from package metadata."""
+    try:
+        from importlib.metadata import version
+
+        return version("exo")
+    except Exception:
+        return "unknown"
+
+
+def _get_git_commit() -> str:
+    """Get the current git commit hash."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "unknown"
 
 
 class NodeNetworkInterfaces(TaggedModel):


### PR DESCRIPTION
## Summary

### Version broadcasting
- Each node now reports its exo version (from `pyproject.toml`) and git commit hash (short SHA) via `StaticNodeInformation`
- Added `exo_version` and `exo_commit` fields to `NodeIdentity` in state
- Dashboard shows a red **EXO VERSION MISMATCH** banner when nodes are running different commits
- Hover tooltip shows per-node version and commit details with fix instructions

### build_model_path fix
- `build_model_path()` previously fell back to `EXO_MODELS_DIR / model_id.normalize()` unconditionally, even when no files existed there
- Runners would crash with `FileNotFoundError: config.json` when staged files had been evicted
- Now verifies the directory exists and contains `config.json` before returning it
- Raises `FileNotFoundError` with a clear message if no valid model directory is found

## Test plan
- [ ] Start multi-node cluster — verify version/commit appears in `/state` endpoint under `nodeIdentities`
- [ ] Deploy different commits to different nodes — verify red mismatch banner appears
- [ ] Deploy same commit to all nodes — verify banner disappears
- [ ] Attempt to load a model that isn't on disk — verify clear error instead of crash
- [ ] Run `uv run basedpyright` — no new type errors
- [ ] Run `uv run pytest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)