### PR TITLE
feat: chat phase 2 — conversations, history, context window

### DIFF
--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -16,6 +16,7 @@ import { InstancePanel, type InstanceCardData } from './components/layout/Instan
 import { addToast } from './hooks/useToast';
 import type { InstanceStatus } from './components/cluster/RunningInstanceCard';
 import { useChatStore } from './stores/chatStore';
+import { useUIStore } from './stores/uiStore';
 
 const Shell = styled.div`
   position: relative;
@@ -104,9 +105,10 @@ function deriveInstanceStatus(
 export function App() {
   const { topology, connected, downloads, nodeDisk, instances, runners } = useClusterState();
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [activeRoute, setActiveRoute] = useState<NavRoute>('cluster');
   const [storeDownloads, setStoreDownloads] = useState<StoreDownload[]>([]);
-  const [panelOpen, setPanelOpen] = useState(true);
+  const { activeRoute, panelOpen } = useUIStore();
+  const setActiveRoute = useUIStore((s) => s.setActiveRoute);
+  const togglePanel = useUIStore((s) => s.togglePanel);
 
   // Poll store downloads for the header progress indicator
   const pollStoreDownloads = useCallback(async () => {
@@ -211,7 +213,7 @@ export function App() {
           instanceCount={instanceCards.length}
           instancesHealthy={instanceCards.every((c) => c.status !== 'failed')}
           mobileRightOpen={panelOpen}
-          onToggleMobileRight={() => setPanelOpen((o) => !o)}
+          onToggleMobileRight={togglePanel}
         />
         <ContentRow>
           <Main>

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -15,6 +15,7 @@ import { ChatView } from './components/pages/ChatView';
 import { InstancePanel, type InstanceCardData } from './components/layout/InstancePanel';
 import { addToast } from './hooks/useToast';
 import type { InstanceStatus } from './components/cluster/RunningInstanceCard';
+import { useChatStore } from './stores/chatStore';
 
 const Shell = styled.div`
   position: relative;
