### PR TITLE
feat(dashboard-react): launch from store, rebrand to Skulk, Outfit font, react-icons

### DIFF
--- a/dashboard-react/index.html
+++ b/dashboard-react/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Skulk</title>
   </head>

--- a/dashboard-react/index.html
+++ b/dashboard-react/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Skulk</title>
   </head>

--- a/dashboard-react/index.html
+++ b/dashboard-react/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Skulk</title>
   </head>

--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -17,6 +17,7 @@
         "marked": "^17.0.5",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-icons": "^5.6.0",
         "react-router-dom": "^7.13.2",
         "styled-components": "^6.3.12",
         "zustand": "^5.0.12"
@@ -5691,6 +5692,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -21,6 +21,7 @@
     "marked": "^17.0.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-icons": "^5.6.0",
     "react-router-dom": "^7.13.2",
     "styled-components": "^6.3.12",
     "zustand": "^5.0.12"

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -26,7 +26,7 @@ const Main = styled.main`
 `;
 
 export function App() {
-  const { topology, connected, downloads, nodeDisk } = useClusterState();
+  const { topology, connected, downloads, nodeDisk, instances } = useClusterState();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [activeRoute, setActiveRoute] = useState<NavRoute>('home');
 
@@ -49,6 +49,7 @@ export function App() {
               topology={topology}
               downloads={downloads}
               nodeDisk={nodeDisk}
+              instances={instances}
             />
           ) : topology ? (
             <TopologyGraph data={topology} />

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -10,7 +10,7 @@ import { ConnectionBanner } from './components/status/ConnectionBanner';
 import { ToastContainer } from './components/status/ToastContainer';
 import { NetworkMesh } from './components/common/NetworkMesh';
 import { SettingsPanel } from './components/layout/SettingsPanel';
-import { DownloadsPage } from './components/pages/DownloadsPage';
+import { ModelStorePage } from './components/pages/DownloadsPage';
 
 const Shell = styled.div`
   position: relative;
@@ -28,7 +28,7 @@ const Main = styled.main`
 export function App() {
   const { topology, connected, downloads, nodeDisk, instances } = useClusterState();
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [activeRoute, setActiveRoute] = useState<NavRoute>('home');
+  const [activeRoute, setActiveRoute] = useState<NavRoute>('cluster');
 
   return (
     <ThemeProvider theme={theme}>
@@ -44,8 +44,8 @@ export function App() {
         />
         <ClusterWarnings topology={topology} />
         <Main>
-          {activeRoute === 'downloads' ? (
-            <DownloadsPage
+          {activeRoute === 'model-store' ? (
+            <ModelStorePage
               topology={topology}
               downloads={downloads}
               nodeDisk={nodeDisk}

--- a/dashboard-react/src/components/chat/ChatAttachments.tsx
+++ b/dashboard-react/src/components/chat/ChatAttachments.tsx
@@ -54,7 +54,7 @@ const FileInfo = styled.div`
 
 const FileName = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: #FFD700;
   white-space: nowrap;
   overflow: hidden;

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -58,8 +58,6 @@ const HeaderRow = styled.div`
   padding: 8px 12px;
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 1px;
   color: ${({ theme }) => theme.colors.textMuted};
 `;
 
@@ -149,8 +147,6 @@ const DragOverlay = styled.div`
   border-radius: ${({ theme }) => theme.radii.lg};
   font-size: ${({ theme }) => theme.fontSizes.md};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 2px;
   color: #FFD700;
 `;
 

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -57,7 +57,7 @@ const HeaderRow = styled.div`
   gap: 8px;
   padding: 8px 12px;
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 1px;
   color: ${({ theme }) => theme.colors.textMuted};
@@ -114,7 +114,7 @@ const AttachBtn = styled(Button)`
 const Prompt = styled.span`
   color: #FFD700;
   font-size: ${({ theme }) => theme.fontSizes.lg};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   flex-shrink: 0;
   line-height: 28px;
 `;
@@ -123,7 +123,7 @@ const TextArea = styled.textarea`
   all: unset;
   flex: 1;
   font-size: ${({ theme }) => theme.fontSizes.md};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.text};
   min-height: 28px;
   max-height: 150px;
@@ -148,7 +148,7 @@ const DragOverlay = styled.div`
   border: 2px dashed #FFD700;
   border-radius: ${({ theme }) => theme.radii.lg};
   font-size: ${({ theme }) => theme.fontSizes.md};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 2px;
   color: #FFD700;
@@ -157,7 +157,7 @@ const DragOverlay = styled.div`
 const HelperText = styled.div`
   padding: 4px 12px 8px;
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
   text-align: center;
 `;

--- a/dashboard-react/src/components/chat/ChatMessages.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.tsx
@@ -53,8 +53,6 @@ const EmptyState = styled.div`
   gap: 16px;
   color: ${({ theme }) => theme.colors.textMuted};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 2px;
   font-size: ${({ theme }) => theme.fontSizes.sm};
 `;
 
@@ -92,8 +90,6 @@ const MsgHeader = styled.div`
   margin-bottom: 8px;
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 1px;
 `;
 
 const RoleLabel = styled.span<{ $role: 'user' | 'assistant' }>`

--- a/dashboard-react/src/components/chat/ChatMessages.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.tsx
@@ -388,7 +388,7 @@ export function ChatMessages({
             {msg.role === 'assistant' ? (
               <>
                 <Dot $color="#FFD700" />
-                <RoleLabel $role="assistant">SKULK</RoleLabel>
+                <RoleLabel $role="assistant">Skulk</RoleLabel>
                 <Timestamp>{formatTime(msg.timestamp)}</Timestamp>
                 {msg.ttftMs != null && <StatLabel>TTFT <span>{Math.round(msg.ttftMs)}ms</span></StatLabel>}
                 {msg.tps != null && <StatLabel>TPS <span>{msg.tps.toFixed(1)}</span></StatLabel>}
@@ -523,7 +523,7 @@ export function ChatMessages({
         <MessageCard $role="assistant">
           <MsgHeader>
             <Dot $color="#FFD700" />
-            <RoleLabel $role="assistant">SKULK</RoleLabel>
+            <RoleLabel $role="assistant">Skulk</RoleLabel>
           </MsgHeader>
           <MarkdownContent content={streamingContent} />
           <Cursor />

--- a/dashboard-react/src/components/chat/ChatMessages.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.tsx
@@ -52,7 +52,7 @@ const EmptyState = styled.div`
   padding: 80px 0;
   gap: 16px;
   color: ${({ theme }) => theme.colors.textMuted};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 2px;
   font-size: ${({ theme }) => theme.fontSizes.sm};
@@ -91,7 +91,7 @@ const MsgHeader = styled.div`
   gap: 8px;
   margin-bottom: 8px;
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 1px;
 `;
@@ -121,7 +121,7 @@ const Dot = styled.span<{ $color: string }>`
 const Spacer = styled.span`flex: 1;`;
 
 const UserContent = styled.div`
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.md};
   white-space: pre-wrap;
   line-height: 1.5;
@@ -159,7 +159,7 @@ const ActiveGhostBtn = styled(Button)<{ $active?: boolean }>`
 const EditArea = styled.textarea`
   all: unset;
   width: 100%;
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.md};
   color: ${({ theme }) => theme.colors.text};
   background: ${({ theme }) => theme.colors.bg};
@@ -185,7 +185,7 @@ const ConfirmBox = styled.div`
   border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: ${({ theme }) => theme.radii.sm};
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: #fca5a5;
 `;
 
@@ -206,7 +206,7 @@ const ThinkingHeader = styled.button`
   width: 100%;
   padding: 6px 10px;
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: rgba(255, 215, 0, 0.6);
   transition: background 0.15s;
   box-sizing: border-box;

--- a/dashboard-react/src/components/chat/ChatModelSelector.tsx
+++ b/dashboard-react/src/components/chat/ChatModelSelector.tsx
@@ -154,8 +154,6 @@ const CardHeader = styled.div`
 const CategoryLabel = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 1px;
   color: ${({ theme }) => theme.colors.textMuted};
   flex: 1;
 `;

--- a/dashboard-react/src/components/chat/ChatModelSelector.tsx
+++ b/dashboard-react/src/components/chat/ChatModelSelector.tsx
@@ -107,7 +107,7 @@ const Header = styled.div`
 
 const ClusterName = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.lg};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: #FFD700;
   margin-top: 4px;
 `;
@@ -153,7 +153,7 @@ const CardHeader = styled.div`
 
 const CategoryLabel = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 1px;
   color: ${({ theme }) => theme.colors.textMuted};
@@ -169,13 +169,13 @@ const InfoBtn = styled.span`
 
 const ModelName = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.text};
 `;
 
 const ModelMeta = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
 `;
 
@@ -197,7 +197,7 @@ const Tooltip = styled.div<{ $x: number; $y: number }>`
   border-radius: ${({ theme }) => theme.radii.sm};
   padding: 4px 8px;
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textSecondary};
   white-space: nowrap;
   pointer-events: none;

--- a/dashboard-react/src/components/chat/ChatSidebar.tsx
+++ b/dashboard-react/src/components/chat/ChatSidebar.tsx
@@ -70,8 +70,6 @@ const SearchInput = styled.input`
 const SectionLabel = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 2px;
   color: ${({ theme }) => theme.colors.textMuted};
   padding: 8px 16px 4px;
 `;
@@ -165,8 +163,6 @@ const ConvCount = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
-  text-transform: uppercase;
-  letter-spacing: 1px;
   margin-top: 8px;
 `;
 
@@ -179,8 +175,6 @@ const EmptyState = styled.div`
   color: ${({ theme }) => theme.colors.textMuted};
   font-size: ${({ theme }) => theme.fontSizes.sm};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 1px;
 `;
 
 /* ---- component ---- */

--- a/dashboard-react/src/components/chat/ChatSidebar.tsx
+++ b/dashboard-react/src/components/chat/ChatSidebar.tsx
@@ -59,7 +59,7 @@ const SearchInput = styled.input`
   border: 1px solid ${({ theme }) => theme.colors.border};
   border-radius: ${({ theme }) => theme.radii.md};
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.text};
   box-sizing: border-box;
 
@@ -69,7 +69,7 @@ const SearchInput = styled.input`
 
 const SectionLabel = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 2px;
   color: ${({ theme }) => theme.colors.textMuted};
@@ -99,7 +99,7 @@ const ConvItem = styled.div<{ $active: boolean }>`
 
 const ConvName = styled.div<{ $active: boolean }>`
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ $active }) => ($active ? '#FFD700' : '#e5e5e5')};
   white-space: nowrap;
   overflow: hidden;
@@ -133,7 +133,7 @@ const EditInput = styled.input`
   border: 1px solid rgba(255, 215, 0, 0.4);
   border-radius: ${({ theme }) => theme.radii.sm};
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.text};
   box-sizing: border-box;
 `;
@@ -144,7 +144,7 @@ const ConfirmBox = styled.div<{ $danger?: boolean }>`
   border: 1px solid ${({ $danger }) => ($danger ? 'rgba(239,68,68,0.3)' : 'rgba(255,215,0,0.2)')};
   border-radius: ${({ theme }) => theme.radii.sm};
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ $danger, theme }) => ($danger ? '#fca5a5' : theme.colors.textSecondary)};
 `;
 
@@ -163,7 +163,7 @@ const Footer = styled.div`
 
 const ConvCount = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -178,7 +178,7 @@ const EmptyState = styled.div`
   padding: 32px 16px;
   color: ${({ theme }) => theme.colors.textMuted};
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 1px;
 `;

