### PR TITLE
feat: chat interface, instance panel, and running instance cards

### DIFF
--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard-react",
-  "version": "0.0.0",
+  "version": "1.01",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard-react",
-      "version": "0.0.0",
+      "version": "1.01",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@tolgee/react": "^6.6.0",

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard-react",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.01",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -212,9 +212,9 @@ export function App() {
           mobileRightOpen={panelOpen}
           onToggleMobileRight={() => setPanelOpen((o) => !o)}
         />
+        <ClusterWarnings topology={topology} />
         <ContentRow>
           <Main>
-            <ClusterWarnings topology={topology} />
             {activeRoute === 'model-store' ? (
               <ModelStorePage
                 topology={topology}

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -11,6 +11,10 @@ import { ToastContainer } from './components/status/ToastContainer';
 import { NetworkMesh } from './components/common/NetworkMesh';
 import { SettingsPanel } from './components/layout/SettingsPanel';
 import { ModelStorePage } from './components/pages/DownloadsPage';
+import { ChatView } from './components/pages/ChatView';
+import { InstancePanel, type InstanceCardData } from './components/layout/InstancePanel';
+import { addToast } from './hooks/useToast';
+import type { InstanceStatus } from './components/cluster/RunningInstanceCard';
 
 const Shell = styled.div`
   position: relative;
@@ -20,9 +24,20 @@ const Shell = styled.div`
   height: 100%;
 `;
 
-const Main = styled.main`
+const ContentRow = styled.div`
   flex: 1;
   min-height: 0;
+  display: flex;
+  flex-direction: row;
+`;
+
+const Main = styled.main`
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 `;
 
 interface StoreDownload {
@@ -31,11 +46,66 @@ interface StoreDownload {
   status: string;
 }
 
+/* ── Runner status → InstanceStatus mapping ───────────── */
+
+function deriveInstanceStatus(
+  runnerIds: string[],
+  runners: Record<string, Record<string, unknown>>,
+): { status: InstanceStatus; message?: string; progress?: number } {
+  if (runnerIds.length === 0) return { status: 'loading', message: 'Waiting for runners...' };
+
+  const statuses = runnerIds.map((rid) => runners[rid]);
+
+  // If any runner has failed, the instance is failed
+  const failed = statuses.find((s) => s && 'RunnerFailed' in s);
+  if (failed) {
+    const inner = failed.RunnerFailed as Record<string, unknown> | undefined;
+    return { status: 'failed', message: inner?.errorMessage as string | undefined };
+  }
+
+  // If any runner is shutting down
+  if (statuses.some((s) => s && ('RunnerShuttingDown' in s || 'RunnerShutdown' in s))) {
+    return { status: 'shutting_down' };
+  }
+
+  // If all runners are ready or running
+  const allReady = statuses.every((s) => s && ('RunnerReady' in s || 'RunnerRunning' in s));
+  if (allReady) {
+    const anyRunning = statuses.some((s) => s && 'RunnerRunning' in s);
+    return { status: anyRunning ? 'running' : 'ready' };
+  }
+
+  // If any runner is warming up
+  if (statuses.some((s) => s && 'RunnerWarmingUp' in s)) {
+    return { status: 'warming_up' };
+  }
+
+  // Loading — try to extract progress from RunnerLoading
+  const loading = statuses.find((s) => s && 'RunnerLoading' in s);
+  if (loading) {
+    const inner = loading.RunnerLoading as Record<string, unknown> | undefined;
+    const loaded = inner?.layersLoaded as number | undefined;
+    const total = inner?.totalLayers as number | undefined;
+    const progress = loaded != null && total != null && total > 0
+      ? Math.round((loaded / total) * 100)
+      : undefined;
+    const message = loaded != null && total != null
+      ? `Downloading layers ${loaded}/${total}...`
+      : 'Loading model...';
+    return { status: 'loading', message, progress };
+  }
+
+  // Connecting or idle
+  return { status: 'loading', message: 'Connecting...' };
+}
+
 export function App() {
   const { topology, connected, downloads, nodeDisk, instances, runners } = useClusterState();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [activeRoute, setActiveRoute] = useState<NavRoute>('cluster');
   const [storeDownloads, setStoreDownloads] = useState<StoreDownload[]>([]);
+  const [panelOpen, setPanelOpen] = useState(true);
+  const [chatModelId, setChatModelId] = useState<string | undefined>(undefined);
 
   // Poll store downloads for the header progress indicator
   const pollStoreDownloads = useCallback(async () => {
@@ -61,6 +131,70 @@ export function App() {
     return { count: storeDownloads.length, percentage: avgPct };
   }, [storeDownloads]);
 
+  // Derive instance card data for the right panel
+  const instanceCards = useMemo<InstanceCardData[]>(() => {
+    const cards: InstanceCardData[] = [];
+    for (const [iid, inst] of Object.entries(instances)) {
+      const isRing = !!inst.MlxRingInstance;
+      const inner = inst.MlxRingInstance ?? inst.MlxJacclInstance;
+      if (!inner) continue;
+      const sa = inner.shardAssignments;
+      const modelId = sa?.modelId;
+      if (!modelId) continue;
+
+      const instanceId = inner.instanceId ?? iid;
+      const nodeToRunner = sa?.nodeToRunner;
+      const runnerIds = nodeToRunner ? Object.values(nodeToRunner) : [];
+      const nodeIds = nodeToRunner ? Object.keys(nodeToRunner) : [];
+
+      // Derive sharding
+      const runnerToShard = sa?.runnerToShard;
+      let sharding: 'Pipeline' | 'Tensor' = 'Pipeline';
+      if (runnerToShard) {
+        const firstShard = Object.values(runnerToShard)[0];
+        if (firstShard && 'TensorShardMetadata' in firstShard) {
+          sharding = 'Tensor';
+        }
+      }
+
+      // Derive status from runners
+      const derived = deriveInstanceStatus(runnerIds, runners);
+
+      // Get first node's friendly name
+      const firstNodeId = nodeIds[0];
+      const nodeName = firstNodeId && topology?.nodes[firstNodeId]?.friendly_name
+        ? topology.nodes[firstNodeId].friendly_name
+        : firstNodeId?.slice(0, 8) ?? 'unknown';
+
+      cards.push({
+        instanceId,
+        modelId,
+        sharding,
+        instanceType: isRing ? 'MlxRing' : 'MlxJaccl',
+        nodeName,
+        status: derived.status,
+        statusMessage: derived.message,
+        loadProgress: derived.progress,
+      });
+    }
+    return cards;
+  }, [instances, runners, topology]);
+
+  const hasInstances = instanceCards.length > 0;
+
+  const handleDeleteInstance = useCallback(async (instanceId: string) => {
+    try {
+      const res = await fetch(`/instance/${instanceId}`, { method: 'DELETE' });
+      if (res.ok) {
+        addToast({ type: 'success', message: 'Instance deleted' });
+      } else {
+        addToast({ type: 'error', message: 'Failed to delete instance' });
+      }
+    } catch {
+      addToast({ type: 'error', message: 'Failed to delete instance' });
+    }
+  }, []);
+
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
@@ -73,25 +207,41 @@ export function App() {
           onNavigate={setActiveRoute}
           onOpenSettings={() => setSettingsOpen(true)}
           downloadProgress={downloadProgress}
+          instanceCount={instanceCards.length}
+          instancesHealthy={instanceCards.every((c) => c.status !== 'failed')}
+          mobileRightOpen={panelOpen}
+          onToggleMobileRight={() => setPanelOpen((o) => !o)}
         />
-        <ClusterWarnings topology={topology} />
-        <Main>
-          {activeRoute === 'model-store' ? (
-            <ModelStorePage
-              topology={topology}
-              downloads={downloads}
-              nodeDisk={nodeDisk}
-              instances={instances}
-              runners={runners}
+        <ContentRow>
+          <Main>
+            <ClusterWarnings topology={topology} />
+            {activeRoute === 'model-store' ? (
+              <ModelStorePage
+                topology={topology}
+                downloads={downloads}
+                nodeDisk={nodeDisk}
+                instances={instances}
+                runners={runners}
+                onChat={(modelId) => { setChatModelId(modelId); setActiveRoute('chat'); }}
+              />
+            ) : activeRoute === 'chat' ? (
+              <ChatView readyInstances={instanceCards} initialModelId={chatModelId} />
+            ) : topology ? (
+              <TopologyGraph data={topology} />
+            ) : (
+              <EmptyState>
+                {connected ? 'Loading cluster state…' : 'Connecting to backend…'}
+              </EmptyState>
+            )}
+          </Main>
+          {hasInstances && panelOpen && (
+            <InstancePanel
+              instances={instanceCards}
+              onDelete={handleDeleteInstance}
+              onChat={(modelId) => { setChatModelId(modelId); setActiveRoute('chat'); }}
             />
-          ) : topology ? (
-            <TopologyGraph data={topology} />
-          ) : (
-            <EmptyState>
-              {connected ? 'Loading cluster state…' : 'Connecting to backend…'}
-            </EmptyState>
           )}
-        </Main>
+        </ContentRow>
         <ToastContainer />
         <SettingsPanel open={settingsOpen} onClose={() => setSettingsOpen(false)} />
       </Shell>

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -13,6 +13,8 @@ export interface ChatFormProps {
   /** Current model label shown in header. */
   modelLabel?: string;
   onOpenModelPicker?: () => void;
+  /** Optional inline model selector element (replaces modelLabel click). */
+  modelSelector?: React.ReactNode;
   /** TTFT in ms. */
   ttftMs?: number | null;
   /** Tokens per second. */
@@ -168,6 +170,7 @@ export function ChatForm({
   autoFocus = true,
   modelLabel,
   onOpenModelPicker,
+  modelSelector,
   ttftMs,
   tps,
   showThinkingToggle = false,
@@ -258,7 +261,7 @@ export function ChatForm({
     });
   }, []);
 
-  const showHeader = modelLabel || showThinkingToggle || ttftMs != null || tps != null;
+  const showHeader = modelLabel || modelSelector || showThinkingToggle || ttftMs != null || tps != null;
 
   return (
     <Form
@@ -276,10 +279,10 @@ export function ChatForm({
       {/* Header: model + thinking + stats */}
       {showHeader && (
         <HeaderRow>
-          {modelLabel && (
+          {(modelLabel || modelSelector) && (
             <>
-              <span>Model</span>
-              <ModelBtn onClick={onOpenModelPicker}>{modelLabel}</ModelBtn>
+              <span>Model:</span>
+              {modelSelector ?? <ModelBtn onClick={onOpenModelPicker}>{modelLabel}</ModelBtn>}
             </>
           )}
           {showThinkingToggle && (

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -289,10 +289,10 @@ export function ChatForm({
           )}
           <Spacer />
           {ttftMs != null && (
-            <Stat>TTFT <StatValue>{Math.round(ttftMs)}ms</StatValue></Stat>
+            <Stat>TTFT <StatValue>{ttftMs.toFixed(1)}ms</StatValue></Stat>
           )}
           {tps != null && (
-            <Stat>TPS <StatValue>{tps.toFixed(1)}</StatValue></Stat>
+            <Stat>TPS <StatValue>{tps.toFixed(1)} tok/s</StatValue> ({(1000 / tps).toFixed(1)} ms/tok)</Stat>
           )}
         </HeaderRow>
       )}

--- a/dashboard-react/src/components/chat/ChatMessages.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.tsx
@@ -12,6 +12,8 @@ export interface ChatMessagesProps {
   messages: ChatMessage[];
   /** Current streaming response text, or null if not streaming. */
   streamingContent?: string | null;
+  /** Current streaming thinking text, or null if not streaming thinking. */
+  streamingThinking?: string | null;
   isLoading?: boolean;
   prefillProgress?: PrefillProgress | null;
   onDelete?: (messageId: string) => void;
@@ -221,6 +223,23 @@ const ThinkingContent = styled.div`
   border-top: 1px solid rgba(255, 215, 0, 0.1);
 `;
 
+const ShowHideBtn = styled.button`
+  all: unset;
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.textMuted};
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  transition: color 0.15s;
+  &:hover { color: ${({ theme }) => theme.colors.text}; }
+`;
+
+const StreamThinkingBody = styled.div`
+  max-height: 400px;
+  overflow-y: auto;
+`;
+
 const ImageGrid = styled.div`
   display: flex;
   flex-wrap: wrap;
@@ -289,6 +308,7 @@ const ScrollBtn = styled.button`
 export function ChatMessages({
   messages,
   streamingContent,
+  streamingThinking,
   isLoading = false,
   prefillProgress,
   onDelete,
@@ -306,7 +326,17 @@ export function ChatMessages({
   const [expandedThinking, setExpandedThinking] = useState<Set<string>>(new Set());
   const [heatmapVisible, setHeatmapVisible] = useState<Set<string>>(new Set());
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  const [streamThinkingOpen, setStreamThinkingOpen] = useState(false);
   const lastCountRef = useRef(messages.length);
+
+  // Reset streaming thinking toggle when new stream starts
+  const prevStreamingThinking = useRef(streamingThinking);
+  useEffect(() => {
+    if (streamingThinking && !prevStreamingThinking.current) {
+      setStreamThinkingOpen(false);
+    }
+    prevStreamingThinking.current = streamingThinking;
+  }, [streamingThinking]);
 
   // Auto-scroll on new messages
   useEffect(() => {
@@ -446,9 +476,13 @@ export function ChatMessages({
                   <ThinkingHeader onClick={() => toggleThinking(msg.id)}>
                     <ThinkingChevron $open={expandedThinking.has(msg.id)}>▶</ThinkingChevron>
                     Thinking
+                    <Spacer />
+                    <ShowHideBtn onClick={(e) => { e.stopPropagation(); toggleThinking(msg.id); }}>
+                      {expandedThinking.has(msg.id) ? 'Hide' : 'Show'}
+                    </ShowHideBtn>
                   </ThinkingHeader>
                   {expandedThinking.has(msg.id) && (
-                    <ThinkingContent>{msg.thinkingContent}</ThinkingContent>
+                    <ThinkingContent><MarkdownContent content={msg.thinkingContent} /></ThinkingContent>
                   )}
                 </ThinkingBlock>
               )}
@@ -519,14 +553,37 @@ export function ChatMessages({
       ))}
 
       {/* Streaming response (not yet a full message) */}
-      {streamingContent && (
+      {(streamingContent != null || streamingThinking) && (
         <MessageCard $role="assistant">
           <MsgHeader>
             <Dot $color="#FFD700" />
             <RoleLabel $role="assistant">Skulk</RoleLabel>
           </MsgHeader>
-          <MarkdownContent content={streamingContent} />
-          <Cursor />
+          {streamingThinking && (
+            <ThinkingBlock $open={streamThinkingOpen}>
+              <ThinkingHeader onClick={() => setStreamThinkingOpen((v) => !v)}>
+                <ThinkingChevron $open={streamThinkingOpen}>▶</ThinkingChevron>
+                Thinking...
+                <Spacer />
+                <ShowHideBtn onClick={(e) => { e.stopPropagation(); setStreamThinkingOpen((v) => !v); }}>
+                  {streamThinkingOpen ? 'Hide' : 'Show'}
+                </ShowHideBtn>
+              </ThinkingHeader>
+              {streamThinkingOpen && (
+                <StreamThinkingBody>
+                  <ThinkingContent><MarkdownContent content={streamingThinking} /></ThinkingContent>
+                </StreamThinkingBody>
+              )}
+            </ThinkingBlock>
+          )}
+          {streamingContent ? (
+            <>
+              <MarkdownContent content={streamingContent} />
+              <Cursor />
+            </>
+          ) : (
+            <Cursor />
+          )}
         </MessageCard>
       )}
 

--- a/dashboard-react/src/components/cluster/RunningInstanceCard.stories.tsx
+++ b/dashboard-react/src/components/cluster/RunningInstanceCard.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { RunningInstanceCard } from './RunningInstanceCard';
+
+const meta: Meta<typeof RunningInstanceCard> = {
+  title: 'Cluster/RunningInstanceCard',
+  component: RunningInstanceCard,
+  decorators: [(Story) => <div style={{ padding: 32, background: '#000' }}><Story /></div>],
+};
+
+export default meta;
+type Story = StoryObj<typeof RunningInstanceCard>;
+
+export const Ready: Story = {
+  args: {
+    instanceId: '4ea190d5-abcd-1234-ef56-789012345678',
+    modelId: 'mlx-community/Qwen3.5-9B-4bit',
+    sharding: 'Pipeline',
+    instanceType: 'MlxRing',
+    nodeName: 'kite2',
+    status: 'ready',
+    onDelete: () => {},
+  },
+};
+
+export const Running: Story = {
+  args: {
+    instanceId: '7fb301c2-1111-2222-3333-444455556666',
+    modelId: 'mlx-community/Llama-3.1-8B-Instruct-4bit',
+    sharding: 'Tensor',
+    instanceType: 'MlxJaccl',
+    nodeName: 'kite1',
+    status: 'running',
+    onDelete: () => {},
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    instanceId: 'b2c4d6e8-aaaa-bbbb-cccc-ddddeeee0000',
+    modelId: 'mlx-community/NVIDIA-Nemotron-Nano-9B-v2-4bits',
+    sharding: 'Pipeline',
+    instanceType: 'MlxRing',
+    nodeName: 'kite3',
+    status: 'loading',
+    loadProgress: 45,
+    statusMessage: 'Downloading layers 14/32...',
+    onDelete: () => {},
+  },
+};
+
+export const WarmingUp: Story = {
+  args: {
+    instanceId: 'c3d5e7f9-1234-5678-9abc-def012345678',
+    modelId: 'mlx-community/Qwen3-30B-A3B-4bit',
+    sharding: 'Pipeline',
+    instanceType: 'MlxRing',
+    nodeName: 'kite2',
+    status: 'warming_up',
+    loadProgress: 90,
+    statusMessage: 'Compiling model graph...',
+    onDelete: () => {},
+  },
+};
+
+export const Failed: Story = {
+  args: {
+    instanceId: 'deadbeef-dead-beef-dead-beefdeadbeef',
+    modelId: 'mlx-community/DeepSeek-V3-0324',
+    sharding: 'Tensor',
+    instanceType: 'MlxJaccl',
+    nodeName: 'kite1',
+    status: 'failed',
+    statusMessage: 'Out of memory: requires 48GB, only 32GB available',
+    onDelete: () => {},
+  },
+};
+
+export const ShuttingDown: Story = {
+  args: {
+    instanceId: 'aabb1122-3344-5566-7788-99aabbccddee',
+    modelId: 'mlx-community/Qwen3.5-9B-4bit',
+    sharding: 'Pipeline',
+    instanceType: 'MlxRing',
+    nodeName: 'kite3',
+    status: 'shutting_down',
+  },
+};
+
+export const NoDeleteButton: Story = {
+  args: {
+    instanceId: '4ea190d5-abcd-1234-ef56-789012345678',
+    modelId: 'mlx-community/Qwen3.5-9B-4bit',
+    sharding: 'Pipeline',
+    instanceType: 'MlxRing',
+    nodeName: 'kite2',
+    status: 'ready',
+  },
+};
+
+export const LongModelId: Story = {
+  args: {
+    instanceId: '12345678-abcd-efgh-ijkl-mnopqrstuvwx',
+    modelId: 'mlx-community/some-very-long-model-name-that-might-wrap-to-multiple-lines-4bit',
+    sharding: 'Pipeline',
+    instanceType: 'MlxRing',
+    nodeName: 'kite2',
+    status: 'ready',
+    onDelete: () => {},
+  },
+};

--- a/dashboard-react/src/components/cluster/RunningInstanceCard.tsx
+++ b/dashboard-react/src/components/cluster/RunningInstanceCard.tsx
@@ -1,0 +1,304 @@
+import styled, { keyframes, css } from 'styled-components';
+import { FiExternalLink } from 'react-icons/fi';
+import { BsChatDotsFill } from 'react-icons/bs';
+
+/* ── Types ────────────────────────────────────────────── */
+
+export type InstanceStatus =
+  | 'loading'
+  | 'warming_up'
+  | 'ready'
+  | 'running'
+  | 'failed'
+  | 'shutting_down';
+
+export interface RunningInstanceCardProps {
+  instanceId: string;
+  modelId: string;
+  sharding: 'Pipeline' | 'Tensor';
+  instanceType: 'MlxRing' | 'MlxJaccl';
+  nodeName: string;
+  status: InstanceStatus;
+  statusMessage?: string;
+  /** 0–100, shown during loading */
+  loadProgress?: number;
+  onDelete?: () => void;
+  onChat?: () => void;
+  className?: string;
+}
+
+/* ── Status helpers ───────────────────────────────────── */
+
+const STATUS_CONFIG: Record<InstanceStatus, { label: string; color: string; glow: string; defaultMessage: string }> = {
+  loading:       { label: 'Loading',       color: '#FFD700', glow: 'rgba(255, 215, 0, 0.25)',  defaultMessage: 'Downloading model...' },
+  warming_up:    { label: 'Warming Up',    color: '#FFD700', glow: 'rgba(255, 215, 0, 0.25)',  defaultMessage: 'Preparing for inference...' },
+  ready:         { label: 'Ready',         color: '#4ade80', glow: 'rgba(74, 222, 128, 0.25)', defaultMessage: 'Ready to chat!' },
+  running:       { label: 'Running',       color: '#4ade80', glow: 'rgba(74, 222, 128, 0.25)', defaultMessage: 'Processing inference...' },
+  failed:        { label: 'Failed',        color: '#ef4444', glow: 'rgba(239, 68, 68, 0.25)',  defaultMessage: 'Instance failed' },
+  shutting_down: { label: 'Shutting Down', color: '#f59e0b', glow: 'rgba(245, 158, 11, 0.25)', defaultMessage: 'Shutting down...' },
+};
+
+function formatInstanceId(id: string): string {
+  return id.slice(0, 8).toUpperCase();
+}
+
+function formatInstanceType(type: 'MlxRing' | 'MlxJaccl'): string {
+  return type === 'MlxRing' ? 'MLX Ring' : 'MLX Jaccl';
+}
+
+function hfUrl(modelId: string): string | null {
+  return modelId.includes('/') ? `https://huggingface.co/${modelId}` : null;
+}
+
+/* ── Animations ───────────────────────────────────────── */
+
+const pulse = keyframes`
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+`;
+
+const progressStripe = keyframes`
+  0% { background-position: 0 0; }
+  100% { background-position: 20px 0; }
+`;
+
+/* ── Styled components ────────────────────────────────── */
+
+const Card = styled.div<{ $color: string; $glow: string }>`
+  background: ${({ theme }) => theme.colors.surface};
+  border: 1px solid ${({ $color }) => $color};
+  border-radius: ${({ theme }) => theme.radii.md};
+  box-shadow: 0 0 12px ${({ $glow }) => $glow}, inset 0 0 12px ${({ $glow }) => $glow};
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 280px;
+  max-width: 380px;
+  font-family: ${({ theme }) => theme.fonts.body};
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+`;
+
+const IdGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const StatusDot = styled.span<{ $color: string }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${({ $color }) => $color};
+  flex-shrink: 0;
+  animation: ${pulse} 1.5s ease-in-out infinite;
+`;
+
+const InstanceIdText = styled.span`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const DeleteBtn = styled.button`
+  all: unset;
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.error};
+  border: 1px solid ${({ theme }) => theme.colors.error};
+  border-radius: ${({ theme }) => theme.radii.sm};
+  padding: 2px 8px;
+  transition: all 0.15s;
+
+  &:hover {
+    background: rgba(239, 68, 68, 0.15);
+  }
+`;
+
+const ModelIdText = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  color: ${({ theme }) => theme.colors.text};
+  font-weight: 500;
+  word-break: break-all;
+`;
+
+const MetaRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const StatusBadge = styled.span<{ $color: string }>`
+  font-size: 10px;
+  font-weight: 600;
+  color: ${({ $color }) => $color};
+  background: ${({ $color }) => $color}1a;
+  border: 1px solid ${({ $color }) => $color}40;
+  border-radius: ${({ theme }) => theme.radii.sm};
+  padding: 1px 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+`;
+
+const HfLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  text-decoration: none;
+  transition: color 0.15s;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.text};
+  }
+`;
+
+const NodeName = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const StatusLabel = styled.div<{ $color: string }>`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-weight: 700;
+  color: ${({ $color }) => $color};
+`;
+
+const StatusMessage = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-style: italic;
+`;
+
+const Footer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const ChatBtn = styled.button`
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: #4ade80;
+  border: 1px solid rgba(74, 222, 128, 0.3);
+  border-radius: ${({ theme }) => theme.radii.sm};
+  padding: 3px 10px;
+  transition: all 0.15s;
+
+  &:hover {
+    background: rgba(74, 222, 128, 0.12);
+    border-color: rgba(74, 222, 128, 0.5);
+  }
+`;
+
+const ProgressTrack = styled.div`
+  width: 100%;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  overflow: hidden;
+`;
+
+const ProgressFill = styled.div<{ $pct: number; $color: string }>`
+  height: 100%;
+  width: ${({ $pct }) => $pct}%;
+  background: ${({ $color }) => $color};
+  border-radius: 2px;
+  transition: width 0.3s ease-out;
+  ${({ $pct }) =>
+    $pct < 100 &&
+    css`
+      background-image: linear-gradient(
+        45deg,
+        rgba(255, 255, 255, 0.15) 25%,
+        transparent 25%,
+        transparent 50%,
+        rgba(255, 255, 255, 0.15) 50%,
+        rgba(255, 255, 255, 0.15) 75%,
+        transparent 75%
+      );
+      background-size: 20px 20px;
+      animation: ${progressStripe} 0.6s linear infinite;
+    `}
+`;
+
+/* ── Component ────────────────────────────────────────── */
+
+export function RunningInstanceCard({
+  instanceId,
+  modelId,
+  sharding,
+  instanceType,
+  nodeName,
+  status,
+  statusMessage,
+  loadProgress,
+  onDelete,
+  onChat,
+  className,
+}: RunningInstanceCardProps) {
+  const cfg = STATUS_CONFIG[status];
+  const link = hfUrl(modelId);
+  const showProgress = (status === 'loading' || status === 'warming_up') && loadProgress != null;
+  const canChat = status === 'ready' || status === 'running';
+
+  return (
+    <Card $color={cfg.color} $glow={cfg.glow} className={className}>
+      <Header>
+        <IdGroup>
+          <StatusDot $color={cfg.color} />
+          <InstanceIdText>{formatInstanceId(instanceId)}</InstanceIdText>
+        </IdGroup>
+        {onDelete && <DeleteBtn onClick={onDelete}>Delete</DeleteBtn>}
+      </Header>
+
+      <ModelIdText>{modelId}</ModelIdText>
+
+      <MetaRow>
+        <span>{sharding} &middot; {formatInstanceType(instanceType)}</span>
+        <StatusBadge $color={cfg.color}>{cfg.label}</StatusBadge>
+      </MetaRow>
+
+      {link && (
+        <HfLink href={link} target="_blank" rel="noopener noreferrer">
+          Hugging Face <FiExternalLink size={11} />
+        </HfLink>
+      )}
+
+      <NodeName>{nodeName}</NodeName>
+
+      {showProgress && (
+        <ProgressTrack>
+          <ProgressFill $pct={loadProgress!} $color={cfg.color} />
+        </ProgressTrack>
+      )}
+
+      <Footer>
+        <div>
+          <StatusLabel $color={cfg.color}>{cfg.label.toUpperCase()}</StatusLabel>
+          <StatusMessage>{statusMessage ?? cfg.defaultMessage}</StatusMessage>
+        </div>
+        {canChat && onChat && (
+          <ChatBtn onClick={onChat}>
+            <BsChatDotsFill size={14} /> Chat
+          </ChatBtn>
+        )}
+      </Footer>
+    </Card>
+  );
+}

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
-import { FiSettings, FiMenu, FiX, FiSidebar, FiDatabase } from 'react-icons/fi';
+import { FiSettings, FiMenu, FiX, FiSidebar, FiDatabase, FiMessageSquare } from 'react-icons/fi';
 import { MdHub } from 'react-icons/md';
 import { MdOutlineViewSidebar } from 'react-icons/md';
 import { Button } from '../common/Button';
 import SkulkIcon from '../icons/SkulkIcon';
 
-export type NavRoute = 'cluster' | 'model-store';
+export type NavRoute = 'cluster' | 'model-store' | 'chat';
 
 export interface HeaderNavProps {
   showHome?: boolean;
@@ -22,6 +22,8 @@ export interface HeaderNavProps {
   showMobileRightToggle?: boolean;
   mobileRightOpen?: boolean;
   onToggleMobileRight?: () => void;
+  instanceCount?: number;
+  instancesHealthy?: boolean;
   downloadProgress?: { count: number; percentage: number } | null;
   onOpenSettings?: () => void;
   className?: string;
@@ -82,8 +84,18 @@ const LogoText = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.xxl};
   font-weight: 700;
   font-family: ${({ theme }) => theme.fonts.body};
-  color: #FFD700;
-  filter: drop-shadow(0 0 4px rgba(255, 215, 0, 0.3));
+  color: #ffffff;
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.2));
+`;
+
+const VersionTag = styled.sup`
+  font-size: 10px;
+  font-weight: 400;
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: rgba(255, 255, 255, 0.88);
+  margin-left: 2px;
+  position: relative;
+  top: -4px;
 `;
 
 const NavLink = styled.button<{ $active?: boolean }>`
@@ -113,6 +125,21 @@ const DownloadBadge = styled.div`
   height: 28px;
 `;
 
+const InstanceToggle = styled.button<{ $healthy: boolean; $active: boolean }>`
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border-radius: 50%;
+  transition: all 0.15s;
+
+  &:hover {
+    filter: brightness(1.2);
+  }
+`;
+
 /* ---- icons (react-icons) ---- */
 
 const MenuIcon = () => <FiMenu size={18} />;
@@ -121,6 +148,7 @@ const SidebarIcon = () => <FiSidebar size={18} />;
 const PanelIcon = () => <MdOutlineViewSidebar size={18} />;
 const ClusterIcon = () => <MdHub size={16} />;
 const StoreIcon = () => <FiDatabase size={16} />;
+const ChatIcon = () => <FiMessageSquare size={16} />;
 const SettingsIcon = () => <FiSettings size={16} />;
 
 function ProgressCircle({ count, percentage }: { count: number; percentage: number }) {
@@ -164,6 +192,8 @@ export function HeaderNav({
   showMobileRightToggle = false,
   mobileRightOpen = false,
   onToggleMobileRight,
+  instanceCount = 0,
+  instancesHealthy = true,
   downloadProgress = null,
   onOpenSettings,
   className,
@@ -187,8 +217,8 @@ export function HeaderNav({
           </ToggleBtn>
         )}
         <LogoBtn $disabled={!showHome} onClick={showHome ? () => navigate('cluster') : undefined}>
-          <SkulkIcon size={32} color="#FFD700" />
-          <LogoText>Skulk</LogoText>
+          <SkulkIcon size={32} color="#ffffff" />
+          <LogoText>Skulk<VersionTag>{__APP_VERSION__}</VersionTag></LogoText>
         </LogoBtn>
       </LeftGroup>
 
@@ -203,15 +233,44 @@ export function HeaderNav({
           <StoreIcon /> Model Store
         </NavLink>
 
+        <NavLink $active={activeRoute === 'chat'} onClick={() => navigate('chat')}>
+          <ChatIcon /> Chat
+        </NavLink>
+
+        {instanceCount > 0 && (
+          <InstanceToggle
+            $healthy={instancesHealthy}
+            $active={mobileRightOpen}
+            onClick={onToggleMobileRight}
+            aria-label="Toggle instances panel"
+            aria-pressed={mobileRightOpen}
+          >
+            <svg width="28" height="28" viewBox="0 0 28 28">
+              <circle
+                cx="14" cy="14" r="11"
+                fill="none"
+                stroke={instancesHealthy ? '#4ade80' : '#ef4444'}
+                strokeWidth="2"
+                opacity={mobileRightOpen ? 1 : 0.7}
+              />
+              <text
+                x="14" y="14"
+                textAnchor="middle"
+                dominantBaseline="central"
+                fill={instancesHealthy ? '#4ade80' : '#ef4444'}
+                fontSize="13"
+                fontFamily="'Outfit', sans-serif"
+                fontWeight="700"
+              >
+                {instanceCount}
+              </text>
+            </svg>
+          </InstanceToggle>
+        )}
+
         <Button variant="ghost" size="lg" icon onClick={() => onOpenSettings?.()} aria-label="Settings">
           <SettingsIcon />
         </Button>
-
-        {showMobileRightToggle && (
-          <ToggleBtn variant="outline" size="lg" icon $active={mobileRightOpen} onClick={onToggleMobileRight} aria-label="Toggle right panel" aria-pressed={mobileRightOpen}>
-            <PanelIcon />
-          </ToggleBtn>
-        )}
       </RightGroup>
     </Nav>
   );

--- a/dashboard-react/src/components/layout/InstancePanel.stories.tsx
+++ b/dashboard-react/src/components/layout/InstancePanel.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { InstancePanel } from './InstancePanel';
+import type { InstanceCardData } from './InstancePanel';
+
+const meta: Meta<typeof InstancePanel> = {
+  title: 'Layout/InstancePanel',
+  component: InstancePanel,
+  decorators: [(Story) => (
+    <div style={{ height: '100vh', display: 'flex', justifyContent: 'flex-end', background: '#000' }}>
+      <Story />
+    </div>
+  )],
+};
+
+export default meta;
+type Story = StoryObj<typeof InstancePanel>;
+
+const readyInstance: InstanceCardData = {
+  instanceId: '4ea190d5-abcd-1234-ef56-789012345678',
+  modelId: 'mlx-community/Qwen3.5-9B-4bit',
+  sharding: 'Pipeline',
+  instanceType: 'MlxRing',
+  nodeName: 'kite2',
+  status: 'ready',
+};
+
+const loadingInstance: InstanceCardData = {
+  instanceId: 'b2c4d6e8-aaaa-bbbb-cccc-ddddeeee0000',
+  modelId: 'mlx-community/NVIDIA-Nemotron-Nano-9B-v2-4bits',
+  sharding: 'Pipeline',
+  instanceType: 'MlxRing',
+  nodeName: 'kite3',
+  status: 'loading',
+  loadProgress: 45,
+  statusMessage: 'Downloading layers 14/32...',
+};
+
+const failedInstance: InstanceCardData = {
+  instanceId: 'deadbeef-dead-beef-dead-beefdeadbeef',
+  modelId: 'mlx-community/DeepSeek-V3-0324',
+  sharding: 'Tensor',
+  instanceType: 'MlxJaccl',
+  nodeName: 'kite1',
+  status: 'failed',
+  statusMessage: 'Out of memory: requires 48GB, only 32GB available',
+};
+
+const runningInstance: InstanceCardData = {
+  instanceId: '7fb301c2-1111-2222-3333-444455556666',
+  modelId: 'mlx-community/Llama-3.1-8B-Instruct-4bit',
+  sharding: 'Tensor',
+  instanceType: 'MlxJaccl',
+  nodeName: 'kite1',
+  status: 'running',
+};
+
+export const SingleReady: Story = {
+  args: {
+    instances: [readyInstance],
+    onDelete: () => {},
+  },
+};
+
+export const MultipleInstances: Story = {
+  args: {
+    instances: [readyInstance, loadingInstance, failedInstance, runningInstance],
+    onDelete: () => {},
+  },
+};
+
+export const AllLoading: Story = {
+  args: {
+    instances: [
+      loadingInstance,
+      { ...loadingInstance, instanceId: 'aabb1122-0000-0000-0000-000000000000', modelId: 'mlx-community/Qwen3-30B-A3B-4bit', loadProgress: 78, statusMessage: 'Downloading layers 25/32...' },
+    ],
+    onDelete: () => {},
+  },
+};

--- a/dashboard-react/src/components/layout/InstancePanel.tsx
+++ b/dashboard-react/src/components/layout/InstancePanel.tsx
@@ -1,0 +1,84 @@
+import styled from 'styled-components';
+import { RunningInstanceCard, type InstanceStatus } from '../cluster/RunningInstanceCard';
+
+/* ── Types ────────────────────────────────────────────── */
+
+export interface InstanceCardData {
+  instanceId: string;
+  modelId: string;
+  sharding: 'Pipeline' | 'Tensor';
+  instanceType: 'MlxRing' | 'MlxJaccl';
+  nodeName: string;
+  status: InstanceStatus;
+  statusMessage?: string;
+  loadProgress?: number;
+}
+
+export interface InstancePanelProps {
+  instances: InstanceCardData[];
+  onDelete?: (instanceId: string) => void;
+  onChat?: (modelId: string) => void;
+  className?: string;
+}
+
+/* ── Styles ───────────────────────────────────────────── */
+
+const Panel = styled.aside`
+  width: 340px;
+  flex-shrink: 0;
+  border-left: 1px solid ${({ theme }) => theme.colors.border};
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+const PanelHeader = styled.div`
+  padding: 12px 16px;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Count = styled.span`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-weight: 400;
+`;
+
+const CardList = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+/* ── Component ────────────────────────────────────────── */
+
+export function InstancePanel({ instances, onDelete, onChat, className }: InstancePanelProps) {
+  return (
+    <Panel className={className}>
+      <PanelHeader>
+        Active Instances
+        <Count>{instances.length}</Count>
+      </PanelHeader>
+      <CardList>
+        {instances.map((inst) => (
+          <RunningInstanceCard
+            key={inst.instanceId}
+            {...inst}
+            onDelete={onDelete ? () => onDelete(inst.instanceId) : undefined}
+            onChat={onChat ? () => onChat(inst.modelId) : undefined}
+          />
+        ))}
+      </CardList>
+    </Panel>
+  );
+}

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import { FiTrash2, FiExternalLink, FiRefreshCw } from 'react-icons/fi';
 import { MdPlayArrow, MdClose } from 'react-icons/md';
+import { BsChatDotsFill } from 'react-icons/bs';
 import { formatBytes } from '../../utils/format';
 import { Button } from '../common/Button';
 import { InfoTooltip } from '../common/InfoTooltip';
@@ -43,6 +44,7 @@ export interface StoreRegistryTableProps {
   onDelete: (entry: StoreRegistryEntry, isActive: boolean) => void;
   onLaunch?: (modelId: string) => void;
   onStop?: (modelId: string) => void;
+  onChat?: (modelId: string) => void;
   clusterCards?: Record<string, Omit<ClusterCardProps, 'onLaunch'>>;
 }
 
@@ -208,6 +210,22 @@ const ActiveDot = styled.span`
   border-radius: 50%;
   background: ${({ theme }) => theme.colors.gold};
   animation: ${pulse} 1.5s ease-in-out infinite;
+`;
+
+const ChatBubble = styled.button`
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  color: #4ade80;
+  padding: 2px;
+  border-radius: ${({ theme }) => theme.radii.sm};
+  transition: all 0.15s;
+
+  &:hover {
+    color: #86efac;
+    filter: drop-shadow(0 0 4px rgba(74, 222, 128, 0.4));
+  }
 `;
 
 const Cell = styled.div<{ $align?: string }>`
@@ -414,6 +432,7 @@ export function StoreRegistryTable({
   onDelete,
   onLaunch,
   onStop,
+  onChat,
   clusterCards = {},
 }: StoreRegistryTableProps) {
   const registeredIds = useMemo(() => new Set(entries.map((e) => e.model_id)), [entries]);
@@ -508,15 +527,22 @@ export function StoreRegistryTable({
                     const badge = ready
                       ? <ReadyBadge><PulseDot /> Ready</ReadyBadge>
                       : <ActiveBadge><ActiveDot /> Loading</ActiveBadge>;
-                    return card ? (
-                      <InfoTooltip
-                        placement="bottom"
-                        delay={100}
-                        content={<ClusterCard {...card} />}
-                      >
-                        {badge}
-                      </InfoTooltip>
-                    ) : badge;
+                    return <>
+                      {card ? (
+                        <InfoTooltip
+                          placement="bottom"
+                          delay={100}
+                          content={<ClusterCard {...card} />}
+                        >
+                          {badge}
+                        </InfoTooltip>
+                      ) : badge}
+                      {ready && onChat && (
+                        <ChatBubble onClick={() => onChat(entry.model_id)} title="Chat with model">
+                          <BsChatDotsFill size={14} />
+                        </ChatBubble>
+                      )}
+                    </>;
                   })()}
                 </ModelCell>
                 <Cell $align="right">{formatBytes(entry.total_bytes)}</Cell>

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -78,6 +78,27 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
   const [ttftMs, setTtftMs] = useState<number | null>(null);
   const [tps, setTps] = useState<number | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const [modelCapabilities, setModelCapabilities] = useState<Record<string, string[]>>({});
+
+  // Fetch model capabilities
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/models');
+        if (!res.ok) return;
+        const data = await res.json();
+        const caps: Record<string, string[]> = {};
+        for (const m of data.data ?? []) {
+          if (m.id && m.capabilities) caps[m.id] = m.capabilities;
+        }
+        setModelCapabilities(caps);
+      } catch { /* ignore */ }
+    })();
+  }, []);
+
+  const supportsThinking = selectedModelId
+    ? (modelCapabilities[selectedModelId]?.includes('thinking_toggle') ?? false)
+    : false;
 
   // Auto-select first ready model if none selected
   const readyModels = useMemo(
@@ -127,9 +148,10 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
     const startTime = performance.now();
     let firstTokenTime: number | null = null;
     let tokenCount = 0;
-    let fullContent = '';
+    let rawContent = '';
     let fullThinking = '';
     let lastTps: number | undefined;
+    let inThinkTag = false;
 
     try {
       const res = await fetch('/v1/chat/completions', {
@@ -184,16 +206,46 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
               setTtftMs(firstTokenTime - startTime);
             }
 
-            // Thinking/reasoning content
+            // Thinking via reasoning_content field
             if (delta?.reasoning_content) {
               fullThinking += delta.reasoning_content;
               setStreamingThinking(fullThinking);
             }
 
-            // Regular content
+            // Content — parse out inline <think> tags
             if (delta?.content) {
-              fullContent += delta.content;
-              setStreamingContent(fullContent);
+              rawContent += delta.content;
+
+              // Process <think> tags incrementally
+              let displayContent = '';
+              let thinkContent = '';
+              let i = 0;
+              let inTag = false;
+              const raw = rawContent;
+
+              while (i < raw.length) {
+                if (!inTag && raw.startsWith('<think>', i)) {
+                  inTag = true;
+                  i += 7;
+                } else if (inTag && raw.startsWith('</think>', i)) {
+                  inTag = false;
+                  i += 8;
+                } else if (inTag) {
+                  thinkContent += raw[i];
+                  i++;
+                } else {
+                  displayContent += raw[i];
+                  i++;
+                }
+              }
+              inThinkTag = inTag;
+
+              // If we found think tags, route to thinking
+              if (thinkContent) {
+                fullThinking = thinkContent;
+                setStreamingThinking(fullThinking);
+              }
+              setStreamingContent(displayContent || null);
             }
 
             // Update TPS on every token (thinking or content)
@@ -216,7 +268,7 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
       if ((err as Error).name === 'AbortError') {
         // User cancelled
       } else {
-        fullContent = fullContent || `Error: ${(err as Error).message}`;
+        rawContent = rawContent || `Error: ${(err as Error).message}`;
       }
     }
 
@@ -224,7 +276,7 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
     const assistantMsg: ChatMessage = {
       id: `msg-${Date.now()}-assistant`,
       role: 'assistant',
-      content: fullContent,
+      content: rawContent.replace(/<think>[\s\S]*?<\/think>/gi, '').replace(/<think>[\s\S]*/i, '').trim(),
       timestamp: Date.now(),
       ttftMs: firstTokenTime ? firstTokenTime - startTime : undefined,
       tps: lastTps,
@@ -276,7 +328,7 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
     );
   }
 
-  const modelPicker = readyModels.length > 1 ? (
+  const modelSelector = readyModels.length > 1 ? (
     <ModelSelect value={selectedModelId ?? ''} onChange={(e) => setSelectedModelId(e.target.value)}>
       {readyModels.map((m) => (
         <option key={m.instanceId} value={m.modelId}>
@@ -305,10 +357,10 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
           onCancel={handleCancel}
           isLoading={isLoading}
           modelLabel={selectedLabel}
-          onOpenModelPicker={modelPicker ? undefined : undefined}
+          modelSelector={modelSelector}
           ttftMs={ttftMs}
           tps={tps}
-          showThinkingToggle
+          showThinkingToggle={supportsThinking}
           thinkingEnabled={thinkingEnabled}
           onToggleThinking={() => setThinkingEnabled((v) => !v)}
           placeholder={selectedModelId ? `Message ${selectedLabel}…` : 'Select a model to chat'}

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -1,0 +1,320 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { ChatMessages } from '../chat/ChatMessages';
+import { ChatForm } from '../chat/ChatForm';
+import type { ChatMessage } from '../../types/chat';
+import type { ChatUploadedFile } from '../../types/chat';
+import type { InstanceCardData } from '../layout/InstancePanel';
+
+/* ── Types ────────────────────────────────────────────── */
+
+export interface ChatViewProps {
+  /** Ready instances the user can chat with. */
+  readyInstances: InstanceCardData[];
+  /** Pre-selected model ID (e.g. from clicking Chat on a card). */
+  initialModelId?: string;
+  className?: string;
+}
+
+/* ── Styles ───────────────────────────────────────────── */
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+const MessagesScroll = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+`;
+
+const InputArea = styled.div`
+  flex-shrink: 0;
+  padding: 12px 24px 16px;
+`;
+
+const NoModels = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 12px;
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+`;
+
+const ModelSelect = styled.select`
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: #FFD700;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  cursor: pointer;
+  outline: none;
+  padding-right: 4px;
+
+  option {
+    background: ${({ theme }) => theme.colors.surface};
+    color: ${({ theme }) => theme.colors.text};
+  }
+`;
+
+/* ── Component ────────────────────────────────────────── */
+
+export function ChatView({ readyInstances, initialModelId, className }: ChatViewProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [streamingContent, setStreamingContent] = useState<string | null>(null);
+  const [streamingThinking, setStreamingThinking] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(initialModelId ?? null);
+  const [thinkingEnabled, setThinkingEnabled] = useState(false);
+  const [ttftMs, setTtftMs] = useState<number | null>(null);
+  const [tps, setTps] = useState<number | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Auto-select first ready model if none selected
+  const readyModels = useMemo(
+    () => readyInstances.filter((i) => i.status === 'ready' || i.status === 'running'),
+    [readyInstances],
+  );
+
+  useEffect(() => {
+    if (!selectedModelId && readyModels.length > 0) {
+      setSelectedModelId(readyModels[0].modelId);
+    }
+  }, [selectedModelId, readyModels]);
+
+  // If initialModelId changes (e.g. user clicked Chat on a different card), update
+  useEffect(() => {
+    if (initialModelId) setSelectedModelId(initialModelId);
+  }, [initialModelId]);
+
+  const selectedLabel = useMemo(() => {
+    if (!selectedModelId) return undefined;
+    const parts = selectedModelId.split('/');
+    return parts[parts.length - 1];
+  }, [selectedModelId]);
+
+  const handleSend = useCallback(async (text: string, _files: ChatUploadedFile[]) => {
+    if (!selectedModelId || isLoading) return;
+
+    const userMsg: ChatMessage = {
+      id: `msg-${Date.now()}-user`,
+      role: 'user',
+      content: text,
+      timestamp: Date.now(),
+    };
+
+    setMessages((prev) => [...prev, userMsg]);
+    setIsLoading(true);
+    setStreamingContent('');
+    setStreamingThinking(null);
+    setTtftMs(null);
+    setTps(null);
+
+    const allMessages = [...messages, userMsg];
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const startTime = performance.now();
+    let firstTokenTime: number | null = null;
+    let tokenCount = 0;
+    let fullContent = '';
+    let fullThinking = '';
+    let lastTps: number | undefined;
+
+    try {
+      const res = await fetch('/v1/chat/completions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: selectedModelId,
+          messages: allMessages.map((m) => ({ role: m.role, content: m.content })),
+          stream: true,
+          ...(thinkingEnabled ? { enable_thinking: true } : {}),
+        }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error((err as Record<string, string>).detail ?? `HTTP ${res.status}`);
+      }
+
+      const reader = res.body?.getReader();
+      const decoder = new TextDecoder();
+
+      if (!reader) throw new Error('No response body');
+
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed.startsWith(':')) continue;
+          if (!trimmed.startsWith('data: ')) continue;
+          const data = trimmed.slice(6);
+          if (data === '[DONE]') continue;
+
+          try {
+            const parsed = JSON.parse(data);
+            const delta = parsed.choices?.[0]?.delta;
+
+            const hasToken = delta?.content || delta?.reasoning_content;
+
+            // Record TTFT on first token of any kind
+            if (hasToken && firstTokenTime === null) {
+              firstTokenTime = performance.now();
+              setTtftMs(firstTokenTime - startTime);
+            }
+
+            // Thinking/reasoning content
+            if (delta?.reasoning_content) {
+              fullThinking += delta.reasoning_content;
+              setStreamingThinking(fullThinking);
+            }
+
+            // Regular content
+            if (delta?.content) {
+              fullContent += delta.content;
+              setStreamingContent(fullContent);
+            }
+
+            // Update TPS on every token (thinking or content)
+            if (hasToken) {
+              tokenCount++;
+              if (firstTokenTime !== null && tokenCount > 1) {
+                const elapsed = (performance.now() - firstTokenTime) / 1000;
+                if (elapsed > 0) {
+                  lastTps = tokenCount / elapsed;
+                  setTps(lastTps);
+                }
+              }
+            }
+          } catch {
+            // skip malformed JSON
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') {
+        // User cancelled
+      } else {
+        fullContent = fullContent || `Error: ${(err as Error).message}`;
+      }
+    }
+
+    // Finalize assistant message
+    const assistantMsg: ChatMessage = {
+      id: `msg-${Date.now()}-assistant`,
+      role: 'assistant',
+      content: fullContent,
+      timestamp: Date.now(),
+      ttftMs: firstTokenTime ? firstTokenTime - startTime : undefined,
+      tps: lastTps,
+      thinkingContent: fullThinking || undefined,
+    };
+
+    setMessages((prev) => [...prev, assistantMsg]);
+    setStreamingContent(null);
+    setStreamingThinking(null);
+    setIsLoading(false);
+    abortRef.current = null;
+  }, [selectedModelId, isLoading, messages, thinkingEnabled]);
+
+  const handleCancel = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const handleDelete = useCallback((id: string) => {
+    setMessages((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  const handleEdit = useCallback((id: string, content: string) => {
+    setMessages((prev) => prev.map((m) => m.id === id ? { ...m, content } : m));
+  }, []);
+
+  const handleRegenerate = useCallback(() => {
+    // Remove last assistant message, re-send last user message
+    setMessages((prev) => {
+      const withoutLast = [...prev];
+      while (withoutLast.length > 0 && withoutLast[withoutLast.length - 1].role === 'assistant') {
+        withoutLast.pop();
+      }
+      return withoutLast;
+    });
+    // Trigger re-send on next tick after state updates
+    setTimeout(() => {
+      const lastUser = messages.filter((m) => m.role === 'user').pop();
+      if (lastUser) {
+        handleSend(lastUser.content, []);
+      }
+    }, 50);
+  }, [messages, handleSend]);
+
+  if (readyModels.length === 0) {
+    return (
+      <NoModels>
+        No models are ready. Launch a model from the Model Store to start chatting.
+      </NoModels>
+    );
+  }
+
+  const modelPicker = readyModels.length > 1 ? (
+    <ModelSelect value={selectedModelId ?? ''} onChange={(e) => setSelectedModelId(e.target.value)}>
+      {readyModels.map((m) => (
+        <option key={m.instanceId} value={m.modelId}>
+          {m.modelId.split('/').pop()}
+        </option>
+      ))}
+    </ModelSelect>
+  ) : undefined;
+
+  return (
+    <Container className={className}>
+      <MessagesScroll>
+        <ChatMessages
+          messages={messages}
+          streamingContent={streamingContent}
+          streamingThinking={streamingThinking}
+          isLoading={isLoading}
+          onDelete={handleDelete}
+          onEdit={handleEdit}
+          onRegenerate={handleRegenerate}
+        />
+      </MessagesScroll>
+      <InputArea>
+        <ChatForm
+          onSend={handleSend}
+          onCancel={handleCancel}
+          isLoading={isLoading}
+          modelLabel={selectedLabel}
+          onOpenModelPicker={modelPicker ? undefined : undefined}
+          ttftMs={ttftMs}
+          tps={tps}
+          showThinkingToggle
+          thinkingEnabled={thinkingEnabled}
+          onToggleThinking={() => setThinkingEnabled((v) => !v)}
+          placeholder={selectedModelId ? `Message ${selectedLabel}…` : 'Select a model to chat'}
+        />
+      </InputArea>
+    </Container>
+  );
+}
+

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -15,6 +15,7 @@ interface ModelStorePageProps {
   nodeDisk: NodeDiskInfo;
   instances: RawInstances;
   runners: RawRunners;
+  onChat?: (modelId: string) => void;
 }
 
 /* ── Data extraction helpers ──────────────────────────── */
@@ -154,7 +155,7 @@ function formatSpeed(bps: number): string {
 
 /* ── Component ────────────────────────────────────────── */
 
-export function ModelStorePage({ topology, downloads, nodeDisk, instances, runners }: ModelStorePageProps) {
+export function ModelStorePage({ topology, downloads, nodeDisk, instances, runners, onChat }: ModelStorePageProps) {
   const [storeEntries, setStoreEntries] = useState<StoreRegistryEntry[]>([]);
   const [storeDownloads, setStoreDownloads] = useState<StoreDownloadProgress[]>([]);
   const [storeLoading, setStoreLoading] = useState(false);
@@ -441,6 +442,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
           onDelete={() => {}}
           onLaunch={handleLaunch}
           onStop={handleStop}
+          onChat={onChat}
           clusterCards={clusterCards}
         />
       <ModelSearchModal

--- a/dashboard-react/src/components/status/ClusterWarnings.tsx
+++ b/dashboard-react/src/components/status/ClusterWarnings.tsx
@@ -127,6 +127,8 @@ const colorMap: Record<ColorKey, { border: string; bg: string; text: string; emp
 };
 
 const WarningsBar = styled.div`
+  position: relative;
+  z-index: 10;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;

--- a/dashboard-react/src/vite-env.d.ts
+++ b/dashboard-react/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/dashboard-react/vite.config.ts
+++ b/dashboard-react/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import pkg from './package.json' with { type: 'json' };
 
 // https://vite.dev/config/
 import path from 'node:path';
@@ -11,6 +12,9 @@ const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(file
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   plugins: [react()],
   server: {
     port: 3000,
@@ -21,6 +25,7 @@ export default defineConfig({
       '/download': 'http://localhost:52415',
       '/models': 'http://localhost:52415',
       '/place_instance': 'http://localhost:52415',
+      '/v1': 'http://localhost:52415',
       '/instance': 'http://localhost:52415',
     },
   },


### PR DESCRIPTION
## Summary
- **Chat view** with streaming SSE responses, real-time TTFT/TPS/ms-per-tok stats, thinking content (both `reasoning_content` and `<think>` tag parsing), inline model selector dropdown, and thinking toggle gated on model capabilities
- **RunningInstanceCard** component with status-colored borders (ready/loading/failed/running), progress bars, chat buttons, and delete actions
- **InstancePanel** — collapsible right-side panel showing all placed instances with instance count indicator in header (green circle = healthy, red = failed)
- **Header updates** — white Skulk logo, version tag from package.json, chat nav link, instance count circle before settings gear
- **Store integration** — chat bubble next to Ready badge, onChat callbacks wired through
- **ClusterWarnings** moved above content area so tooltips aren't clipped
- **Vite proxy** for `/v1` endpoints

## Test plan
- [ ] Launch a model, verify RunningInstanceCard appears in the instance panel
- [ ] Verify instance count circle in header (green when all healthy)
- [ ] Click Chat button on instance card or store Ready badge → navigates to chat
- [ ] Send a message, verify streaming response with live TTFT/TPS stats
- [ ] Test with thinking model (e.g. Nemotron) — thinking block should appear collapsed with Show/Hide
- [ ] Switch models via inline dropdown when multiple are ready
- [ ] Delete instance from panel, verify panel disappears when last instance removed
- [ ] Verify ClusterWarnings tooltips render above chat content

🤖 Generated with [Claude Code](https://claude.com/claude-code)