@@ -37,7 +38,8 @@ const Main = styled.main`
   min-height: 0;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 `;
 
 interface StoreDownload {
@@ -105,7 +107,6 @@ export function App() {
   const [activeRoute, setActiveRoute] = useState<NavRoute>('cluster');
   const [storeDownloads, setStoreDownloads] = useState<StoreDownload[]>([]);
   const [panelOpen, setPanelOpen] = useState(true);
-  const [chatModelId, setChatModelId] = useState<string | undefined>(undefined);
 
   // Poll store downloads for the header progress indicator
   const pollStoreDownloads = useCallback(async () => {
@@ -212,9 +213,9 @@ export function App() {
           mobileRightOpen={panelOpen}
           onToggleMobileRight={() => setPanelOpen((o) => !o)}
         />
-        <ClusterWarnings topology={topology} />
         <ContentRow>
           <Main>
+            <ClusterWarnings topology={topology} />
             {activeRoute === 'model-store' ? (
               <ModelStorePage
                 topology={topology}
@@ -222,10 +223,10 @@ export function App() {
                 nodeDisk={nodeDisk}
                 instances={instances}
                 runners={runners}
-                onChat={(modelId) => { setChatModelId(modelId); setActiveRoute('chat'); }}
+                onChat={(modelId) => { useChatStore.getState().selectModel(modelId); setActiveRoute('chat'); }}
               />
             ) : activeRoute === 'chat' ? (
-              <ChatView readyInstances={instanceCards} initialModelId={chatModelId} />
+              <ChatView readyInstances={instanceCards} />
             ) : topology ? (
               <TopologyGraph data={topology} />
             ) : (
@@ -238,7 +239,7 @@ export function App() {
             <InstancePanel
               instances={instanceCards}
               onDelete={handleDeleteInstance}
-              onChat={(modelId) => { setChatModelId(modelId); setActiveRoute('chat'); }}
+              onChat={(modelId) => { useChatStore.getState().selectModel(modelId); setActiveRoute('chat'); }}
             />
           )}
         </ContentRow>

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -107,7 +107,9 @@ export function App() {
   const { topology, connected, downloads, nodeDisk, instances, runners } = useClusterState();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [storeDownloads, setStoreDownloads] = useState<StoreDownload[]>([]);
-  const { activeRoute, panelOpen, historyPanelOpen } = useUIStore();
+  const activeRoute = useUIStore((s) => s.activeRoute);
+  const panelOpen = useUIStore((s) => s.panelOpen);
+  const historyPanelOpen = useUIStore((s) => s.historyPanelOpen);
   const setActiveRoute = useUIStore((s) => s.setActiveRoute);
   const togglePanel = useUIStore((s) => s.togglePanel);
   const toggleHistoryPanel = useUIStore((s) => s.toggleHistoryPanel);

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -13,6 +13,7 @@ import { SettingsPanel } from './components/layout/SettingsPanel';
 import { ModelStorePage } from './components/pages/DownloadsPage';
 import { ChatView } from './components/pages/ChatView';
 import { InstancePanel, type InstanceCardData } from './components/layout/InstancePanel';
+import { ConversationPanel } from './components/layout/ConversationPanel';
 import { addToast } from './hooks/useToast';
 import type { InstanceStatus } from './components/cluster/RunningInstanceCard';
 import { useChatStore } from './stores/chatStore';
@@ -106,9 +107,20 @@ export function App() {
   const { topology, connected, downloads, nodeDisk, instances, runners } = useClusterState();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [storeDownloads, setStoreDownloads] = useState<StoreDownload[]>([]);
-  const { activeRoute, panelOpen } = useUIStore();
+  const { activeRoute, panelOpen, historyPanelOpen } = useUIStore();
   const setActiveRoute = useUIStore((s) => s.setActiveRoute);
   const togglePanel = useUIStore((s) => s.togglePanel);
+  const toggleHistoryPanel = useUIStore((s) => s.toggleHistoryPanel);
+  const conversationsMap = useChatStore((s) => s.conversations);
+  const allConversations = useMemo(
+    () => Object.values(conversationsMap).sort((a, b) => b.updatedAt - a.updatedAt),
+    [conversationsMap],
+  );
+  const activeConversationId = useChatStore((s) => s.activeConversationId);
+  const selectedModelId = useChatStore((s) => s.selectedModelId);
+  const selectConversation = useChatStore((s) => s.selectConversation);
+  const deleteConversation = useChatStore((s) => s.deleteConversation);
+  const newConversation = useChatStore((s) => s.newConversation);
 
   // Poll store downloads for the header progress indicator
   const pollStoreDownloads = useCallback(async () => {
@@ -210,12 +222,24 @@ export function App() {
           onNavigate={setActiveRoute}
           onOpenSettings={() => setSettingsOpen(true)}
           downloadProgress={downloadProgress}
+          showSidebarToggle={activeRoute === 'chat' && allConversations.length > 0}
+          sidebarVisible={historyPanelOpen}
+          onToggleSidebar={toggleHistoryPanel}
           instanceCount={instanceCards.length}
           instancesHealthy={instanceCards.every((c) => c.status !== 'failed')}
           mobileRightOpen={panelOpen}
           onToggleMobileRight={togglePanel}
         />
         <ContentRow>
+          {activeRoute === 'chat' && allConversations.length > 0 && historyPanelOpen && (
+            <ConversationPanel
+              conversations={allConversations}
+              activeConversationId={activeConversationId}
+              onSelect={selectConversation}
+              onDelete={deleteConversation}
+              onNewChat={() => { if (selectedModelId) newConversation(selectedModelId); }}
+            />
+          )}
           <Main>
             <ClusterWarnings topology={topology} />
             {activeRoute === 'model-store' ? (

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -19,6 +19,8 @@ export interface ChatFormProps {
   ttftMs?: number | null;
   /** Tokens per second. */
   tps?: number | null;
+  /** Context window size in tokens (0 = unknown). */
+  contextLength?: number;
   /** Enable thinking toggle. */
   showThinkingToggle?: boolean;
   thinkingEnabled?: boolean;
@@ -173,6 +175,7 @@ export function ChatForm({
   modelSelector,
   ttftMs,
   tps,
+  contextLength = 0,
   showThinkingToggle = false,
   thinkingEnabled = false,
   onToggleThinking,
@@ -284,6 +287,9 @@ export function ChatForm({
               <span>Model:</span>
               {modelSelector ?? <ModelBtn onClick={onOpenModelPicker}>{modelLabel}</ModelBtn>}
             </>
+          )}
+          {contextLength > 0 && (
+            <Stat>{(contextLength / 1024).toFixed(0)}K ctx</Stat>
           )}
           {showThinkingToggle && (
             <ThinkingBtn $active={thinkingEnabled} onClick={onToggleThinking}>

--- a/dashboard-react/src/components/chat/ChatMessages.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.tsx
@@ -20,6 +20,9 @@ export interface ChatMessagesProps {
   onEdit?: (messageId: string, content: string) => void;
   onRegenerate?: () => void;
   onRegenerateFromToken?: (tokenIndex: number) => void;
+  /** Externally controlled expanded thinking message IDs */
+  expandedThinkingIds?: Set<string>;
+  onToggleThinking?: (messageId: string) => void;
   className?: string;
 }
 
@@ -53,9 +56,10 @@ const EmptyState = styled.div`
   justify-content: center;
   padding: 80px 0;
   gap: 16px;
-  color: ${({ theme }) => theme.colors.textMuted};
+  color: ${({ theme }) => theme.colors.textSecondary};
   font-family: ${({ theme }) => theme.fonts.body};
-  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  letter-spacing: 1px;
 `;
 
 const Circle = styled.div<{ $size: number; $opacity: number }>`
@@ -63,7 +67,8 @@ const Circle = styled.div<{ $size: number; $opacity: number }>`
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
   border-radius: 50%;
-  border: 1px solid rgba(255, 215, 0, ${({ $opacity }) => $opacity});
+  border: 1.5px solid rgba(255, 215, 0, ${({ $opacity }) => $opacity});
+  box-shadow: 0 0 8px rgba(255, 215, 0, ${({ $opacity }) => $opacity * 0.5});
 `;
 
 const MessageCard = styled.div<{ $role: 'user' | 'assistant' }>`
@@ -227,8 +232,7 @@ const ThinkingContent = styled.div`
   }
 `;
 
-const ShowHideBtn = styled.button`
-  all: unset;
+const ShowHideBtn = styled.span`
   cursor: pointer;
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
@@ -319,6 +323,8 @@ export function ChatMessages({
   onEdit,
   onRegenerate,
   onRegenerateFromToken,
+  expandedThinkingIds: externalExpanded,
+  onToggleThinking: externalToggle,
   className,
 }: ChatMessagesProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -327,7 +333,8 @@ export function ChatMessages({
   const [editContent, setEditContent] = useState('');
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
-  const [expandedThinking, setExpandedThinking] = useState<Set<string>>(new Set());
+  const [internalExpanded, setInternalExpanded] = useState<Set<string>>(new Set());
+  const expandedThinking = externalExpanded ?? internalExpanded;
   const [heatmapVisible, setHeatmapVisible] = useState<Set<string>>(new Set());
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
   const [streamThinkingOpen, setStreamThinkingOpen] = useState(false);
@@ -380,12 +387,16 @@ export function ChatMessages({
   }, [editingId, editContent, onEdit]);
 
   const toggleThinking = useCallback((id: string) => {
-    setExpandedThinking((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id); else next.add(id);
-      return next;
-    });
-  }, []);
+    if (externalToggle) {
+      externalToggle(id);
+    } else {
+      setInternalExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id); else next.add(id);
+        return next;
+      });
+    }
+  }, [externalToggle]);
 
   const toggleHeatmap = useCallback((id: string) => {
     setHeatmapVisible((prev) => {
@@ -403,9 +414,9 @@ export function ChatMessages({
       <Container ref={containerRef} className={className}>
         <EmptyState>
           <div style={{ position: 'relative', width: 80, height: 80 }}>
-            <Circle $size={80} $opacity={0.15} />
-            <Circle $size={56} $opacity={0.1} style={{ top: 12, left: 12 }} />
-            <Circle $size={32} $opacity={0.08} style={{ top: 24, left: 24 }} />
+            <Circle $size={80} $opacity={0.35} />
+            <Circle $size={56} $opacity={0.25} style={{ top: 12, left: 12 }} />
+            <Circle $size={32} $opacity={0.18} style={{ top: 24, left: 24 }} />
           </div>
           Awaiting Input
         </EmptyState>

--- a/dashboard-react/src/components/chat/ChatMessages.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.tsx
@@ -219,8 +219,12 @@ const ThinkingChevron = styled.span<{ $open: boolean }>`
 const ThinkingContent = styled.div`
   padding: 8px 10px;
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
-  color: ${({ theme }) => theme.colors.textSecondary};
+  color: ${({ theme }) => theme.colors.textMuted};
   border-top: 1px solid rgba(255, 215, 0, 0.1);
+
+  & * {
+    color: inherit;
+  }
 `;
 
 const ShowHideBtn = styled.button`

--- a/dashboard-react/src/components/chat/ChatSidebar.stories.tsx
+++ b/dashboard-react/src/components/chat/ChatSidebar.stories.tsx
@@ -6,11 +6,11 @@ import type { Conversation } from '../../types/chat';
 const now = Date.now();
 
 const sampleConversations: Conversation[] = [
-  { id: '1', name: 'Distributed inference setup', modelId: 'qwen3-30b-4bit', updatedAt: now - 1000, messages: [] },
-  { id: '2', name: 'Python async patterns', modelId: 'llama-8b-4bit', updatedAt: now - 3600000, messages: [] },
-  { id: '3', name: 'Debugging RDMA connections', modelId: 'qwen3-30b-4bit', updatedAt: now - 86400000, messages: [] },
-  { id: '4', name: 'MLX optimization tips', updatedAt: now - 172800000, messages: [] },
-  { id: '5', name: 'Kubernetes cluster design', updatedAt: now - 604800000, messages: [] },
+  { id: '1', name: 'Distributed inference setup', modelId: 'qwen3-30b-4bit', createdAt: now - 2000, updatedAt: now - 1000, messages: [] },
+  { id: '2', name: 'Python async patterns', modelId: 'llama-8b-4bit', createdAt: now - 7200000, updatedAt: now - 3600000, messages: [] },
+  { id: '3', name: 'Debugging RDMA connections', modelId: 'qwen3-30b-4bit', createdAt: now - 90000000, updatedAt: now - 86400000, messages: [] },
+  { id: '4', name: 'MLX optimization tips', modelId: 'qwen3-30b-4bit', createdAt: now - 200000000, updatedAt: now - 172800000, messages: [] },
+  { id: '5', name: 'Kubernetes cluster design', modelId: 'llama-8b-4bit', createdAt: now - 700000000, updatedAt: now - 604800000, messages: [] },
 ];
 
 const meta: Meta<typeof ChatSidebar> = {

--- a/dashboard-react/src/components/layout/ConversationPanel.tsx
+++ b/dashboard-react/src/components/layout/ConversationPanel.tsx
@@ -1,0 +1,217 @@
+import styled from 'styled-components';
+import type { Conversation } from '../../types/chat';
+
+/* ── Types ────────────────────────────────────────────── */
+
+export interface ConversationPanelProps {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  onSelect: (conversationId: string) => void;
+  onDelete: (conversationId: string) => void;
+  onNewChat: () => void;
+  className?: string;
+}
+
+/* ── Helpers ──────────────────────────────────────────── */
+
+function formatDate(ts: number): string {
+  const d = new Date(ts);
+  const now = new Date();
+  const diffMs = now.getTime() - ts;
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffDays === 0) {
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return d.toLocaleDateString([], { weekday: 'long' });
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+function modelLabel(modelId: string): string {
+  const parts = modelId.split('/');
+  return parts[parts.length - 1];
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + '...';
+}
+
+/* ── Styles ───────────────────────────────────────────── */
+
+const Panel = styled.aside`
+  width: 340px;
+  flex-shrink: 0;
+  border-right: 1px solid ${({ theme }) => theme.colors.border};
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+const PanelHeader = styled.div`
+  padding: 12px 16px;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const NewChatBtn = styled.button`
+  all: unset;
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.gold};
+  padding: 2px 8px;
+  border: 1px solid ${({ theme }) => theme.colors.goldDim};
+  border-radius: ${({ theme }) => theme.radii.sm};
+  transition: all 0.15s;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.goldBg};
+  }
+`;
+
+const CardList = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const Card = styled.button<{ $active: boolean }>`
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 12px;
+  border-radius: ${({ theme }) => theme.radii.md};
+  border: 1px solid ${({ $active, theme }) => $active ? theme.colors.goldDim : 'transparent'};
+  background: ${({ $active, theme }) => $active ? theme.colors.goldBg : 'transparent'};
+  transition: all 0.15s;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.surfaceHover};
+    border-color: ${({ theme }) => theme.colors.border};
+  }
+`;
+
+const CardTitle = styled.div<{ $active: boolean }>`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-weight: 500;
+  color: ${({ $active, theme }) => $active ? theme.colors.gold : theme.colors.text};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const CardMeta = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const Dot = styled.span`
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const CardSummary = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.textMuted};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const DeleteBtn = styled.span`
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  margin-left: auto;
+  opacity: 0;
+  transition: all 0.15s;
+
+  ${Card}:hover & {
+    opacity: 1;
+  }
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.error};
+  }
+`;
+
+const EmptyText = styled.div`
+  padding: 24px 16px;
+  text-align: center;
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+/* ── Component ────────────────────────────────────────── */
+
+export function ConversationPanel({
+  conversations,
+  activeConversationId,
+  onSelect,
+  onDelete,
+  onNewChat,
+  className,
+}: ConversationPanelProps) {
+  return (
+    <Panel className={className}>
+      <PanelHeader>
+        History
+        <NewChatBtn onClick={onNewChat}>+ New</NewChatBtn>
+      </PanelHeader>
+      <CardList>
+        {conversations.length === 0 ? (
+          <EmptyText>No conversations yet</EmptyText>
+        ) : (
+          conversations.map((convo) => {
+            const active = convo.id === activeConversationId;
+            const description = convo.summary
+              ?? convo.messages.find((m) => m.role === 'user')?.content
+              ?? '';
+            return (
+              <Card
+                key={convo.id}
+                $active={active}
+                onClick={() => onSelect(convo.id)}
+              >
+                <CardTitle $active={active}>
+                  {truncate(convo.name, 40)}
+                </CardTitle>
+                <CardMeta>
+                  <span>{formatDate(convo.updatedAt)}</span>
+                  <Dot>&middot;</Dot>
+                  <span>{modelLabel(convo.modelId)}</span>
+                  <DeleteBtn onClick={(e) => { e.stopPropagation(); onDelete(convo.id); }}>
+                    &times;
+                  </DeleteBtn>
+                </CardMeta>
+                {description && (
+                  <CardSummary>{truncate(description, 60)}</CardSummary>
+                )}
+              </Card>
+            );
+          })
+        )}
+      </CardList>
+    </Panel>
+  );
+}

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -125,6 +125,18 @@ const DownloadBadge = styled.div`
   height: 28px;
 `;
 
+const IconToggle = styled.span<{ $active: boolean }>`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  color: ${({ $active, theme }) => $active ? theme.colors.gold : theme.colors.textMuted};
+  transition: color 0.15s;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.text};
+  }
+`;
+
 const InstanceToggle = styled.button<{ $healthy: boolean; $active: boolean }>`
   all: unset;
   cursor: pointer;
@@ -212,9 +224,9 @@ export function HeaderNav({
           </ToggleBtn>
         )}
         {showSidebarToggle && (
-          <ToggleBtn variant="outline" size="lg" icon $active={sidebarVisible} onClick={onToggleSidebar} aria-label="Toggle sidebar" aria-pressed={sidebarVisible}>
+          <IconToggle $active={sidebarVisible} onClick={onToggleSidebar} aria-label="Toggle sidebar">
             <SidebarIcon />
-          </ToggleBtn>
+          </IconToggle>
         )}
         <LogoBtn $disabled={!showHome} onClick={showHome ? () => navigate('cluster') : undefined}>
           <SkulkIcon size={32} color="#ffffff" />

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { ChatMessages } from '../chat/ChatMessages';
 import { ChatForm } from '../chat/ChatForm';
@@ -17,47 +17,6 @@ export interface ChatViewProps {
 }
 
 /* ── AI Summary ───────────────────────────────────────── */
-
-async function generateSummary(convoId: string, modelId: string, messages: ChatMessage[]) {
-  try {
-    // Build a condensed transcript for the summary prompt
-    const transcript = messages
-      .slice(0, 6)
-      .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content.slice(0, 200)}`)
-      .join('\n');
-
-    const res = await fetch('/v1/chat/completions', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model: modelId,
-        messages: [
-          {
-            role: 'system',
-            content: 'You are a summarizer. Given a conversation transcript, reply with ONLY a short title (max 8 words) that describes the topic. No thinking, no explanation, no punctuation except what is needed. Just the title.',
-          },
-          {
-            role: 'user',
-            content: transcript,
-          },
-        ],
-        max_tokens: 50,
-      }),
-    });
-    if (!res.ok) return;
-    const data = await res.json();
-    let summary = data.choices?.[0]?.message?.content?.trim() ?? '';
-    // Strip any <think> tags that thinking models might emit
-    summary = summary.replace(/<think>[\s\S]*?<\/think>/gi, '').replace(/<think>[\s\S]*/i, '').trim();
-    // Remove surrounding quotes if present
-    summary = summary.replace(/^["']|["']$/g, '').trim();
-    if (summary && summary.length > 0 && summary.length < 80) {
-      useChatStore.getState().setSummary(convoId, summary);
-    }
-  } catch {
-    // silent failure
-  }
-}
 
 /* ── Styles ───────────────────────────────────────────── */
 
@@ -162,11 +121,15 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     return () => timers.forEach(clearTimeout);
   }, [messages.length, chatScrollTop]);
 
-  // Save scroll position on scroll
+  // Save scroll position on scroll (throttled to avoid jank)
+  const scrollRaf = useRef<number>(0);
   const handleScroll = useCallback(() => {
-    if (scrollRef.current) {
-      setChatScrollTop(scrollRef.current.scrollTop);
-    }
+    cancelAnimationFrame(scrollRaf.current);
+    scrollRaf.current = requestAnimationFrame(() => {
+      if (scrollRef.current) {
+        setChatScrollTop(scrollRef.current.scrollTop);
+      }
+    });
   }, [setChatScrollTop]);
 
   // Fetch model capabilities and context lengths
@@ -380,8 +343,6 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     setIsLoading(false);
     abortRef.current = null;
 
-    // AI summary disabled for now — small models produce low-quality results
-    // TODO: revisit when larger models or smarter extraction is available
   }, [selectedModelId, isLoading, thinkingEnabled, addMessage]);
 
   const handleCancel = useCallback(() => {

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { ChatMessages } from '../chat/ChatMessages';
 import { ChatForm } from '../chat/ChatForm';
 import type { ChatMessage } from '../../types/chat';
 import type { ChatUploadedFile } from '../../types/chat';
 import type { InstanceCardData } from '../layout/InstancePanel';
-import { useChatStore, selectActiveMessages, selectActiveConversation } from '../../stores/chatStore';
+import { useChatStore } from '../../stores/chatStore';
+import { useUIStore } from '../../stores/uiStore';
 
 /* ── Types ────────────────────────────────────────────── */
 
@@ -95,14 +96,22 @@ const ModelSelect = styled.select`
   }
 `;
 
+const EMPTY_MESSAGES: ChatMessage[] = [];
+
 /* ── Component ────────────────────────────────────────── */
 
 export function ChatView({ readyInstances, className }: ChatViewProps) {
   // Store state
   const selectedModelId = useChatStore((s) => s.selectedModelId);
-  const messages = useChatStore(selectActiveMessages);
-  const activeConversation = useChatStore(selectActiveConversation);
-  const { selectModel, addMessage, deleteMessage, editMessage, removeLastAssistantMessages } = useChatStore();
+  const activeConversationId = useChatStore((s) => s.activeConversationId);
+  const messages = useChatStore((s) =>
+    s.activeConversationId ? s.conversations[s.activeConversationId]?.messages ?? EMPTY_MESSAGES : EMPTY_MESSAGES,
+  );
+  const selectModel = useChatStore((s) => s.selectModel);
+  const addMessage = useChatStore((s) => s.addMessage);
+  const deleteMessageAction = useChatStore((s) => s.deleteMessage);
+  const editMessageAction = useChatStore((s) => s.editMessage);
+  const removeLastAssistantMessages = useChatStore((s) => s.removeLastAssistantMessages);
 
   // Local transient state
   const [streamingContent, setStreamingContent] = useState<string | null>(null);
@@ -112,7 +121,39 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
   const [ttftMs, setTtftMs] = useState<number | null>(null);
   const [tps, setTps] = useState<number | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const [modelCapabilities, setModelCapabilities] = useState<Record<string, string[]>>({});
+
+  // Restore scroll position after store hydration + DOM render
+  const chatScrollTop = useUIStore((s) => s.chatScrollTop);
+  const setChatScrollTop = useUIStore((s) => s.setChatScrollTop);
+  const scrollRestored = useRef(false);
+  useEffect(() => {
+    if (scrollRestored.current || chatScrollTop <= 0) return;
+
+    // Wait for store to hydrate and DOM to render messages
+    const tryRestore = () => {
+      const el = scrollRef.current;
+      if (!el) return;
+      // Only restore once the scroll container has enough content
+      if (el.scrollHeight > el.clientHeight) {
+        scrollRestored.current = true;
+        el.scrollTop = chatScrollTop;
+      }
+    };
+
+    // Poll briefly — store hydration + DOM render may take a few frames
+    const attempts = [0, 50, 100, 200, 500];
+    const timers = attempts.map((ms) => setTimeout(tryRestore, ms));
+    return () => timers.forEach(clearTimeout);
+  }, [messages.length, chatScrollTop]);
+
+  // Save scroll position on scroll
+  const handleScroll = useCallback(() => {
+    if (scrollRef.current) {
+      setChatScrollTop(scrollRef.current.scrollTop);
+    }
+  }, [setChatScrollTop]);
 
   // Fetch model capabilities
   useEffect(() => {
@@ -334,12 +375,12 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
   }, []);
 
   const handleDelete = useCallback((id: string) => {
-    deleteMessage(id);
-  }, [deleteMessage]);
+    deleteMessageAction(id);
+  }, [deleteMessageAction]);
 
   const handleEdit = useCallback((id: string, content: string) => {
-    editMessage(id, content);
-  }, [editMessage]);
+    editMessageAction(id, content);
+  }, [editMessageAction]);
 
   const handleRegenerate = useCallback(() => {
     removeLastAssistantMessages();
@@ -354,6 +395,22 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
       }
     }, 50);
   }, [handleSend, removeLastAssistantMessages]);
+
+  // Thinking expansion state — persisted per conversation in session store
+  const expandedThinkingMap = useUIStore((s) => s.expandedThinking);
+  const setExpandedThinking = useUIStore((s) => s.setExpandedThinking);
+  const expandedThinkingIds = useMemo(
+    () => new Set(activeConversationId ? expandedThinkingMap[activeConversationId] ?? [] : []),
+    [expandedThinkingMap, activeConversationId],
+  );
+  const handleToggleThinking = useCallback((messageId: string) => {
+    if (!activeConversationId) return;
+    const current = expandedThinkingMap[activeConversationId] ?? [];
+    const next = current.includes(messageId)
+      ? current.filter((id) => id !== messageId)
+      : [...current, messageId];
+    setExpandedThinking(activeConversationId, next);
+  }, [activeConversationId, expandedThinkingMap, setExpandedThinking]);
 
   if (readyModels.length === 0) {
     return (
@@ -375,7 +432,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
 
   return (
     <Container className={className}>
-      <MessagesScroll>
+      <MessagesScroll ref={scrollRef} onScroll={handleScroll}>
         <ChatMessages
           messages={messages}
           streamingContent={streamingContent}
@@ -384,6 +441,8 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
           onDelete={handleDelete}
           onEdit={handleEdit}
           onRegenerate={handleRegenerate}
+          expandedThinkingIds={expandedThinkingIds}
+          onToggleThinking={handleToggleThinking}
         />
       </MessagesScroll>
       <InputArea>

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -194,9 +194,16 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     setTps(null);
 
     // Read messages from store (includes the user message we just added)
-    const allMessages = useChatStore.getState().conversations[
-      useChatStore.getState().activeConversationId!
-    ]?.messages ?? [];
+    const storeState = useChatStore.getState();
+    const activeConvo = storeState.activeConversationId
+      ? storeState.conversations[storeState.activeConversationId]
+      : undefined;
+    if (!activeConvo) {
+      setIsLoading(false);
+      setStreamingContent(null);
+      return;
+    }
+    const allMessages = activeConvo.messages;
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -361,10 +368,12 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     removeLastAssistantMessages();
     // Re-send last user message on next tick after store updates
     setTimeout(() => {
-      const convo = useChatStore.getState().conversations[
-        useChatStore.getState().activeConversationId!
-      ];
-      const lastUser = convo?.messages.filter((m) => m.role === 'user').pop();
+      const state = useChatStore.getState();
+      const convo = state.activeConversationId
+        ? state.conversations[state.activeConversationId]
+        : undefined;
+      if (!convo) return;
+      const lastUser = convo.messages.filter((m) => m.role === 'user').pop();
       if (lastUser) {
         handleSend(lastUser.content, []);
       }

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -20,25 +20,38 @@ export interface ChatViewProps {
 
 async function generateSummary(convoId: string, modelId: string, messages: ChatMessage[]) {
   try {
+    // Build a condensed transcript for the summary prompt
+    const transcript = messages
+      .slice(0, 6)
+      .map((m) => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content.slice(0, 200)}`)
+      .join('\n');
+
     const res = await fetch('/v1/chat/completions', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         model: modelId,
         messages: [
-          ...messages.slice(0, 6).map((m) => ({ role: m.role, content: m.content })),
+          {
+            role: 'system',
+            content: 'You are a summarizer. Given a conversation transcript, reply with ONLY a short title (max 8 words) that describes the topic. No thinking, no explanation, no punctuation except what is needed. Just the title.',
+          },
           {
             role: 'user',
-            content: 'Summarize this conversation in one short sentence (max 10 words). Reply with only the summary, nothing else.',
+            content: transcript,
           },
         ],
-        max_tokens: 30,
+        max_tokens: 50,
       }),
     });
     if (!res.ok) return;
     const data = await res.json();
-    const summary = data.choices?.[0]?.message?.content?.trim();
-    if (summary) {
+    let summary = data.choices?.[0]?.message?.content?.trim() ?? '';
+    // Strip any <think> tags that thinking models might emit
+    summary = summary.replace(/<think>[\s\S]*?<\/think>/gi, '').replace(/<think>[\s\S]*/i, '').trim();
+    // Remove surrounding quotes if present
+    summary = summary.replace(/^["']|["']$/g, '').trim();
+    if (summary && summary.length > 0 && summary.length < 80) {
       useChatStore.getState().setSummary(convoId, summary);
     }
   } catch {
@@ -123,6 +136,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [modelCapabilities, setModelCapabilities] = useState<Record<string, string[]>>({});
+  const [modelContextLengths, setModelContextLengths] = useState<Record<string, number>>({});
 
   // Restore scroll position after store hydration + DOM render
   const chatScrollTop = useUIStore((s) => s.chatScrollTop);
@@ -155,7 +169,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     }
   }, [setChatScrollTop]);
 
-  // Fetch model capabilities
+  // Fetch model capabilities and context lengths
   useEffect(() => {
     (async () => {
       try {
@@ -163,13 +177,18 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
         if (!res.ok) return;
         const data = await res.json();
         const caps: Record<string, string[]> = {};
+        const ctxLens: Record<string, number> = {};
         for (const m of data.data ?? []) {
           if (m.id && m.capabilities) caps[m.id] = m.capabilities;
+          if (m.id && m.context_length) ctxLens[m.id] = m.context_length;
         }
         setModelCapabilities(caps);
+        setModelContextLengths(ctxLens);
       } catch { /* ignore */ }
     })();
   }, []);
+
+  const contextLength = selectedModelId ? modelContextLengths[selectedModelId] ?? 0 : 0;
 
   const supportsThinking = selectedModelId
     ? (modelCapabilities[selectedModelId]?.includes('thinking_toggle') ?? false)
@@ -361,13 +380,8 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     setIsLoading(false);
     abortRef.current = null;
 
-    // Trigger AI summary if conversation has enough exchanges
-    const convo = useChatStore.getState().conversations[
-      useChatStore.getState().activeConversationId!
-    ];
-    if (convo && !convo.summary && convo.messages.length >= 4) {
-      generateSummary(convo.id, convo.modelId, convo.messages);
-    }
+    // AI summary disabled for now — small models produce low-quality results
+    // TODO: revisit when larger models or smarter extraction is available
   }, [selectedModelId, isLoading, thinkingEnabled, addMessage]);
 
   const handleCancel = useCallback(() => {
@@ -454,6 +468,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
           modelSelector={modelSelector}
           ttftMs={ttftMs}
           tps={tps}
+          contextLength={contextLength}
           showThinkingToggle={supportsThinking}
           thinkingEnabled={thinkingEnabled}
           onToggleThinking={() => setThinkingEnabled((v) => !v)}

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -5,15 +5,44 @@ import { ChatForm } from '../chat/ChatForm';
 import type { ChatMessage } from '../../types/chat';
 import type { ChatUploadedFile } from '../../types/chat';
 import type { InstanceCardData } from '../layout/InstancePanel';
+import { useChatStore, selectActiveMessages, selectActiveConversation } from '../../stores/chatStore';
 
 /* ── Types ────────────────────────────────────────────── */
 
 export interface ChatViewProps {
   /** Ready instances the user can chat with. */
   readyInstances: InstanceCardData[];
-  /** Pre-selected model ID (e.g. from clicking Chat on a card). */
-  initialModelId?: string;
   className?: string;
+}
+
+/* ── AI Summary ───────────────────────────────────────── */
+
+async function generateSummary(convoId: string, modelId: string, messages: ChatMessage[]) {
+  try {
+    const res = await fetch('/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: modelId,
+        messages: [
+          ...messages.slice(0, 6).map((m) => ({ role: m.role, content: m.content })),
+          {
+            role: 'user',
+            content: 'Summarize this conversation in one short sentence (max 10 words). Reply with only the summary, nothing else.',
+          },
+        ],
+        max_tokens: 30,
+      }),
+    });
+    if (!res.ok) return;
+    const data = await res.json();
+    const summary = data.choices?.[0]?.message?.content?.trim();
+    if (summary) {
+      useChatStore.getState().setSummary(convoId, summary);
+    }
+  } catch {
+    // silent failure
+  }
 }
 
 /* ── Styles ───────────────────────────────────────────── */
@@ -68,12 +97,17 @@ const ModelSelect = styled.select`
 
 /* ── Component ────────────────────────────────────────── */
 
-export function ChatView({ readyInstances, initialModelId, className }: ChatViewProps) {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+export function ChatView({ readyInstances, className }: ChatViewProps) {
+  // Store state
+  const selectedModelId = useChatStore((s) => s.selectedModelId);
+  const messages = useChatStore(selectActiveMessages);
+  const activeConversation = useChatStore(selectActiveConversation);
+  const { selectModel, addMessage, deleteMessage, editMessage, removeLastAssistantMessages } = useChatStore();
+
+  // Local transient state
   const [streamingContent, setStreamingContent] = useState<string | null>(null);
   const [streamingThinking, setStreamingThinking] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [selectedModelId, setSelectedModelId] = useState<string | null>(initialModelId ?? null);
   const [thinkingEnabled, setThinkingEnabled] = useState(false);
   const [ttftMs, setTtftMs] = useState<number | null>(null);
   const [tps, setTps] = useState<number | null>(null);
@@ -100,22 +134,18 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
     ? (modelCapabilities[selectedModelId]?.includes('thinking_toggle') ?? false)
     : false;
 
-  // Auto-select first ready model if none selected
+  // Ready models
   const readyModels = useMemo(
     () => readyInstances.filter((i) => i.status === 'ready' || i.status === 'running'),
     [readyInstances],
   );
 
+  // Auto-select first ready model if none selected
   useEffect(() => {
     if (!selectedModelId && readyModels.length > 0) {
-      setSelectedModelId(readyModels[0].modelId);
+      selectModel(readyModels[0].modelId);
     }
-  }, [selectedModelId, readyModels]);
-
-  // If initialModelId changes (e.g. user clicked Chat on a different card), update
-  useEffect(() => {
-    if (initialModelId) setSelectedModelId(initialModelId);
-  }, [initialModelId]);
+  }, [selectedModelId, readyModels, selectModel]);
 
   const selectedLabel = useMemo(() => {
     if (!selectedModelId) return undefined;
@@ -127,20 +157,23 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
     if (!selectedModelId || isLoading) return;
 
     const userMsg: ChatMessage = {
-      id: `msg-${Date.now()}-user`,
+      id: crypto.randomUUID(),
       role: 'user',
       content: text,
       timestamp: Date.now(),
     };
 
-    setMessages((prev) => [...prev, userMsg]);
+    addMessage(userMsg);
     setIsLoading(true);
     setStreamingContent('');
     setStreamingThinking(null);
     setTtftMs(null);
     setTps(null);
 
-    const allMessages = [...messages, userMsg];
+    // Read messages from store (includes the user message we just added)
+    const allMessages = useChatStore.getState().conversations[
+      useChatStore.getState().activeConversationId!
+    ]?.messages ?? [];
 
     const controller = new AbortController();
     abortRef.current = controller;
@@ -151,7 +184,6 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
     let rawContent = '';
     let fullThinking = '';
     let lastTps: number | undefined;
-    let inThinkTag = false;
 
     try {
       const res = await fetch('/v1/chat/completions', {
@@ -238,7 +270,6 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
                   i++;
                 }
               }
-              inThinkTag = inTag;
 
               // If we found think tags, route to thinking
               if (thinkContent) {
@@ -274,7 +305,7 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
 
     // Finalize assistant message
     const assistantMsg: ChatMessage = {
-      id: `msg-${Date.now()}-assistant`,
+      id: crypto.randomUUID(),
       role: 'assistant',
       content: rawContent.replace(/<think>[\s\S]*?<\/think>/gi, '').replace(/<think>[\s\S]*/i, '').trim(),
       timestamp: Date.now(),
@@ -283,42 +314,46 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
       thinkingContent: fullThinking || undefined,
     };
 
-    setMessages((prev) => [...prev, assistantMsg]);
+    addMessage(assistantMsg);
     setStreamingContent(null);
     setStreamingThinking(null);
     setIsLoading(false);
     abortRef.current = null;
-  }, [selectedModelId, isLoading, messages, thinkingEnabled]);
+
+    // Trigger AI summary if conversation has enough exchanges
+    const convo = useChatStore.getState().conversations[
+      useChatStore.getState().activeConversationId!
+    ];
+    if (convo && !convo.summary && convo.messages.length >= 4) {
+      generateSummary(convo.id, convo.modelId, convo.messages);
+    }
+  }, [selectedModelId, isLoading, thinkingEnabled, addMessage]);
 
   const handleCancel = useCallback(() => {
     abortRef.current?.abort();
   }, []);
 
   const handleDelete = useCallback((id: string) => {
-    setMessages((prev) => prev.filter((m) => m.id !== id));
-  }, []);
+    deleteMessage(id);
+  }, [deleteMessage]);
 
   const handleEdit = useCallback((id: string, content: string) => {
-    setMessages((prev) => prev.map((m) => m.id === id ? { ...m, content } : m));
-  }, []);
+    editMessage(id, content);
+  }, [editMessage]);
 
   const handleRegenerate = useCallback(() => {
-    // Remove last assistant message, re-send last user message
-    setMessages((prev) => {
-      const withoutLast = [...prev];
-      while (withoutLast.length > 0 && withoutLast[withoutLast.length - 1].role === 'assistant') {
-        withoutLast.pop();
-      }
-      return withoutLast;
-    });
-    // Trigger re-send on next tick after state updates
+    removeLastAssistantMessages();
+    // Re-send last user message on next tick after store updates
     setTimeout(() => {
-      const lastUser = messages.filter((m) => m.role === 'user').pop();
+      const convo = useChatStore.getState().conversations[
+        useChatStore.getState().activeConversationId!
+      ];
+      const lastUser = convo?.messages.filter((m) => m.role === 'user').pop();
       if (lastUser) {
         handleSend(lastUser.content, []);
       }
     }, 50);
-  }, [messages, handleSend]);
+  }, [handleSend, removeLastAssistantMessages]);
 
   if (readyModels.length === 0) {
     return (
@@ -329,7 +364,7 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
   }
 
   const modelSelector = readyModels.length > 1 ? (
-    <ModelSelect value={selectedModelId ?? ''} onChange={(e) => setSelectedModelId(e.target.value)}>
+    <ModelSelect value={selectedModelId ?? ''} onChange={(e) => selectModel(e.target.value)}>
       {readyModels.map((m) => (
         <option key={m.instanceId} value={m.modelId}>
           {m.modelId.split('/').pop()}
@@ -369,4 +404,3 @@ export function ChatView({ readyInstances, initialModelId, className }: ChatView
     </Container>
   );
 }
-

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -395,6 +395,24 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
     }
   }, [modelToInstanceId]);
 
+  const handleDelete = useCallback(async (entry: { model_id: string }, isActive: boolean) => {
+    if (isActive) {
+      addToast({ type: 'error', message: 'Stop the model before deleting' });
+      return;
+    }
+    try {
+      const res = await fetch(`/store/models/${encodeURIComponent(entry.model_id)}`, { method: 'DELETE' });
+      if (res.ok) {
+        addToast({ type: 'success', message: `Deleted ${entry.model_id}` });
+        loadRegistry();
+      } else {
+        addToast({ type: 'error', message: `Failed to delete ${entry.model_id}` });
+      }
+    } catch {
+      addToast({ type: 'error', message: 'Failed to delete model' });
+    }
+  }, [loadRegistry]);
+
   return (
     <Container>
       {purgeConfirm && (
@@ -439,7 +457,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
             </>
           }
           onRefresh={loadRegistry}
-          onDelete={() => {}}
+          onDelete={handleDelete}
           onLaunch={handleLaunch}
           onStop={handleStop}
           onChat={onChat}

--- a/dashboard-react/src/stores/chatStore.ts
+++ b/dashboard-react/src/stores/chatStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { devtools, persist, createJSONStorage } from 'zustand/middleware';
 import type { ChatMessage, Conversation } from '../types/chat';
 
 /* ── Helpers ──────────────────────────────────────────── */
@@ -72,6 +72,7 @@ export const selectConversationsForModel = (modelId: string) => (state: ChatStat
 /* ── Store ────────────────────────────────────────────── */
 
 export const useChatStore = create<ChatState>()(
+  devtools(
   persist(
     (set, get) => ({
       conversations: {},
@@ -291,14 +292,48 @@ export const useChatStore = create<ChatState>()(
       },
     }),
     {
-      name: 'skulk-conversations',
+      name: 'skulk-chat',
       version: 1,
+      storage: createJSONStorage(() => ({
+        getItem: (name: string) => {
+          const durable = localStorage.getItem(name);
+          const session = sessionStorage.getItem(name + '-session');
+          const d = durable ? JSON.parse(durable) : {};
+          const s = session ? JSON.parse(session) : {};
+          return JSON.stringify({
+            state: { ...(d.state ?? {}), ...(s.state ?? {}) },
+            version: d.version ?? s.version ?? 1,
+          });
+        },
+        setItem: (name: string, value: string) => {
+          const parsed = JSON.parse(value);
+          const state = parsed.state ?? {};
+          const { activeConversationId, selectedModelId, ...rest } = state;
+          localStorage.setItem(name, JSON.stringify({
+            state: {
+              conversations: rest.conversations,
+              modelToConversationId: rest.modelToConversationId,
+            },
+            version: parsed.version,
+          }));
+          sessionStorage.setItem(name + '-session', JSON.stringify({
+            state: { activeConversationId, selectedModelId },
+            version: parsed.version,
+          }));
+        },
+        removeItem: (name: string) => {
+          localStorage.removeItem(name);
+          sessionStorage.removeItem(name + '-session');
+        },
+      })),
       partialize: (state) => ({
         conversations: stripTransientFields(state.conversations),
+        modelToConversationId: state.modelToConversationId,
         activeConversationId: state.activeConversationId,
         selectedModelId: state.selectedModelId,
-        modelToConversationId: state.modelToConversationId,
       }),
     },
+  ),
+  { name: 'ChatStore' },
   ),
 );

--- a/dashboard-react/src/stores/chatStore.ts
+++ b/dashboard-react/src/stores/chatStore.ts
@@ -317,16 +317,19 @@ export const useChatStore = create<ChatState>()(
         getItem: (name: string) => {
           const durable = localStorage.getItem(name);
           const session = sessionStorage.getItem(name + '-session');
-          const d = durable ? JSON.parse(durable) : {};
-          const s = session ? JSON.parse(session) : {};
+          let d: Record<string, unknown> = {};
+          let s: Record<string, unknown> = {};
+          try { if (durable) d = JSON.parse(durable); } catch { /* corrupted — reset */ }
+          try { if (session) s = JSON.parse(session); } catch { /* corrupted — reset */ }
           return JSON.stringify({
-            state: { ...(d.state ?? {}), ...(s.state ?? {}) },
-            version: d.version ?? s.version ?? 1,
+            state: { ...((d as Record<string, unknown>).state ?? {}), ...((s as Record<string, unknown>).state ?? {}) },
+            version: (d as Record<string, unknown>).version ?? (s as Record<string, unknown>).version ?? 1,
           });
         },
         setItem: (name: string, value: string) => {
-          const parsed = JSON.parse(value);
-          const state = parsed.state ?? {};
+          let parsed: Record<string, unknown>;
+          try { parsed = JSON.parse(value); } catch { return; }
+          const state = (parsed.state ?? {}) as Record<string, unknown>;
           const { activeConversationId, selectedModelId, ...rest } = state;
           localStorage.setItem(name, JSON.stringify({
             state: {

--- a/dashboard-react/src/stores/chatStore.ts
+++ b/dashboard-react/src/stores/chatStore.ts
@@ -1,0 +1,304 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { ChatMessage, Conversation } from '../types/chat';
+
+/* ── Helpers ──────────────────────────────────────────── */
+
+function uuid(): string {
+  return crypto.randomUUID();
+}
+
+function stripTransientFields(
+  conversations: Record<string, Conversation>,
+): Record<string, Conversation> {
+  const stripped: Record<string, Conversation> = {};
+  for (const [id, convo] of Object.entries(conversations)) {
+    stripped[id] = {
+      ...convo,
+      messages: convo.messages.map((msg) => {
+        const { tokens, generatedImages, ...rest } = msg;
+        return rest;
+      }),
+    };
+  }
+  return stripped;
+}
+
+function autoName(content: string): string {
+  const trimmed = content.trim();
+  if (!trimmed) return 'New conversation';
+  if (trimmed.length <= 50) return trimmed;
+  return trimmed.slice(0, 50) + '...';
+}
+
+/* ── Store Interface ──────────────────────────────────── */
+
+export interface ChatState {
+  conversations: Record<string, Conversation>;
+  activeConversationId: string | null;
+  selectedModelId: string | null;
+  modelToConversationId: Record<string, string>;
+
+  // Actions
+  selectModel: (modelId: string) => void;
+  addMessage: (message: ChatMessage) => void;
+  deleteMessage: (messageId: string) => void;
+  editMessage: (messageId: string, content: string) => void;
+  removeLastAssistantMessages: () => void;
+  newConversation: (modelId: string) => string;
+  selectConversation: (conversationId: string) => void;
+  deleteConversation: (conversationId: string) => void;
+  setSummary: (conversationId: string, summary: string) => void;
+}
+
+/* ── Selectors ────────────────────────────────────────── */
+
+export const selectActiveConversation = (state: ChatState): Conversation | null =>
+  state.activeConversationId
+    ? state.conversations[state.activeConversationId] ?? null
+    : null;
+
+export const selectActiveMessages = (state: ChatState): ChatMessage[] =>
+  selectActiveConversation(state)?.messages ?? [];
+
+export const selectAllConversationsSorted = (state: ChatState): Conversation[] =>
+  Object.values(state.conversations).sort((a, b) => b.updatedAt - a.updatedAt);
+
+export const selectConversationsForModel = (modelId: string) => (state: ChatState): Conversation[] =>
+  Object.values(state.conversations)
+    .filter((c) => c.modelId === modelId)
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+
+/* ── Store ────────────────────────────────────────────── */
+
+export const useChatStore = create<ChatState>()(
+  persist(
+    (set, get) => ({
+      conversations: {},
+      activeConversationId: null,
+      selectedModelId: null,
+      modelToConversationId: {},
+
+      selectModel: (modelId: string) => {
+        const state = get();
+        const now = Date.now();
+        const conversations = { ...state.conversations };
+
+        // Update timestamp on current conversation
+        if (state.activeConversationId && conversations[state.activeConversationId]) {
+          conversations[state.activeConversationId] = {
+            ...conversations[state.activeConversationId],
+            updatedAt: now,
+          };
+        }
+
+        // If same model, no switch needed
+        if (modelId === state.selectedModelId && state.activeConversationId) {
+          set({ conversations });
+          return;
+        }
+
+        // Find or create conversation for new model
+        const existingId = state.modelToConversationId[modelId];
+        if (existingId && conversations[existingId]) {
+          set({
+            conversations,
+            activeConversationId: existingId,
+            selectedModelId: modelId,
+          });
+        } else {
+          const newId = uuid();
+          conversations[newId] = {
+            id: newId,
+            name: 'New conversation',
+            modelId,
+            createdAt: now,
+            updatedAt: now,
+            messages: [],
+          };
+          set({
+            conversations,
+            activeConversationId: newId,
+            selectedModelId: modelId,
+            modelToConversationId: {
+              ...state.modelToConversationId,
+              [modelId]: newId,
+            },
+          });
+        }
+      },
+
+      addMessage: (message: ChatMessage) => {
+        const state = get();
+        const convoId = state.activeConversationId;
+        if (!convoId || !state.conversations[convoId]) return;
+
+        const convo = state.conversations[convoId];
+        const updatedMessages = [...convo.messages, message];
+
+        // Auto-name from first user message
+        let name = convo.name;
+        if (name === 'New conversation' && message.role === 'user') {
+          name = autoName(message.content);
+        }
+
+        set({
+          conversations: {
+            ...state.conversations,
+            [convoId]: {
+              ...convo,
+              messages: updatedMessages,
+              name,
+              updatedAt: Date.now(),
+            },
+          },
+        });
+      },
+
+      deleteMessage: (messageId: string) => {
+        const state = get();
+        const convoId = state.activeConversationId;
+        if (!convoId || !state.conversations[convoId]) return;
+
+        const convo = state.conversations[convoId];
+        set({
+          conversations: {
+            ...state.conversations,
+            [convoId]: {
+              ...convo,
+              messages: convo.messages.filter((m) => m.id !== messageId),
+              updatedAt: Date.now(),
+            },
+          },
+        });
+      },
+
+      editMessage: (messageId: string, content: string) => {
+        const state = get();
+        const convoId = state.activeConversationId;
+        if (!convoId || !state.conversations[convoId]) return;
+
+        const convo = state.conversations[convoId];
+        set({
+          conversations: {
+            ...state.conversations,
+            [convoId]: {
+              ...convo,
+              messages: convo.messages.map((m) =>
+                m.id === messageId ? { ...m, content } : m,
+              ),
+              updatedAt: Date.now(),
+            },
+          },
+        });
+      },
+
+      removeLastAssistantMessages: () => {
+        const state = get();
+        const convoId = state.activeConversationId;
+        if (!convoId || !state.conversations[convoId]) return;
+
+        const convo = state.conversations[convoId];
+        const msgs = [...convo.messages];
+        while (msgs.length > 0 && msgs[msgs.length - 1].role === 'assistant') {
+          msgs.pop();
+        }
+        set({
+          conversations: {
+            ...state.conversations,
+            [convoId]: { ...convo, messages: msgs, updatedAt: Date.now() },
+          },
+        });
+      },
+
+      newConversation: (modelId: string) => {
+        const now = Date.now();
+        const newId = uuid();
+        const newConvo: Conversation = {
+          id: newId,
+          name: 'New conversation',
+          modelId,
+          createdAt: now,
+          updatedAt: now,
+          messages: [],
+        };
+
+        set((state) => ({
+          conversations: { ...state.conversations, [newId]: newConvo },
+          activeConversationId: newId,
+          selectedModelId: modelId,
+          modelToConversationId: {
+            ...state.modelToConversationId,
+            [modelId]: newId,
+          },
+        }));
+
+        return newId;
+      },
+
+      selectConversation: (conversationId: string) => {
+        const state = get();
+        const convo = state.conversations[conversationId];
+        if (!convo) return;
+
+        set({
+          activeConversationId: conversationId,
+          selectedModelId: convo.modelId,
+          modelToConversationId: {
+            ...state.modelToConversationId,
+            [convo.modelId]: conversationId,
+          },
+        });
+      },
+
+      deleteConversation: (conversationId: string) => {
+        const state = get();
+        const convo = state.conversations[conversationId];
+        if (!convo) return;
+
+        const { [conversationId]: _, ...rest } = state.conversations;
+        const modelMap = { ...state.modelToConversationId };
+        if (modelMap[convo.modelId] === conversationId) {
+          delete modelMap[convo.modelId];
+        }
+
+        set({
+          conversations: rest,
+          modelToConversationId: modelMap,
+          activeConversationId:
+            state.activeConversationId === conversationId ? null : state.activeConversationId,
+          selectedModelId:
+            state.activeConversationId === conversationId ? null : state.selectedModelId,
+        });
+      },
+
+      setSummary: (conversationId: string, summary: string) => {
+        const state = get();
+        const convo = state.conversations[conversationId];
+        if (!convo) return;
+
+        // Update name if still default or auto-generated
+        const name = convo.name === 'New conversation' || convo.name.endsWith('...')
+          ? summary
+          : convo.name;
+
+        set({
+          conversations: {
+            ...state.conversations,
+            [conversationId]: { ...convo, summary, name, updatedAt: Date.now() },
+          },
+        });
+      },
+    }),
+    {
+      name: 'skulk-conversations',
+      version: 1,
+      partialize: (state) => ({
+        conversations: stripTransientFields(state.conversations),
+        activeConversationId: state.activeConversationId,
+        selectedModelId: state.selectedModelId,
+        modelToConversationId: state.modelToConversationId,
+      }),
+    },
+  ),
+);

--- a/dashboard-react/src/stores/chatStore.ts
+++ b/dashboard-react/src/stores/chatStore.ts
@@ -84,19 +84,43 @@ export const useChatStore = create<ChatState>()(
         const state = get();
         const now = Date.now();
         const conversations = { ...state.conversations };
-
-        // Update timestamp on current conversation
-        if (state.activeConversationId && conversations[state.activeConversationId]) {
-          conversations[state.activeConversationId] = {
-            ...conversations[state.activeConversationId],
-            updatedAt: now,
-          };
-        }
+        const currentConvo = state.activeConversationId
+          ? conversations[state.activeConversationId]
+          : null;
 
         // If same model, no switch needed
         if (modelId === state.selectedModelId && state.activeConversationId) {
-          set({ conversations });
           return;
+        }
+
+        // If current conversation is empty, just re-assign it to the new model
+        // instead of creating a new one
+        if (currentConvo && currentConvo.messages.length === 0) {
+          const updatedConvo = { ...currentConvo, modelId, updatedAt: now };
+          conversations[currentConvo.id] = updatedConvo;
+
+          // Update model mapping
+          const modelMap = { ...state.modelToConversationId };
+          // Remove old model's pointer if it pointed here
+          if (modelMap[currentConvo.modelId] === currentConvo.id) {
+            delete modelMap[currentConvo.modelId];
+          }
+          modelMap[modelId] = currentConvo.id;
+
+          set({
+            conversations,
+            selectedModelId: modelId,
+            modelToConversationId: modelMap,
+          });
+          return;
+        }
+
+        // Current conversation has messages — save it and switch
+        if (currentConvo) {
+          conversations[currentConvo.id] = {
+            ...currentConvo,
+            updatedAt: now,
+          };
         }
 
         // Find or create conversation for new model
@@ -278,15 +302,10 @@ export const useChatStore = create<ChatState>()(
         const convo = state.conversations[conversationId];
         if (!convo) return;
 
-        // Update name if still default or auto-generated
-        const name = convo.name === 'New conversation' || convo.name.endsWith('...')
-          ? summary
-          : convo.name;
-
         set({
           conversations: {
             ...state.conversations,
-            [conversationId]: { ...convo, summary, name, updatedAt: Date.now() },
+            [conversationId]: { ...convo, summary, updatedAt: Date.now() },
           },
         });
       },

--- a/dashboard-react/src/stores/uiStore.ts
+++ b/dashboard-react/src/stores/uiStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+import { devtools, persist, createJSONStorage } from 'zustand/middleware';
+import type { NavRoute } from '../components/layout/HeaderNav';
+
+export interface UIState {
+  activeRoute: NavRoute;
+  panelOpen: boolean;
+  chatScrollTop: number;
+  /** Message IDs with thinking expanded, keyed by conversation ID */
+  expandedThinking: Record<string, string[]>;
+
+  setActiveRoute: (route: NavRoute) => void;
+  setPanelOpen: (open: boolean) => void;
+  togglePanel: () => void;
+  setChatScrollTop: (pos: number) => void;
+  setExpandedThinking: (conversationId: string, messageIds: string[]) => void;
+}
+
+export const useUIStore = create<UIState>()(
+  devtools(
+  persist(
+    (set) => ({
+      activeRoute: 'cluster',
+      panelOpen: true,
+      chatScrollTop: 0,
+      expandedThinking: {},
+
+      setActiveRoute: (route) => set({ activeRoute: route }),
+      setPanelOpen: (open) => set({ panelOpen: open }),
+      togglePanel: () => set((s) => ({ panelOpen: !s.panelOpen })),
+      setChatScrollTop: (pos) => set({ chatScrollTop: pos }),
+      setExpandedThinking: (conversationId, messageIds) =>
+        set((s) => ({
+          expandedThinking: { ...s.expandedThinking, [conversationId]: messageIds },
+        })),
+    }),
+    {
+      name: 'skulk-ui',
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+  { name: 'UIStore' },
+  ),
+);

--- a/dashboard-react/src/stores/uiStore.ts
+++ b/dashboard-react/src/stores/uiStore.ts
@@ -5,6 +5,7 @@ import type { NavRoute } from '../components/layout/HeaderNav';
 export interface UIState {
   activeRoute: NavRoute;
   panelOpen: boolean;
+  historyPanelOpen: boolean;
   chatScrollTop: number;
   /** Message IDs with thinking expanded, keyed by conversation ID */
   expandedThinking: Record<string, string[]>;
@@ -12,6 +13,7 @@ export interface UIState {
   setActiveRoute: (route: NavRoute) => void;
   setPanelOpen: (open: boolean) => void;
   togglePanel: () => void;
+  toggleHistoryPanel: () => void;
   setChatScrollTop: (pos: number) => void;
   setExpandedThinking: (conversationId: string, messageIds: string[]) => void;
 }
@@ -22,12 +24,14 @@ export const useUIStore = create<UIState>()(
     (set) => ({
       activeRoute: 'cluster',
       panelOpen: true,
+      historyPanelOpen: true,
       chatScrollTop: 0,
       expandedThinking: {},
 
       setActiveRoute: (route) => set({ activeRoute: route }),
       setPanelOpen: (open) => set({ panelOpen: open }),
       togglePanel: () => set((s) => ({ panelOpen: !s.panelOpen })),
+      toggleHistoryPanel: () => set((s) => ({ historyPanelOpen: !s.historyPanelOpen })),
       setChatScrollTop: (pos) => set({ chatScrollTop: pos }),
       setExpandedThinking: (conversationId, messageIds) =>
         set((s) => ({

--- a/dashboard-react/src/types/chat.ts
+++ b/dashboard-react/src/types/chat.ts
@@ -37,9 +37,12 @@ export interface ChatMessage {
 export interface Conversation {
   id: string;
   name: string;
-  modelId?: string;
+  modelId: string;
+  createdAt: number;
   updatedAt: number;
   messages: ChatMessage[];
+  summary?: string;
+  originNodeId?: string;
 }
 
 export interface ChatModelInfo {

--- a/resources/inference_model_cards/mlx-community--GLM-4.7-Flash-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--GLM-4.7-Flash-4bit.toml
@@ -8,6 +8,7 @@ family = "glm"
 quantization = "4bit"
 base_model = "GLM 4.7 Flash"
 capabilities = ["text", "thinking", "thinking_toggle"]
+context_length = 202752
 
 [storage_size]
 in_bytes = 19327352832

--- a/resources/inference_model_cards/mlx-community--Llama-3.1-Nemotron-Nano-4B-v1.1-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Llama-3.1-Nemotron-Nano-4B-v1.1-4bit.toml
@@ -7,6 +7,7 @@ family = "llama"
 quantization = "4bit"
 base_model = "NVIDIA Llama-3.1-Nemotron-Nano-4B-v1.1"
 capabilities = ["text"]
+context_length = 131072
 
 [storage_size]
 in_bytes = 2538706944

--- a/resources/inference_model_cards/mlx-community--Meta-Llama-3.1-8B-Instruct-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Meta-Llama-3.1-8B-Instruct-4bit.toml
@@ -8,6 +8,7 @@ family = "llama"
 quantization = "4bit"
 base_model = "Llama 3.1 8B"
 capabilities = ["text"]
+context_length = 131072
 
 [storage_size]
 in_bytes = 4637851648

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-Nano-9B-v2-4bits.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-Nano-9B-v2-4bits.toml
@@ -7,6 +7,7 @@ family = "nemotron"
 quantization = "4bit"
 base_model = "NVIDIA Nemotron-Nano-9B-v2"
 capabilities = ["text"]
+context_length = 131072
 
 [storage_size]
 in_bytes = 5002791936

--- a/resources/inference_model_cards/mlx-community--Qwen3-30B-A3B-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3-30B-A3B-4bit.toml
@@ -8,6 +8,7 @@ family = "qwen"
 quantization = "4bit"
 base_model = "Qwen3 30B"
 capabilities = ["text", "thinking", "thinking_toggle"]
+context_length = 40960
 
 [storage_size]
 in_bytes = 17612931072

--- a/resources/inference_model_cards/mlx-community--Qwen3.5-9B-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3.5-9B-4bit.toml
@@ -8,6 +8,7 @@ family = "qwen"
 quantization = "4bit"
 base_model = "Qwen3.5 9B"
 capabilities = ["text", "thinking"]
+context_length = 262144
 
 [storage_size]
 in_bytes = 5950062560

--- a/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
+++ b/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
@@ -8,6 +8,7 @@ family = "gpt-oss"
 quantization = "MXFP4-Q8"
 base_model = "GPT-OSS 20B"
 capabilities = ["text", "thinking"]
+context_length = 131072
 
 [storage_size]
 in_bytes = 12025908224

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -1594,6 +1594,7 @@ class API:
                     quantization=card.quantization,
                     base_model=card.base_model,
                     capabilities=card.capabilities,
+                    context_length=card.context_length,
                 )
                 for card in cards
             ]
@@ -1618,6 +1619,7 @@ class API:
             supports_tensor=card.supports_tensor,
             tasks=[task.value for task in card.tasks],
             is_custom=True,
+            context_length=card.context_length,
         )
 
     async def delete_custom_model(self, model_id: ModelId) -> JSONResponse:

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -90,6 +90,7 @@ class ModelCard(CamelCaseModel):
     quantization: str = ""
     base_model: str = ""
     capabilities: list[str] = []
+    context_length: int = 0
     uses_cfg: bool = False
     trust_remote_code: bool = True
 
@@ -139,6 +140,7 @@ class ModelCard(CamelCaseModel):
             hidden_size=config_data.hidden_size or 0,
             supports_tensor=config_data.supports_tensor,
             num_key_value_heads=config_data.num_key_value_heads,
+            context_length=config_data.max_position_embeddings or 0,
             tasks=[ModelTask.TextGeneration],
             trust_remote_code=False,
         )
@@ -183,6 +185,7 @@ class ConfigData(BaseModel):
             "decoder_layers",
         )
     )
+    max_position_embeddings: int | None = None
 
     @property
     def supports_tensor(self) -> bool:
@@ -219,6 +222,7 @@ class ConfigData(BaseModel):
             "n_layers",
             "num_decoder_layers",
             "decoder_layers",
+            "max_position_embeddings",
         ]:
             if (val := text_config.get(field)) is not None:  # pyright: ignore[reportAny]
                 data[field] = val


### PR DESCRIPTION
## Summary
- **Zustand conversation store** with localStorage persistence and model-scoped conversations
- **Session-scoped UI recovery** — route, panel state, scroll position, thinking expansion all survive refresh
- **Conversation history panel** — left sidebar with date, model, description per conversation
- **Context window exposure** — extract `max_position_embeddings` from model `config.json`, surface via `/models` API, display in chat header as "256K ctx"
- **Model store delete** — wire up `DELETE /store/models/{id}` (was a no-op)
- **Empty conversation model switching** — re-assigns model instead of creating empty conversations
- **Thinking content** renders in muted color via CSS inheritance

## Backend changes
- `ModelCard` gains `context_length` field
- `ConfigData` extracts `max_position_embeddings` from `config.json` (with `text_config` fallback)
- `/models` API populates `context_length`
- 7 TOML model cards backfilled with context_length

## Test plan
- [ ] Chat with a model, refresh — conversation and scroll position restore
- [ ] Switch models — previous conversation saved, new/resumed for target model
- [ ] Switch model on empty conversation — no new conversation created
- [ ] Open conversation history sidebar, click a past conversation — loads it
- [ ] Delete a conversation from history panel
- [ ] Check chat header shows context window (e.g. "256K ctx")
- [ ] Delete a model from store registry — model removed
- [ ] Close tab, reopen — starts fresh but conversations persist in localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)