### PR TITLE
fix: validate RDMA interfaces exist — prevent segfault on TB4

### DIFF
--- a/dashboard/src/lib/stores/app.svelte.ts
+++ b/dashboard/src/lib/stores/app.svelte.ts
@@ -245,7 +245,7 @@ interface RawStateResponse {
     }
   >;
   // RDMA ctl status per node
-  nodeRdmaCtl?: Record<string, { enabled: boolean }>;
+  nodeRdmaCtl?: Record<string, { enabled: boolean; interfacesPresent?: boolean }>;
   // Thunderbolt bridge status per node
   nodeThunderboltBridge?: Record<
     string,
@@ -572,7 +572,7 @@ class AppStore {
       }
     >
   >({});
-  nodeRdmaCtl = $state<Record<string, { enabled: boolean }>>({});
+  nodeRdmaCtl = $state<Record<string, { enabled: boolean; interfacesPresent?: boolean }>>({});
   nodeThunderboltBridge = $state<
     Record<
       string,

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -174,6 +174,15 @@
   });
   let tb5InfoDismissed = $state(false);
 
+  // Detect nodes where RDMA is "enabled" but interfaces don't actually exist (TB4 hardware)
+  const rdmaPhantom = $derived.by(() => {
+    const rdmaCtl = rdmaCtlData;
+    if (!rdmaCtl) return false;
+    return Object.values(rdmaCtl).some(
+      (status) => status.enabled && status.interfacesPresent === false,
+    );
+  });
+
   // Detect Mac Studio nodes using RDMA on en2 (the port next to ethernet — RDMA doesn't work there)
   const macStudioEn2RdmaWarning = $derived.by(() => {
     const edges = data?.edges;
@@ -3243,7 +3252,7 @@
 </script>
 
 {#snippet clusterWarnings()}
-  {#if tbBridgeCycles.length > 0 || macosVersionMismatch || exoVersionMismatch || (tb5WithoutRdma && !tb5InfoDismissed) || (macStudioEn2RdmaWarning && !macStudioEn2Dismissed)}
+  {#if tbBridgeCycles.length > 0 || macosVersionMismatch || exoVersionMismatch || rdmaPhantom || (tb5WithoutRdma && !tb5InfoDismissed) || (macStudioEn2RdmaWarning && !macStudioEn2Dismissed)}
     <div class="absolute top-4 left-4 flex flex-col gap-2 z-40">
       {#if tbBridgeCycles.length > 0}
         {@const cycle = tbBridgeCycles[0]}
@@ -3409,6 +3418,47 @@
             <p class="text-xs text-white/60">
               <span class="text-red-300">Action required:</span> Update all nodes
               to the same version with <code class="text-red-200">git pull && uv sync</code>.
+            </p>
+          </div>
+        </div>
+      {/if}
+
+      {#if rdmaPhantom}
+        <div class="group relative" role="alert">
+          <div
+            class="flex items-center gap-2 px-3 py-2 rounded border border-orange-500/50 bg-orange-500/10 backdrop-blur-sm cursor-help"
+          >
+            <svg
+              class="w-5 h-5 text-orange-400 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d={warningIconPath}
+              />
+            </svg>
+            <span class="text-sm font-mono text-orange-200">
+              RDMA NOT AVAILABLE
+            </span>
+          </div>
+
+          <div
+            class="absolute top-full left-0 mt-2 w-80 p-3 rounded border border-orange-500/30 bg-exo-dark-gray/95 backdrop-blur-sm opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50 shadow-lg"
+          >
+            <p class="text-xs text-white/80 mb-2">
+              macOS reports RDMA as enabled but no RDMA network interfaces
+              exist. This typically means your hardware has Thunderbolt 4
+              ports, which do not support RDMA. Thunderbolt 5 (M4 Pro/Max
+              or newer) is required for RDMA.
+            </p>
+            <p class="text-xs text-white/60">
+              <span class="text-orange-300">Impact:</span> Tensor parallel
+              (MlxJaccl) is not available. Pipeline parallel (MlxRing)
+              works normally over Thunderbolt.
             </p>
           </div>
         </div>
@@ -3739,7 +3789,7 @@
 {/snippet}
 
 {#snippet clusterWarningsCompact()}
-  {#if tbBridgeCycles.length > 0 || macosVersionMismatch || exoVersionMismatch || (tb5WithoutRdma && !tb5InfoDismissed) || (macStudioEn2RdmaWarning && !macStudioEn2Dismissed)}
+  {#if tbBridgeCycles.length > 0 || macosVersionMismatch || exoVersionMismatch || rdmaPhantom || (tb5WithoutRdma && !tb5InfoDismissed) || (macStudioEn2RdmaWarning && !macStudioEn2Dismissed)}
     <div class="absolute top-2 left-2 flex flex-col gap-1">
       {#if tbBridgeCycles.length > 0}
         <div
@@ -3785,6 +3835,47 @@
           >
         </div>
       {/if}
+      {#if rdmaPhantom}
+        <div class="group relative" role="alert">
+          <div
+            class="flex items-center gap-2 px-3 py-2 rounded border border-orange-500/50 bg-orange-500/10 backdrop-blur-sm cursor-help"
+          >
+            <svg
+              class="w-5 h-5 text-orange-400 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d={warningIconPath}
+              />
+            </svg>
+            <span class="text-sm font-mono text-orange-200">
+              RDMA NOT AVAILABLE
+            </span>
+          </div>
+
+          <div
+            class="absolute top-full left-0 mt-2 w-80 p-3 rounded border border-orange-500/30 bg-exo-dark-gray/95 backdrop-blur-sm opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50 shadow-lg"
+          >
+            <p class="text-xs text-white/80 mb-2">
+              macOS reports RDMA as enabled but no RDMA network interfaces
+              exist. This typically means your hardware has Thunderbolt 4
+              ports, which do not support RDMA. Thunderbolt 5 (M4 Pro/Max
+              or newer) is required for RDMA.
+            </p>
+            <p class="text-xs text-white/60">
+              <span class="text-orange-300">Impact:</span> Tensor parallel
+              (MlxJaccl) is not available. Pipeline parallel (MlxRing)
+              works normally over Thunderbolt.
+            </p>
+          </div>
+        </div>
+      {/if}
+
       {#if tb5WithoutRdma && !tb5InfoDismissed}
         <div
           class="flex items-center gap-1.5 px-2 py-1 rounded border border-yellow-500/50 bg-yellow-500/10 backdrop-blur-sm"
@@ -4796,7 +4887,48 @@
           {@render clusterWarnings()}
 
           <!-- TB5 RDMA Not Enabled Warning -->
-          {#if tb5WithoutRdma && !tb5InfoDismissed}
+          {#if rdmaPhantom}
+        <div class="group relative" role="alert">
+          <div
+            class="flex items-center gap-2 px-3 py-2 rounded border border-orange-500/50 bg-orange-500/10 backdrop-blur-sm cursor-help"
+          >
+            <svg
+              class="w-5 h-5 text-orange-400 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d={warningIconPath}
+              />
+            </svg>
+            <span class="text-sm font-mono text-orange-200">
+              RDMA NOT AVAILABLE
+            </span>
+          </div>
+
+          <div
+            class="absolute top-full left-0 mt-2 w-80 p-3 rounded border border-orange-500/30 bg-exo-dark-gray/95 backdrop-blur-sm opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50 shadow-lg"
+          >
+            <p class="text-xs text-white/80 mb-2">
+              macOS reports RDMA as enabled but no RDMA network interfaces
+              exist. This typically means your hardware has Thunderbolt 4
+              ports, which do not support RDMA. Thunderbolt 5 (M4 Pro/Max
+              or newer) is required for RDMA.
+            </p>
+            <p class="text-xs text-white/60">
+              <span class="text-orange-300">Impact:</span> Tensor parallel
+              (MlxJaccl) is not available. Pipeline parallel (MlxRing)
+              works normally over Thunderbolt.
+            </p>
+          </div>
+        </div>
+      {/if}
+
+      {#if tb5WithoutRdma && !tb5InfoDismissed}
             <div
               class="absolute left-4 group"
               class:top-16={tbBridgeCycles.length > 0}
@@ -4941,7 +5073,48 @@
             {@render clusterWarnings()}
 
             <!-- TB5 RDMA Not Enabled Warning -->
-            {#if tb5WithoutRdma && !tb5InfoDismissed}
+            {#if rdmaPhantom}
+        <div class="group relative" role="alert">
+          <div
+            class="flex items-center gap-2 px-3 py-2 rounded border border-orange-500/50 bg-orange-500/10 backdrop-blur-sm cursor-help"
+          >
+            <svg
+              class="w-5 h-5 text-orange-400 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d={warningIconPath}
+              />
+            </svg>
+            <span class="text-sm font-mono text-orange-200">
+              RDMA NOT AVAILABLE
+            </span>
+          </div>
+
+          <div
+            class="absolute top-full left-0 mt-2 w-80 p-3 rounded border border-orange-500/30 bg-exo-dark-gray/95 backdrop-blur-sm opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50 shadow-lg"
+          >
+            <p class="text-xs text-white/80 mb-2">
+              macOS reports RDMA as enabled but no RDMA network interfaces
+              exist. This typically means your hardware has Thunderbolt 4
+              ports, which do not support RDMA. Thunderbolt 5 (M4 Pro/Max
+              or newer) is required for RDMA.
+            </p>
+            <p class="text-xs text-white/60">
+              <span class="text-orange-300">Impact:</span> Tensor parallel
+              (MlxJaccl) is not available. Pipeline parallel (MlxRing)
+              works normally over Thunderbolt.
+            </p>
+          </div>
+        </div>
+      {/if}
+
+      {#if tb5WithoutRdma && !tb5InfoDismissed}
               <div
                 class="absolute left-4 group"
                 class:top-16={tbBridgeCycles.length > 0}

--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -369,7 +369,10 @@ def apply_node_gathered_info(event: NodeGatheredInfo, state: State) -> State:
         case RdmaCtlStatus():
             update["node_rdma_ctl"] = {
                 **state.node_rdma_ctl,
-                event.node_id: NodeRdmaCtlStatus(enabled=info.enabled),
+                event.node_id: NodeRdmaCtlStatus(
+                    enabled=info.enabled,
+                    interfaces_present=info.interfaces_present,
+                ),
             }
 
     return state.model_copy(update=update)

--- a/src/exo/shared/types/profiling.py
+++ b/src/exo/shared/types/profiling.py
@@ -103,6 +103,7 @@ class NodeRdmaCtlStatus(CamelCaseModel):
     """Whether RDMA is enabled on this node (via rdma_ctl)."""
 
     enabled: bool
+    interfaces_present: bool = True
 
 
 class ThunderboltBridgeStatus(CamelCaseModel):

--- a/src/exo/utils/info_gatherer/info_gatherer.py
+++ b/src/exo/utils/info_gatherer/info_gatherer.py
@@ -244,6 +244,7 @@ class MacThunderboltConnections(TaggedModel):
 
 class RdmaCtlStatus(TaggedModel):
     enabled: bool
+    interfaces_present: bool
 
     @classmethod
     async def gather(cls) -> Self | None:
@@ -258,10 +259,24 @@ class RdmaCtlStatus(TaggedModel):
             return None
         output = proc.stdout.decode("utf-8").lower().strip()
         if "enabled" in output:
-            return cls(enabled=True)
+            return cls(enabled=True, interfaces_present=_rdma_interfaces_exist())
         if "disabled" in output:
-            return cls(enabled=False)
+            return cls(enabled=False, interfaces_present=False)
         return None
+
+
+def _rdma_interfaces_exist() -> bool:
+    """Check if any rdma_* network interfaces actually exist at the OS level.
+
+    On TB4 hardware, rdma_ctl may report enabled but no rdma_* interfaces
+    are created because the hardware doesn't support RDMA.
+    """
+    import socket
+
+    try:
+        return any(name.startswith("rdma_") for _, name in socket.if_nameindex())
+    except OSError:
+        return False
 
 
 class ThunderboltBridgeInfo(TaggedModel):
@@ -481,11 +496,27 @@ class InfoGatherer:
                     idents = [
                         it for i in data if (it := i.ident(iface_map)) is not None
                     ]
+
+                    # Filter to only interfaces that actually exist at the OS level.
+                    # On TB4 hardware, system_profiler reports rdma_* identifiers
+                    # but the interfaces are never created — RDMA requires TB5.
+                    if idents and not _rdma_interfaces_exist():
+                        logger.info(
+                            "Thunderbolt: rdma_ctl reports RDMA but no rdma_* interfaces "
+                            "exist (TB4 hardware?) — suppressing RDMA identifiers"
+                        )
+                        idents = []
+
                     await self.info_sender.send(
                         MacThunderboltIdentifiers(idents=idents)
                     )
 
-                    conns = [it for i in data if (it := i.conn()) is not None]
+                    # Only emit connections if we have valid identifiers
+                    conns = (
+                        [it for i in data if (it := i.conn()) is not None]
+                        if idents
+                        else []
+                    )
                     await self.info_sender.send(MacThunderboltConnections(conns=conns))
             except Exception as e:
                 logger.warning(f"Error gathering Thunderbolt data: {e}")


### PR DESCRIPTION
## Summary

On Thunderbolt 4 hardware (Mac Mini M4 base), macOS reports RDMA as enabled and system_profiler shows `rdma_*` interface identifiers — but the actual network interfaces are never created. RDMA requires Thunderbolt 5 (M4 Pro/Max).

This caused:
- Fake RDMA edges in the topology
- MlxJaccl (tensor parallel) being offered as a placement option
- Segfault (signal 11) when MLX tried RDMA operations on nonexistent interfaces

### Changes
- **`RdmaCtlStatus`**: New `interfaces_present` field — checks `socket.if_nameindex()` for actual `rdma_*` interfaces
- **`_monitor_system_profiler_thunderbolt_data`**: Suppresses RDMA identifiers when interfaces don't exist, preventing fake `RDMAConnection` edges from forming
- **`NodeRdmaCtlStatus`**: Carries `interfaces_present` to dashboard
- **Dashboard**: Orange **RDMA NOT AVAILABLE** banner when RDMA is enabled but interfaces are missing, explaining TB4 vs TB5 requirement

### Effect
- No more fake RDMA topology edges on TB4 hardware
- MlxJaccl won't be offered (no RDMA cycles can form)
- Pipeline parallel (MlxRing) continues to work normally over Thunderbolt
- Clear user-facing explanation instead of a segfault

## Test plan
- [ ] Deploy on TB4 Mac Minis — verify no RDMA edges in topology
- [ ] Verify orange "RDMA NOT AVAILABLE" banner appears
- [ ] Verify MlxJaccl is not offered in placement options
- [ ] Verify MlxRing pipeline parallel still works
- [ ] On TB5 hardware (if available): verify RDMA edges still form normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)