### PR TITLE
feat: placement manager, docs rebrand, store fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,12 @@
-# Contributing to EXO
+<!-- Copyright 2025 Foxlight Foundation -->
 
-Thank you for your interest in contributing to EXO!
+# Contributing to Skulk
+
+Thank you for your interest in contributing to Skulk! Skulk is maintained by [Foxlight Foundation](https://github.com/foxlight-foundation) and forked from [exo](https://github.com/exo-explore/exo).
 
 ## Getting Started
 
-To run EXO from source:
+To run Skulk from source:
 
 **Prerequisites:**
 - [uv](https://github.com/astral-sh/uv) (for Python dependency management)
@@ -17,15 +19,15 @@ To run EXO from source:
   ```
 
 ```bash
-git clone https://github.com/exo-explore/exo.git
-cd exo/dashboard
+git clone https://github.com/foxlight-foundation/skulk.git
+cd skulk/dashboard
 npm install && npm run build && cd ..
 uv run exo
 ```
 
 ## Development
 
-EXO is built with a mix of Rust, Python, and TypeScript (Svelte for the dashboard), and the codebase is actively evolving. Before starting work:
+Skulk is built with a mix of Rust, Python, and TypeScript (Svelte for the dashboard), and the codebase is actively evolving. Before starting work:
 
 - Pull the latest source to ensure you're working with the most recent code
 - Keep your changes focused - implement one feature or fix per pull request
@@ -41,7 +43,7 @@ Run `nix fmt` to auto-format your code before submitting.
 
 ## Model Cards
 
-EXO uses TOML-based model cards to define model metadata and capabilities. Model cards are stored in:
+Skulk uses TOML-based model cards to define model metadata and capabilities. Model cards are stored in:
 - `resources/inference_model_cards/` for text generation models
 - `resources/image_model_cards/` for image generation models
 - `~/.exo/custom_model_cards/` for user-added custom models
@@ -97,7 +99,7 @@ By default, `trust_remote_code` is set to `false` for security. Only enable it i
 
 ## API Adapters
 
-EXO supports multiple API formats through an adapter pattern. Adapters convert API-specific request formats to the internal `TextGenerationTaskParams` format and convert internal token chunks back to API-specific responses.
+Skulk supports multiple API formats through an adapter pattern. Adapters convert API-specific request formats to the internal `TextGenerationTaskParams` format and convert internal token chunks back to API-specific responses.
 
 ### Adapter Architecture
 
@@ -154,7 +156,7 @@ For detailed API documentation, see [docs/api.md](docs/api.md).
 
 ## Testing
 
-EXO relies heavily on manual testing at this point in the project, but this is evolving. Before submitting a change, test both before and after to demonstrate how your change improves behavior. Do the best you can with the hardware you have available - if you need help testing, ask and we'll do our best to assist. Add automated tests where possible - we're actively working to substantially improve our automated testing story.
+Skulk relies heavily on manual testing at this point in the project, but this is evolving. Before submitting a change, test both before and after to demonstrate how your change improves behavior. Do the best you can with the hardware you have available - if you need help testing, ask and we'll do our best to assist. Add automated tests where possible - we're actively working to substantially improve our automated testing story.
 
 ## Submitting Changes
 
@@ -174,5 +176,4 @@ If you find a bug or have a feature request, please open an issue on GitHub with
 
 ## Questions?
 
-Join our community:
-- [X](https://x.com/exolabs)
+Open an issue or discussion on the [Skulk repository](https://github.com/foxlight-foundation/skulk).

--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -1,4 +1,6 @@
-# EXO Platform support (partial roadmap)
+<!-- Copyright 2025 Foxlight Foundation -->
+
+# Skulk Platform Support (partial roadmap)
 
 ## Tier 1 support - tested and maintained
 
@@ -35,4 +37,3 @@ Linux CUDA Support -- depends heavily on ecosystem
 Windows CUDA Support
 
 Windows CPU Support
-

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # **Skulk**
 
+<!-- Copyright 2025 Foxlight Foundation -->
+
 <div align="center">
 
 </div>
 
 ### **Skulk** (*noun*): A group of foxes.
 >*A skulk moves together without a central authority telling each fox what to do; the skulk coordinates naturally, quietly, with each member contributing to the whole.*
+
+> Skulk is maintained by [Foxlight Foundation](https://github.com/foxlight-foundation) and forked from [exo](https://github.com/exo-explore/exo).
 
 ### **What is it?**
 
@@ -28,25 +32,25 @@
 ---
 ## About EXO
 
-exo connects all your devices into an AI cluster. Not only does exo enable running models larger than would fit on a single device, but with [day-0 support for RDMA over Thunderbolt](https://x.com/exolabs/status/2001817749744476256?s=20), makes models run faster as you add more devices.
+EXO is the upstream project from which Skulk is forked. EXO connects all your devices into an AI cluster. Not only does it enable running models larger than would fit on a single device, but with [day-0 support for RDMA over Thunderbolt](https://x.com/exolabs/status/2001817749744476256?s=20), makes models run faster as you add more devices.
 
 ## Features
 
-- **Automatic Device Discovery**: Devices running exo automatically discover each other - no manual configuration.
-- **RDMA over Thunderbolt**: exo ships with [day-0 support for RDMA over Thunderbolt 5](https://x.com/exolabs/status/2001817749744476256?s=20), enabling 99% reduction in latency between devices.
-- **Topology-Aware Auto Parallel**: exo figures out the best way to split your model across all available devices based on a realtime view of your device topology. It takes into account device resources and network latency/bandwidth between each link.
-- **Tensor Parallelism**: exo supports sharding models, for up to 1.8x speedup on 2 devices and 3.2x speedup on 4 devices.
-- **MLX Support**: exo uses [MLX](https://github.com/ml-explore/mlx) as an inference backend and [MLX distributed](https://ml-explore.github.io/mlx/build/html/usage/distributed.html) for distributed communication.
+- **Automatic Device Discovery**: Devices running Skulk automatically discover each other - no manual configuration.
+- **RDMA over Thunderbolt**: Skulk ships with [day-0 support for RDMA over Thunderbolt 5](https://x.com/exolabs/status/2001817749744476256?s=20), enabling 99% reduction in latency between devices.
+- **Topology-Aware Auto Parallel**: Skulk figures out the best way to split your model across all available devices based on a realtime view of your device topology. It takes into account device resources and network latency/bandwidth between each link.
+- **Tensor Parallelism**: Skulk supports sharding models, for up to 1.8x speedup on 2 devices and 3.2x speedup on 4 devices.
+- **MLX Support**: Skulk uses [MLX](https://github.com/ml-explore/mlx) as an inference backend and [MLX distributed](https://ml-explore.github.io/mlx/build/html/usage/distributed.html) for distributed communication.
 - **Multiple API Compatibility**: Compatible with OpenAI Chat Completions API, Claude Messages API, OpenAI Responses API, and Ollama API - use your existing tools and clients.
 - **Custom Model Support**: Load custom models from HuggingFace hub to expand the range of available models.
 - **Experimental KV Cache Backends**: Skulk includes opt-in MLX quantized and TurboQuant-inspired KV cache backends for long-context memory experiments. See [docs/kv-cache-backends.md](docs/kv-cache-backends.md).
 
 ## Dashboard
 
-exo includes a built-in dashboard for managing your cluster and chatting with models.
+Skulk includes a built-in dashboard for managing your cluster and chatting with models.
 
 <p align="center">
-  <img src="docs/imgs/dashboard-cluster-view.png" alt="exo dashboard - cluster view showing 4 x M3 Ultra Mac Studio with DeepSeek v3.1 and Kimi-K2-Thinking loaded" width="80%" />
+  <img src="docs/imgs/dashboard-cluster-view.png" alt="Skulk dashboard - cluster view showing 4 x M3 Ultra Mac Studio with DeepSeek v3.1 and Kimi-K2-Thinking loaded" width="80%" />
 </p>
 <p align="center"><em>4 × 512GB M3 Ultra Mac Studio running DeepSeek v3.1 (8-bit) and Kimi-K2-Thinking (4-bit)</em></p>
 
@@ -80,13 +84,13 @@ exo includes a built-in dashboard for managing your cluster and chatting with mo
 
 ## Quick Start
 
-Devices running exo automatically discover each other, without needing any manual configuration. Each device provides an API and a dashboard for interacting with your cluster (runs at `http://localhost:52415`).
+Devices running Skulk automatically discover each other, without needing any manual configuration. Each device provides an API and a dashboard for interacting with your cluster (runs at `http://localhost:52415`).
 
-There are two ways to run exo:
+There are two ways to run Skulk:
 
 ### Run from Source (macOS)
 
-If you have [Nix](https://nixos.org/) installed, you can skip most of the steps below and run exo directly:
+If you have [Nix](https://nixos.org/) installed, you can skip most of the steps below and run directly:
 
 ```bash
 nix run .#exo
@@ -120,20 +124,20 @@ Then restart the Nix daemon: `sudo launchctl kickstart -k system/org.nixos.nix-d
   rustup toolchain install nightly
   ```
 
-Clone the repo, build the dashboard, and run exo:
+Clone the repo, build the dashboard, and run Skulk:
 
 ```bash
-# Clone exo
-git clone https://github.com/exo-explore/exo
+# Clone the repo
+git clone https://github.com/foxlight-foundation/skulk
 
 # Build dashboard
-cd exo/dashboard && npm install && npm run build && cd ..
+cd skulk/dashboard && npm install && npm run build && cd ..
 
-# Run exo
+# Run Skulk
 uv run exo
 ```
 
-This starts the exo dashboard and API at http://localhost:52415/
+This starts the Skulk dashboard and API at http://localhost:52415/
 
 ## Experimental KV Cache Backends
 
@@ -205,26 +209,26 @@ rustup toolchain install nightly
 
 **Note:** The `macmon` package is macOS-only and not required for Linux.
 
-Clone the repo, build the dashboard, and run exo:
+Clone the repo, build the dashboard, and run Skulk:
 
 ```bash
-# Clone exo
-git clone https://github.com/exo-explore/exo
+# Clone the repo
+git clone https://github.com/foxlight-foundation/skulk
 
 # Build dashboard
-cd exo/dashboard && npm install && npm run build && cd ..
+cd skulk/dashboard && npm install && npm run build && cd ..
 
-# Run exo
+# Run Skulk
 uv run exo
 ```
 
-This starts the exo dashboard and API at http://localhost:52415/
+This starts the Skulk dashboard and API at http://localhost:52415/
 
-**Important note for Linux users:** Currently, exo runs on CPU on Linux. GPU support for Linux platforms is under development. If you'd like to see support for your specific Linux hardware, please [search for existing feature requests](https://github.com/exo-explore/exo/issues) or create a new one.
+**Important note for Linux users:** Currently, Skulk runs on CPU on Linux. GPU support for Linux platforms is under development. If you'd like to see support for your specific Linux hardware, please [search for existing feature requests](https://github.com/foxlight-foundation/skulk/issues) or create a new one.
 
 **Configuration Options:**
 
-- `--no-worker`: Run exo without the worker component. Useful for coordinator-only nodes that handle networking and orchestration but don't execute inference tasks. This is helpful for machines without sufficient GPU resources but with good network connectivity.
+- `--no-worker`: Run Skulk without the worker component. Useful for coordinator-only nodes that handle networking and orchestration but don't execute inference tasks. This is helpful for machines without sufficient GPU resources but with good network connectivity.
 
   ```bash
   uv run exo --no-worker
@@ -232,7 +236,7 @@ This starts the exo dashboard and API at http://localhost:52415/
 
 **File Locations (Linux):**
 
-exo follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) on Linux:
+Skulk follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) on Linux:
 
 - **Configuration files**: `~/.config/exo/` (or `$XDG_CONFIG_HOME/exo/`)
 - **Data files**: `~/.local/share/exo/` (or `$XDG_DATA_HOME/exo/`)
@@ -244,9 +248,9 @@ You can override these locations by setting the corresponding XDG environment va
 
 ### macOS App
 
-exo ships a macOS app that runs in the background on your Mac.
+Skulk ships a macOS app that runs in the background on your Mac.
 
-<img src="docs/imgs/macos-app-one-macbook.png" alt="exo macOS App - running on a MacBook" width="35%" />
+<img src="docs/imgs/macos-app-one-macbook.png" alt="Skulk macOS App - running on a MacBook" width="35%" />
 
 The macOS app requires macOS Tahoe 26.2 or later.
 
@@ -256,10 +260,10 @@ The app will ask for permission to modify system settings and install a new Netw
 
 **Custom Namespace for Cluster Isolation:**
 
-The macOS app includes a custom namespace feature that allows you to isolate your exo cluster from others on the same network. This is configured through the `EXO_LIBP2P_NAMESPACE` setting:
+The macOS app includes a custom namespace feature that allows you to isolate your cluster from others on the same network. This is configured through the `EXO_LIBP2P_NAMESPACE` setting:
 
 - **Use cases**:
-  - Running multiple separate exo clusters on the same network
+  - Running multiple separate clusters on the same network
   - Isolating development/testing clusters from production clusters
   - Preventing accidental cluster joining
 
@@ -306,7 +310,7 @@ To enable RDMA on macOS, follow these steps:
    and press Enter.
 6. Reboot your Mac.
 
-After that, RDMA will be enabled in macOS and exo will take care of the rest.
+After that, RDMA will be enabled in macOS and Skulk will take care of the rest.
 
 **Important Caveats**
 
@@ -320,12 +324,12 @@ After that, RDMA will be enabled in macOS and exo will take care of the rest.
 
 ## Environment Variables
 
-exo supports several environment variables for configuration:
+Skulk supports several environment variables for configuration:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `EXO_MODELS_PATH` | Colon-separated paths to search for pre-downloaded models (e.g., on NFS mounts or shared storage) | None |
-| `EXO_MODELS_DIR` | Directory where exo downloads and stores models | `~/.local/share/exo/models` (Linux) or `~/.exo/models` (macOS) |
+| `EXO_MODELS_DIR` | Directory where Skulk downloads and stores models | `~/.local/share/exo/models` (Linux) or `~/.exo/models` (macOS) |
 | `EXO_OFFLINE` | Run without internet connection (uses only local models) | `false` |
 | `EXO_ENABLE_IMAGE_MODELS` | Enable image model support | `false` |
 | `EXO_LIBP2P_NAMESPACE` | Custom namespace for cluster isolation | None |
@@ -366,14 +370,14 @@ For more detail on KV cache backends, supported model cache layouts, current lim
 
 ### Using the API
 
-exo provides multiple API-compatible interfaces for maximum compatibility with existing tools:
+Skulk provides multiple API-compatible interfaces for maximum compatibility with existing tools:
 
 - **OpenAI Chat Completions API** - Compatible with OpenAI clients
 - **Claude Messages API** - Compatible with Anthropic's Claude format
 - **OpenAI Responses API** - Compatible with OpenAI's Responses format
 - **Ollama API** - Compatible with Ollama and tools like OpenWebUI
 
-If you prefer to interact with exo via the API, here is an example creating an instance of a small model (`mlx-community/Llama-3.2-1B-Instruct-4bit`), sending a chat completions request and deleting the instance.
+If you prefer to interact with Skulk via the API, here is an example creating an instance of a small model (`mlx-community/Llama-3.2-1B-Instruct-4bit`), sending a chat completions request and deleting the instance.
 
 ---
 
@@ -497,7 +501,7 @@ curl -N -X POST http://localhost:52415/v1/responses \
 
 ### Ollama API Compatibility
 
-exo supports Ollama API endpoints for compatibility with tools like OpenWebUI:
+Skulk supports Ollama API endpoints for compatibility with tools like OpenWebUI:
 
 ```bash
 # Ollama chat
@@ -593,10 +597,10 @@ The tool outputs performance metrics including prompt tokens per second (prompt_
 
 ## Hardware Accelerator Support
 
-On macOS, exo uses the GPU. On Linux, exo currently runs on CPU. We are working on extending hardware accelerator support. If you'd like support for a new hardware platform, please [search for an existing feature request](https://github.com/exo-explore/exo/issues) and add a thumbs up so we know what hardware is important to the community.
+On macOS, Skulk uses the GPU. On Linux, Skulk currently runs on CPU. We are working on extending hardware accelerator support. If you'd like support for a new hardware platform, please [search for an existing feature request](https://github.com/foxlight-foundation/skulk/issues) and add a thumbs up so we know what hardware is important to the community.
 
 ---
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to exo.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to Skulk.

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -5,7 +5,7 @@ import { theme, GlobalStyle } from './theme';
 import { useClusterState } from './hooks/useClusterState';
 import { HeaderNav, type NavRoute } from './components/layout/HeaderNav';
 import { TopologyGraph } from './components/topology/TopologyGraph';
-import { ClusterWarnings } from './components/status/ClusterWarnings';
+// ClusterWarnings replaced by inline header warning indicator
 import { ConnectionBanner } from './components/status/ConnectionBanner';
 import { ToastContainer } from './components/status/ToastContainer';
 import { NetworkMesh } from './components/common/NetworkMesh';
@@ -124,6 +124,37 @@ export function App() {
   const deleteConversation = useChatStore((s) => s.deleteConversation);
   const newConversation = useChatStore((s) => s.newConversation);
 
+  // Compute cluster warnings from topology
+  const clusterWarnings = useMemo(() => {
+    const nodes = topology?.nodes;
+    if (!nodes) return null;
+    const items: { level: 'error' | 'warning'; message: string }[] = [];
+
+    // Version mismatch (error)
+    const entries = Object.values(nodes).filter(
+      (n) => n.exo_commit && n.exo_commit !== 'Unknown' && n.exo_commit !== 'unknown',
+    );
+    if (entries.length >= 2) {
+      const commits = new Set(entries.map((n) => n.exo_commit));
+      if (commits.size > 1) {
+        const details = entries.map((n) => `${n.friendly_name ?? 'Unknown'} (${n.exo_version ?? '?'})`).join(', ');
+        items.push({ level: 'error', message: `Version mismatch: ${details}. Update all nodes with git pull && uv sync.` });
+      }
+    }
+
+    // RDMA phantom (warning)
+    const hasRdmaPhantom = Object.values(nodes).some(
+      (n) => n.rdma_enabled && n.rdma_interfaces_present === false,
+    );
+    if (hasRdmaPhantom) {
+      items.push({ level: 'warning', message: 'RDMA reported as enabled but no RDMA interfaces exist. Thunderbolt 5 (M4 Pro/Max+) is required for tensor parallel.' });
+    }
+
+    if (items.length === 0) return null;
+    const worstLevel = items.some((i) => i.level === 'error') ? 'error' : 'warning';
+    return { level: worstLevel as 'error' | 'warning', items };
+  }, [topology]);
+
   // Poll store downloads for the header progress indicator
   const pollStoreDownloads = useCallback(async () => {
     try {
@@ -224,6 +255,7 @@ export function App() {
           onNavigate={setActiveRoute}
           onOpenSettings={() => setSettingsOpen(true)}
           downloadProgress={downloadProgress}
+          warnings={clusterWarnings}
           showSidebarToggle={activeRoute === 'chat' && allConversations.length > 0}
           sidebarVisible={historyPanelOpen}
           onToggleSidebar={toggleHistoryPanel}
@@ -243,7 +275,6 @@ export function App() {
             />
           )}
           <Main>
-            <ClusterWarnings topology={topology} />
             {activeRoute === 'model-store' ? (
               <ModelStorePage
                 topology={topology}

--- a/dashboard-react/src/components/cluster/PlacementManager.tsx
+++ b/dashboard-react/src/components/cluster/PlacementManager.tsx
@@ -1,34 +1,27 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { FiX, FiInfo } from 'react-icons/fi';
 import { MdPlayArrow } from 'react-icons/md';
 import type { TopologyData } from '../../types/topology';
+import type { PlacementPreview } from '../../types/models';
+import { ModelCard } from '../models/ModelCard';
 import { Button } from '../common/Button';
 
 /* ── Types ────────────────────────────────────────────── */
 
 export interface PlacementManagerProps {
   modelId: string;
+  modelSizeMb?: number;
   topology: TopologyData;
   open: boolean;
   onClose: () => void;
   onLaunch: (params: { modelId: string; sharding: string; instanceMeta: string; minNodes: number }) => void;
 }
 
-interface RawPreview {
-  model_id: string;
-  sharding: string;
-  instance_meta: string;
-  instance: unknown | null;
-  memory_delta_by_node: Record<string, number> | null;
-  error: string | null;
-}
-
 interface ComboStatus {
   available: boolean;
   error?: string;
-  memoryDelta?: Record<string, number>;
-  nodeIds?: string[];
+  preview?: PlacementPreview;
 }
 
 interface NodeCountOptions {
@@ -45,28 +38,22 @@ function modelLabel(modelId: string): string {
   return parts[parts.length - 1];
 }
 
-function formatBytes(bytes: number): string {
-  const gb = Math.abs(bytes) / 1e9;
-  const sign = bytes >= 0 ? '+' : '-';
-  return `${sign}${gb.toFixed(1)}GB`;
-}
-
 function comboKey(sharding: string, meta: string): keyof NodeCountOptions {
   const s = sharding === 'Tensor' ? 'tensor' : 'pipeline';
   const m = meta === 'MlxJaccl' ? 'jaccl' : 'ring';
   return `${s}_${m}` as keyof NodeCountOptions;
 }
 
-function extractNodeIds(instance: unknown): string[] {
-  if (!instance || typeof instance !== 'object') return [];
-  const inner = (instance as Record<string, unknown>).MlxRingInstance
-    ?? (instance as Record<string, unknown>).MlxJacclInstance;
-  if (!inner || typeof inner !== 'object') return [];
+function extractNodeCount(preview: PlacementPreview): number {
+  if (!preview.instance || typeof preview.instance !== 'object') return 1;
+  const inner = (preview.instance as Record<string, unknown>).MlxRingInstance
+    ?? (preview.instance as Record<string, unknown>).MlxJacclInstance;
+  if (!inner || typeof inner !== 'object') return 1;
   const sa = (inner as Record<string, unknown>).shardAssignments;
-  if (!sa || typeof sa !== 'object') return [];
+  if (!sa || typeof sa !== 'object') return 1;
   const ntr = (sa as Record<string, unknown>).nodeToRunner;
-  if (!ntr || typeof ntr !== 'object') return [];
-  return Object.keys(ntr as Record<string, unknown>);
+  if (!ntr || typeof ntr !== 'object') return 1;
+  return Object.keys(ntr as Record<string, unknown>).length;
 }
 
 /* ── Styles ───────────────────────────────────────────── */
@@ -85,8 +72,8 @@ const Modal = styled.div`
   background: ${({ theme }) => theme.colors.surface};
   border: 1px solid ${({ theme }) => theme.colors.border};
   border-radius: ${({ theme }) => theme.radii.lg};
-  width: 520px;
-  max-height: 80vh;
+  width: 560px;
+  max-height: 85vh;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -160,41 +147,6 @@ const SliderValue = styled.span`
   text-align: right;
 `;
 
-const NodeGrid = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-`;
-
-const NodeCard = styled.div<{ $active: boolean }>`
-  padding: 8px 12px;
-  border-radius: ${({ theme }) => theme.radii.md};
-  border: 1px solid ${({ $active, theme }) => $active ? 'rgba(74, 222, 128, 0.4)' : theme.colors.border};
-  background: ${({ $active }) => $active ? 'rgba(74, 222, 128, 0.06)' : 'transparent'};
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 100px;
-  transition: all 0.15s;
-`;
-
-const NodeName = styled.div<{ $active: boolean }>`
-  font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-family: ${({ theme }) => theme.fonts.body};
-  font-weight: 500;
-  color: ${({ $active }) => $active ? '#4ade80' : 'rgba(255,255,255,0.7)'};
-`;
-
-const NodeMem = styled.div`
-  font-size: ${({ theme }) => theme.fontSizes.xs};
-  font-family: ${({ theme }) => theme.fonts.mono};
-  color: ${({ theme }) => theme.colors.textMuted};
-`;
-
-const MemDelta = styled.span<{ $positive: boolean }>`
-  color: ${({ $positive }) => $positive ? '#f59e0b' : '#4ade80'};
-`;
-
 const OptionRow = styled.div`
   display: flex;
   gap: 12px;
@@ -248,6 +200,19 @@ const Callout = styled.div`
   color: rgba(245, 158, 11, 0.9);
 `;
 
+const ErrorCallout = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: ${({ theme }) => theme.radii.md};
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: rgba(248, 113, 113, 1);
+`;
+
 const Footer = styled.div`
   display: flex;
   justify-content: flex-end;
@@ -267,10 +232,14 @@ const Loading = styled.div`
   color: ${({ theme }) => theme.colors.textMuted};
 `;
 
+const CardWrapper = styled.div`
+  pointer-events: none;
+`;
+
 /* ── Component ────────────────────────────────────────── */
 
-export function PlacementManager({ modelId, topology, open, onClose, onLaunch }: PlacementManagerProps) {
-  const [previews, setPreviews] = useState<RawPreview[]>([]);
+export function PlacementManager({ modelId, modelSizeMb, topology, open, onClose, onLaunch }: PlacementManagerProps) {
+  const [previews, setPreviews] = useState<PlacementPreview[]>([]);
   const [loading, setLoading] = useState(false);
   const [minNodes, setMinNodes] = useState(1);
   const [sharding, setSharding] = useState<'Pipeline' | 'Tensor'>('Pipeline');
@@ -302,49 +271,60 @@ export function PlacementManager({ modelId, topology, open, onClose, onLaunch }:
   // Group previews by node count
   const optionsByNodeCount = useMemo(() => {
     const map: Record<number, NodeCountOptions> = {};
+    const empty: ComboStatus = { available: false, error: 'No preview available' };
 
     for (let n = 1; n <= totalNodes; n++) {
-      map[n] = {
-        pipeline_ring: { available: false, error: 'No preview available' },
-        pipeline_jaccl: { available: false, error: 'No preview available' },
-        tensor_ring: { available: false, error: 'No preview available' },
-        tensor_jaccl: { available: false, error: 'No preview available' },
-      };
+      map[n] = { pipeline_ring: { ...empty }, pipeline_jaccl: { ...empty }, tensor_ring: { ...empty }, tensor_jaccl: { ...empty } };
     }
 
     for (const p of previews) {
-      const nodeIds = p.instance ? extractNodeIds(p.instance) : [];
-      const count = nodeIds.length || 1;
+      const count = p.instance ? extractNodeCount(p) : 1;
       const key = comboKey(p.sharding, p.instance_meta);
-
-      if (!map[count]) {
-        map[count] = {
-          pipeline_ring: { available: false, error: 'No preview available' },
-          pipeline_jaccl: { available: false, error: 'No preview available' },
-          tensor_ring: { available: false, error: 'No preview available' },
-          tensor_jaccl: { available: false, error: 'No preview available' },
-        };
-      }
+      if (!map[count]) continue;
 
       map[count][key] = p.error
         ? { available: false, error: p.error }
-        : { available: true, memoryDelta: p.memory_delta_by_node ?? undefined, nodeIds };
+        : { available: true, preview: p };
     }
 
     return map;
   }, [previews, totalNodes]);
 
-  // Current options for selected node count
+  // Default to first valid node count + combo after previews load
+  const defaultsSet = useRef(false);
+  useEffect(() => {
+    if (defaultsSet.current || Object.keys(optionsByNodeCount).length === 0) return;
+    const combos: (keyof NodeCountOptions)[] = ['pipeline_ring', 'tensor_ring', 'pipeline_jaccl', 'tensor_jaccl'];
+    for (let n = 1; n <= totalNodes; n++) {
+      const opts = optionsByNodeCount[n];
+      if (!opts) continue;
+      for (const k of combos) {
+        if (opts[k]?.available) {
+          setMinNodes(n);
+          setSharding(k.startsWith('tensor') ? 'Tensor' : 'Pipeline');
+          setInstanceMeta(k.endsWith('jaccl') ? 'MlxJaccl' : 'MlxRing');
+          defaultsSet.current = true;
+          return;
+        }
+      }
+    }
+  }, [optionsByNodeCount, totalNodes]);
+
+  // Reset defaults flag when modal reopens
+  useEffect(() => {
+    if (open) defaultsSet.current = false;
+  }, [open]);
+
   const currentOptions = optionsByNodeCount[minNodes];
-  const currentCombo = currentOptions?.[comboKey(sharding, instanceMeta)];
+  const currentKey = comboKey(sharding, instanceMeta);
+  const currentCombo = currentOptions?.[currentKey];
+  const currentPreview = currentCombo?.available ? currentCombo.preview ?? null : null;
 
   // Auto-select first available combo when node count changes
   useEffect(() => {
     if (!currentOptions) return;
-    const key = comboKey(sharding, instanceMeta);
-    if (currentOptions[key]?.available) return; // current selection still valid
+    if (currentOptions[currentKey]?.available) return;
 
-    // Try to find a valid combo
     const priorities: (keyof NodeCountOptions)[] = ['pipeline_ring', 'tensor_ring', 'pipeline_jaccl', 'tensor_jaccl'];
     for (const k of priorities) {
       if (currentOptions[k]?.available) {
@@ -353,12 +333,7 @@ export function PlacementManager({ modelId, topology, open, onClose, onLaunch }:
         return;
       }
     }
-  }, [minNodes, currentOptions, sharding, instanceMeta]);
-
-  // Nodes that would be used
-  const activeNodeIds = useMemo(() => {
-    return currentCombo?.nodeIds ?? [];
-  }, [currentCombo]);
+  }, [minNodes, currentOptions, currentKey]);
 
   const handleLaunch = useCallback(() => {
     onLaunch({ modelId, sharding, instanceMeta, minNodes });
@@ -373,11 +348,25 @@ export function PlacementManager({ modelId, topology, open, onClose, onLaunch }:
   const tensorRing = currentOptions?.tensor_ring;
   const tensorJaccl = currentOptions?.tensor_jaccl;
 
-  // Determine sharding/networking errors for callouts
-  const shardingError = sharding === 'Tensor'
+  const noComboAvailable = currentOptions
+    && !pipelineRing?.available && !pipelineJaccl?.available
+    && !tensorRing?.available && !tensorJaccl?.available;
+
+  // Check if ANY node count has a valid placement at all
+  const anyPlacementPossible = Object.values(optionsByNodeCount).some((opts) =>
+    opts.pipeline_ring.available || opts.pipeline_jaccl.available
+    || opts.tensor_ring.available || opts.tensor_jaccl.available,
+  );
+
+  // Find the most relevant error to show when nothing works
+  const placementError = noComboAvailable
+    ? (pipelineRing?.error ?? tensorRing?.error ?? pipelineJaccl?.error ?? tensorJaccl?.error ?? 'No valid placement found')
+    : null;
+
+  const shardingError = !noComboAvailable && sharding === 'Tensor'
     ? tensorRing?.error ?? tensorJaccl?.error
-    : pipelineRing?.error ?? pipelineJaccl?.error;
-  const networkError = instanceMeta === 'MlxJaccl'
+    : !noComboAvailable ? (pipelineRing?.error ?? pipelineJaccl?.error) : undefined;
+  const networkError = !noComboAvailable && instanceMeta === 'MlxJaccl'
     ? (sharding === 'Pipeline' ? pipelineJaccl?.error : tensorJaccl?.error)
     : undefined;
 
@@ -394,120 +383,135 @@ export function PlacementManager({ modelId, topology, open, onClose, onLaunch }:
             <Loading>Analyzing placement options...</Loading>
           ) : (
             <>
-              {/* Node count slider */}
+              {/* Cluster visualization via ModelCard */}
               <Section>
-                <SectionLabel>Nodes</SectionLabel>
-                <SliderRow>
-                  <Slider
-                    type="range"
-                    min={1}
-                    max={Math.max(totalNodes, 1)}
-                    value={minNodes}
-                    onChange={(e) => setMinNodes(Number(e.target.value))}
+                <SectionLabel>Cluster Preview</SectionLabel>
+                <CardWrapper>
+                  <ModelCard
+                    model={{ id: modelId, name: modelLabel(modelId), storage_size_megabytes: modelSizeMb }}
+                    nodes={topology?.nodes ?? {}}
+                    sharding={sharding}
+                    runtime={instanceMeta}
+                    apiPreview={currentPreview}
+                    hideActions
                   />
-                  <SliderValue>{minNodes} of {totalNodes}</SliderValue>
-                </SliderRow>
+                </CardWrapper>
               </Section>
 
-              {/* Node visualization */}
-              <Section>
-                <NodeGrid>
-                  {Object.entries(topology?.nodes ?? {}).map(([nodeId, node]) => {
-                    const active = activeNodeIds.includes(nodeId);
-                    const mem = node.macmon_info?.memory;
-                    const delta = currentCombo?.memoryDelta?.[nodeId];
-                    return (
-                      <NodeCard key={nodeId} $active={active}>
-                        <NodeName $active={active}>
-                          {node.friendly_name ?? nodeId.slice(0, 8)}
-                        </NodeName>
-                        <NodeMem>
-                          {mem ? `${(mem.ram_usage / 1e9).toFixed(1)}/${(mem.ram_total / 1e9).toFixed(0)}GB` : '—'}
-                          {active && delta != null && (
-                            <> <MemDelta $positive={delta > 0}>{formatBytes(delta)}</MemDelta></>
-                          )}
-                        </NodeMem>
-                      </NodeCard>
-                    );
-                  })}
-                </NodeGrid>
-              </Section>
+              {/* Placement error — shown when nothing works at any node count */}
+              {!anyPlacementPossible && placementError && (
+                <ErrorCallout>
+                  <FiInfo size={16} style={{ flexShrink: 0, marginTop: 1 }} />
+                  {placementError}
+                </ErrorCallout>
+              )}
 
-              {/* Sharding */}
-              <Section>
-                <SectionLabel>Sharding</SectionLabel>
-                <OptionRow>
-                  <OptionBtn
-                    $selected={sharding === 'Pipeline'}
-                    $disabled={!pipelineRing?.available && !pipelineJaccl?.available}
-                    onClick={() => {
-                      if (pipelineRing?.available || pipelineJaccl?.available) setSharding('Pipeline');
-                    }}
-                  >
-                    <OptionLabel $selected={sharding === 'Pipeline'}>Pipeline</OptionLabel>
-                    <OptionSub>Layers split across nodes</OptionSub>
-                  </OptionBtn>
-                  <OptionBtn
-                    $selected={sharding === 'Tensor'}
-                    $disabled={!tensorRing?.available && !tensorJaccl?.available}
-                    onClick={() => {
-                      if (tensorRing?.available || tensorJaccl?.available) setSharding('Tensor');
-                    }}
-                  >
-                    <OptionLabel $selected={sharding === 'Tensor'}>Tensor</OptionLabel>
-                    <OptionSub>Weights split across nodes</OptionSub>
-                  </OptionBtn>
-                </OptionRow>
-                {shardingError && !canLaunch && (
-                  <Callout><FiInfo size={14} style={{ flexShrink: 0, marginTop: 1 }} /> {shardingError}</Callout>
-                )}
-              </Section>
+              {/* Node count slider — only when placement is possible */}
+              {anyPlacementPossible && (
+                <Section>
+                  <SectionLabel>Nodes</SectionLabel>
+                  <SliderRow>
+                    <Slider
+                      type="range"
+                      min={1}
+                      max={Math.max(totalNodes, 1)}
+                      value={minNodes}
+                      onChange={(e) => setMinNodes(Number(e.target.value))}
+                    />
+                    <SliderValue>{minNodes} of {totalNodes}</SliderValue>
+                  </SliderRow>
+                </Section>
+              )}
 
-              {/* Networking */}
-              <Section>
-                <SectionLabel>Networking</SectionLabel>
-                <OptionRow>
-                  <OptionBtn
-                    $selected={instanceMeta === 'MlxRing'}
-                    $disabled={!(sharding === 'Pipeline' ? pipelineRing : tensorRing)?.available}
-                    onClick={() => {
-                      const combo = sharding === 'Pipeline' ? pipelineRing : tensorRing;
-                      if (combo?.available) setInstanceMeta('MlxRing');
-                    }}
-                  >
-                    <OptionLabel $selected={instanceMeta === 'MlxRing'}>MLX Ring</OptionLabel>
-                    <OptionSub>Works over any network</OptionSub>
-                  </OptionBtn>
-                  <OptionBtn
-                    $selected={instanceMeta === 'MlxJaccl'}
-                    $disabled={!(sharding === 'Pipeline' ? pipelineJaccl : tensorJaccl)?.available}
-                    onClick={() => {
-                      const combo = sharding === 'Pipeline' ? pipelineJaccl : tensorJaccl;
-                      if (combo?.available) setInstanceMeta('MlxJaccl');
-                    }}
-                  >
-                    <OptionLabel $selected={instanceMeta === 'MlxJaccl'}>MLX Jaccl</OptionLabel>
-                    <OptionSub>RDMA / Thunderbolt 5</OptionSub>
-                  </OptionBtn>
-                </OptionRow>
-                {networkError && (
-                  <Callout><FiInfo size={14} style={{ flexShrink: 0, marginTop: 1 }} /> {networkError}</Callout>
-                )}
-              </Section>
+              {/* Per-node-count error */}
+              {anyPlacementPossible && noComboAvailable && placementError && (
+                <ErrorCallout>
+                  <FiInfo size={16} style={{ flexShrink: 0, marginTop: 1 }} />
+                  {placementError}
+                </ErrorCallout>
+              )}
+
+              {anyPlacementPossible && (
+                <>
+                  {/* Sharding */}
+                  <Section>
+                    <SectionLabel>Sharding</SectionLabel>
+                    <OptionRow>
+                      <OptionBtn
+                        $selected={sharding === 'Pipeline'}
+                        $disabled={!pipelineRing?.available && !pipelineJaccl?.available}
+                        onClick={() => {
+                          if (pipelineRing?.available || pipelineJaccl?.available) setSharding('Pipeline');
+                        }}
+                      >
+                        <OptionLabel $selected={sharding === 'Pipeline'}>Pipeline</OptionLabel>
+                        <OptionSub>Layers split across nodes</OptionSub>
+                      </OptionBtn>
+                      <OptionBtn
+                        $selected={sharding === 'Tensor'}
+                        $disabled={!tensorRing?.available && !tensorJaccl?.available}
+                        onClick={() => {
+                          if (tensorRing?.available || tensorJaccl?.available) setSharding('Tensor');
+                        }}
+                      >
+                        <OptionLabel $selected={sharding === 'Tensor'}>Tensor</OptionLabel>
+                        <OptionSub>Weights split across nodes</OptionSub>
+                      </OptionBtn>
+                    </OptionRow>
+                    {shardingError && !canLaunch && (
+                      <Callout><FiInfo size={14} style={{ flexShrink: 0, marginTop: 1 }} /> {shardingError}</Callout>
+                    )}
+                  </Section>
+
+                  {/* Networking */}
+                  <Section>
+                    <SectionLabel>Networking</SectionLabel>
+                    <OptionRow>
+                      <OptionBtn
+                        $selected={instanceMeta === 'MlxRing'}
+                        $disabled={!(sharding === 'Pipeline' ? pipelineRing : tensorRing)?.available}
+                        onClick={() => {
+                          const combo = sharding === 'Pipeline' ? pipelineRing : tensorRing;
+                          if (combo?.available) setInstanceMeta('MlxRing');
+                        }}
+                      >
+                        <OptionLabel $selected={instanceMeta === 'MlxRing'}>MLX Ring</OptionLabel>
+                        <OptionSub>Works over any network</OptionSub>
+                      </OptionBtn>
+                      <OptionBtn
+                        $selected={instanceMeta === 'MlxJaccl'}
+                        $disabled={!(sharding === 'Pipeline' ? pipelineJaccl : tensorJaccl)?.available}
+                        onClick={() => {
+                          const combo = sharding === 'Pipeline' ? pipelineJaccl : tensorJaccl;
+                          if (combo?.available) setInstanceMeta('MlxJaccl');
+                        }}
+                      >
+                        <OptionLabel $selected={instanceMeta === 'MlxJaccl'}>MLX Jaccl</OptionLabel>
+                        <OptionSub>RDMA / Thunderbolt 5</OptionSub>
+                      </OptionBtn>
+                    </OptionRow>
+                    {networkError && (
+                      <Callout><FiInfo size={14} style={{ flexShrink: 0, marginTop: 1 }} /> {networkError}</Callout>
+                    )}
+                  </Section>
+                </>
+              )}
             </>
           )}
         </Body>
 
-        <Footer>
-          <LaunchBtn
-            variant="primary"
-            size="md"
-            disabled={!canLaunch || loading}
-            onClick={handleLaunch}
-          >
-            <MdPlayArrow size={18} /> Launch Model
-          </LaunchBtn>
-        </Footer>
+        {anyPlacementPossible && (
+          <Footer>
+            <LaunchBtn
+              variant="primary"
+              size="md"
+              disabled={!canLaunch || loading}
+              onClick={handleLaunch}
+            >
+              <MdPlayArrow size={18} /> Launch Model
+            </LaunchBtn>
+          </Footer>
+        )}
       </Modal>
     </Overlay>
   );

--- a/dashboard-react/src/components/cluster/PlacementManager.tsx
+++ b/dashboard-react/src/components/cluster/PlacementManager.tsx
@@ -381,7 +381,7 @@ export function PlacementManager({ modelId, modelSizeMb, topology, open, onClose
       <Modal onClick={(e) => e.stopPropagation()}>
         <Header>
           <Title>Place <ModelName>{modelLabel(modelId)}</ModelName></Title>
-          <CloseBtn onClick={onClose}><FiX size={18} /></CloseBtn>
+          <CloseBtn onClick={onClose} aria-label="Close placement manager"><FiX size={18} /></CloseBtn>
         </Header>
 
         <Body>

--- a/dashboard-react/src/components/cluster/PlacementManager.tsx
+++ b/dashboard-react/src/components/cluster/PlacementManager.tsx
@@ -1,0 +1,514 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { FiX, FiInfo } from 'react-icons/fi';
+import { MdPlayArrow } from 'react-icons/md';
+import type { TopologyData } from '../../types/topology';
+import { Button } from '../common/Button';
+
+/* ── Types ────────────────────────────────────────────── */
+
+export interface PlacementManagerProps {
+  modelId: string;
+  topology: TopologyData;
+  open: boolean;
+  onClose: () => void;
+  onLaunch: (params: { modelId: string; sharding: string; instanceMeta: string; minNodes: number }) => void;
+}
+
+interface RawPreview {
+  model_id: string;
+  sharding: string;
+  instance_meta: string;
+  instance: unknown | null;
+  memory_delta_by_node: Record<string, number> | null;
+  error: string | null;
+}
+
+interface ComboStatus {
+  available: boolean;
+  error?: string;
+  memoryDelta?: Record<string, number>;
+  nodeIds?: string[];
+}
+
+interface NodeCountOptions {
+  pipeline_ring: ComboStatus;
+  pipeline_jaccl: ComboStatus;
+  tensor_ring: ComboStatus;
+  tensor_jaccl: ComboStatus;
+}
+
+/* ── Helpers ──────────────────────────────────────────── */
+
+function modelLabel(modelId: string): string {
+  const parts = modelId.split('/');
+  return parts[parts.length - 1];
+}
+
+function formatBytes(bytes: number): string {
+  const gb = Math.abs(bytes) / 1e9;
+  const sign = bytes >= 0 ? '+' : '-';
+  return `${sign}${gb.toFixed(1)}GB`;
+}
+
+function comboKey(sharding: string, meta: string): keyof NodeCountOptions {
+  const s = sharding === 'Tensor' ? 'tensor' : 'pipeline';
+  const m = meta === 'MlxJaccl' ? 'jaccl' : 'ring';
+  return `${s}_${m}` as keyof NodeCountOptions;
+}
+
+function extractNodeIds(instance: unknown): string[] {
+  if (!instance || typeof instance !== 'object') return [];
+  const inner = (instance as Record<string, unknown>).MlxRingInstance
+    ?? (instance as Record<string, unknown>).MlxJacclInstance;
+  if (!inner || typeof inner !== 'object') return [];
+  const sa = (inner as Record<string, unknown>).shardAssignments;
+  if (!sa || typeof sa !== 'object') return [];
+  const ntr = (sa as Record<string, unknown>).nodeToRunner;
+  if (!ntr || typeof ntr !== 'object') return [];
+  return Object.keys(ntr as Record<string, unknown>);
+}
+
+/* ── Styles ───────────────────────────────────────────── */
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Modal = styled.div`
+  background: ${({ theme }) => theme.colors.surface};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.radii.lg};
+  width: 520px;
+  max-height: 80vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+const Title = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const ModelName = styled.span`
+  color: ${({ theme }) => theme.colors.gold};
+  font-weight: 500;
+`;
+
+const CloseBtn = styled.button`
+  all: unset;
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.textMuted};
+  &:hover { color: ${({ theme }) => theme.colors.text}; }
+`;
+
+const Body = styled.div`
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const SectionLabel = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+`;
+
+const SliderRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const Slider = styled.input`
+  flex: 1;
+  accent-color: ${({ theme }) => theme.colors.gold};
+`;
+
+const SliderValue = styled.span`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.gold};
+  min-width: 60px;
+  text-align: right;
+`;
+
+const NodeGrid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const NodeCard = styled.div<{ $active: boolean }>`
+  padding: 8px 12px;
+  border-radius: ${({ theme }) => theme.radii.md};
+  border: 1px solid ${({ $active, theme }) => $active ? 'rgba(74, 222, 128, 0.4)' : theme.colors.border};
+  background: ${({ $active }) => $active ? 'rgba(74, 222, 128, 0.06)' : 'transparent'};
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 100px;
+  transition: all 0.15s;
+`;
+
+const NodeName = styled.div<{ $active: boolean }>`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-weight: 500;
+  color: ${({ $active }) => $active ? '#4ade80' : 'rgba(255,255,255,0.7)'};
+`;
+
+const NodeMem = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const MemDelta = styled.span<{ $positive: boolean }>`
+  color: ${({ $positive }) => $positive ? '#f59e0b' : '#4ade80'};
+`;
+
+const OptionRow = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+const OptionBtn = styled.button<{ $selected: boolean; $disabled: boolean }>`
+  all: unset;
+  cursor: ${({ $disabled }) => $disabled ? 'not-allowed' : 'pointer'};
+  flex: 1;
+  padding: 10px 14px;
+  border-radius: ${({ theme }) => theme.radii.md};
+  border: 1px solid ${({ $selected, $disabled, theme }) =>
+    $disabled ? 'rgba(255,255,255,0.08)' : $selected ? theme.colors.goldDim : theme.colors.border};
+  background: ${({ $selected, $disabled }) =>
+    $disabled ? 'rgba(255,255,255,0.02)' : $selected ? 'rgba(255, 215, 0, 0.08)' : 'transparent'};
+  opacity: ${({ $disabled }) => $disabled ? 0.5 : 1};
+  transition: all 0.15s;
+  text-align: center;
+
+  ${({ $disabled }) => !$disabled && css`
+    &:hover {
+      border-color: rgba(255, 215, 0, 0.4);
+    }
+  `}
+`;
+
+const OptionLabel = styled.div<{ $selected: boolean }>`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-weight: 500;
+  color: ${({ $selected }) => $selected ? '#FFD700' : 'rgba(255,255,255,0.7)'};
+`;
+
+const OptionSub = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.textMuted};
+  margin-top: 2px;
+`;
+
+const Callout = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: ${({ theme }) => theme.radii.sm};
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: rgba(245, 158, 11, 0.9);
+`;
+
+const Footer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding: 16px 20px;
+  border-top: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+const LaunchBtn = styled(Button)`
+  gap: 6px;
+`;
+
+const Loading = styled.div`
+  padding: 40px;
+  text-align: center;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+/* ── Component ────────────────────────────────────────── */
+
+export function PlacementManager({ modelId, topology, open, onClose, onLaunch }: PlacementManagerProps) {
+  const [previews, setPreviews] = useState<RawPreview[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [minNodes, setMinNodes] = useState(1);
+  const [sharding, setSharding] = useState<'Pipeline' | 'Tensor'>('Pipeline');
+  const [instanceMeta, setInstanceMeta] = useState<'MlxRing' | 'MlxJaccl'>('MlxRing');
+
+  const totalNodes = Object.keys(topology?.nodes ?? {}).length;
+
+  // Fetch previews when modal opens
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setPreviews([]);
+    setMinNodes(1);
+    setSharding('Pipeline');
+    setInstanceMeta('MlxRing');
+
+    (async () => {
+      try {
+        const res = await fetch(`/instance/previews?model_id=${encodeURIComponent(modelId)}`);
+        if (res.ok) {
+          const data = await res.json();
+          setPreviews(data.previews ?? data ?? []);
+        }
+      } catch { /* ignore */ }
+      finally { setLoading(false); }
+    })();
+  }, [open, modelId]);
+
+  // Group previews by node count
+  const optionsByNodeCount = useMemo(() => {
+    const map: Record<number, NodeCountOptions> = {};
+
+    for (let n = 1; n <= totalNodes; n++) {
+      map[n] = {
+        pipeline_ring: { available: false, error: 'No preview available' },
+        pipeline_jaccl: { available: false, error: 'No preview available' },
+        tensor_ring: { available: false, error: 'No preview available' },
+        tensor_jaccl: { available: false, error: 'No preview available' },
+      };
+    }
+
+    for (const p of previews) {
+      const nodeIds = p.instance ? extractNodeIds(p.instance) : [];
+      const count = nodeIds.length || 1;
+      const key = comboKey(p.sharding, p.instance_meta);
+
+      if (!map[count]) {
+        map[count] = {
+          pipeline_ring: { available: false, error: 'No preview available' },
+          pipeline_jaccl: { available: false, error: 'No preview available' },
+          tensor_ring: { available: false, error: 'No preview available' },
+          tensor_jaccl: { available: false, error: 'No preview available' },
+        };
+      }
+
+      map[count][key] = p.error
+        ? { available: false, error: p.error }
+        : { available: true, memoryDelta: p.memory_delta_by_node ?? undefined, nodeIds };
+    }
+
+    return map;
+  }, [previews, totalNodes]);
+
+  // Current options for selected node count
+  const currentOptions = optionsByNodeCount[minNodes];
+  const currentCombo = currentOptions?.[comboKey(sharding, instanceMeta)];
+
+  // Auto-select first available combo when node count changes
+  useEffect(() => {
+    if (!currentOptions) return;
+    const key = comboKey(sharding, instanceMeta);
+    if (currentOptions[key]?.available) return; // current selection still valid
+
+    // Try to find a valid combo
+    const priorities: (keyof NodeCountOptions)[] = ['pipeline_ring', 'tensor_ring', 'pipeline_jaccl', 'tensor_jaccl'];
+    for (const k of priorities) {
+      if (currentOptions[k]?.available) {
+        setSharding(k.startsWith('tensor') ? 'Tensor' : 'Pipeline');
+        setInstanceMeta(k.endsWith('jaccl') ? 'MlxJaccl' : 'MlxRing');
+        return;
+      }
+    }
+  }, [minNodes, currentOptions, sharding, instanceMeta]);
+
+  // Nodes that would be used
+  const activeNodeIds = useMemo(() => {
+    return currentCombo?.nodeIds ?? [];
+  }, [currentCombo]);
+
+  const handleLaunch = useCallback(() => {
+    onLaunch({ modelId, sharding, instanceMeta, minNodes });
+    onClose();
+  }, [modelId, sharding, instanceMeta, minNodes, onLaunch, onClose]);
+
+  if (!open) return null;
+
+  const canLaunch = currentCombo?.available ?? false;
+  const pipelineRing = currentOptions?.pipeline_ring;
+  const pipelineJaccl = currentOptions?.pipeline_jaccl;
+  const tensorRing = currentOptions?.tensor_ring;
+  const tensorJaccl = currentOptions?.tensor_jaccl;
+
+  // Determine sharding/networking errors for callouts
+  const shardingError = sharding === 'Tensor'
+    ? tensorRing?.error ?? tensorJaccl?.error
+    : pipelineRing?.error ?? pipelineJaccl?.error;
+  const networkError = instanceMeta === 'MlxJaccl'
+    ? (sharding === 'Pipeline' ? pipelineJaccl?.error : tensorJaccl?.error)
+    : undefined;
+
+  return (
+    <Overlay onClick={onClose}>
+      <Modal onClick={(e) => e.stopPropagation()}>
+        <Header>
+          <Title>Place <ModelName>{modelLabel(modelId)}</ModelName></Title>
+          <CloseBtn onClick={onClose}><FiX size={18} /></CloseBtn>
+        </Header>
+
+        <Body>
+          {loading ? (
+            <Loading>Analyzing placement options...</Loading>
+          ) : (
+            <>
+              {/* Node count slider */}
+              <Section>
+                <SectionLabel>Nodes</SectionLabel>
+                <SliderRow>
+                  <Slider
+                    type="range"
+                    min={1}
+                    max={Math.max(totalNodes, 1)}
+                    value={minNodes}
+                    onChange={(e) => setMinNodes(Number(e.target.value))}
+                  />
+                  <SliderValue>{minNodes} of {totalNodes}</SliderValue>
+                </SliderRow>
+              </Section>
+
+              {/* Node visualization */}
+              <Section>
+                <NodeGrid>
+                  {Object.entries(topology?.nodes ?? {}).map(([nodeId, node]) => {
+                    const active = activeNodeIds.includes(nodeId);
+                    const mem = node.macmon_info?.memory;
+                    const delta = currentCombo?.memoryDelta?.[nodeId];
+                    return (
+                      <NodeCard key={nodeId} $active={active}>
+                        <NodeName $active={active}>
+                          {node.friendly_name ?? nodeId.slice(0, 8)}
+                        </NodeName>
+                        <NodeMem>
+                          {mem ? `${(mem.ram_usage / 1e9).toFixed(1)}/${(mem.ram_total / 1e9).toFixed(0)}GB` : '—'}
+                          {active && delta != null && (
+                            <> <MemDelta $positive={delta > 0}>{formatBytes(delta)}</MemDelta></>
+                          )}
+                        </NodeMem>
+                      </NodeCard>
+                    );
+                  })}
+                </NodeGrid>
+              </Section>
+
+              {/* Sharding */}
+              <Section>
+                <SectionLabel>Sharding</SectionLabel>
+                <OptionRow>
+                  <OptionBtn
+                    $selected={sharding === 'Pipeline'}
+                    $disabled={!pipelineRing?.available && !pipelineJaccl?.available}
+                    onClick={() => {
+                      if (pipelineRing?.available || pipelineJaccl?.available) setSharding('Pipeline');
+                    }}
+                  >
+                    <OptionLabel $selected={sharding === 'Pipeline'}>Pipeline</OptionLabel>
+                    <OptionSub>Layers split across nodes</OptionSub>
+                  </OptionBtn>
+                  <OptionBtn
+                    $selected={sharding === 'Tensor'}
+                    $disabled={!tensorRing?.available && !tensorJaccl?.available}
+                    onClick={() => {
+                      if (tensorRing?.available || tensorJaccl?.available) setSharding('Tensor');
+                    }}
+                  >
+                    <OptionLabel $selected={sharding === 'Tensor'}>Tensor</OptionLabel>
+                    <OptionSub>Weights split across nodes</OptionSub>
+                  </OptionBtn>
+                </OptionRow>
+                {shardingError && !canLaunch && (
+                  <Callout><FiInfo size={14} style={{ flexShrink: 0, marginTop: 1 }} /> {shardingError}</Callout>
+                )}
+              </Section>
+
+              {/* Networking */}
+              <Section>
+                <SectionLabel>Networking</SectionLabel>
+                <OptionRow>
+                  <OptionBtn
+                    $selected={instanceMeta === 'MlxRing'}
+                    $disabled={!(sharding === 'Pipeline' ? pipelineRing : tensorRing)?.available}
+                    onClick={() => {
+                      const combo = sharding === 'Pipeline' ? pipelineRing : tensorRing;
+                      if (combo?.available) setInstanceMeta('MlxRing');
+                    }}
+                  >
+                    <OptionLabel $selected={instanceMeta === 'MlxRing'}>MLX Ring</OptionLabel>
+                    <OptionSub>Works over any network</OptionSub>
+                  </OptionBtn>
+                  <OptionBtn
+                    $selected={instanceMeta === 'MlxJaccl'}
+                    $disabled={!(sharding === 'Pipeline' ? pipelineJaccl : tensorJaccl)?.available}
+                    onClick={() => {
+                      const combo = sharding === 'Pipeline' ? pipelineJaccl : tensorJaccl;
+                      if (combo?.available) setInstanceMeta('MlxJaccl');
+                    }}
+                  >
+                    <OptionLabel $selected={instanceMeta === 'MlxJaccl'}>MLX Jaccl</OptionLabel>
+                    <OptionSub>RDMA / Thunderbolt 5</OptionSub>
+                  </OptionBtn>
+                </OptionRow>
+                {networkError && (
+                  <Callout><FiInfo size={14} style={{ flexShrink: 0, marginTop: 1 }} /> {networkError}</Callout>
+                )}
+              </Section>
+            </>
+          )}
+        </Body>
+
+        <Footer>
+          <LaunchBtn
+            variant="primary"
+            size="md"
+            disabled={!canLaunch || loading}
+            onClick={handleLaunch}
+          >
+            <MdPlayArrow size={18} /> Launch Model
+          </LaunchBtn>
+        </Footer>
+      </Modal>
+    </Overlay>
+  );
+}

--- a/dashboard-react/src/components/cluster/PlacementManager.tsx
+++ b/dashboard-react/src/components/cluster/PlacementManager.tsx
@@ -284,13 +284,23 @@ export function PlacementManager({ modelId, modelSizeMb, topology, open, onClose
     }
 
     for (const p of previews) {
-      const count = p.instance ? extractNodeCount(p) : 1;
       const key = comboKey(p.sharding, p.instance_meta);
-      if (!map[count]) continue;
 
-      map[count][key] = p.error
-        ? { available: false, error: p.error }
-        : { available: true, preview: p };
+      if (p.instance && !p.error) {
+        // Successful placement — map to the actual node count
+        const count = extractNodeCount(p);
+        if (map[count]) {
+          map[count][key] = { available: true, preview: p };
+        }
+      } else if (p.error) {
+        // Error preview — no instance, so apply error to all node counts
+        // that don't already have a successful placement for this combo
+        for (let n = 1; n <= totalNodes; n++) {
+          if (map[n] && !map[n][key].available) {
+            map[n][key] = { available: false, error: p.error };
+          }
+        }
+      }
     }
 
     return map;

--- a/dashboard-react/src/components/cluster/PlacementManager.tsx
+++ b/dashboard-react/src/components/cluster/PlacementManager.tsx
@@ -256,16 +256,22 @@ export function PlacementManager({ modelId, modelSizeMb, topology, open, onClose
     setSharding('Pipeline');
     setInstanceMeta('MlxRing');
 
+    const controller = new AbortController();
     (async () => {
       try {
-        const res = await fetch(`/instance/previews?model_id=${encodeURIComponent(modelId)}`);
-        if (res.ok) {
+        const res = await fetch(`/instance/previews?model_id=${encodeURIComponent(modelId)}`, {
+          signal: controller.signal,
+        });
+        if (res.ok && !controller.signal.aborted) {
           const data = await res.json();
           setPreviews(data.previews ?? data ?? []);
         }
-      } catch { /* ignore */ }
-      finally { setLoading(false); }
+      } catch {
+        if (controller.signal.aborted) return;
+      }
+      finally { if (!controller.signal.aborted) setLoading(false); }
     })();
+    return () => controller.abort();
   }, [open, modelId]);
 
   // Group previews by node count

--- a/dashboard-react/src/components/common/Button.tsx
+++ b/dashboard-react/src/components/common/Button.tsx
@@ -149,7 +149,7 @@ const StyledButton = styled.button<{
 
   /* Disabled */
   &:disabled {
-    opacity: 0.35;
+    opacity: 0.88;
     cursor: not-allowed;
   }
 `;

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -25,6 +25,7 @@ export interface HeaderNavProps {
   instanceCount?: number;
   instancesHealthy?: boolean;
   downloadProgress?: { count: number; percentage: number } | null;
+  warnings?: { level: 'error' | 'warning'; items: { level: 'error' | 'warning'; message: string }[] } | null;
   onOpenSettings?: () => void;
   className?: string;
 }
@@ -137,6 +138,74 @@ const IconToggle = styled.span<{ $active: boolean }>`
   }
 `;
 
+const WarningDot = styled.div<{ $level: 'error' | 'warning' }>`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: help;
+
+  &:hover > .warning-tooltip {
+    opacity: 1;
+    visibility: visible;
+  }
+`;
+
+const WarningCircle = styled.div<{ $level: 'error' | 'warning' }>`
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: ${({ $level }) => $level === 'error' ? '#ef4444' : '#f59e0b'};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: #ffffff;
+`;
+
+const WarningTooltip = styled.div`
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  padding-top: 8px;
+  width: 300px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s, visibility 0.2s;
+  z-index: 50;
+`;
+
+const WarningTooltipInner = styled.div`
+  background: rgba(17, 17, 17, 0.95);
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.radii.md};
+  padding: 10px 12px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const WarningItem = styled.div<{ $level: 'error' | 'warning' }>`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ $level }) => $level === 'error' ? '#fca5a5' : '#fcd34d'};
+  line-height: 1.4;
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+
+  &::before {
+    content: '${({ $level }) => $level === 'error' ? '●' : '●'}';
+    color: ${({ $level }) => $level === 'error' ? '#ef4444' : '#f59e0b'};
+    flex-shrink: 0;
+  }
+`;
+
 const InstanceToggle = styled.button<{ $healthy: boolean; $active: boolean }>`
   all: unset;
   cursor: pointer;
@@ -207,6 +276,7 @@ export function HeaderNav({
   instanceCount = 0,
   instancesHealthy = true,
   downloadProgress = null,
+  warnings = null,
   onOpenSettings,
   className,
 }: HeaderNavProps) {
@@ -232,6 +302,18 @@ export function HeaderNav({
           <SkulkIcon size={32} color="#ffffff" />
           <LogoText>Skulk<VersionTag>{__APP_VERSION__}</VersionTag></LogoText>
         </LogoBtn>
+        {warnings && warnings.items.length > 0 && (
+          <WarningDot $level={warnings.level}>
+            <WarningCircle $level={warnings.level}>!</WarningCircle>
+            <WarningTooltip className="warning-tooltip">
+              <WarningTooltipInner>
+                {warnings.items.map((item, i) => (
+                  <WarningItem key={i} $level={item.level}>{item.message}</WarningItem>
+                ))}
+              </WarningTooltipInner>
+            </WarningTooltip>
+          </WarningDot>
+        )}
       </LeftGroup>
 
       <RightGroup>

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -47,6 +47,8 @@ export interface StoreRegistryTableProps {
   onChat?: (modelId: string) => void;
   onPlacement?: (modelId: string) => void;
   clusterCards?: Record<string, Omit<ClusterCardProps, 'onLaunch'>>;
+  /** Total available cluster RAM in bytes — used to disable launch for models that won't fit */
+  totalClusterMemoryBytes?: number;
 }
 
 /* ---- helpers ---- */
@@ -128,7 +130,7 @@ const Table = styled.div`
 
 const THead = styled.div`
   display: grid;
-  grid-template-columns: 36px 1fr 80px 60px 100px 60px;
+  grid-template-columns: 36px 32px 1fr 80px 60px 100px 60px;
   gap: 8px;
   padding: 8px 12px;
   background: rgba(0, 0, 0, 0.4);
@@ -139,7 +141,7 @@ const THead = styled.div`
 
 const TRow = styled.div<{ $highlight?: boolean }>`
   display: grid;
-  grid-template-columns: 36px 1fr 80px 60px 100px 60px;
+  grid-template-columns: 36px 32px 1fr 80px 60px 100px 60px;
   gap: 8px;
   padding: 10px 12px;
   align-items: center;
@@ -310,6 +312,18 @@ const PlayBtn = styled.button`
   }
 `;
 
+const DisabledBtn = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: ${({ theme }) => theme.colors.textMuted};
+  opacity: 0.4;
+  cursor: not-allowed;
+`;
+
 const PlacementBtn = styled.button`
   all: unset;
   cursor: pointer;
@@ -454,6 +468,7 @@ export function StoreRegistryTable({
   onChat,
   onPlacement,
   clusterCards = {},
+  totalClusterMemoryBytes = 0,
 }: StoreRegistryTableProps) {
   const registeredIds = useMemo(() => new Set(entries.map((e) => e.model_id)), [entries]);
   const pendingDownloads = useMemo(
@@ -494,6 +509,7 @@ export function StoreRegistryTable({
         <Table>
           <THead>
             <div />
+            <div />
             <div>Model</div>
             <div style={{ textAlign: 'right' }}>Size</div>
             <div style={{ textAlign: 'right' }}>Files</div>
@@ -504,6 +520,7 @@ export function StoreRegistryTable({
           {/* Pending downloads (not yet registered) */}
           {pendingDownloads.map((dl) => (
             <TRow key={dl.modelId} $highlight>
+              <Cell />
               <Cell />
               <ModelCell>
                 <ModelId title={dl.modelId}>{dl.modelId}</ModelId>
@@ -526,6 +543,7 @@ export function StoreRegistryTable({
           {entries.map((entry) => {
             const dl = downloadMap.get(entry.model_id);
             const active = isActive(entry.model_id);
+            const tooLarge = totalClusterMemoryBytes > 0 && entry.total_bytes > totalClusterMemoryBytes;
             return (
               <TRow key={entry.model_id}>
                 <PlayCell>
@@ -533,19 +551,25 @@ export function StoreRegistryTable({
                     <StopBtn onClick={() => onStop(entry.model_id)} title="Stop model">
                       <MdClose size={20} />
                     </StopBtn>
-                  ) : !active && !dl ? (
-                    <>
-                      {onLaunch && (
-                        <PlayBtn onClick={() => onLaunch(entry.model_id)} title="Launch model">
+                  ) : !active && !dl && onLaunch ? (
+                    tooLarge ? (
+                      <InfoTooltip content="Insufficient cluster memory" placement="right" delay={0}>
+                        <DisabledBtn aria-label="Insufficient memory">
                           <MdPlayArrow size={20} />
-                        </PlayBtn>
-                      )}
-                      {onPlacement && (
-                        <PlacementBtn onClick={() => onPlacement(entry.model_id)} title="Configure placement">
-                          <MdTune size={18} />
-                        </PlacementBtn>
-                      )}
-                    </>
+                        </DisabledBtn>
+                      </InfoTooltip>
+                    ) : (
+                      <PlayBtn onClick={() => onLaunch(entry.model_id)} title="Launch model">
+                        <MdPlayArrow size={20} />
+                      </PlayBtn>
+                    )
+                  ) : null}
+                </PlayCell>
+                <PlayCell>
+                  {!active && !dl && onPlacement ? (
+                    <PlacementBtn onClick={() => onPlacement(entry.model_id)} title="Configure placement">
+                      <MdTune size={18} />
+                    </PlacementBtn>
                   ) : null}
                 </PlayCell>
                 <ModelCell>

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import { FiTrash2, FiExternalLink, FiRefreshCw } from 'react-icons/fi';
-import { MdPlayArrow, MdClose } from 'react-icons/md';
+import { MdPlayArrow, MdClose, MdTune } from 'react-icons/md';
 import { BsChatDotsFill } from 'react-icons/bs';
 import { formatBytes } from '../../utils/format';
 import { Button } from '../common/Button';
@@ -45,6 +45,7 @@ export interface StoreRegistryTableProps {
   onLaunch?: (modelId: string) => void;
   onStop?: (modelId: string) => void;
   onChat?: (modelId: string) => void;
+  onPlacement?: (modelId: string) => void;
   clusterCards?: Record<string, Omit<ClusterCardProps, 'onLaunch'>>;
 }
 
@@ -309,6 +310,24 @@ const PlayBtn = styled.button`
   }
 `;
 
+const PlacementBtn = styled.button`
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: ${({ theme }) => theme.colors.textMuted};
+  transition: all 0.15s;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.gold};
+    background: rgba(255, 215, 0, 0.1);
+  }
+`;
+
 const StopBtn = styled.button`
   all: unset;
   cursor: pointer;
