### PR TITLE
Add experimental TurboQuant KV cache backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ exo connects all your devices into an AI cluster. Not only does exo enable runni
 - **MLX Support**: exo uses [MLX](https://github.com/ml-explore/mlx) as an inference backend and [MLX distributed](https://ml-explore.github.io/mlx/build/html/usage/distributed.html) for distributed communication.
 - **Multiple API Compatibility**: Compatible with OpenAI Chat Completions API, Claude Messages API, OpenAI Responses API, and Ollama API - use your existing tools and clients.
 - **Custom Model Support**: Load custom models from HuggingFace hub to expand the range of available models.
+- **Experimental KV Cache Backends**: Skulk includes opt-in MLX quantized and TurboQuant-inspired KV cache backends for long-context memory experiments. See [docs/kv-cache-backends.md](docs/kv-cache-backends.md).
 
 ## Dashboard
 
@@ -133,6 +134,33 @@ uv run exo
 ```
 
 This starts the exo dashboard and API at http://localhost:52415/
+
+## Experimental KV Cache Backends
+
+Skulk includes opt-in KV cache backends for MLX text generation:
+
+- `default`: current behavior, unchanged unless you explicitly opt in
+- `mlx_quantized`: MLX LM's built-in `QuantizedKVCache`
+- `turboquant`: a correctness-first TurboQuant-inspired KV cache for standard `KVCache` layers
+- `turboquant_adaptive`: keeps the first and last KV layers in FP16 and applies TurboQuant only to middle KV layers
+
+Current recommended experimental setting:
+
+```bash
+EXO_KV_CACHE_BACKEND=turboquant_adaptive \
+EXO_TQ_K_BITS=3 \
+EXO_TQ_V_BITS=4 \
+EXO_TQ_FP16_LAYERS=4 \
+uv run exo
+```
+
+Important notes:
+
+- These backends are opt-in. If `EXO_KV_CACHE_BACKEND` is unset, behavior remains the same as before.
+- The current implementation is primarily a memory optimization for long-context experiments, not a guaranteed tokens-per-second optimization.
+- Quantized KV cache backends currently force sequential generation because batch/history mode is not supported yet.
+
+More detail, current limitations, and testing guidance live in [docs/kv-cache-backends.md](docs/kv-cache-backends.md).
 
 
 *Please view the section on RDMA to enable this feature on MacOS >=26.2!*
@@ -303,6 +331,12 @@ exo supports several environment variables for configuration:
 | `EXO_LIBP2P_NAMESPACE` | Custom namespace for cluster isolation | None |
 | `EXO_FAST_SYNCH` | Control MLX_METAL_FAST_SYNCH behavior (for JACCL backend) | Auto |
 | `EXO_TRACING_ENABLED` | Enable distributed tracing for performance analysis | `false` |
+| `EXO_KV_CACHE_BACKEND` | Select KV cache backend: `default`, `mlx_quantized`, `turboquant`, or `turboquant_adaptive` | `default` |
+| `EXO_KV_CACHE_BITS` | Bit width for MLX built-in quantized KV cache. Required when `EXO_KV_CACHE_BACKEND=mlx_quantized` | None |
+| `EXO_TQ_K_BITS` | Key-cache bit width for TurboQuant backends | `3` |
+| `EXO_TQ_V_BITS` | Value-cache bit width for TurboQuant backends | `4` |
+| `EXO_TQ_FP16_LAYERS` | Number of KV layers at each edge kept in FP16 for `turboquant_adaptive` | `4` |
+| `EXO_NO_BATCH` | Disable batch generation. Quantized KV backends currently force this behavior automatically as a temporary fallback | `false` |
 
 **Example usage:**
 
@@ -318,7 +352,15 @@ EXO_ENABLE_IMAGE_MODELS=true uv run exo
 
 # Use custom namespace for cluster isolation
 EXO_LIBP2P_NAMESPACE=my-dev-cluster uv run exo
+
+# Use MLX built-in quantized KV cache
+EXO_KV_CACHE_BACKEND=mlx_quantized EXO_KV_CACHE_BITS=4 uv run exo
+
+# Use the current recommended TurboQuant adaptive setting
+EXO_KV_CACHE_BACKEND=turboquant_adaptive EXO_TQ_K_BITS=3 EXO_TQ_V_BITS=4 EXO_TQ_FP16_LAYERS=4 uv run exo
 ```
+
+For more detail on KV cache backends, supported model cache layouts, current limitations, and testing guidance, see [docs/kv-cache-backends.md](docs/kv-cache-backends.md).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ There are currently 5 major systems:
 - Runner
     
     Executes inference jobs (for now) in an isolated process from the worker for fault-tolerance.
+    The runner is also where MLX inference generators and KV cache backends are selected. Experimental KV cache backend selection is process-local and opt-in via environment variables.
 
 - API
     

--- a/docs/kv-cache-backends.md
+++ b/docs/kv-cache-backends.md
@@ -1,0 +1,157 @@
+# KV Cache Backends
+
+Skulk now includes several opt-in KV cache backends for MLX text generation. These backends are intended for long-context and memory-pressure experiments, while preserving existing behavior unless explicitly enabled.
+
+## Current Status
+
+- `default`: existing behavior
+- `mlx_quantized`: MLX LM built-in `QuantizedKVCache`
+- `turboquant`: correctness-first TurboQuant-inspired KV cache for standard `KVCache` layers
+- `turboquant_adaptive`: keeps outer KV layers in FP16 and applies TurboQuant to middle KV layers
+
+If `EXO_KV_CACHE_BACKEND` is unset, or is set to `default`, Skulk behaves as before.
+
+## Recommended Setting
+
+The current best experimental setting during local testing has been:
+
+```bash
+EXO_KV_CACHE_BACKEND=turboquant_adaptive \
+EXO_TQ_K_BITS=3 \
+EXO_TQ_V_BITS=4 \
+EXO_TQ_FP16_LAYERS=4 \
+uv run exo
+```
+
+This mode keeps the first and last 4 KV layers in normal FP16-style cache and applies TurboQuant only to the middle KV layers.
+
+## Available Environment Variables
+
+- `EXO_KV_CACHE_BACKEND`
+  - `default`
+  - `mlx_quantized`
+  - `turboquant`
+  - `turboquant_adaptive`
+- `EXO_KV_CACHE_BITS`
+  - Required when `EXO_KV_CACHE_BACKEND=mlx_quantized`
+- `EXO_TQ_K_BITS`
+  - Optional for `turboquant` and `turboquant_adaptive`
+  - Defaults to `3`
+- `EXO_TQ_V_BITS`
+  - Optional for `turboquant` and `turboquant_adaptive`
+  - Defaults to `4`
+- `EXO_TQ_FP16_LAYERS`
+  - Used by `turboquant_adaptive`
+  - Defaults to `4`
+
+## Invocation Examples
+
+Default behavior:
+
+```bash
+EXO_KV_CACHE_BACKEND=default uv run exo
+```
+
+MLX quantized KV cache:
+
+```bash
+EXO_KV_CACHE_BACKEND=mlx_quantized EXO_KV_CACHE_BITS=4 uv run exo
+```
+
+TurboQuant adaptive:
+
+```bash
+EXO_KV_CACHE_BACKEND=turboquant_adaptive EXO_TQ_K_BITS=3 EXO_TQ_V_BITS=4 EXO_TQ_FP16_LAYERS=4 uv run exo
+```
+
+Full TurboQuant:
+
+```bash
+EXO_KV_CACHE_BACKEND=turboquant EXO_TQ_K_BITS=3 EXO_TQ_V_BITS=4 uv run exo
+```
+
+## Practical Expectations
+
+These backends should currently be thought of as memory-oriented, not throughput-oriented.
+
+- `default`
+  - Best baseline for quality
+  - Highest KV memory use
+- `mlx_quantized`
+  - Lower KV memory than `default`
+  - Easier comparison point against built-in MLX quantization
+- `turboquant_adaptive`
+  - Lower KV memory with safer quality than full TurboQuant
+  - Best current experimental candidate
+- `turboquant`
+  - Most aggressive compression path currently available
+  - Higher quality risk than adaptive mode
+
+In the current implementation, these backends may be slower than baseline decode in exchange for reduced KV memory use and better long-context headroom.
+
+## Supported Cache Layouts
+
+The current TurboQuant implementation compresses only standard `KVCache` entries and preserves these cache types unchanged:
+
+- `ArraysCache`
+- `RotatingKVCache`
+
+Mixed cache layouts such as these are supported:
+
+- `KVCache` + `ArraysCache`
+- `KVCache` + `RotatingKVCache`
+- `KVCache` + `ArraysCache` + `RotatingKVCache`
+
+If a model uses other cache types, Skulk will fail with an explicit error showing the discovered cache types.
+
+## Current Limitations
+
+These backends are still experimental.
+
+- Quantized KV cache backends do not yet support batch/history mode
+- When `mlx_quantized`, `turboquant`, or `turboquant_adaptive` is enabled, Skulk currently forces sequential generation as a temporary safety fallback
+- The current TurboQuant path is correctness-first and does not yet include:
+  - QJL residual correction
+  - bit-packed storage
+  - fused kernels
+  - optimized incremental dequant paths
+  - full paper-faithful TurboQuant estimator behavior
+
+The forced sequential fallback should be removed once quantized KV cache backends support batch/history semantics properly.
+
+## Manual Testing Guidance
+
+The most useful current comparisons are:
+
+1. `default`
+2. `mlx_quantized`
+3. `turboquant_adaptive`
+
+Recommended prompt sequence:
+
+1. Short prompt sanity check
+2. Multi-turn factual recall
+3. Long-context retrieval
+4. Long-context summarization
+
+Things to compare:
+
+- completion success vs failure
+- obvious quality degradation
+- follow-up turn correctness
+- long-context recall
+- subjective latency
+- memory headroom and stability
+
+## Roadmap
+
+The next major steps are:
+
+1. add observability and backend-specific runtime logging
+2. build a repeatable evaluation harness
+3. add TurboQuantProd-style QJL residual correction so inner product estimates are unbiased
+4. replace the current Gaussian codebooks with precomputed Beta codebooks
+5. retune adaptive defaults across more models after the estimator path is improved
+6. add real batch/history support so the forced sequential fallback can be removed
+7. implement bit-packing and better decode efficiency
+8. evaluate whether deeper kernel-level optimization, including fused kernels, is justified

--- a/exo.yaml.example
+++ b/exo.yaml.example
@@ -8,6 +8,11 @@
 # every node in your cluster.  If this file is absent, exo behaves
 # identically to the upstream default (zero-config compatibility).
 #
+# NOTE: Experimental KV cache backend controls such as
+# EXO_KV_CACHE_BACKEND, EXO_KV_CACHE_BITS, EXO_TQ_K_BITS,
+# EXO_TQ_V_BITS, and EXO_TQ_FP16_LAYERS are currently environment
+# variables, not exo.yaml settings. See docs/kv-cache-backends.md.
+#
 # ─────────────────────────────────────────────────────────────────────────────
 # MODEL STORE
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/exo/shared/types/mlx.py
+++ b/src/exo/shared/types/mlx.py
@@ -4,18 +4,9 @@ from collections.abc import Sequence
 
 from mlx import core as mx
 from mlx import nn as nn
-from mlx_lm.models.cache import (
-    ArraysCache,
-    CacheList,
-    KVCache,
-    QuantizedKVCache,
-    RotatingKVCache,
-)
 
 # This list contains one cache entry per transformer layer
-KVCacheType = Sequence[
-    KVCache | RotatingKVCache | QuantizedKVCache | ArraysCache | CacheList
-]
+KVCacheType = Sequence[object]
 
 
 # Model is a wrapper function to fix the fact that mlx is not strongly typed in the same way that EXO is.

--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -5,7 +5,6 @@ import mlx.core as mx
 import psutil
 from mlx_lm.models.cache import (
     ArraysCache,
-    CacheList,
     KVCache,
     QuantizedKVCache,
     RotatingKVCache,
@@ -14,7 +13,23 @@ from mlx_lm.tokenizer_utils import TokenizerWrapper
 
 from exo.shared.types.memory import Memory
 from exo.shared.types.mlx import KVCacheType, Model
-from exo.worker.engines.mlx.constants import CACHE_GROUP_SIZE, KV_CACHE_BITS
+from exo.worker.engines.mlx.constants import (
+    CACHE_GROUP_SIZE,
+    DEFAULT_KV_CACHE_BACKEND,
+    DEFAULT_TURBOQUANT_K_BITS,
+    DEFAULT_TURBOQUANT_V_BITS,
+    KV_CACHE_BACKEND,
+    KV_CACHE_BITS,
+    TURBOQUANT_FP16_LAYERS,
+    TURBOQUANT_K_BITS,
+    TURBOQUANT_V_BITS,
+    KVCacheBackend,
+)
+from exo.worker.engines.mlx.turboquant import (
+    make_turboquant_adaptive_cache,
+    make_turboquant_cache_from_template,
+)
+from exo.worker.engines.mlx.turboquant.cache import ensure_standard_attention
 from exo.worker.runner.bootstrap import logger
 
 
@@ -200,7 +215,7 @@ class KVPrefixCache:
             # Reset cache offset to match trimmed length
             for c in prompt_cache:
                 if hasattr(c, "offset"):
-                    c.offset = restore_pos
+                    c.offset = restore_pos  # pyright: ignore[reportAttributeAccessIssue]
 
         self._access_counter += 1
         self._last_used[best_index] = self._access_counter
@@ -255,7 +270,9 @@ def trim_cache(
             else:
                 c.state = [None] * len(c.state)
         else:
-            c.trim(num_tokens)
+            trim_fn = getattr(c, "trim", None)
+            if callable(trim_fn):
+                trim_fn(num_tokens)
 
 
 def encode_prompt(tokenizer: TokenizerWrapper, prompt: str) -> mx.array:
@@ -270,12 +287,10 @@ def encode_prompt(tokenizer: TokenizerWrapper, prompt: str) -> mx.array:
     return mx.array(prompt_tokens)
 
 
-def _entry_length(
-    c: KVCache | RotatingKVCache | QuantizedKVCache | ArraysCache | CacheList,
-) -> int:
+def _entry_length(c: object) -> int:
     # Use .offset attribute which KVCache types have (len() not implemented in older QuantizedKVCache).
     if hasattr(c, "offset"):
-        return c.offset
+        return int(c.offset)  # type: ignore[attr-defined]
     # For CacheList
     if hasattr(c, "size"):
         return int(c.size())  # type: ignore
@@ -314,20 +329,67 @@ def make_kv_cache(
 ) -> KVCacheType:
     assert hasattr(model, "layers")
 
+    backend = get_kv_cache_backend()
+    if max_kv_size is not None:
+        logger.info(f"Using rotating KV cache with {max_kv_size=} with {keep=}")
+        return [RotatingKVCache(max_size=max_kv_size, keep=keep) for _ in model.layers]
+
+    if backend == "mlx_quantized":
+        if KV_CACHE_BITS is None:
+            raise ValueError(
+                "EXO_KV_CACHE_BACKEND=mlx_quantized requires EXO_KV_CACHE_BITS to be set"
+            )
+        logger.info(
+            f"Using MLX quantized KV cache with bits={KV_CACHE_BITS} group_size={CACHE_GROUP_SIZE}"
+        )
+        return [
+            QuantizedKVCache(group_size=CACHE_GROUP_SIZE, bits=KV_CACHE_BITS)
+            for _ in model.layers
+        ]
+
+    if backend in ("turboquant", "turboquant_adaptive"):
+        ensure_standard_attention(model)
+        key_bits = TURBOQUANT_K_BITS or DEFAULT_TURBOQUANT_K_BITS
+        value_bits = TURBOQUANT_V_BITS or DEFAULT_TURBOQUANT_V_BITS
+        if backend == "turboquant_adaptive":
+            logger.info(
+                "Using TurboQuant adaptive KV cache "
+                f"with key_bits={key_bits} value_bits={value_bits} fp16_layers={TURBOQUANT_FP16_LAYERS}"
+            )
+            return make_turboquant_adaptive_cache(
+                model,
+                key_bits=key_bits,
+                value_bits=value_bits,
+                fp16_layers=TURBOQUANT_FP16_LAYERS,
+            )
+        logger.info(
+            f"Using TurboQuant KV cache with key_bits={key_bits} value_bits={value_bits}"
+        )
+        return make_turboquant_cache_from_template(
+            model,
+            key_bits=key_bits,
+            value_bits=value_bits,
+        )
+
     if hasattr(model, "make_cache"):
         logger.info("Using MLX LM's make cache")
         return model.make_cache()  # type: ignore
 
-    if max_kv_size is None:
-        if KV_CACHE_BITS is None:
-            logger.info("Using default KV cache")
-            return [KVCache() for _ in model.layers]
-        else:
-            logger.info("Using quantized KV cache")
-            return [
-                QuantizedKVCache(group_size=CACHE_GROUP_SIZE, bits=KV_CACHE_BITS)
-                for _ in model.layers
-            ]
-    else:
-        logger.info(f"Using rotating KV cache with {max_kv_size=} with {keep=}")
-        return [RotatingKVCache(max_size=max_kv_size, keep=keep) for _ in model.layers]
+    logger.info("Using default KV cache")
+    return [KVCache() for _ in model.layers]
+
+
+def get_kv_cache_backend() -> KVCacheBackend:
+    backend = KV_CACHE_BACKEND
+    valid_backends: tuple[KVCacheBackend, ...] = (
+        "default",
+        "mlx_quantized",
+        "turboquant",
+        "turboquant_adaptive",
+    )
+    if backend not in valid_backends:
+        logger.warning(
+            f"Unknown EXO_KV_CACHE_BACKEND={backend!r}; falling back to {DEFAULT_KV_CACHE_BACKEND!r}"
+        )
+        return DEFAULT_KV_CACHE_BACKEND
+    return backend

--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -1,5 +1,6 @@
 import os
 from copy import deepcopy
+from typing import cast
 
 import mlx.core as mx
 import psutil
@@ -342,6 +343,23 @@ def make_kv_cache(
         logger.info(
             f"Using MLX quantized KV cache with bits={KV_CACHE_BITS} group_size={CACHE_GROUP_SIZE}"
         )
+        if hasattr(model, "make_cache"):
+            template_cache = cast(
+                list[object],
+                model.make_cache(),  # type: ignore[reportUnknownMemberType]
+            )
+            caches: list[object] = []
+            for entry in template_cache:
+                if isinstance(entry, KVCache):
+                    caches.append(
+                        QuantizedKVCache(
+                            group_size=CACHE_GROUP_SIZE,
+                            bits=KV_CACHE_BITS,
+                        )
+                    )
+                else:
+                    caches.append(entry)
+            return caches
         return [
             QuantizedKVCache(group_size=CACHE_GROUP_SIZE, bits=KV_CACHE_BITS)
             for _ in model.layers

--- a/src/exo/worker/engines/mlx/constants.py
+++ b/src/exo/worker/engines/mlx/constants.py
@@ -1,3 +1,6 @@
+import os
+from typing import Literal, cast
+
 # TODO: Do we want so many constants?
 #  I think we want a lot of these as parameters?
 
@@ -9,7 +12,31 @@ MAX_KV_SIZE: int | None = 3200
 KEEP_KV_SIZE: int | None = 1600
 QUANTIZE_MODEL_MODE: str | None = "affine"
 CACHE_GROUP_SIZE: int = 64
-KV_CACHE_BITS: int | None = None
+KV_CACHE_BITS: int | None = (
+    int(os.environ["EXO_KV_CACHE_BITS"])
+    if "EXO_KV_CACHE_BITS" in os.environ
+    else None
+)
+KVCacheBackend = Literal[
+    "default",
+    "mlx_quantized",
+    "turboquant",
+    "turboquant_adaptive",
+]
+DEFAULT_KV_CACHE_BACKEND: KVCacheBackend = "default"
+KV_CACHE_BACKEND: KVCacheBackend = cast(
+    KVCacheBackend,
+    os.environ.get("EXO_KV_CACHE_BACKEND", DEFAULT_KV_CACHE_BACKEND),
+)
+TURBOQUANT_K_BITS: int | None = (
+    int(os.environ["EXO_TQ_K_BITS"]) if "EXO_TQ_K_BITS" in os.environ else None
+)
+TURBOQUANT_V_BITS: int | None = (
+    int(os.environ["EXO_TQ_V_BITS"]) if "EXO_TQ_V_BITS" in os.environ else None
+)
+TURBOQUANT_FP16_LAYERS: int = int(os.environ.get("EXO_TQ_FP16_LAYERS", "4"))
+DEFAULT_TURBOQUANT_K_BITS: int = 3
+DEFAULT_TURBOQUANT_V_BITS: int = 4
 
 DEFAULT_TOP_LOGPROBS: int = 5
 

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -47,6 +47,7 @@ from exo.worker.engines.mlx.cache import (
 from exo.worker.engines.mlx.constants import (
     DEFAULT_TOP_LOGPROBS,
     KV_BITS,
+    KV_CACHE_BACKEND,
     KV_GROUP_SIZE,
     MAX_TOKENS,
 )
@@ -64,6 +65,10 @@ _MIN_PREFIX_HIT_RATIO_TO_UPDATE = 0.5
 
 class PrefillCancelled(BaseException):
     """Raised when prefill is cancelled via the progress callback."""
+
+
+def _noop_quantize_cache(_cache: KVCacheType) -> None:
+    return None
 
 
 def _has_pipeline_communication_layer(model: Model):
@@ -106,12 +111,19 @@ def pipeline_parallel_prefill(
     """
     prefill_step_size = prefill_step_size // min(4, group.size())
 
-    quantize_cache_fn: Callable[..., None] = functools.partial(
-        maybe_quantize_kv_cache,
-        quantized_kv_start=0,
-        kv_group_size=kv_group_size,
-        kv_bits=kv_bits,
-    )
+    quantize_cache_fn: Callable[[KVCacheType], None]
+    if KV_CACHE_BACKEND == "mlx_quantized":
+        quantize_cache_fn = cast(
+            Callable[[KVCacheType], None],
+            functools.partial(
+            maybe_quantize_kv_cache,
+            quantized_kv_start=0,
+            kv_group_size=kv_group_size,
+            kv_bits=kv_bits,
+            ),
+        )
+    else:
+        quantize_cache_fn = _noop_quantize_cache
 
     _prompt_cache: KVCacheType = prompt_cache
     rank = group.rank()
@@ -293,7 +305,9 @@ def prefill(
                 cache[i] = deepcopy(pre_gen.states[i])  # type: ignore
         else:
             assert not isinstance(c, (ArraysCache, RotatingKVCache))
-            c.trim(2)
+            trim_fn = getattr(c, "trim", None)
+            assert callable(trim_fn)
+            trim_fn(2)
 
     elapsed = time.perf_counter() - start_time
     tokens_per_sec = num_tokens / elapsed if elapsed > 0 else 0.0

--- a/src/exo/worker/engines/mlx/turboquant/__init__.py
+++ b/src/exo/worker/engines/mlx/turboquant/__init__.py
@@ -1,0 +1,11 @@
+from exo.worker.engines.mlx.turboquant.cache import (
+    TurboQuantKVCache,
+    make_turboquant_adaptive_cache,
+    make_turboquant_cache_from_template,
+)
+
+__all__ = [
+    "TurboQuantKVCache",
+    "make_turboquant_adaptive_cache",
+    "make_turboquant_cache_from_template",
+]

--- a/src/exo/worker/engines/mlx/turboquant/cache.py
+++ b/src/exo/worker/engines/mlx/turboquant/cache.py
@@ -1,0 +1,381 @@
+from collections.abc import Sequence
+from typing import cast
+
+import mlx.core as mx
+from mlx_lm.models.cache import (
+    ArraysCache,
+    KVCache,
+    RotatingKVCache,
+    create_attention_mask,
+)
+
+from exo.shared.types.mlx import KVCacheType, Model
+from exo.worker.engines.mlx.turboquant.quantizer import TurboQuantizer
+
+
+class TurboQuantKVCache:
+    step = 256
+
+    def __init__(
+        self,
+        *,
+        key_bits: int,
+        value_bits: int,
+        seed: int = 42,
+    ) -> None:
+        self.key_bits = key_bits
+        self.value_bits = value_bits
+        self.seed = seed
+        self.offset = 0
+
+        self.key_indices: mx.array | None = None
+        self.key_norms: mx.array | None = None
+        self.value_indices: mx.array | None = None
+        self.value_norms: mx.array | None = None
+
+        self.key_dim: int | None = None
+        self.value_dim: int | None = None
+        self._key_quantizer: TurboQuantizer | None = None
+        self._value_quantizer: TurboQuantizer | None = None
+
+    def _ensure_quantizers(self, key_dim: int, value_dim: int) -> None:
+        if self._key_quantizer is None:
+            self._key_quantizer = TurboQuantizer(key_dim, self.key_bits, self.seed)
+            self.key_dim = key_dim
+        if self._value_quantizer is None:
+            self._value_quantizer = TurboQuantizer(
+                value_dim,
+                self.value_bits,
+                self.seed + 1,
+            )
+            self.value_dim = value_dim
+
+    def _expand_storage(
+        self,
+        batch_size: int,
+        kv_heads: int,
+        steps: int,
+        key_dim: int,
+        value_dim: int,
+    ) -> None:
+        needed = self.offset + steps
+        if self.key_indices is not None and needed <= self.key_indices.shape[2]:
+            return
+
+        new_steps = ((steps + self.step - 1) // self.step) * self.step
+        base_shape = (batch_size, kv_heads, new_steps)
+        new_key_indices = mx.zeros((*base_shape, key_dim), dtype=mx.uint8)
+        new_key_norms = mx.zeros(base_shape, dtype=mx.float32)
+        new_value_indices = mx.zeros((*base_shape, value_dim), dtype=mx.uint8)
+        new_value_norms = mx.zeros(base_shape, dtype=mx.float32)
+
+        old_key_indices = self.key_indices
+        old_key_norms = self.key_norms
+        old_value_indices = self.value_indices
+        old_value_norms = self.value_norms
+        if old_key_indices is None:
+            self.key_indices = new_key_indices
+            self.key_norms = new_key_norms
+            self.value_indices = new_value_indices
+            self.value_norms = new_value_norms
+            return
+
+        assert old_key_norms is not None
+        assert old_value_indices is not None
+        assert old_value_norms is not None
+        self.key_indices = mx.concatenate(
+            [old_key_indices[..., : self.offset, :], new_key_indices],
+            axis=2,
+        )
+        self.key_norms = mx.concatenate(
+            [old_key_norms[..., : self.offset], new_key_norms],
+            axis=2,
+        )
+        self.value_indices = mx.concatenate(
+            [old_value_indices[..., : self.offset, :], new_value_indices],
+            axis=2,
+        )
+        self.value_norms = mx.concatenate(
+            [old_value_norms[..., : self.offset], new_value_norms],
+            axis=2,
+        )
+
+    def update_and_fetch(
+        self,
+        keys: mx.array,
+        values: mx.array,
+    ) -> tuple[mx.array, mx.array]:
+        batch_size, kv_heads, steps, key_dim = keys.shape
+        value_dim = int(values.shape[3])
+        prev = self.offset
+
+        self._ensure_quantizers(key_dim, value_dim)
+        self._expand_storage(batch_size, kv_heads, steps, key_dim, value_dim)
+
+        assert self.key_indices is not None
+        assert self.key_norms is not None
+        assert self.value_indices is not None
+        assert self.value_norms is not None
+        assert self._key_quantizer is not None
+        assert self._value_quantizer is not None
+
+        key_indices, key_norms = self._key_quantizer.quantize(keys.reshape(-1, key_dim))
+        value_indices, value_norms = self._value_quantizer.quantize(
+            values.reshape(-1, value_dim)
+        )
+
+        self.key_indices[..., prev : prev + steps, :] = key_indices.reshape(
+            batch_size,
+            kv_heads,
+            steps,
+            key_dim,
+        )
+        self.key_norms[..., prev : prev + steps] = key_norms.reshape(
+            batch_size,
+            kv_heads,
+            steps,
+        )
+        self.value_indices[..., prev : prev + steps, :] = value_indices.reshape(
+            batch_size,
+            kv_heads,
+            steps,
+            value_dim,
+        )
+        self.value_norms[..., prev : prev + steps] = value_norms.reshape(
+            batch_size,
+            kv_heads,
+            steps,
+        )
+        self.offset += steps
+
+        dequant_keys = self._key_quantizer.dequantize(
+            self.key_indices[..., : self.offset, :],
+            self.key_norms[..., : self.offset],
+            keys.dtype,
+        )
+        dequant_values = self._value_quantizer.dequantize(
+            self.value_indices[..., : self.offset, :],
+            self.value_norms[..., : self.offset],
+            values.dtype,
+        )
+        return dequant_keys, dequant_values
+
+    def size(self) -> int:
+        return self.offset
+
+    @property
+    def state(self) -> object:
+        if self.key_indices is None:
+            return []
+        assert self.key_norms is not None
+        assert self.value_indices is not None
+        assert self.value_norms is not None
+        return (
+            self.key_indices[..., : self.offset, :],
+            self.key_norms[..., : self.offset],
+            self.value_indices[..., : self.offset, :],
+            self.value_norms[..., : self.offset],
+        )
+
+    @state.setter
+    def state(self, v: object) -> None:
+        (
+            self.key_indices,
+            self.key_norms,
+            self.value_indices,
+            self.value_norms,
+        ) = cast(Sequence[mx.array], v)
+        self.offset = int(self.key_indices.shape[2])
+
+    @property
+    def meta_state(self) -> object:
+        key_dim = -1 if self.key_dim is None else self.key_dim
+        value_dim = -1 if self.value_dim is None else self.value_dim
+        return (
+            str(self.offset),
+            str(self.key_bits),
+            str(self.value_bits),
+            str(self.seed),
+            str(key_dim),
+            str(value_dim),
+        )
+
+    @meta_state.setter
+    def meta_state(self, v: object) -> None:
+        (
+            offset,
+            key_bits,
+            value_bits,
+            seed,
+            key_dim,
+            value_dim,
+        ) = map(int, cast(Sequence[str], v))
+        self.offset = offset
+        self.key_bits = key_bits
+        self.value_bits = value_bits
+        self.seed = seed
+        self.key_dim = None if key_dim < 0 else key_dim
+        self.value_dim = None if value_dim < 0 else value_dim
+        self._key_quantizer = (
+            None
+            if self.key_dim is None
+            else TurboQuantizer(self.key_dim, self.key_bits, self.seed)
+        )
+        self._value_quantizer = (
+            None
+            if self.value_dim is None
+            else TurboQuantizer(self.value_dim, self.value_bits, self.seed + 1)
+        )
+
+    def is_trimmable(self) -> bool:
+        return True
+
+    def trim(self, n: int) -> int:
+        trimmed = min(self.offset, n)
+        self.offset -= trimmed
+        return trimmed
+
+    def make_mask(self, *args: object, **kwargs: object) -> object:
+        if len(args) == 0 or not isinstance(args[0], int):
+            return None
+        window_size = kwargs.get("window_size")
+        return_array = kwargs.get("return_array", False)
+        if not isinstance(window_size, (int, type(None))):
+            return None
+        if not isinstance(return_array, bool):
+            return None
+        return create_attention_mask(
+            args[0],
+            offset=self.offset,
+            window_size=window_size,
+            return_array=return_array,
+        )
+
+    def empty(self) -> bool:
+        return self.key_indices is None
+
+    @property
+    def nbytes(self) -> int:
+        if self.key_indices is None:
+            return 0
+        assert self.key_norms is not None
+        assert self.value_indices is not None
+        assert self.value_norms is not None
+        return (
+            self.key_indices.nbytes
+            + self.key_norms.nbytes
+            + self.value_indices.nbytes
+            + self.value_norms.nbytes
+        )
+
+
+def ensure_standard_attention(model: Model) -> None:
+    if not hasattr(model, "make_cache"):
+        return
+
+    sample_cache = cast(
+        list[object],
+        model.make_cache(),  # type: ignore[reportUnknownMemberType]
+    )
+    if len(sample_cache) == 0:
+        return
+    if not all(
+        isinstance(entry, (KVCache, ArraysCache, RotatingKVCache))
+        for entry in sample_cache
+    ):
+        cache_types = ", ".join(sorted({type(entry).__name__ for entry in sample_cache}))
+        raise ValueError(
+            "TurboQuant backend currently supports KVCache entries plus optional ArraysCache "
+            "and RotatingKVCache entries; "
+            f"found cache type(s): {cache_types}"
+        )
+
+
+def make_turboquant_cache_from_template(
+    model: Model,
+    *,
+    key_bits: int,
+    value_bits: int,
+    seed: int = 42,
+) -> KVCacheType:
+    ensure_standard_attention(model)
+    if not hasattr(model, "make_cache"):
+        return [
+            TurboQuantKVCache(
+                key_bits=key_bits,
+                value_bits=value_bits,
+                seed=seed + index,
+            )
+            for index, _layer in enumerate(model.layers)
+        ]
+
+    template_cache = cast(
+        list[object],
+        model.make_cache(),  # type: ignore[reportUnknownMemberType]
+    )
+    caches: list[object] = []
+    kv_index = 0
+    for entry in template_cache:
+        if isinstance(entry, KVCache):
+            caches.append(
+                TurboQuantKVCache(
+                    key_bits=key_bits,
+                    value_bits=value_bits,
+                    seed=seed + kv_index,
+                )
+            )
+            kv_index += 1
+        else:
+            caches.append(entry)
+    return caches
+
+
+def make_turboquant_adaptive_cache(
+    model: Model,
+    *,
+    key_bits: int,
+    value_bits: int,
+    fp16_layers: int,
+    seed: int = 42,
+) -> KVCacheType:
+    ensure_standard_attention(model)
+    if not hasattr(model, "make_cache"):
+        caches: list[object] = []
+        for index, _layer in enumerate(model.layers):
+            if index < fp16_layers or index >= len(model.layers) - fp16_layers:
+                caches.append(KVCache())
+            else:
+                caches.append(
+                    TurboQuantKVCache(
+                        key_bits=key_bits,
+                        value_bits=value_bits,
+                        seed=seed + index,
+                    )
+                )
+        return caches
+
+    template_cache = cast(
+        list[object],
+        model.make_cache(),  # type: ignore[reportUnknownMemberType]
+    )
+    kv_positions = [
+        index for index, entry in enumerate(template_cache) if isinstance(entry, KVCache)
+    ]
+    caches = []
+    for index, entry in enumerate(template_cache):
+        if not isinstance(entry, KVCache):
+            caches.append(entry)
+            continue
+
+        kv_order = kv_positions.index(index)
+        if kv_order < fp16_layers or kv_order >= len(kv_positions) - fp16_layers:
+            caches.append(KVCache())
+        else:
+            caches.append(
+                TurboQuantKVCache(
+                    key_bits=key_bits,
+                    value_bits=value_bits,
+                    seed=seed + kv_order,
+                )
+            )
+    return caches

--- a/src/exo/worker/engines/mlx/turboquant/quantizer.py
+++ b/src/exo/worker/engines/mlx/turboquant/quantizer.py
@@ -1,0 +1,83 @@
+import math
+
+import mlx.core as mx
+
+from exo.worker.engines.mlx.turboquant.rotation import (
+    inverse_randomized_hadamard_transform,
+    is_power_of_two,
+    randomized_hadamard_transform,
+    randomized_signs,
+)
+
+_GAUSSIAN_CODEBOOKS: dict[int, list[float]] = {
+    1: [-0.7979, 0.7979],
+    2: [-1.5104, -0.4528, 0.4528, 1.5104],
+    3: [-2.1520, -1.3440, -0.7560, -0.2451, 0.2451, 0.7560, 1.3440, 2.1520],
+    4: [
+        -2.7326,
+        -2.0690,
+        -1.6180,
+        -1.2562,
+        -0.9423,
+        -0.6568,
+        -0.3881,
+        -0.1284,
+        0.1284,
+        0.3881,
+        0.6568,
+        0.9423,
+        1.2562,
+        1.6180,
+        2.0690,
+        2.7326,
+    ],
+}
+
+
+class TurboQuantizer:
+    def __init__(self, dim: int, bits: int, seed: int) -> None:
+        if bits not in _GAUSSIAN_CODEBOOKS:
+            raise ValueError(f"Unsupported TurboQuant bit width: {bits}")
+        if not is_power_of_two(dim):
+            raise ValueError(
+                f"TurboQuant currently requires power-of-two head dimensions, got {dim}"
+            )
+
+        self.dim = dim
+        self.bits = bits
+        self.signs = randomized_signs(dim, seed)
+        self.centroids = mx.array(_GAUSSIAN_CODEBOOKS[bits], dtype=mx.float32)
+        self.boundary_values = [
+            (left + right) / 2.0
+            for left, right in zip(
+                _GAUSSIAN_CODEBOOKS[bits][:-1],
+                _GAUSSIAN_CODEBOOKS[bits][1:],
+                strict=True,
+            )
+        ]
+        self.scale = 1.0 / math.sqrt(dim)
+
+    def quantize(self, x: mx.array) -> tuple[mx.array, mx.array]:
+        x32 = x.astype(mx.float32)
+        norms = mx.sqrt(mx.sum(x32 * x32, axis=-1, keepdims=True))
+        safe_norms = mx.maximum(norms, 1e-8)
+        unit = x32 / safe_norms
+        rotated = randomized_hadamard_transform(unit, self.signs)
+        scaled = rotated / self.scale
+
+        indices = mx.zeros(scaled.shape, dtype=mx.uint8)
+        for boundary in self.boundary_values:
+            indices = indices + (scaled > boundary).astype(mx.uint8)
+        return indices, mx.squeeze(norms, axis=-1)
+
+    def dequantize(
+        self,
+        indices: mx.array,
+        norms: mx.array,
+        output_dtype: mx.Dtype,
+    ) -> mx.array:
+        flat = indices.reshape(-1).astype(mx.int32)
+        values = self.centroids[flat].reshape(*indices.shape)
+        values = values * self.scale
+        restored = inverse_randomized_hadamard_transform(values, self.signs)
+        return (restored * norms[..., None]).astype(output_dtype)

--- a/src/exo/worker/engines/mlx/turboquant/rotation.py
+++ b/src/exo/worker/engines/mlx/turboquant/rotation.py
@@ -1,0 +1,39 @@
+from typing import cast
+
+import mlx.core as mx
+
+
+def is_power_of_two(value: int) -> bool:
+    return value > 0 and (value & (value - 1)) == 0
+
+
+def randomized_signs(dim: int, seed: int) -> mx.array:
+    indices = mx.arange(dim, dtype=mx.int32)
+    return (((indices * 1103515245 + seed) % 2).astype(mx.float32) * 2.0) - 1.0
+
+
+def hadamard_transform(x: mx.array) -> mx.array:
+    dim = int(x.shape[-1])
+    if not is_power_of_two(dim):
+        raise ValueError(f"Hadamard transform requires power-of-two dimension, got {dim}")
+
+    output = x
+    step = 1
+    while step < dim:
+        reshaped = output.reshape(*output.shape[:-1], dim // (2 * step), 2, step)
+        left = reshaped[..., 0, :]
+        right = reshaped[..., 1, :]
+        output = mx.concatenate([left + right, left - right], axis=-1).reshape(
+            *x.shape[:-1],
+            dim,
+        )
+        step *= 2
+    return cast(mx.array, output / (dim**0.5))
+
+
+def randomized_hadamard_transform(x: mx.array, signs: mx.array) -> mx.array:
+    return hadamard_transform(x * signs)
+
+
+def inverse_randomized_hadamard_transform(x: mx.array, signs: mx.array) -> mx.array:
+    return hadamard_transform(x) * signs

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -52,7 +52,7 @@ from exo.shared.types.worker.runners import (
     RunnerWarmingUp,
 )
 from exo.utils.channels import MpReceiver, MpSender
-from exo.worker.engines.mlx.cache import KVPrefixCache
+from exo.worker.engines.mlx.cache import KVPrefixCache, get_kv_cache_backend
 from exo.worker.engines.mlx.utils_mlx import (
     initialize_mlx,
     load_mlx_items,
@@ -405,8 +405,24 @@ class Builder:
         kv_prefix_cache = KVPrefixCache(self.group)
 
         device_rank = 0 if self.group is None else self.group.rank()
-        if os.environ.get("EXO_NO_BATCH"):
-            logger.info("using SequentialGenerator (batching disabled)")
+        kv_backend = get_kv_cache_backend()
+        # TODO: Remove this forced sequential fallback once quantized KV cache
+        # backends support BatchGenerator history merge/extract semantics.
+        force_sequential = kv_backend in (
+            "mlx_quantized",
+            "turboquant",
+            "turboquant_adaptive",
+        )
+        if os.environ.get("EXO_NO_BATCH") or force_sequential:
+            if force_sequential and not os.environ.get("EXO_NO_BATCH"):
+                logger.warning(
+                    "Quantized KV cache backend does not yet support "
+                    "batch/history mode; forcing SequentialGenerator "
+                    f"(kv_backend={kv_backend})"
+                )
+                logger.info(f"using SequentialGenerator (kv_backend={kv_backend})")
+            else:
+                logger.info("using SequentialGenerator (batching disabled)")
             return SequentialGenerator(
                 model=self.inference_model,
                 tokenizer=self.tokenizer,

--- a/src/exo/worker/tests/unittests/test_mlx/test_batch_vs_generate.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_batch_vs_generate.py
@@ -140,8 +140,8 @@ def _compare_cache_arrays(
         assert type(a) is type(b), (
             f"{label}Layer {i}: type {type(a).__name__} vs {type(b).__name__}"
         )
-        states_a = a.state
-        states_b = b.state
+        states_a = _safe_state(a)
+        states_b = _safe_state(b)
         assert len(states_a) == len(states_b), (
             f"{label}Layer {i}: state count {len(states_a)} vs {len(states_b)}"
         )

--- a/src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import mlx.core as mx
 import pytest
-from mlx_lm.models.cache import KVCache
+from mlx_lm.models.cache import KVCache, QuantizedKVCache
 from mlx_lm.sample_utils import make_sampler
 
 from exo.shared.types.common import ModelId
@@ -15,6 +15,7 @@ from exo.worker.engines.mlx.cache import (
     KVPrefixCache,
     cache_length,
     encode_prompt,
+    get_kv_cache_backend,
     get_prefix_length,
     make_kv_cache,
 )
@@ -104,6 +105,82 @@ class TestKVPrefix:
         cache = KVPrefixCache(None)
         cache.clear()
         assert len(cache.prompts) == 0
+
+
+class TestKVCacheBackends:
+    def test_unknown_backend_falls_back_to_default(self):
+        with patch(
+            "exo.worker.engines.mlx.cache.KV_CACHE_BACKEND",
+            cast(object, "mystery"),
+        ):
+            assert get_kv_cache_backend() == "default"
+
+    def test_make_kv_cache_default_backend(self):
+        model = cast(Model, type("FakeModel", (), {"layers": [object(), object()]})())
+        with patch("exo.worker.engines.mlx.cache.KV_CACHE_BACKEND", "default"):
+            cache = make_kv_cache(model)
+
+        assert len(cache) == 2
+        assert all(isinstance(layer, KVCache) for layer in cache)
+
+    def test_make_kv_cache_mlx_quantized_backend(self):
+        model = cast(Model, type("FakeModel", (), {"layers": [object(), object()]})())
+        with (
+            patch("exo.worker.engines.mlx.cache.KV_CACHE_BACKEND", "mlx_quantized"),
+            patch("exo.worker.engines.mlx.cache.KV_CACHE_BITS", 4),
+            patch("exo.worker.engines.mlx.cache.CACHE_GROUP_SIZE", 32),
+        ):
+            cache = make_kv_cache(model)
+
+        assert len(cache) == 2
+        assert all(isinstance(layer, QuantizedKVCache) for layer in cache)
+
+    def test_make_kv_cache_mlx_quantized_backend_requires_bits(self):
+        model = cast(Model, type("FakeModel", (), {"layers": [object()]})())
+        with (
+            patch("exo.worker.engines.mlx.cache.KV_CACHE_BACKEND", "mlx_quantized"),
+            patch("exo.worker.engines.mlx.cache.KV_CACHE_BITS", None),
+            pytest.raises(ValueError, match="EXO_KV_CACHE_BITS"),
+        ):
+            _ = make_kv_cache(model)
+
+    def test_make_kv_cache_turboquant_backend(self):
+        class FakeModel:
+            layers = [object(), object()]
+
+            def make_cache(self):
+                return [KVCache(), KVCache()]
+
+        model = cast(Model, FakeModel())
+        with (
+            patch("exo.worker.engines.mlx.cache.KV_CACHE_BACKEND", "turboquant"),
+            patch("exo.worker.engines.mlx.cache.TURBOQUANT_K_BITS", 3),
+            patch("exo.worker.engines.mlx.cache.TURBOQUANT_V_BITS", 4),
+        ):
+            cache = make_kv_cache(model)
+
+        assert len(cache) == 2
+
+    def test_make_kv_cache_turboquant_adaptive_backend(self):
+        class FakeModel:
+            layers = [object(), object(), object(), object()]
+
+            def make_cache(self):
+                return [KVCache(), KVCache(), KVCache(), KVCache()]
+
+        model = cast(Model, FakeModel())
+        with (
+            patch(
+                "exo.worker.engines.mlx.cache.KV_CACHE_BACKEND",
+                "turboquant_adaptive",
+            ),
+            patch("exo.worker.engines.mlx.cache.TURBOQUANT_K_BITS", 3),
+            patch("exo.worker.engines.mlx.cache.TURBOQUANT_V_BITS", 4),
+            patch("exo.worker.engines.mlx.cache.TURBOQUANT_FP16_LAYERS", 1),
+        ):
+            cache = make_kv_cache(model)
+
+        assert len(cache) == 4
 
 
 def _load_gpt_oss() -> tuple[Model, object]:

--- a/src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_kv_prefix_cache.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import mlx.core as mx
 import pytest
-from mlx_lm.models.cache import KVCache, QuantizedKVCache
+from mlx_lm.models.cache import ArraysCache, KVCache, QuantizedKVCache, RotatingKVCache
 from mlx_lm.sample_utils import make_sampler
 
 from exo.shared.types.common import ModelId
@@ -134,6 +134,44 @@ class TestKVCacheBackends:
 
         assert len(cache) == 2
         assert all(isinstance(layer, QuantizedKVCache) for layer in cache)
+
+    def test_make_kv_cache_mlx_quantized_backend_preserves_arrays_cache(self):
+        class FakeModel:
+            layers = [object(), object(), object()]
+
+            def make_cache(self):
+                return [ArraysCache(1), KVCache(), KVCache()]
+
+        model = cast(Model, FakeModel())
+        with (
+            patch("exo.worker.engines.mlx.cache.KV_CACHE_BACKEND", "mlx_quantized"),
+            patch("exo.worker.engines.mlx.cache.KV_CACHE_BITS", 4),
+            patch("exo.worker.engines.mlx.cache.CACHE_GROUP_SIZE", 32),
+        ):
+            cache = make_kv_cache(model)
+
+        assert isinstance(cache[0], ArraysCache)
+        assert isinstance(cache[1], QuantizedKVCache)
+        assert isinstance(cache[2], QuantizedKVCache)
+
+    def test_make_kv_cache_mlx_quantized_backend_preserves_rotating_cache(self):
+        class FakeModel:
+            layers = [object(), object(), object()]
+
+            def make_cache(self):
+                return [RotatingKVCache(max_size=32), KVCache(), KVCache()]
+
+        model = cast(Model, FakeModel())
+        with (
+            patch("exo.worker.engines.mlx.cache.KV_CACHE_BACKEND", "mlx_quantized"),
+            patch("exo.worker.engines.mlx.cache.KV_CACHE_BITS", 4),
+            patch("exo.worker.engines.mlx.cache.CACHE_GROUP_SIZE", 32),
+        ):
+            cache = make_kv_cache(model)
+
+        assert isinstance(cache[0], RotatingKVCache)
+        assert isinstance(cache[1], QuantizedKVCache)
+        assert isinstance(cache[2], QuantizedKVCache)
 
     def test_make_kv_cache_mlx_quantized_backend_requires_bits(self):
         model = cast(Model, type("FakeModel", (), {"layers": [object()]})())

--- a/src/exo/worker/tests/unittests/test_mlx/test_turboquant_cache.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_turboquant_cache.py
@@ -1,0 +1,130 @@
+from typing import cast
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
+
+from exo.shared.types.mlx import Model
+from exo.worker.engines.mlx.turboquant.cache import (
+    TurboQuantKVCache,
+    ensure_standard_attention,
+    make_turboquant_adaptive_cache,
+    make_turboquant_cache_from_template,
+)
+
+
+class FakeStandardModel:
+    def __init__(self, num_layers: int) -> None:
+        self.layers = [object() for _ in range(num_layers)]
+
+    def make_cache(self) -> list[KVCache]:
+        return [KVCache() for _ in self.layers]
+
+
+class FakeUnsupportedCache:
+    pass
+
+
+class FakeUnsupportedModel:
+    def __init__(self) -> None:
+        self.layers = [object()]
+
+    def make_cache(self) -> list[FakeUnsupportedCache]:
+        return [FakeUnsupportedCache()]
+
+
+class FakeMixedCacheModel:
+    def __init__(self) -> None:
+        self.layers = [object(), object(), object()]
+
+    def make_cache(self) -> list[object]:
+        return [ArraysCache(1), KVCache(), KVCache()]
+
+
+class FakeRotatingMixedCacheModel:
+    def __init__(self) -> None:
+        self.layers = [object(), object(), object()]
+
+    def make_cache(self) -> list[object]:
+        return [RotatingKVCache(max_size=32), KVCache(), KVCache()]
+
+
+def test_turboquant_cache_roundtrip_shape_and_offset() -> None:
+    cache = TurboQuantKVCache(key_bits=3, value_bits=4)
+    keys = mx.random.normal(shape=(1, 2, 3, 128)).astype(mx.float16)
+    values = mx.random.normal(shape=(1, 2, 3, 128)).astype(mx.float16)
+
+    fetched_keys, fetched_values = cache.update_and_fetch(keys, values)
+
+    assert fetched_keys.shape == keys.shape
+    assert fetched_values.shape == values.shape
+    assert cache.offset == 3
+
+
+def test_turboquant_cache_state_and_meta_state_roundtrip() -> None:
+    cache = TurboQuantKVCache(key_bits=3, value_bits=4, seed=99)
+    keys = mx.random.normal(shape=(1, 1, 2, 128)).astype(mx.float16)
+    values = mx.random.normal(shape=(1, 1, 2, 128)).astype(mx.float16)
+    _ = cache.update_and_fetch(keys, values)
+
+    restored = TurboQuantKVCache(key_bits=1, value_bits=1)
+    restored.state = cache.state
+    restored.meta_state = cache.meta_state
+
+    assert restored.offset == cache.offset
+    assert restored.meta_state == cache.meta_state
+
+
+def test_turboquant_cache_trim() -> None:
+    cache = TurboQuantKVCache(key_bits=3, value_bits=4)
+    keys = mx.random.normal(shape=(1, 1, 4, 128)).astype(mx.float16)
+    values = mx.random.normal(shape=(1, 1, 4, 128)).astype(mx.float16)
+    _ = cache.update_and_fetch(keys, values)
+
+    trimmed = cache.trim(2)
+
+    assert trimmed == 2
+    assert cache.offset == 2
+
+
+def test_adaptive_cache_uses_fp16_outer_layers() -> None:
+    caches = make_turboquant_adaptive_cache(
+        cast(Model, cast(object, FakeStandardModel(6))),
+        key_bits=3,
+        value_bits=4,
+        fp16_layers=1,
+    )
+
+    assert isinstance(caches[0], KVCache)
+    assert isinstance(caches[-1], KVCache)
+    assert isinstance(caches[1], TurboQuantKVCache)
+    assert isinstance(caches[-2], TurboQuantKVCache)
+
+
+def test_ensure_standard_attention_rejects_unsupported_cache() -> None:
+    with pytest.raises(ValueError, match="RotatingKVCache entries"):
+        ensure_standard_attention(cast(Model, cast(object, FakeUnsupportedModel())))
+
+
+def test_make_turboquant_cache_from_template_preserves_arrays_cache() -> None:
+    caches = make_turboquant_cache_from_template(
+        cast(Model, cast(object, FakeMixedCacheModel())),
+        key_bits=3,
+        value_bits=4,
+    )
+
+    assert isinstance(caches[0], ArraysCache)
+    assert isinstance(caches[1], TurboQuantKVCache)
+    assert isinstance(caches[2], TurboQuantKVCache)
+
+
+def test_make_turboquant_cache_from_template_preserves_rotating_cache() -> None:
+    caches = make_turboquant_cache_from_template(
+        cast(Model, cast(object, FakeRotatingMixedCacheModel())),
+        key_bits=3,
+        value_bits=4,
+    )
+
+    assert isinstance(caches[0], RotatingKVCache)
+    assert isinstance(caches[1], TurboQuantKVCache)
+    assert isinstance(caches[2], TurboQuantKVCache)

--- a/src/exo/worker/tests/unittests/test_runner/test_turboquant_batch_guard.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_turboquant_batch_guard.py
@@ -1,0 +1,58 @@
+from typing import cast
+
+import mlx.core as mx
+import pytest
+from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+from exo.shared.types.common import ModelId
+from exo.shared.types.events import Event
+from exo.shared.types.mlx import Model
+from exo.shared.types.tasks import TaskId
+from exo.utils.channels import mp_channel
+from exo.worker.runner.llm_inference.batch_generator import (
+    BatchGenerator,
+    SequentialGenerator,
+)
+from exo.worker.runner.llm_inference.runner import Builder
+
+
+class _FakeTokenizer:
+    has_tool_calling = False
+    tool_call_start = None
+    tool_call_end = None
+    tool_parser = None
+
+
+class _FakeModel:
+    layers = []
+
+
+@pytest.mark.parametrize(
+    "kv_backend",
+    ["mlx_quantized", "turboquant", "turboquant_adaptive"],
+)
+def test_builder_forces_sequential_for_quantized_kv_backends(
+    monkeypatch: pytest.MonkeyPatch,
+    kv_backend: str,
+) -> None:
+    _, cancel_recv = mp_channel[TaskId]()
+    event_send, _ = mp_channel[Event]()
+
+    monkeypatch.setattr(
+        "exo.worker.runner.llm_inference.runner.get_kv_cache_backend",
+        lambda: kv_backend,
+    )
+
+    builder = Builder(
+        model_id=ModelId("test-model"),
+        event_sender=event_send,
+        cancel_receiver=cancel_recv,
+        inference_model=cast(Model, cast(object, _FakeModel())),
+        tokenizer=cast(TokenizerWrapper, cast(object, _FakeTokenizer())),
+        group=cast(mx.distributed.Group | None, None),
+    )
+
+    generator = builder.build()
+
+    assert isinstance(generator, SequentialGenerator)
+    assert not isinstance(generator, BatchGenerator)


### PR DESCRIPTION
## Summary
- add opt-in MLX quantized and TurboQuant KV cache backend selection
- add a correctness-first TurboQuant adaptive backend with mixed cache layout support
- document the new flags, current limitations, and roadmap

## Notes
- default behavior is unchanged unless `EXO_KV_CACHE_BACKEND` is set
- quantized KV cache backends currently force sequential generation as a temporary safety fallback because batch/history mode is not supported yet
- current recommended experimental setting is `turboquant_adaptive` with `EXO_TQ_K_BITS=3`, `EXO_TQ_V_BITS=4`, and `EXO_TQ_FP16_LAYERS=4`

## Validation
- focused `ruff`, `basedpyright`, and unit tests for the new MLX/TurboQuant paths passed
- full repo-wide checks still have unrelated pre-existing failures outside this change set