--- a/dashboard-react/src/components/common/Button.tsx
+++ b/dashboard-react/src/components/common/Button.tsx
@@ -123,8 +123,6 @@ const StyledButton = styled.button<{
   justify-content: center;
   gap: 6px;
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   border-radius: ${({ theme }) => theme.radii.md};
   transition: all 0.15s;
   white-space: nowrap;

--- a/dashboard-react/src/components/common/Button.tsx
+++ b/dashboard-react/src/components/common/Button.tsx
@@ -122,7 +122,7 @@ const StyledButton = styled.button<{
   align-items: center;
   justify-content: center;
   gap: 6px;
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 0.5px;
   border-radius: ${({ theme }) => theme.radii.md};

--- a/dashboard-react/src/components/common/InfoTooltip.tsx
+++ b/dashboard-react/src/components/common/InfoTooltip.tsx
@@ -55,7 +55,7 @@ const TooltipBox = styled.div`
   border-radius: ${({ theme }) => theme.radii.md};
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textSecondary};
   line-height: 1.5;
   z-index: 9999;

--- a/dashboard-react/src/components/common/SegmentedControl.tsx
+++ b/dashboard-react/src/components/common/SegmentedControl.tsx
@@ -39,8 +39,6 @@ const Segment = styled.button<{
   padding: ${({ $size }) => sizeConfig[$size].padding};
   font-size: ${({ $size }) => sizeConfig[$size].fontSize};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   transition: all 0.15s;
   white-space: nowrap;
 

--- a/dashboard-react/src/components/common/SegmentedControl.tsx
+++ b/dashboard-react/src/components/common/SegmentedControl.tsx
@@ -38,7 +38,7 @@ const Segment = styled.button<{
   cursor: pointer;
   padding: ${({ $size }) => sizeConfig[$size].padding};
   font-size: ${({ $size }) => sizeConfig[$size].fontSize};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 0.5px;
   transition: all 0.15s;

--- a/dashboard-react/src/components/common/StepSlider.tsx
+++ b/dashboard-react/src/components/common/StepSlider.tsx
@@ -85,7 +85,7 @@ const Dot = styled.span<{ $active: boolean; $size: number; $inactiveSize: number
 
 const Label = styled.span<{ $active: boolean }>`
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ $active }) => ($active ? '#FFD700' : 'rgba(179, 179, 179, 0.6)')};
   font-weight: ${({ $active }) => ($active ? 600 : 400)};
   transition: color 0.15s;

--- a/dashboard-react/src/components/display/ImageParamsPanel.tsx
+++ b/dashboard-react/src/components/display/ImageParamsPanel.tsx
@@ -66,8 +66,6 @@ const ParamGroup = styled.div`
 `;
 
 const Label = styled.span`
-  text-transform: uppercase;
-  letter-spacing: 1px;
   font-size: ${({ theme }) => theme.fontSizes.xs};
   color: ${({ theme }) => theme.colors.textMuted};
 `;
@@ -81,7 +79,6 @@ const Select = styled.select`
   font: inherit;
   color: ${({ theme }) => theme.colors.text};
   cursor: pointer;
-  text-transform: uppercase;
 
   &:focus {
     border-color: rgba(255, 215, 0, 0.7);
@@ -101,7 +98,6 @@ const ToggleBtn = styled.button<{ $active: boolean }>`
   cursor: pointer;
   padding: 4px 10px;
   font: inherit;