@@ -433,6 +452,7 @@ export function StoreRegistryTable({
   onLaunch,
   onStop,
   onChat,
+  onPlacement,
   clusterCards = {},
 }: StoreRegistryTableProps) {
   const registeredIds = useMemo(() => new Set(entries.map((e) => e.model_id)), [entries]);
@@ -513,10 +533,19 @@ export function StoreRegistryTable({
                     <StopBtn onClick={() => onStop(entry.model_id)} title="Stop model">
                       <MdClose size={20} />
                     </StopBtn>
-                  ) : !active && !dl && onLaunch ? (
-                    <PlayBtn onClick={() => onLaunch(entry.model_id)} title="Launch model">
-                      <MdPlayArrow size={20} />
-                    </PlayBtn>
+                  ) : !active && !dl ? (
+                    <>
+                      {onLaunch && (
+                        <PlayBtn onClick={() => onLaunch(entry.model_id)} title="Launch model">
+                          <MdPlayArrow size={20} />
+                        </PlayBtn>
+                      )}
+                      {onPlacement && (
+                        <PlacementBtn onClick={() => onPlacement(entry.model_id)} title="Configure placement">
+                          <MdTune size={18} />
+                        </PlacementBtn>
+                      )}
+                    </>
                   ) : null}
                 </PlayCell>
                 <ModelCell>

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -567,7 +567,7 @@ export function StoreRegistryTable({
                 </PlayCell>
                 <PlayCell>
                   {!active && !dl && onPlacement ? (
-                    <PlacementBtn onClick={() => onPlacement(entry.model_id)} title="Configure placement">
+                    <PlacementBtn onClick={() => onPlacement(entry.model_id)} title="Configure placement" aria-label="Configure placement">
                       <MdTune size={18} />
                     </PlacementBtn>
                   ) : null}

--- a/dashboard-react/src/components/models/ModelCard.tsx
+++ b/dashboard-react/src/components/models/ModelCard.tsx
@@ -33,6 +33,7 @@ export interface ModelCardProps {
   tags?: string[];
   apiPreview?: PlacementPreview | null;
   modelIdOverride?: string | null;
+  hideActions?: boolean;
 }
 
 /* ================================================================
@@ -149,15 +150,8 @@ const pulseSlow = keyframes`
 
 const Card = styled.div<{ $canFit: boolean }>`
   position: relative;
-  background: rgba(17, 17, 17, 0.6);
-  border: 1px solid ${({ $canFit }) => ($canFit ? 'rgba(255,215,0,0.2)' : 'rgba(239,68,68,0.2)')};
+  background: transparent;
   padding: 12px;
-  transition: all 0.2s;
-
-  &:hover {
-    border-color: ${({ $canFit }) => ($canFit ? 'rgba(255,215,0,0.4)' : 'rgba(239,68,68,0.3)')};
-    box-shadow: ${({ $canFit }) => ($canFit ? '0 0 15px rgba(255,215,0,0.1)' : 'none')};
-  }
 `;
 
 const Corner = styled.div<{ $canFit: boolean; $pos: string }>`
@@ -285,7 +279,7 @@ const ProgressFill = styled.div<{ $status: string }>`
 
 const PreviewBox = styled.div`
   margin-bottom: 12px;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(80, 80, 80, 0.2);
   border-radius: ${({ theme }) => theme.radii.sm};
   padding: 8px;
@@ -318,9 +312,10 @@ const LaunchBtn = styled(Button)<{ $canFit: boolean; $launching: boolean }>`
     !$launching &&
     css`
       background: rgba(239, 68, 68, 0.1);
-      color: rgba(248, 113, 113, 0.7);
+      color: rgba(248, 113, 113, 1);
       border-color: rgba(239, 68, 68, 0.3);
       cursor: not-allowed;
+      opacity: 1;
     `}
 `;
 
@@ -354,6 +349,7 @@ export function ModelCard({
   tags = [],
   apiPreview = null,
   modelIdOverride = null,
+  hideActions = false,
 }: ModelCardProps) {
   const estimatedMemory = model.storage_size_megabytes
     ? Math.round(model.storage_size_megabytes / 1024)
@@ -369,11 +365,6 @@ export function ModelCard({
 
   return (
     <Card $canFit={canFit}>
-      <Corner $canFit={canFit} $pos="tl" />
-      <Corner $canFit={canFit} $pos="tr" />
-      <Corner $canFit={canFit} $pos="bl" />
-      <Corner $canFit={canFit} $pos="br" />
-
       {/* Header: name + memory */}
       <Header>
         <div style={{ flex: 1, minWidth: 0 }}>
@@ -474,7 +465,7 @@ export function ModelCard({
                   stroke={n.isUsed && n2.isUsed ? '#FFD700' : '#374151'}
                   strokeWidth={1}
                   strokeDasharray={n.isUsed && n2.isUsed ? '4,2' : '2,4'}
-                  opacity={n.isUsed && n2.isUsed ? 0.4 : 0.15}
+                  opacity={n.isUsed && n2.isUsed ? 0.5 : 0.25}
                 />
               )),
             )}
@@ -484,7 +475,7 @@ export function ModelCard({
               <g
                 key={node.id}
                 transform={`translate(${node.x}, ${node.y})`}
-                opacity={node.isUsed ? 1 : 0.25}
+                opacity={node.isUsed ? 1 : 0.7}
                 filter={node.isUsed ? `url(#nodeGlow-${filterId})` : undefined}
               >
                 <PlacementDeviceIcon node={node} filterId={filterId} />
@@ -493,7 +484,7 @@ export function ModelCard({
                   textAnchor="middle"
                   fontSize={8}
                   fontFamily="SF Mono, Monaco, monospace"
-                  fill={node.isUsed ? (node.newPercent > 90 ? '#f87171' : '#FFD700') : '#4B5563'}
+                  fill={node.isUsed ? (node.newPercent > 90 ? '#f87171' : '#FFD700') : '#9CA3AF'}
                 >
                   {node.newPercent.toFixed(0)}%
                 </text>
@@ -504,23 +495,25 @@ export function ModelCard({
       )}
 
       {/* Launch button */}
-      <LaunchBtn
-        variant="outline"
-        size="lg"
-        block
-        $canFit={canFit}
-        $launching={isLaunching}
-        disabled={isLaunching || !canFit}
-        onClick={onLaunch}
-      >
-        {isLaunching ? (
-          <><LaunchSpinner /> LAUNCHING...</>
-        ) : !canFit ? (
-          'INSUFFICIENT MEMORY'
-        ) : (
-          '▸ LAUNCH'
-        )}
-      </LaunchBtn>
+      {!hideActions && (
+        <LaunchBtn
+          variant="outline"
+          size="lg"
+          block
+          $canFit={canFit}
+          $launching={isLaunching}
+          disabled={isLaunching || !canFit}
+          onClick={onLaunch}
+        >
+          {isLaunching ? (
+            <><LaunchSpinner /> LAUNCHING...</>
+          ) : !canFit ? (
+            'INSUFFICIENT MEMORY'
+          ) : (
+            '▸ LAUNCH'
+          )}
+        </LaunchBtn>
+      )}
     </Card>
   );
 }
@@ -532,7 +525,7 @@ export function ModelCard({
 function PlacementDeviceIcon({ node, filterId }: { node: PlacementNode; filterId: string }) {
   const s = node.iconSize;
   const half = s / 2;
-  const stroke = node.isUsed ? '#FFD700' : '#4B5563';
+  const stroke = node.isUsed ? '#FFD700' : '#6B7280';
   const screenH = s * 0.58;
   const currentFillH = screenH * (node.currentPercent / 100);
   const modelFillH = screenH * ((node.newPercent - node.currentPercent) / 100);
@@ -542,8 +535,8 @@ function PlacementDeviceIcon({ node, filterId }: { node: PlacementNode; filterId
       return (
         <g transform={`translate(${-half}, ${-half})`}>
           <rect x={2} y={0} width={s - 4} height={s * 0.65} rx={2} fill="none" stroke={stroke} strokeWidth={1.5} />
-          <rect x={4} y={2} width={s - 8} height={screenH} fill="#0a0a0a" />
-          <rect x={4} y={2 + screenH - currentFillH} width={s - 8} height={currentFillH} fill="#374151" />
+          <rect x={4} y={2} width={s - 8} height={screenH} fill="#1a1a1a" />
+          <rect x={4} y={2 + screenH - currentFillH} width={s - 8} height={currentFillH} fill="#4B5563" />
           {node.modelUsageGB > 0 && node.isUsed && (
             <ModelFill x={4} y={2 + screenH - currentFillH - modelFillH} width={s - 8} height={modelFillH} fill="#FFD700" filter={`url(#memGlow-${filterId})`} />
           )}
@@ -554,8 +547,8 @@ function PlacementDeviceIcon({ node, filterId }: { node: PlacementNode; filterId
       return (
         <g transform={`translate(${-half}, ${-half})`}>
           <rect x={2} y={2} width={s - 4} height={s - 4} rx={4} fill="none" stroke={stroke} strokeWidth={1.5} />
-          <rect x={4} y={4} width={s - 8} height={s - 8} fill="#0a0a0a" />
-          <rect x={4} y={4 + (s - 8) * (1 - node.currentPercent / 100)} width={s - 8} height={(s - 8) * (node.currentPercent / 100)} fill="#374151" />
+          <rect x={4} y={4} width={s - 8} height={s - 8} fill="#1a1a1a" />
+          <rect x={4} y={4 + (s - 8) * (1 - node.currentPercent / 100)} width={s - 8} height={(s - 8) * (node.currentPercent / 100)} fill="#4B5563" />
           {node.modelUsageGB > 0 && node.isUsed && (
             <ModelFill x={4} y={4 + (s - 8) * (1 - node.newPercent / 100)} width={s - 8} height={(s - 8) * ((node.newPercent - node.currentPercent) / 100)} fill="#FFD700" filter={`url(#memGlow-${filterId})`} />
           )}
@@ -565,8 +558,8 @@ function PlacementDeviceIcon({ node, filterId }: { node: PlacementNode; filterId
       return (
         <g transform={`translate(${-half}, ${-half})`}>
           <rect x={2} y={s * 0.3} width={s - 4} height={s * 0.4} rx={3} fill="none" stroke={stroke} strokeWidth={1.5} />
-          <rect x={4} y={s * 0.32} width={s - 8} height={s * 0.36} fill="#0a0a0a" />
-          <rect x={4} y={s * 0.32 + s * 0.36 * (1 - node.currentPercent / 100)} width={s - 8} height={s * 0.36 * (node.currentPercent / 100)} fill="#374151" />
+          <rect x={4} y={s * 0.32} width={s - 8} height={s * 0.36} fill="#1a1a1a" />
+          <rect x={4} y={s * 0.32 + s * 0.36 * (1 - node.currentPercent / 100)} width={s - 8} height={s * 0.36 * (node.currentPercent / 100)} fill="#4B5563" />
           {node.modelUsageGB > 0 && node.isUsed && (
             <ModelFill x={4} y={s * 0.32 + s * 0.36 * (1 - node.newPercent / 100)} width={s - 8} height={s * 0.36 * ((node.newPercent - node.currentPercent) / 100)} fill="#FFD700" filter={`url(#memGlow-${filterId})`} />
           )}

--- a/dashboard-react/src/components/models/ModelCard.tsx
+++ b/dashboard-react/src/components/models/ModelCard.tsx
@@ -154,28 +154,6 @@ const Card = styled.div<{ $canFit: boolean }>`
   padding: 12px;
 `;
 
-const Corner = styled.div<{ $canFit: boolean; $pos: string }>`
-  position: absolute;
-  width: 8px;
-  height: 8px;
-  transition: border-color 0.2s;
-
-  ${({ $pos }) => {
-    switch ($pos) {
-      case 'tl': return css`top: -1px; left: -1px; border-left: 1px solid; border-top: 1px solid;`;
-      case 'tr': return css`top: -1px; right: -1px; border-right: 1px solid; border-top: 1px solid;`;
-      case 'bl': return css`bottom: -1px; left: -1px; border-left: 1px solid; border-bottom: 1px solid;`;
-      case 'br': return css`bottom: -1px; right: -1px; border-right: 1px solid; border-bottom: 1px solid;`;
-    }
-  }}
-
-  border-color: ${({ $canFit }) => ($canFit ? 'rgba(255,215,0,0.3)' : 'rgba(239,68,68,0.3)')};
-
-  ${Card}:hover & {
-    border-color: ${({ $canFit }) => ($canFit ? 'rgba(255,215,0,0.6)' : 'rgba(239,68,68,0.4)')};
-  }
-`;
-
 const Header = styled.div`
   display: flex;
   align-items: flex-start;

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -8,6 +8,7 @@ import { ModelSearchModal } from './ModelSearchModal';
 import { FiTrash2, FiSearch, FiCheck } from 'react-icons/fi';
 import { Button } from '../common/Button';
 import { addToast } from '../../hooks/useToast';
+import { PlacementManager } from '../cluster/PlacementManager';
 
 interface ModelStorePageProps {
   topology: TopologyData | null;
@@ -159,6 +160,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
   const [storeEntries, setStoreEntries] = useState<StoreRegistryEntry[]>([]);
   const [storeDownloads, setStoreDownloads] = useState<StoreDownloadProgress[]>([]);
   const [storeLoading, setStoreLoading] = useState(false);
+  const [placementModelId, setPlacementModelId] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
   // Extract model card info from download data for the store table tooltips
@@ -354,28 +356,32 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
     return cards;
   }, [instances, runners, topology, storeEntries]);
 
-  const handleLaunch = useCallback(async (modelId: string) => {
+  const handleLaunchWithParams = useCallback(async (params: { modelId: string; sharding: string; instanceMeta: string; minNodes: number }) => {
     try {
       const res = await fetch('/place_instance', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          model_id: modelId,
-          sharding: 'Pipeline',
-          instance_meta: 'MlxRing',
-          min_nodes: 1,
+          model_id: params.modelId,
+          sharding: params.sharding,
+          instance_meta: params.instanceMeta,
+          min_nodes: params.minNodes,
         }),
       });
       if (res.ok) {
-        addToast({ type: 'success', message: `Launching ${modelId}` });
+        addToast({ type: 'success', message: `Launching ${params.modelId}` });
       } else {
         const err = await res.json().catch(() => ({}));
-        addToast({ type: 'error', message: (err as Record<string, string>).detail ?? `Failed to launch ${modelId}` });
+        addToast({ type: 'error', message: (err as Record<string, string>).detail ?? `Failed to launch ${params.modelId}` });
       }
     } catch {
       addToast({ type: 'error', message: `Failed to launch model` });
     }
   }, []);
+
+  const handleLaunch = useCallback((modelId: string) => {
+    handleLaunchWithParams({ modelId, sharding: 'Pipeline', instanceMeta: 'MlxRing', minNodes: 1 });
+  }, [handleLaunchWithParams]);
 
   const handleStop = useCallback(async (modelId: string) => {
     const instanceId = modelToInstanceId[modelId];
@@ -461,6 +467,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
           onLaunch={handleLaunch}
           onStop={handleStop}
           onChat={onChat}
+          onPlacement={setPlacementModelId}
           clusterCards={clusterCards}
         />
       <ModelSearchModal
@@ -469,6 +476,15 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
         existingModelIds={storeModelIds}
         onDownloadStarted={loadRegistry}
       />
+      {placementModelId && topology && (
+        <PlacementManager
+          modelId={placementModelId}
+          topology={topology}
+          open={!!placementModelId}
+          onClose={() => setPlacementModelId(null)}
+          onLaunch={handleLaunchWithParams}
+        />
+      )}
     </Container>
   );
 }

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -282,6 +282,17 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
     [storeEntries],
   );
 
+  // Total cluster available (free) RAM
+  const totalClusterMemoryBytes = useMemo(() => {
+    if (!topology?.nodes) return 0;
+    return Object.values(topology.nodes).reduce((sum, node) => {
+      const mem = node.macmon_info?.memory;
+      if (!mem) return sum;
+      const available = mem.ram_total - mem.ram_usage;
+      return sum + Math.max(available, 0);
+    }, 0);
+  }, [topology]);
+
   // Derive active model IDs and model→instanceId mapping from running instances
   const { activeModelIds, modelToInstanceId } = useMemo(() => {
     const ids: string[] = [];
@@ -469,6 +480,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
           onChat={onChat}
           onPlacement={setPlacementModelId}
           clusterCards={clusterCards}
+          totalClusterMemoryBytes={totalClusterMemoryBytes}
         />
       <ModelSearchModal
         open={searchOpen}
@@ -479,6 +491,9 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
       {placementModelId && topology && (
         <PlacementManager
           modelId={placementModelId}
+          modelSizeMb={storeEntries.find((e) => e.model_id === placementModelId)?.total_bytes
+            ? Math.round(storeEntries.find((e) => e.model_id === placementModelId)!.total_bytes / 1e6)
+            : undefined}
           topology={topology}
           open={!!placementModelId}
           onClose={() => setPlacementModelId(null)}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,8 @@
-# EXO API – Technical Reference
+<!-- Copyright 2025 Foxlight Foundation -->
 
-This document describes the REST API exposed by the **EXO** service, as implemented in:
+# Skulk API -- Technical Reference
+
+This document describes the REST API exposed by **Skulk** (forked from exo), as implemented in:
 
 `src/exo/master/api.py`
 
@@ -377,7 +379,7 @@ Returns 404 if the command is not found or already completed.
 
 ## 5. Ollama API Compatibility
 
-EXO provides Ollama API compatibility for tools like OpenWebUI.
+Skulk provides Ollama API compatibility for tools like OpenWebUI.
 
 ### Ollama Chat
 
@@ -692,14 +694,14 @@ GET     /images/{image_id}
 
 ### API Compatibility
 
-EXO provides multiple API-compatible interfaces:
+Skulk provides multiple API-compatible interfaces:
 
 * **OpenAI Chat Completions API** - Compatible with OpenAI clients and tools
 * **Claude Messages API** - Compatible with Anthropic's Claude API format
 * **OpenAI Responses API** - Compatible with OpenAI's Responses API format
 * **Ollama API** - Compatible with Ollama and tools like OpenWebUI
 
-Existing OpenAI, Claude, or Ollama clients can be pointed to EXO by changing the base URL.
+Existing OpenAI, Claude, or Ollama clients can be pointed to Skulk by changing the base URL.
 
 ### Custom Models
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,8 @@
-# EXO Architecture overview
+<!-- Copyright 2025 Foxlight Foundation -->
 
-EXO uses an _Event Sourcing_ architecture, and Erlang-style _message passing_. To facilitate this, we've written a channel library extending anyio channels with inspiration from tokio::sync::mpsc. 
+# Skulk Architecture Overview
+
+Skulk (forked from exo) uses an _Event Sourcing_ architecture, and Erlang-style _message passing_. To facilitate this, we've written a channel library extending anyio channels with inspiration from tokio::sync::mpsc.
 
 Each logical module - designed to be functional independently of the others - communicates with the rest of the system by sending messages on topics.
 
@@ -9,24 +11,24 @@ Each logical module - designed to be functional independently of the others - co
 There are currently 5 major systems:
 
 - Master
-    
+
     Executes placement and orders events through a single writer
 
 - Worker
-    
+
     Schedules work on a node, gathers system information, etc.#
 
 - Runner
-    
+
     Executes inference jobs (for now) in an isolated process from the worker for fault-tolerance.
     The runner is also where MLX inference generators and KV cache backends are selected. Experimental KV cache backend selection is process-local and opt-in via environment variables.
 
 - API
-    
+
     Runs a python webserver for exposing state and commands to client applications
 
 - Election
-    
+
     Implements a distributed algorithm for master election in unstable networking conditions
 
 ## API Layer
@@ -35,7 +37,7 @@ The API system uses multiple adapters to support multiple API formats, convertin
 
 ### Adapter Pattern
 
-Adapters convert between external API formats and EXO's internal types:
+Adapters convert between external API formats and Skulk's internal types:
 
 ```
 Chat Completions → [adapter] → TextGenerationTaskParams → Application

--- a/docs/kv-cache-backends.md
+++ b/docs/kv-cache-backends.md
@@ -1,6 +1,8 @@
+<!-- Copyright 2025 Foxlight Foundation -->
+
 # KV Cache Backends
 
-Skulk now includes several opt-in KV cache backends for MLX text generation. These backends are intended for long-context and memory-pressure experiments, while preserving existing behavior unless explicitly enabled.
+Skulk includes several opt-in KV cache backends for MLX text generation. These backends are intended for long-context and memory-pressure experiments, while preserving existing behavior unless explicitly enabled.
 
 ## Current Status
 

--- a/docs/model-store.md
+++ b/docs/model-store.md
@@ -1,4 +1,6 @@
-# exo Model Store
+<!-- Copyright 2025 Foxlight Foundation -->
+
+# Skulk Model Store
 
 > **Status:** Phase 1+3 — centralized LAN distribution with dashboard integration
 > **Config file:** `exo.yaml` (optional, zero-config compatible — can be configured via the dashboard)
@@ -7,13 +9,13 @@
 
 ## What problem does this solve?
 
-In a standard exo cluster every node independently downloads its assigned
+In a standard Skulk cluster every node independently downloads its assigned
 model shard from HuggingFace at inference time.  For a small home cluster
-(2–8 machines) this creates four pain points:
+(2-8 machines) this creates four pain points:
 
 | Pain point | Impact |
 |---|---|
-| Redundant downloads | Every node pulls the same model files; a 30B model may mean 20 GB × N nodes of internet traffic |
+| Redundant downloads | Every node pulls the same model files; a 30B model may mean 20 GB x N nodes of internet traffic |
 | Slow cold starts | A node that hasn't seen a model yet blocks inference for the whole cluster |
 | Version drift | Each node downloads on its own schedule; model files can diverge |
 | No offline mode | The cluster is dead without an internet connection after the first run |
@@ -26,17 +28,17 @@ instead of from HuggingFace.
 
 ---
 
-## How it extends EXO
+## How it extends Skulk
 
-This is a **non-breaking opt-in extension** to the existing exo architecture.
+This is a **non-breaking opt-in extension** to the existing architecture.
 If `exo.yaml` is absent (the default for any existing deployment), the model
-store is not active and exo behaves identically to the upstream default.
+store is not active and Skulk behaves identically to the upstream default.
 
 ### What changes when the model store is enabled
 
 | Component | Without store | With store |
 |---|---|---|
-| `DownloadCoordinator` | Uses `ResumableShardDownloader` → HuggingFace | Uses `ModelStoreDownloader` wrapping `ResumableShardDownloader` |
+| `DownloadCoordinator` | Uses `ResumableShardDownloader` -> HuggingFace | Uses `ModelStoreDownloader` wrapping `ResumableShardDownloader` |
 | `ModelStoreDownloader` | n/a | Intercepts `ensure_shard()`, stages from store; falls back to inner downloader if model not present |
 | Store host startup | n/a | `ModelStore` (registry) + `ModelStoreServer` (HTTP) started alongside other node components |
 | Worker shutdown | n/a | `ModelStoreClient.evict_shard()` removes staged files when `cleanup_on_deactivate: true` |
@@ -112,14 +114,14 @@ src/exo/store/
 
 ## Prerequisites
 
-- All nodes running the same exo build
+- All nodes running the same Skulk build
 - The store host node has the storage device mounted and accessible at `store_path`
 - Config is distributed automatically when using the dashboard Settings page.
   If configuring manually, `exo.yaml` must be present at the project root on
   **every node** (or absent to fall back to standard behaviour on that node)
 
 The store server uses port `58080` for model file transfers over the same
-Thunderbolt/ethernet links that exo already uses for the cluster ring network.
+Thunderbolt/ethernet links that the cluster already uses for the ring network.
 No additional network configuration is needed.
 
 ---
@@ -130,13 +132,13 @@ There are two ways to configure the model store: via the **dashboard** (recommen
 
 ### Option A — Configure via the dashboard (recommended)
 
-1. Start exo on all nodes: `uv run exo`
+1. Start Skulk on all nodes: `uv run exo`
 2. Open the dashboard on the node you want to be the store host: `http://localhost:52415`
 3. Navigate to **Settings** (gear icon in the header)
 4. Toggle **"This node is the store host"** — hostname and IP are filled in automatically
 5. Click the folder icon next to **Store Path** and browse to your storage volume (e.g. `/Volumes/ModelStore/models`)
 6. Click **Save** — the config is written to `exo.yaml` and synced to all nodes in the cluster automatically
-7. Restart exo on all nodes for changes to take effect
+7. Restart Skulk on all nodes for changes to take effect
 
 ### Option B — Edit `exo.yaml` manually
 
@@ -152,7 +154,7 @@ model_store:
 Copy this to the same path on every node.  Use `node_overrides` to tune
 per-node staging (see [Configuration reference](#configuration-reference)).
 
-### After configuration — run exo normally
+### After configuration — run Skulk normally
 
 ```bash
 uv run exo
@@ -238,7 +240,7 @@ Set it to the **hostname** of your store node for simplest configuration.
 #### `model_store.staging.node_cache_path`
 
 MLX loads the model from this path.  Default is `~/.exo/staging/`, which
-sits alongside the existing `~/.exo/models/` cache exo already uses.
+sits alongside the existing `~/.exo/models/` cache already in use.
 
 For the store host, point this at the same directory as `store_path` so that
 no local copy is made — MLX loads directly from the store device:
@@ -296,7 +298,7 @@ curl -H "Range: bytes=1073741824-" \
 
 ## Dashboard API (FastAPI, port 52415)
 
-These endpoints are served by the main exo API alongside all existing
+These endpoints are served by the main Skulk API alongside all existing
 endpoints.  The dashboard uses them for the Settings page and Store
 Registry view.
 
@@ -569,7 +571,7 @@ then loads only the relevant shard.  This wastes local staging space.
 Scope:
 - Accept a `ShardMetadata` in `stage_shard()` and filter the file list to
   only the safetensors files that correspond to the assigned layer range.
-- Requires understanding the safetensors index to map layers → files.
+- Requires understanding the safetensors index to map layers -> files.
 - Unlocks running models on nodes with less RAM than the full shard.
 - Directly enables "Manual shard control" as a user-facing feature.
 

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -128,6 +128,20 @@ class Node:
                 f"ModelStore: added staging path {staging_path} to EXO_MODELS_PATH"
             )
 
+            # If this node is the store host, also add the store root to the
+            # search path.  This lets the worker detect store-resident models
+            # as "pre-downloaded" (via resolve_model_in_path), which skips
+            # the redundant staging copy to the system disk.
+            if is_store_host:
+                store_root = str(Path(ms.store_path).expanduser())
+                if store_root not in paths:
+                    paths.append(store_root)
+                    os.environ["EXO_MODELS_PATH"] = ":".join(paths)
+                    add_model_search_path(Path(ms.store_path))
+                    logger.info(
+                        f"ModelStore: store host — added store root {store_root} to EXO_MODELS_PATH (skip staging)"
+                    )
+
         # Create DownloadCoordinator (unless --no-downloads)
         if not args.no_downloads:
             base_downloader = exo_shard_downloader(offline=args.offline)

--- a/src/exo/store/model_store.py
+++ b/src/exo/store/model_store.py
@@ -179,8 +179,17 @@ class ModelStore:
         return model_path
 
     def list_models(self) -> list[StoreModelEntry]:
-        """Return all :class:`StoreModelEntry` objects currently in the registry."""
-        return list(self._read_registry().values())
+        """Return all :class:`StoreModelEntry` objects currently in the registry
+        whose directories still exist on disk.
+
+        Entries whose model directory has been removed are silently excluded.
+        """
+        registry = self._read_registry()
+        return [
+            entry
+            for entry in registry.values()
+            if (self._store_path / entry.store_path).exists()
+        ]
 
     def delete_model(self, model_id: str) -> bool:
         """Remove *model_id* from the registry and delete its files from disk.


### PR DESCRIPTION
## Summary
- **PlacementManager modal** — smart model placement UI with node slider, topology preview via ModelCard, sharding/networking selectors with availability explanations, auto-defaults to first valid placement
- **Docs rebrand** — all documentation rebranded from EXO to Skulk (Foxlight Foundation) with copyright headers. Python package paths, env vars, and config paths preserved
- **Store host model resolution** — adds store root to EXO_MODELS_PATH on store host, preventing "model not found" errors and eliminating redundant staging copies to system disk
- **Registry ghost entries** — list_models() now filters entries whose directories don't exist on disk
- **ModelCard polish** — removed borders/corners, brightened unused node visibility, hideActions prop, insufficient memory shown as callout not button
- **Play button disabled** with tooltip when model exceeds available cluster RAM
- **Disabled button opacity** bumped globally from 0.35 to 0.88

## Backend changes
- `src/exo/main.py` — store host adds store root to EXO_MODELS_PATH
- `src/exo/store/model_store.py` — list_models filters by directory existence

## Test plan
- [ ] Open placement manager on a model — see node slider default to first valid placement
- [ ] Slide nodes — options and topology preview update
- [ ] Unavailable options disabled with error callouts
- [ ] Launch from placement manager — model starts with selected params
- [ ] Insufficient memory model — play disabled, placement shows error callout
- [ ] Store host: model launches without staging to system disk
- [ ] Ghost registry entries no longer appear in store list
- [ ] Docs: README, CONTRIBUTING, api.md etc. all show Skulk branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)