-  text-transform: uppercase;
   transition: all 0.15s;
 
   ${({ $active }) =>

--- a/dashboard-react/src/components/display/ImageParamsPanel.tsx
+++ b/dashboard-react/src/components/display/ImageParamsPanel.tsx
@@ -55,7 +55,7 @@ const Panel = styled.div`
   align-items: center;
   gap: 12px;
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textSecondary};
 `;
 

--- a/dashboard-react/src/components/display/MarkdownContent.tsx
+++ b/dashboard-react/src/components/display/MarkdownContent.tsx
@@ -183,8 +183,6 @@ const Container = styled.div`
   .mc-code-lang {
     font-size: ${({ theme }) => theme.fontSizes.label};
     font-family: ${({ theme }) => theme.fonts.mono};
-    text-transform: uppercase;
-    letter-spacing: 1px;
     color: rgba(255, 215, 0, 0.6);
   }
 

--- a/dashboard-react/src/components/display/PrefillProgressBar.tsx
+++ b/dashboard-react/src/components/display/PrefillProgressBar.tsx
@@ -50,7 +50,7 @@ const LabelRow = styled.div`
 `;
 
 const TokenCount = styled.span`
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
 `;
 
 const Track = styled.div`
@@ -73,7 +73,7 @@ const FooterRow = styled.div`
   align-items: center;
   justify-content: space-between;
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: rgba(179, 179, 179, 0.7);
   margin-top: 4px;
 `;

--- a/dashboard-react/src/components/display/TokenHeatmap.tsx
+++ b/dashboard-react/src/components/display/TokenHeatmap.tsx
@@ -89,13 +89,13 @@ const TooltipHeader = styled.div`
 `;
 
 const TooltipToken = styled.span`
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: #fff;
 `;
 
 const LogprobText = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: rgba(156, 163, 175, 0.8);
   margin-bottom: 8px;
 `;
@@ -104,7 +104,7 @@ const AltRow = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.label};
   padding: 2px 0;
   color: rgba(209, 213, 219, 0.8);

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -1,4 +1,6 @@
 import styled, { css } from 'styled-components';
+import { FiHome, FiDownload, FiSettings, FiMenu, FiX, FiSidebar } from 'react-icons/fi';
+import { MdOutlineViewSidebar } from 'react-icons/md';
 import { Button } from '../common/Button';
 
 export type NavRoute = 'home' | 'downloads';
@@ -109,52 +111,15 @@ const DownloadBadge = styled.div`
   height: 28px;
 `;
 
-/* ---- icons ---- */
+/* ---- icons (react-icons) ---- */
 
-const MenuIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-    <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" />
-  </svg>
-);
-
-const CloseIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-    <path d="M6 18L18 6M6 6l12 12" />
-  </svg>
-);
-
-const SidebarIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-    <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" />
-  </svg>
-);
-
-const PanelIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-    <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="15" y1="3" x2="15" y2="21" />
-  </svg>
-);
-
-const DownloadIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
-    <polyline points="7 10 12 15 17 10" /><line x1="12" y1="15" x2="12" y2="3" />
-  </svg>
-);
-
-const HomeIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-    <polyline points="9 22 9 12 15 12 15 22" />
-  </svg>
-);
-
-const SettingsIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-    <circle cx="12" cy="12" r="3" />
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-  </svg>
-);
+const MenuIcon = () => <FiMenu size={18} />;
+const CloseIcon = () => <FiX size={18} />;
+const SidebarIcon = () => <FiSidebar size={18} />;
+const PanelIcon = () => <MdOutlineViewSidebar size={18} />;
+const DownloadIcon = () => <FiDownload size={16} />;
+const HomeIcon = () => <FiHome size={16} />;
+const SettingsIcon = () => <FiSettings size={16} />;
 
 function ProgressCircle({ count, percentage }: { count: number; percentage: number }) {
   const r = 10;

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -95,8 +95,6 @@ const NavLink = styled.button<{ $active?: boolean }>`
   background: ${({ $active, theme }) => $active ? theme.colors.goldBg : 'transparent'};
   font-size: ${({ theme }) => theme.fontSizes.nav};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 1px;
   color: ${({ $active, theme }) => $active ? theme.colors.gold : theme.colors.textSecondary};
   transition: all 0.15s;
 

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -1,9 +1,10 @@
 import styled, { css } from 'styled-components';
-import { FiHome, FiDownload, FiSettings, FiMenu, FiX, FiSidebar } from 'react-icons/fi';
+import { FiSettings, FiMenu, FiX, FiSidebar, FiDatabase } from 'react-icons/fi';
+import { MdHub } from 'react-icons/md';
 import { MdOutlineViewSidebar } from 'react-icons/md';
 import { Button } from '../common/Button';
 
-export type NavRoute = 'home' | 'downloads';
+export type NavRoute = 'cluster' | 'model-store';
 
 export interface HeaderNavProps {
   showHome?: boolean;
@@ -117,8 +118,8 @@ const MenuIcon = () => <FiMenu size={18} />;
 const CloseIcon = () => <FiX size={18} />;
 const SidebarIcon = () => <FiSidebar size={18} />;
 const PanelIcon = () => <MdOutlineViewSidebar size={18} />;
-const DownloadIcon = () => <FiDownload size={16} />;
-const HomeIcon = () => <FiHome size={16} />;
+const ClusterIcon = () => <MdHub size={16} />;
+const StoreIcon = () => <FiDatabase size={16} />;
 const SettingsIcon = () => <FiSettings size={16} />;
 
 function ProgressCircle({ count, percentage }: { count: number; percentage: number }) {
@@ -151,7 +152,7 @@ function ProgressCircle({ count, percentage }: { count: number; percentage: numb
 export function HeaderNav({
   showHome = true,
   onHome,
-  activeRoute = 'home',
+  activeRoute = 'cluster',
   onNavigate,
   showSidebarToggle = false,
   sidebarVisible = true,
@@ -168,7 +169,7 @@ export function HeaderNav({
 }: HeaderNavProps) {
   const navigate = (route: NavRoute) => {
     onNavigate?.(route);
-    if (route === 'home') onHome?.();
+    if (route === 'cluster') onHome?.();
   };
 
   return (
@@ -184,7 +185,7 @@ export function HeaderNav({
             <SidebarIcon />
           </ToggleBtn>
         )}
-        <LogoBtn $disabled={!showHome} onClick={showHome ? () => navigate('home') : undefined}>
+        <LogoBtn $disabled={!showHome} onClick={showHome ? () => navigate('cluster') : undefined}>
           <LogoText>Skulk</LogoText>
         </LogoBtn>
       </LeftGroup>
@@ -192,12 +193,12 @@ export function HeaderNav({
       <RightGroup>
         {downloadProgress && <ProgressCircle count={downloadProgress.count} percentage={downloadProgress.percentage} />}
 
-        <NavLink $active={activeRoute === 'home'} onClick={() => navigate('home')}>
-          <HomeIcon /> Home
+        <NavLink $active={activeRoute === 'cluster'} onClick={() => navigate('cluster')}>
+          <ClusterIcon /> Cluster
         </NavLink>
 
-        <NavLink $active={activeRoute === 'downloads'} onClick={() => navigate('downloads')}>
-          <DownloadIcon /> Downloads
+        <NavLink $active={activeRoute === 'model-store'} onClick={() => navigate('model-store')}>
+          <StoreIcon /> Model Store
         </NavLink>
 
         <Button variant="ghost" size="lg" icon onClick={() => onOpenSettings?.()} aria-label="Settings">

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -78,7 +78,7 @@ const LogoBtn = styled.button<{ $disabled: boolean }>`
 const LogoText = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.xxl};
   font-weight: 700;
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: #FFD700;
   filter: drop-shadow(0 0 4px rgba(255, 215, 0, 0.3));
 `;
@@ -94,7 +94,7 @@ const NavLink = styled.button<{ $active?: boolean }>`
   border: 1px solid ${({ $active, theme }) => $active ? theme.colors.goldDim : theme.colors.border};
   background: ${({ $active, theme }) => $active ? theme.colors.goldBg : 'transparent'};
   font-size: ${({ theme }) => theme.fontSizes.nav};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 1px;
   color: ${({ $active, theme }) => $active ? theme.colors.gold : theme.colors.textSecondary};

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -61,8 +61,6 @@ const Title = styled.h2`
   font-size: ${({ theme }) => theme.fontSizes.md};
   font-family: ${({ theme }) => theme.fonts.body};
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
   color: #FFD700;
 `;
 
@@ -96,8 +94,6 @@ const Legend = styled.legend`
   font-size: ${({ theme }) => theme.fontSizes.label};
   font-family: ${({ theme }) => theme.fonts.body};
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 1px;
   color: ${({ theme }) => theme.colors.textSecondary};
   padding: 0 6px;
 `;
@@ -172,8 +168,6 @@ const LoadingText = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.sm};
   font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
-  text-transform: uppercase;
-  letter-spacing: 1px;
 `;
 
 const Spacer = styled.span`

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -59,7 +59,7 @@ const Header = styled.div`
 
 const Title = styled.h2`
   font-size: ${({ theme }) => theme.fontSizes.md};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 1.5px;
@@ -94,7 +94,7 @@ const Fieldset = styled.fieldset`
 
 const Legend = styled.legend`
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -114,7 +114,7 @@ const FieldLabel = styled.span`
   align-items: center;
   gap: 6px;
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textSecondary};
   white-space: nowrap;
 `;
@@ -154,13 +154,13 @@ const StyledField = styled(Field)`
 
 const ConfigPath = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
 `;
 
 const ErrorText = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: #ef4444;
 `;
 
@@ -170,7 +170,7 @@ const LoadingText = styled.div`
   justify-content: center;
   height: 200px;
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
   text-transform: uppercase;
   letter-spacing: 1px;

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 import styled, { css, keyframes } from 'styled-components';
+import { FiTrash2, FiExternalLink } from 'react-icons/fi';
+import { MdPlayArrow, MdClose } from 'react-icons/md';
 import { formatBytes } from '../../utils/format';
 import { Button } from '../common/Button';
 import { InfoTooltip } from '../common/InfoTooltip';
@@ -274,13 +276,7 @@ const ActionsCell = styled.div`
    Component
    ================================================================ */
 
-const LinkIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
-    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-    <polyline points="15 3 21 3 21 9" />
-    <line x1="10" y1="14" x2="21" y2="3" />
-  </svg>
-);
+const LinkIcon = () => <FiExternalLink size={14} style={{ flexShrink: 0 }} />;
 
 function ModelInfoContent({ entry, card }: { entry: StoreRegistryEntry; card?: ModelCardInfo }) {
   const hfUrl = entry.model_id.includes('/')
@@ -445,15 +441,11 @@ export function StoreRegistryTable({
                 <PlayCell>
                   {active && onStop ? (
                     <StopBtn onClick={() => onStop(entry.model_id)} title="Stop model">
-                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M18 6L6 18M6 6l12 12" />
-                      </svg>
+                      <MdClose size={20} />
                     </StopBtn>
                   ) : !active && !dl && onLaunch ? (
                     <PlayBtn onClick={() => onLaunch(entry.model_id)} title="Launch model">
-                      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                        <polygon points="5 3 19 12 5 21 5 3" />
-                      </svg>
+                      <MdPlayArrow size={20} />
                     </PlayBtn>
                   ) : null}
                 </PlayCell>
@@ -485,9 +477,7 @@ export function StoreRegistryTable({
                     delay={100}
                   />
                   <Button variant="danger" size="sm" icon onClick={() => onDelete(entry, active)} title="Delete model">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                      <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                    </svg>
+                    <FiTrash2 size={18} />
                   </Button>
                 </ActionsCell>
               </TRow>

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -38,6 +38,7 @@ export interface StoreRegistryTableProps {
   actions?: React.ReactNode;
   onRefresh: () => void;
   onDelete: (entry: StoreRegistryEntry, isActive: boolean) => void;
+  onLaunch?: (modelId: string) => void;
 }
 
 /* ---- helpers ---- */
@@ -322,6 +323,7 @@ export function StoreRegistryTable({
   actions,
   onRefresh,
   onDelete,
+  onLaunch,
 }: StoreRegistryTableProps) {
   const registeredIds = useMemo(() => new Set(entries.map((e) => e.model_id)), [entries]);
   const pendingDownloads = useMemo(
@@ -413,6 +415,13 @@ export function StoreRegistryTable({
                   )}
                 </Cell>
                 <ActionsCell>
+                  {onLaunch && !active && !dl && (
+                    <Button variant="primary" size="sm" icon onClick={() => onLaunch(entry.model_id)} title="Launch model">
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                        <polygon points="5 3 19 12 5 21 5 3" />
+                      </svg>
+                    </Button>
+                  )}
                   <InfoTooltip
                     content={<ModelInfoContent entry={entry} card={modelCards[entry.model_id]} />}
                     placement="left"

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -39,6 +39,7 @@ export interface StoreRegistryTableProps {
   onRefresh: () => void;
   onDelete: (entry: StoreRegistryEntry, isActive: boolean) => void;
   onLaunch?: (modelId: string) => void;
+  onStop?: (modelId: string) => void;
 }
 
 /* ---- helpers ---- */
@@ -120,7 +121,7 @@ const Table = styled.div`
 
 const THead = styled.div`
   display: grid;
-  grid-template-columns: 1fr 80px 60px 100px 60px;
+  grid-template-columns: 36px 1fr 80px 60px 100px 60px;
   gap: 8px;
   padding: 8px 12px;
   background: rgba(0, 0, 0, 0.4);
@@ -133,7 +134,7 @@ const THead = styled.div`
 
 const TRow = styled.div<{ $highlight?: boolean }>`
   display: grid;
-  grid-template-columns: 1fr 80px 60px 100px 60px;
+  grid-template-columns: 36px 1fr 80px 60px 100px 60px;
   gap: 8px;
   padding: 10px 12px;
   align-items: center;
@@ -213,6 +214,48 @@ const ProgressText = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.label};
   font-family: ${({ theme }) => theme.fonts.mono};
   color: #FFD700;
+`;
+
+const PlayCell = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const PlayBtn = styled.button`
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: ${({ theme }) => theme.colors.gold};
+  transition: background 0.15s, transform 0.1s;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.goldBg};
+    transform: scale(1.1);
+  }
+`;
+
+const StopBtn = styled.button`
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: ${({ theme }) => theme.colors.error};
+  transition: background 0.15s, transform 0.1s;
+
+  &:hover {
+    background: rgba(239, 68, 68, 0.1);
+    transform: scale(1.1);
+  }
 `;
 
 const ActionsCell = styled.div`
@@ -324,6 +367,7 @@ export function StoreRegistryTable({
   onRefresh,
   onDelete,
   onLaunch,
+  onStop,
 }: StoreRegistryTableProps) {
   const registeredIds = useMemo(() => new Set(entries.map((e) => e.model_id)), [entries]);
   const pendingDownloads = useMemo(
@@ -361,6 +405,7 @@ export function StoreRegistryTable({
       ) : (
         <Table>
           <THead>
+            <div />
             <div>Model</div>
             <div style={{ textAlign: 'right' }}>Size</div>
             <div style={{ textAlign: 'right' }}>Files</div>
@@ -371,6 +416,7 @@ export function StoreRegistryTable({
           {/* Pending downloads (not yet registered) */}
           {pendingDownloads.map((dl) => (
             <TRow key={dl.modelId} $highlight>
+              <Cell />
               <ModelCell>
                 <ModelId title={dl.modelId}>{dl.modelId}</ModelId>
               </ModelCell>
@@ -394,6 +440,21 @@ export function StoreRegistryTable({
             const active = isActive(entry.model_id);
             return (
               <TRow key={entry.model_id}>
+                <PlayCell>
+                  {active && onStop ? (
+                    <StopBtn onClick={() => onStop(entry.model_id)} title="Stop model">
+                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M18 6L6 18M6 6l12 12" />
+                      </svg>
+                    </StopBtn>
+                  ) : !active && !dl && onLaunch ? (
+                    <PlayBtn onClick={() => onLaunch(entry.model_id)} title="Launch model">
+                      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                        <polygon points="5 3 19 12 5 21 5 3" />
+                      </svg>
+                    </PlayBtn>
+                  ) : null}
+                </PlayCell>
                 <ModelCell>
                   <ModelId title={entry.model_id}>{entry.model_id}</ModelId>
                   {active && (
@@ -415,13 +476,6 @@ export function StoreRegistryTable({
                   )}
                 </Cell>
                 <ActionsCell>
-                  {onLaunch && !active && !dl && (
-                    <Button variant="primary" size="sm" icon onClick={() => onLaunch(entry.model_id)} title="Launch model">
-                      <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                        <polygon points="5 3 19 12 5 21 5 3" />
-                      </svg>
-                    </Button>
-                  )}
                   <InfoTooltip
                     content={<ModelInfoContent entry={entry} card={modelCards[entry.model_id]} />}
                     placement="left"

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -129,8 +129,6 @@ const THead = styled.div`
   background: rgba(0, 0, 0, 0.4);
   font-size: ${({ theme }) => theme.fontSizes.tableHead};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
   color: ${({ theme }) => theme.colors.textMuted};
 `;
 
@@ -173,7 +171,6 @@ const ActiveBadge = styled.span`
   flex-shrink: 0;
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
-  text-transform: uppercase;
   color: #4ade80;
   background: rgba(34, 197, 94, 0.1);
   border: 1px solid rgba(34, 197, 94, 0.2);

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -232,10 +232,11 @@ const PlayBtn = styled.button`
   height: 28px;
   border-radius: 50%;
   color: ${({ theme }) => theme.colors.gold};
+  background: rgba(255, 215, 0, 0.15);
   transition: background 0.15s, transform 0.1s;
 
   &:hover {
-    background: ${({ theme }) => theme.colors.goldBg};
+    background: rgba(255, 215, 0, 0.3);
     transform: scale(1.1);
   }
 `;
@@ -250,10 +251,11 @@ const StopBtn = styled.button`
   height: 28px;
   border-radius: 50%;
   color: ${({ theme }) => theme.colors.error};
+  background: rgba(239, 68, 68, 0.15);
   transition: background 0.15s, transform 0.1s;
 
   &:hover {
-    background: rgba(239, 68, 68, 0.1);
+    background: rgba(239, 68, 68, 0.3);
     transform: scale(1.1);
   }
 `;

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import styled, { css, keyframes } from 'styled-components';
-import { FiTrash2, FiExternalLink } from 'react-icons/fi';
+import { FiTrash2, FiExternalLink, FiRefreshCw } from 'react-icons/fi';
 import { MdPlayArrow, MdClose } from 'react-icons/md';
 import { formatBytes } from '../../utils/format';
 import { Button } from '../common/Button';
@@ -218,6 +218,33 @@ const ProgressText = styled.span`
   color: #FFD700;
 `;
 
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`;
+
+const RefreshBtn = styled.button<{ $spinning: boolean }>`
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.gold};
+    background: ${({ theme }) => theme.colors.goldBg};
+  }
+
+  svg {
+    ${({ $spinning }) => $spinning && css`animation: ${spin} 0.8s linear infinite;`}
+  }
+`;
+
 const PlayCell = styled.div`
   display: flex;
   align-items: center;
@@ -390,7 +417,9 @@ export function StoreRegistryTable({
         </HeaderText>
         <HeaderActions>
           {actions}
-          <Button variant="outline" size="sm" onClick={onRefresh}>Refresh</Button>
+          <RefreshBtn onClick={onRefresh} $spinning={loading} title="Refresh">
+            <FiRefreshCw size={16} />
+          </RefreshBtn>
         </HeaderActions>
       </HeaderRow>
 

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -91,7 +91,7 @@ const HeaderActions = styled.div`
 
 const HeaderText = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textSecondary};
 `;
 
@@ -111,7 +111,7 @@ const EmptyBox = styled.div`
   padding: 24px;
   text-align: center;
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
 `;
 
@@ -128,7 +128,7 @@ const THead = styled.div`
   padding: 8px 12px;
   background: rgba(0, 0, 0, 0.4);
   font-size: ${({ theme }) => theme.fontSizes.tableHead};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   letter-spacing: 1.5px;
   color: ${({ theme }) => theme.colors.textMuted};
@@ -159,7 +159,7 @@ const ModelCell = styled.div`
 
 const ModelId = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.text};
   white-space: nowrap;
   overflow: hidden;
@@ -172,7 +172,7 @@ const ActiveBadge = styled.span`
   gap: 4px;
   flex-shrink: 0;
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   text-transform: uppercase;
   color: #4ade80;
   background: rgba(34, 197, 94, 0.1);
@@ -191,7 +191,7 @@ const PulseDot = styled.span`
 
 const Cell = styled.div<{ $align?: string }>`
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textSecondary};
   text-align: ${({ $align }) => $align ?? 'left'};
 `;
@@ -214,7 +214,7 @@ const ProgressFill = styled.div<{ $pct: number }>`
 
 const ProgressText = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: #FFD700;
 `;
 

--- a/dashboard-react/src/components/models/HuggingFaceResultItem.tsx
+++ b/dashboard-react/src/components/models/HuggingFaceResultItem.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { FiCheck, FiDownload, FiExternalLink } from 'react-icons/fi';
 import type { HuggingFaceModel } from '../../types/models';
 import { Button } from '../common/Button';
 import { InfoTooltip } from '../common/InfoTooltip';
@@ -76,19 +77,8 @@ const SelectBtn = styled(Button)`
   &:hover:not(:disabled) { background: rgba(255, 215, 0, 0.25); }
 `;
 
-const CheckIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" strokeWidth="2.5">
-    <polyline points="20 6 9 17 4 12" />
-  </svg>
-);
-
-const StoreDownloadIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
-    <polyline points="7 10 12 15 17 10" />
-    <line x1="12" y1="15" x2="12" y2="3" />
-  </svg>
-);
+const CheckIcon = () => <FiCheck size={16} color="#22c55e" strokeWidth={2.5} />;
+const StoreDownloadIcon = () => <FiDownload size={14} />;
 
 export function HuggingFaceResultItem({
   model,
@@ -120,11 +110,7 @@ export function HuggingFaceResultItem({
           onMouseLeave={(e) => { e.currentTarget.style.color = 'rgba(255,255,255,0.5)'; }}
           title="Open on HuggingFace"
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-            <polyline points="15 3 21 3 21 9" />
-            <line x1="10" y1="14" x2="21" y2="3" />
-          </svg>
+          <FiExternalLink size={14} />
         </a>
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '4px 12px' }}>

--- a/dashboard-react/src/components/models/ModelBrowser.tsx
+++ b/dashboard-react/src/components/models/ModelBrowser.tsx
@@ -89,8 +89,6 @@ const ListArea = styled.div`
 const SectionHeader = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.label};
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   color: ${({ theme }) => theme.colors.textMuted};
   padding: 12px 12px 6px;
 `;

--- a/dashboard-react/src/components/models/ModelCard.tsx
+++ b/dashboard-react/src/components/models/ModelCard.tsx
@@ -193,7 +193,6 @@ const Header = styled.div`
 const ModelName = styled.div<{ $canFit: boolean }>`
   font-size: ${({ theme }) => theme.fontSizes.sm};
   font-family: ${({ theme }) => theme.fonts.body};
-  letter-spacing: 0.5px;
   color: ${({ $canFit }) => ($canFit ? '#FFD700' : '#f87171')};
   white-space: nowrap;
   overflow: hidden;
@@ -234,8 +233,6 @@ const BadgeRow = styled.div`
 const Badge = styled.span<{ $color?: string }>`
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
-  letter-spacing: 1px;
-  text-transform: uppercase;
   padding: 2px 6px;
   background: rgba(80, 80, 80, 0.3);
   border: 1px solid rgba(80, 80, 80, 0.4);
@@ -245,8 +242,6 @@ const Badge = styled.span<{ $color?: string }>`
 const TagBadge = styled.span<{ $variant: 'green' | 'purple' }>`
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
-  letter-spacing: 1px;
-  text-transform: uppercase;
   padding: 2px 6px;
   border-radius: ${({ theme }) => theme.radii.sm};
   ${({ $variant }) =>
@@ -258,8 +253,6 @@ const TagBadge = styled.span<{ $variant: 'green' | 'purple' }>`
 const SectionTitle = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
-  letter-spacing: 2px;
-  text-transform: uppercase;
   color: rgba(255, 255, 255, 0.2);
   margin-bottom: 4px;
 `;
@@ -310,7 +303,6 @@ const PreviewBox = styled.div`
 
 const LaunchBtn = styled(Button)<{ $canFit: boolean; $launching: boolean }>`
   width: 100%;
-  letter-spacing: 2px;
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
 
   ${({ $launching }) =>

--- a/dashboard-react/src/components/models/ModelCard.tsx
+++ b/dashboard-react/src/components/models/ModelCard.tsx
@@ -192,7 +192,7 @@ const Header = styled.div`
 
 const ModelName = styled.div<{ $canFit: boolean }>`
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   letter-spacing: 0.5px;
   color: ${({ $canFit }) => ($canFit ? '#FFD700' : '#f87171')};
   white-space: nowrap;
@@ -202,7 +202,7 @@ const ModelName = styled.div<{ $canFit: boolean }>`
 
 const ModelId = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: rgba(179, 179, 179, 0.8);
   white-space: nowrap;
   overflow: hidden;
@@ -212,7 +212,7 @@ const ModelId = styled.div`
 
 const MemorySize = styled.div<{ $canFit: boolean }>`
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ $canFit }) => ($canFit ? '#FFD700' : '#f87171')};
   flex-shrink: 0;
 `;
@@ -233,7 +233,7 @@ const BadgeRow = styled.div`
 
 const Badge = styled.span<{ $color?: string }>`
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   letter-spacing: 1px;
   text-transform: uppercase;
   padding: 2px 6px;
@@ -244,7 +244,7 @@ const Badge = styled.span<{ $color?: string }>`
 
 const TagBadge = styled.span<{ $variant: 'green' | 'purple' }>`
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   letter-spacing: 1px;
   text-transform: uppercase;
   padding: 2px 6px;
@@ -257,7 +257,7 @@ const TagBadge = styled.span<{ $variant: 'green' | 'purple' }>`
 
 const SectionTitle = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   letter-spacing: 2px;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.2);
@@ -269,7 +269,7 @@ const DownloadRow = styled.div`
   align-items: center;
   gap: 8px;
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
 `;
 
 const ProgressTrack = styled.div`

--- a/dashboard-react/src/components/models/ModelFilterPopover.tsx
+++ b/dashboard-react/src/components/models/ModelFilterPopover.tsx
@@ -29,8 +29,6 @@ const Panel = styled.div`
 const SectionLabel = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.label};
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   color: ${({ theme }) => theme.colors.textMuted};
   margin-bottom: 6px;
 `;

--- a/dashboard-react/src/components/models/ModelPickerGroup.tsx
+++ b/dashboard-react/src/components/models/ModelPickerGroup.tsx
@@ -1,4 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
+import { FiDownload, FiCheck } from 'react-icons/fi';
 import type {
   ModelGroup,
   ModelInfo,
@@ -170,19 +171,8 @@ const FavStar = styled.button<{ $active: boolean }>`
   }
 `;
 
-const DownloadIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#22c55e" strokeWidth="2">
-    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
-    <polyline points="7 10 12 15 17 10" />
-    <line x1="12" y1="15" x2="12" y2="3" />
-  </svg>
-);
-
-const CheckMark = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" strokeWidth="2.5">
-    <polyline points="20 6 9 17 4 12" />
-  </svg>
-);
+const DownloadIcon = () => <FiDownload size={14} color="#22c55e" />;
+const CheckMark = () => <FiCheck size={16} color="#22c55e" strokeWidth={2.5} />;
 
 const VariantList = styled.div`
   padding: 4px 0 4px 32px;

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import type { TopologyData } from '../../types/topology';
-import type { RawDownloads, NodeDiskInfo } from '../../hooks/useClusterState';
+import type { RawDownloads, NodeDiskInfo, RawInstances } from '../../hooks/useClusterState';
 import { StoreRegistryTable, type StoreRegistryEntry, type StoreDownloadProgress, type ModelCardInfo } from '../layout/StoreRegistryTable';
 import { ModelSearchModal } from './ModelSearchModal';
 import { Button } from '../common/Button';
@@ -13,6 +13,7 @@ interface DownloadsPageProps {
   topology: TopologyData | null;
   downloads: RawDownloads;
   nodeDisk: NodeDiskInfo;
+  instances: RawInstances;
 }
 
 /* ── Data extraction helpers ──────────────────────────── */
@@ -163,7 +164,7 @@ function formatSpeed(bps: number): string {
 
 /* ── Component ────────────────────────────────────────── */
 
-export function DownloadsPage({ topology, downloads, nodeDisk }: DownloadsPageProps) {
+export function DownloadsPage({ topology, downloads, nodeDisk, instances }: DownloadsPageProps) {
   const [tab, setTab] = useState<Tab | null>(null);
   const [storeAvailable, setStoreAvailable] = useState(false);
   const [storeEntries, setStoreEntries] = useState<StoreRegistryEntry[]>([]);
@@ -311,6 +312,41 @@ export function DownloadsPage({ topology, downloads, nodeDisk }: DownloadsPagePr
     [storeEntries],
   );
 
+  // Derive active model IDs from running instances
+  const activeModelIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const inst of Object.values(instances)) {
+      const modelId =
+        inst.MlxRingInstance?.shard_assignments?.model_id ??
+        inst.MlxJacclInstance?.shard_assignments?.model_id;
+      if (modelId) ids.push(modelId);
+    }
+    return ids;
+  }, [instances]);
+
+  const handleLaunch = useCallback(async (modelId: string) => {
+    try {
+      const res = await fetch('/place_instance', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model_id: modelId,
+          sharding: 'Pipeline',
+          instance_meta: 'MlxRing',
+          min_nodes: 1,
+        }),
+      });
+      if (res.ok) {
+        addToast({ type: 'success', message: `Launching ${modelId}` });
+      } else {
+        const err = await res.json().catch(() => ({}));
+        addToast({ type: 'error', message: (err as Record<string, string>).detail ?? `Failed to launch ${modelId}` });
+      }
+    } catch {
+      addToast({ type: 'error', message: `Failed to launch model` });
+    }
+  }, []);
+
   const activeTab = tab ?? 'nodes';
 
   return (
@@ -397,6 +433,7 @@ export function DownloadsPage({ topology, downloads, nodeDisk }: DownloadsPagePr
           entries={storeEntries}
           activeDownloads={storeDownloads}
           loading={storeLoading}
+          activeModelIds={activeModelIds}
           modelCards={modelCards}
           actions={
             <>
@@ -410,6 +447,7 @@ export function DownloadsPage({ topology, downloads, nodeDisk }: DownloadsPagePr
           }
           onRefresh={loadRegistry}
           onDelete={() => {}}
+          onLaunch={handleLaunch}
         />
       )}
       <ModelSearchModal

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -4,6 +4,7 @@ import type { TopologyData } from '../../types/topology';
 import type { RawDownloads, NodeDiskInfo, RawInstances } from '../../hooks/useClusterState';
 import { StoreRegistryTable, type StoreRegistryEntry, type StoreDownloadProgress, type ModelCardInfo } from '../layout/StoreRegistryTable';
 import { ModelSearchModal } from './ModelSearchModal';
+import { FiTrash2, FiSearch, FiCheck } from 'react-icons/fi';
 import { Button } from '../common/Button';
 import { addToast } from '../../hooks/useToast';
 
@@ -140,19 +141,8 @@ function formatBytes(bytes: number): string {
   return `${val.toFixed(val >= 10 ? 0 : 1)}${units[i]}`;
 }
 
-const TrashIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="3 6 5 6 21 6" />
-    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-  </svg>
-);
-
-const SearchIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <circle cx="11" cy="11" r="8" />
-    <line x1="21" y1="21" x2="16.65" y2="16.65" />
-  </svg>
-);
+const TrashIcon = () => <FiTrash2 size={14} />;
+const SearchIcon = () => <FiSearch size={14} />;
 
 function formatSpeed(bps: number): string {
   if (!bps || bps <= 0) return '--';
@@ -519,11 +509,7 @@ function CellContent({ cell }: { cell: CellStatus }) {
 }
 
 function CheckIcon() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#4ade80" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-      <polyline points="20 6 9 17 4 12" />
-    </svg>
-  );
+  return <FiCheck size={20} color="#4ade80" strokeWidth={2.5} />;
 }
 
 /* ── Styles ───────────────────────────────────────────── */

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -312,16 +312,19 @@ export function DownloadsPage({ topology, downloads, nodeDisk, instances }: Down
     [storeEntries],
   );
 
-  // Derive active model IDs from running instances
-  const activeModelIds = useMemo(() => {
+  // Derive active model IDs and model→instanceId mapping from running instances
+  const { activeModelIds, modelToInstanceId } = useMemo(() => {
     const ids: string[] = [];
-    for (const inst of Object.values(instances)) {
-      const modelId =
-        inst.MlxRingInstance?.shardAssignments?.modelId ??
-        inst.MlxJacclInstance?.shardAssignments?.modelId;
-      if (modelId) ids.push(modelId);
+    const mapping: Record<string, string> = {};
+    for (const [iid, inst] of Object.entries(instances)) {
+      const inner = inst.MlxRingInstance ?? inst.MlxJacclInstance;
+      const modelId = inner?.shardAssignments?.modelId;
+      if (modelId) {
+        ids.push(modelId);
+        mapping[modelId] = (inner as Record<string, unknown>).instanceId as string ?? iid;
+      }
     }
-    return ids;
+    return { activeModelIds: ids, modelToInstanceId: mapping };
   }, [instances]);
 
   const handleLaunch = useCallback(async (modelId: string) => {
@@ -346,6 +349,24 @@ export function DownloadsPage({ topology, downloads, nodeDisk, instances }: Down
       addToast({ type: 'error', message: `Failed to launch model` });
     }
   }, []);
+
+  const handleStop = useCallback(async (modelId: string) => {
+    const instanceId = modelToInstanceId[modelId];
+    if (!instanceId) {
+      addToast({ type: 'error', message: `No running instance found for ${modelId}` });
+      return;
+    }
+    try {
+      const res = await fetch(`/instance/${encodeURIComponent(instanceId)}`, { method: 'DELETE' });
+      if (res.ok) {
+        addToast({ type: 'success', message: `Stopping ${modelId}` });
+      } else {
+        addToast({ type: 'error', message: `Failed to stop ${modelId}` });
+      }
+    } catch {
+      addToast({ type: 'error', message: `Failed to stop model` });
+    }
+  }, [modelToInstanceId]);
 
   const activeTab = tab ?? 'nodes';
 
@@ -448,6 +469,7 @@ export function DownloadsPage({ topology, downloads, nodeDisk, instances }: Down
           onRefresh={loadRegistry}
           onDelete={() => {}}
           onLaunch={handleLaunch}
+          onStop={handleStop}
         />
       )}
       <ModelSearchModal

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -421,7 +421,7 @@ function CellContent({ cell }: { cell: CellStatus }) {
         </CellInner>
       );
     case 'failed':
-      return <FailedText>FAILED</FailedText>;
+      return <FailedText>Failed</FailedText>;
     default:
       return <NotPresent>--</NotPresent>;
   }

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -473,8 +473,6 @@ const ModalBox = styled.div`
 const ModalTitle = styled.h3`
   font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.sm};
-  text-transform: uppercase;
-  letter-spacing: 1px;
   color: ${({ theme }) => theme.colors.error};
   margin: 0 0 12px;
 `;
@@ -512,8 +510,6 @@ const SegmentBtn = styled.button<{ $active: boolean }>`
   padding: 8px 20px;
   font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.nav};
-  text-transform: uppercase;
-  letter-spacing: 1px;
   transition: all 0.15s;
 
   ${({ $active, theme }) =>
@@ -570,8 +566,6 @@ const ModelHeader = styled.th`
   color: ${({ theme }) => theme.colors.gold};
   font-size: ${({ theme }) => theme.fontSizes.tableHead};
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 1px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.border};
 `;
 
@@ -585,7 +579,6 @@ const NodeName = styled.div`
   color: ${({ theme }) => theme.colors.text};
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
   font-weight: 600;
-  letter-spacing: 0.5px;
 `;
 
 const DiskFree = styled.div`
@@ -630,7 +623,6 @@ const FailedText = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.sm};
   font-weight: 600;
   color: ${({ theme }) => theme.colors.error};
-  text-transform: uppercase;
 `;
 
 const NotPresent = styled.div`

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -317,8 +317,8 @@ export function DownloadsPage({ topology, downloads, nodeDisk, instances }: Down
     const ids: string[] = [];
     for (const inst of Object.values(instances)) {
       const modelId =
-        inst.MlxRingInstance?.shard_assignments?.model_id ??
-        inst.MlxJacclInstance?.shard_assignments?.model_id;
+        inst.MlxRingInstance?.shardAssignments?.modelId ??
+        inst.MlxJacclInstance?.shardAssignments?.modelId;
       if (modelId) ids.push(modelId);
     }
     return ids;

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -8,9 +8,7 @@ import { FiTrash2, FiSearch, FiCheck } from 'react-icons/fi';
 import { Button } from '../common/Button';
 import { addToast } from '../../hooks/useToast';
 
-type Tab = 'nodes' | 'store';
-
-interface DownloadsPageProps {
+interface ModelStorePageProps {
   topology: TopologyData | null;
   downloads: RawDownloads;
   nodeDisk: NodeDiskInfo;
@@ -154,18 +152,11 @@ function formatSpeed(bps: number): string {
 
 /* ── Component ────────────────────────────────────────── */
 
-export function DownloadsPage({ topology, downloads, nodeDisk, instances }: DownloadsPageProps) {
-  const [tab, setTab] = useState<Tab | null>(null);
-  const [storeAvailable, setStoreAvailable] = useState(false);
+export function ModelStorePage({ topology, downloads, nodeDisk, instances }: ModelStorePageProps) {
   const [storeEntries, setStoreEntries] = useState<StoreRegistryEntry[]>([]);
   const [storeDownloads, setStoreDownloads] = useState<StoreDownloadProgress[]>([]);
   const [storeLoading, setStoreLoading] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval>>(undefined);
-
-  const { rows, columns } = useMemo(
-    () => buildGrid(downloads, topology, nodeDisk),
-    [downloads, topology, nodeDisk],
-  );
 
   // Extract model card info from download data for the store table tooltips
   const modelCards = useMemo<Record<string, ModelCardInfo>>(() => {
@@ -243,26 +234,10 @@ export function DownloadsPage({ topology, downloads, nodeDisk, instances }: Down
     finally { setStoreLoading(false); }
   }, [fetchDownloads]);
 
-  // Detect store availability and set default tab
+  // Load store registry on mount
   useEffect(() => {
-    if (tab !== null) return;
-    (async () => {
-      try {
-        const res = await fetch('/store/health');
-        if (res.ok) {
-          setStoreAvailable(true);
-          setTab('store');
-          return;
-        }
-      } catch { /* ignore */ }
-      setTab('nodes');
-    })();
-  }, [tab]);
-
-  // Load store registry when switching to store tab
-  useEffect(() => {
-    if (tab === 'store') loadRegistry();
-  }, [tab, loadRegistry]);
+    loadRegistry();
+  }, [loadRegistry]);
 
   // Cleanup polling on unmount
   useEffect(() => {
@@ -358,23 +333,8 @@ export function DownloadsPage({ topology, downloads, nodeDisk, instances }: Down
     }
   }, [modelToInstanceId]);
 
-  const activeTab = tab ?? 'nodes';
-
   return (
     <Container>
-      {storeAvailable && (
-        <TopBar>
-          <SegmentedToggle>
-            <SegmentBtn $active={activeTab === 'nodes'} onClick={() => setTab('nodes')}>
-              Node Downloads
-            </SegmentBtn>
-            <SegmentBtn $active={activeTab === 'store'} onClick={() => setTab('store')}>
-              Store Registry
-            </SegmentBtn>
-          </SegmentedToggle>
-        </TopBar>
-      )}
-
       {purgeConfirm && (
         <PurgeModal>
           <ModalBackdrop onClick={() => setPurgeConfirm(false)} />
@@ -400,47 +360,7 @@ export function DownloadsPage({ topology, downloads, nodeDisk, instances }: Down
         </PurgeModal>
       )}
 
-      {activeTab === 'nodes' ? (
-        rows.length === 0 ? (
-          <EmptyState>
-            No downloads found. Start a model download to see progress here.
-          </EmptyState>
-        ) : (
-          <TableWrap>
-            <Table>
-              <thead>
-                <tr>
-                  <ModelHeader>MODEL</ModelHeader>
-                  {columns.map((col) => (
-                    <NodeHeader key={col.nodeId}>
-                      <NodeName>{col.label.toUpperCase()}</NodeName>
-                      {col.diskFreeBytes != null && (
-                        <DiskFree>{formatBytes(col.diskFreeBytes)} free</DiskFree>
-                      )}
-                    </NodeHeader>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((row) => (
-                  <tr key={row.modelId}>
-                    <ModelCell>{row.modelId}</ModelCell>
-                    {columns.map((col) => {
-                      const cell = row.cells[col.nodeId];
-                      return (
-                        <StatusCell key={col.nodeId}>
-                          {cell ? <CellContent cell={cell} /> : <NotPresent>--</NotPresent>}
-                        </StatusCell>
-                      );
-                    })}
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          </TableWrap>
-        )
-      ) : (
-        <StoreRegistryTable
+      <StoreRegistryTable
           entries={storeEntries}
           activeDownloads={storeDownloads}
           loading={storeLoading}
@@ -461,7 +381,6 @@ export function DownloadsPage({ topology, downloads, nodeDisk, instances }: Down
           onLaunch={handleLaunch}
           onStop={handleStop}
         />
-      )}
       <ModelSearchModal
         open={searchOpen}
         onClose={() => setSearchOpen(false)}

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -471,7 +471,7 @@ const ModalBox = styled.div`
 `;
 
 const ModalTitle = styled.h3`
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.sm};
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -480,7 +480,7 @@ const ModalTitle = styled.h3`
 `;
 
 const ModalText = styled.p`
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.sm};
   color: ${({ theme }) => theme.colors.textSecondary};
   line-height: 1.5;
@@ -488,7 +488,7 @@ const ModalText = styled.p`
 `;
 
 const ModalNote = styled.p`
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.xs};
   color: ${({ theme }) => theme.colors.textMuted};
   margin: 0 0 16px;
@@ -510,7 +510,7 @@ const SegmentBtn = styled.button<{ $active: boolean }>`
   all: unset;
   cursor: pointer;
   padding: 8px 20px;
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.nav};
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -545,7 +545,7 @@ const EmptyState = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.border};
   border-radius: ${({ theme }) => theme.radii.md};
   background: rgba(0, 0, 0, 0.2);
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
   color: ${({ theme }) => theme.colors.textMuted};
 `;
@@ -560,7 +560,7 @@ const TableWrap = styled.div`
 const Table = styled.table`
   width: 100%;
   border-collapse: collapse;
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
 `;
 

--- a/dashboard-react/src/components/pages/ModelSearchModal.tsx
+++ b/dashboard-react/src/components/pages/ModelSearchModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
+import { FiX } from 'react-icons/fi';
 import { ModelBrowser } from '../models/ModelBrowser';
 import type { ModelInfo, HuggingFaceModel, DownloadAvailability } from '../../types/models';
 import { addToast } from '../../hooks/useToast';
@@ -126,9 +127,7 @@ export function ModelSearchModal({
         <ModalHeader>
           <ModalTitle>Find Models</ModalTitle>
           <CloseButton onClick={onClose} aria-label="Close">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <FiX size={20} />
           </CloseButton>
         </ModalHeader>
         <ModalBody>

--- a/dashboard-react/src/components/pages/ModelSearchModal.tsx
+++ b/dashboard-react/src/components/pages/ModelSearchModal.tsx
@@ -193,8 +193,6 @@ const ModalTitle = styled.h2`
   font-weight: 600;
   color: ${({ theme }) => theme.colors.gold};
   margin: 0;
-  text-transform: uppercase;
-  letter-spacing: 1px;
 `;
 
 const CloseButton = styled.button`

--- a/dashboard-react/src/components/pages/ModelSearchModal.tsx
+++ b/dashboard-react/src/components/pages/ModelSearchModal.tsx
@@ -188,7 +188,7 @@ const ModalHeader = styled.div`
 `;
 
 const ModalTitle = styled.h2`
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.lg};
   font-weight: 600;
   color: ${({ theme }) => theme.colors.gold};

--- a/dashboard-react/src/components/status/ClusterWarnings.tsx
+++ b/dashboard-react/src/components/status/ClusterWarnings.tsx
@@ -52,7 +52,7 @@ export function ClusterWarnings({ topology }: ClusterWarningsProps) {
       {showVersion && (
         <WarningPill $color="error">
           <WarningIcon $color="error" />
-          <WarningLabel $color="error">VERSION MISMATCH</WarningLabel>
+          <WarningLabel $color="error">Version Mismatch</WarningLabel>
           <DismissButton $color="error" onClick={() => setVersionDismissed(true)} aria-label="Dismiss">
             <FiX size={14} />
           </DismissButton>
@@ -82,7 +82,7 @@ export function ClusterWarnings({ topology }: ClusterWarningsProps) {
       {showRdma && (
         <WarningPill $color="warning">
           <WarningIcon $color="warning" />
-          <WarningLabel $color="warning">RDMA NOT AVAILABLE</WarningLabel>
+          <WarningLabel $color="warning">RDMA Not Available</WarningLabel>
           <DismissButton $color="warning" onClick={() => setRdmaDismissed(true)} aria-label="Dismiss">
             <FiX size={14} />
           </DismissButton>

--- a/dashboard-react/src/components/status/ClusterWarnings.tsx
+++ b/dashboard-react/src/components/status/ClusterWarnings.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import styled from 'styled-components';
+import { FiAlertTriangle, FiX } from 'react-icons/fi';
 import type { TopologyData } from '../../types/topology';
 
 interface ClusterWarningsProps {
@@ -12,8 +13,7 @@ interface VersionEntry {
   commit: string;
 }
 
-const WARNING_ICON = 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z';
-const CLOSE_ICON = 'M6 18L18 6M6 6l12 12';
+// Icons now from react-icons
 
 export function ClusterWarnings({ topology }: ClusterWarningsProps) {
   const nodes = topology?.nodes;
@@ -51,12 +51,10 @@ export function ClusterWarnings({ topology }: ClusterWarningsProps) {
     <WarningsBar>
       {showVersion && (
         <WarningPill $color="error">
-          <WarningIcon d={WARNING_ICON} $color="error" />
+          <WarningIcon $color="error" />
           <WarningLabel $color="error">VERSION MISMATCH</WarningLabel>
           <DismissButton $color="error" onClick={() => setVersionDismissed(true)} aria-label="Dismiss">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d={CLOSE_ICON} />
-            </svg>
+            <FiX size={14} />
           </DismissButton>
           <Tooltip className="warning-tooltip" $color="error">
             <TooltipInner $color="error">
@@ -83,12 +81,10 @@ export function ClusterWarnings({ topology }: ClusterWarningsProps) {
 
       {showRdma && (
         <WarningPill $color="warning">
-          <WarningIcon d={WARNING_ICON} $color="warning" />
+          <WarningIcon $color="warning" />
           <WarningLabel $color="warning">RDMA NOT AVAILABLE</WarningLabel>
           <DismissButton $color="warning" onClick={() => setRdmaDismissed(true)} aria-label="Dismiss">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d={CLOSE_ICON} />
-            </svg>
+            <FiX size={14} />
           </DismissButton>
           <Tooltip className="warning-tooltip" $color="warning">
             <TooltipInner $color="warning">
@@ -164,21 +160,9 @@ const WarningLabel = styled.span<{ $color: ColorKey }>`
   letter-spacing: 0.5px;
 `;
 
-function WarningIcon({ d, $color }: { d: string; $color: ColorKey }) {
+function WarningIcon({ $color }: { d?: string; $color: ColorKey }) {
   return (
-    <svg
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke={colorMap[$color].emphasis}
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      style={{ flexShrink: 0 }}
-    >
-      <path d={d} />
-    </svg>
+    <FiAlertTriangle size={18} color={colorMap[$color].emphasis} style={{ flexShrink: 0 }} />
   );
 }
 

--- a/dashboard-react/src/components/status/ClusterWarnings.tsx
+++ b/dashboard-react/src/components/status/ClusterWarnings.tsx
@@ -156,8 +156,6 @@ const WarningLabel = styled.span<{ $color: ColorKey }>`
   font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.sm};
   color: ${({ $color }) => colorMap[$color].text};
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
 `;
 
 function WarningIcon({ $color }: { d?: string; $color: ColorKey }) {

--- a/dashboard-react/src/components/status/ClusterWarnings.tsx
+++ b/dashboard-react/src/components/status/ClusterWarnings.tsx
@@ -153,7 +153,7 @@ const WarningPill = styled.div<{ $color: ColorKey }>`
 `;
 
 const WarningLabel = styled.span<{ $color: ColorKey }>`
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.sm};
   color: ${({ $color }) => colorMap[$color].text};
   text-transform: uppercase;

--- a/dashboard-react/src/components/status/ConnectionBanner.tsx
+++ b/dashboard-react/src/components/status/ConnectionBanner.tsx
@@ -32,8 +32,6 @@ const Dot = styled.div`
 const Text = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.label};
   font-family: ${({ theme }) => theme.fonts.body};
-  letter-spacing: 1px;
-  text-transform: uppercase;
   color: #fca5a5;
 `;
 

--- a/dashboard-react/src/components/status/ConnectionBanner.tsx
+++ b/dashboard-react/src/components/status/ConnectionBanner.tsx
@@ -31,7 +31,7 @@ const Dot = styled.div`
 
 const Text = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.label};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   letter-spacing: 1px;
   text-transform: uppercase;
   color: #fca5a5;

--- a/dashboard-react/src/components/status/ToastContainer.tsx
+++ b/dashboard-react/src/components/status/ToastContainer.tsx
@@ -86,7 +86,7 @@ const Body = styled.div`
 const Message = styled.p`
   flex: 1;
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  font-family: ${({ theme }) => theme.fonts.body};
   color: rgba(255, 255, 255, 0.9);
   line-height: 1.4;
   margin: 0;

--- a/dashboard-react/src/hooks/useClusterState.ts
+++ b/dashboard-react/src/hooks/useClusterState.ts
@@ -213,12 +213,15 @@ const POLL_INTERVAL = 1000;
 export type RawDownloads = Record<string, unknown[]>;
 export type NodeDiskInfo = Record<string, { total: { inBytes: number }; available: { inBytes: number } }>;
 
+export type RawInstances = Record<string, { MlxRingInstance?: { shard_assignments?: { model_id?: string } }; MlxJacclInstance?: { shard_assignments?: { model_id?: string } } }>;
+
 export interface ClusterState {
   topology: TopologyData | null;
   connected: boolean;
   lastUpdate: number | null;
   downloads: RawDownloads;
   nodeDisk: NodeDiskInfo;
+  instances: RawInstances;
 }
 
 export function useClusterState(): ClusterState {
@@ -227,6 +230,7 @@ export function useClusterState(): ClusterState {
   const [lastUpdate, setLastUpdate] = useState<number | null>(null);
   const [downloads, setDownloads] = useState<RawDownloads>({});
   const [nodeDisk, setNodeDisk] = useState<NodeDiskInfo>({});
+  const [instances, setInstances] = useState<RawInstances>({});
   const failuresRef = useRef(0);
 
   const fetchState = useCallback(async () => {
@@ -250,6 +254,7 @@ export function useClusterState(): ClusterState {
 
       setDownloads(data.downloads ?? {});
       setNodeDisk(data.nodeDisk ?? {});
+      setInstances((data.instances ?? {}) as RawInstances);
       setLastUpdate(Date.now());
       failuresRef.current = 0;
       setConnected(true);
@@ -267,5 +272,5 @@ export function useClusterState(): ClusterState {
     return () => clearInterval(id);
   }, [fetchState]);
 
-  return { topology, connected, lastUpdate, downloads, nodeDisk };
+  return { topology, connected, lastUpdate, downloads, nodeDisk, instances };
 }

--- a/dashboard-react/src/hooks/useClusterState.ts
+++ b/dashboard-react/src/hooks/useClusterState.ts
@@ -213,7 +213,7 @@ const POLL_INTERVAL = 1000;
 export type RawDownloads = Record<string, unknown[]>;
 export type NodeDiskInfo = Record<string, { total: { inBytes: number }; available: { inBytes: number } }>;
 
-export type RawInstances = Record<string, { MlxRingInstance?: { shard_assignments?: { model_id?: string } }; MlxJacclInstance?: { shard_assignments?: { model_id?: string } } }>;
+export type RawInstances = Record<string, { MlxRingInstance?: { shardAssignments?: { modelId?: string } }; MlxJacclInstance?: { shardAssignments?: { modelId?: string } } }>;
 
 export interface ClusterState {
   topology: TopologyData | null;

--- a/dashboard-react/src/theme/theme.ts
+++ b/dashboard-react/src/theme/theme.ts
@@ -18,7 +18,7 @@ export const theme = {
     info: '#3b82f6',
   },
   fonts: {
-    body: "'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    body: "'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
     mono: "'JetBrains Mono', 'Fira Code', monospace",
   },
   fontSizes: {

--- a/dashboard-react/src/theme/theme.ts
+++ b/dashboard-react/src/theme/theme.ts
@@ -18,7 +18,7 @@ export const theme = {
     info: '#3b82f6',
   },
   fonts: {
-    body: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    body: "'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
     mono: "'JetBrains Mono', 'Fira Code', monospace",
   },
   fontSizes: {

--- a/dashboard-react/vite.config.ts
+++ b/dashboard-react/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       '/download': 'http://localhost:52415',
       '/models': 'http://localhost:52415',
       '/place_instance': 'http://localhost:52415',
+      '/instance': 'http://localhost:52415',
     },
   },
   test: {

--- a/dashboard-react/vite.config.ts
+++ b/dashboard-react/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       '/store': 'http://localhost:52415',
       '/download': 'http://localhost:52415',
       '/models': 'http://localhost:52415',
+      '/place_instance': 'http://localhost:52415',
     },
   },
   test: {


### PR DESCRIPTION
## Summary

12 commits — major UX overhaul.

### Launch from Store
- Play button on each store model — calls POST /place_instance (Pipeline/MlxRing)
- Stop button (red X) on active models — calls DELETE /instance/{id}
- Active models show pulsing green badge, play button hidden
- Instances exposed from useClusterState for active model tracking

### Rebrand & Navigation
- Home → **Cluster** (MdHub icon), Downloads → **Model Store** (FiDatabase icon)
- Removed node downloads view and segmented toggle entirely
- Model Store page shows store registry directly
- Page title: Skulk
- All "EXO" references removed

### react-icons
- Installed react-icons library, replaced 138 lines of inline SVG across 7 files
- Feather (Fi*) and Material Design (Md*) icons throughout
- Tree-shaken — only imported icons bundled

### Animated Refresh
- Round FiRefreshCw icon that spins while loading, gold on hover

### Outfit Font
- Google Fonts Outfit loaded, replaced across entire dashboard
- Mono only retained for code blocks

### Proper Casing
- Removed all 32 text-transform: uppercase declarations
- Removed all 31 letter-spacing declarations  
- All labels use proper title case

## Test plan
- [ ] Click play on store model — verify launch across nodes
- [ ] Click X on active model — verify stop
- [ ] Verify Cluster/Model Store nav labels and highlighting
- [ ] Verify Outfit font renders across all views
- [ ] Verify no ALL CAPS labels remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)