### PR TITLE
feat: KV cache backend selector in settings panel

### DIFF
--- a/dashboard-react/src/components/common/InfoTooltip.tsx
+++ b/dashboard-react/src/components/common/InfoTooltip.tsx
@@ -58,6 +58,7 @@ const TooltipBox = styled.div`
   font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textSecondary};
   line-height: 1.5;
+  white-space: pre-line;
   z-index: 9999;
 `;
 

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -399,22 +399,27 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
           {/* Inference — always shown, not gated on model_store config */}
           <Fieldset>
             <Legend>Inference</Legend>
-            <Row>
-              <FieldLabel>
-                KV Cache Backend
-                <InfoTooltip
-                  filled
-                  content="Select the KV cache quantization strategy. OptiQ uses rotation-based quantization for best quality. TurboQuant Adaptive is a proven stable alternative. Default uses no cache quantization. Takes effect on next model launch."
-                />
-              </FieldLabel>
-              <Select value={kvBackend} onChange={(e) => setKvBackend(e.target.value)}>
-                <option value="default">Default (no quantization)</option>
-                <option value="optiq">OptiQ (rotation-based)</option>
-                <option value="turboquant_adaptive">TurboQuant Adaptive</option>
-                <option value="turboquant">TurboQuant</option>
-                <option value="mlx_quantized">MLX Quantized</option>
-              </Select>
-            </Row>
+            <FieldLabel>
+              KV Cache Backend
+              <InfoTooltip
+                filled
+                content={
+                  `• Default — No cache quantization. Best baseline quality, highest memory use.\n` +
+                  `• OptiQ — Rotation-based quantization via mlx-optiq. Best long-context quality.\n` +
+                  `• TurboQuant Adaptive — Quantizes middle KV layers, keeps edge layers in FP16. Proven stable.\n` +
+                  `• TurboQuant — Quantizes all KV layers. Most aggressive compression, higher quality risk.\n` +
+                  `• MLX Quantized — MLX's built-in cache quantization.\n\n` +
+                  `Takes effect on next model launch. Incompatible models fall back to Default automatically.`
+                }
+              />
+            </FieldLabel>
+            <Select value={kvBackend} onChange={(e) => setKvBackend(e.target.value)}>
+              <option value="default">Default (no quantization)</option>
+              <option value="optiq">OptiQ (rotation-based)</option>
+              <option value="turboquant_adaptive">TurboQuant Adaptive</option>
+              <option value="turboquant">TurboQuant</option>
+              <option value="mlx_quantized">MLX Quantized</option>
+            </Select>
             <HintText>Changes take effect on the next model launch. Models with incompatible architectures (GQA, non-power-of-two head_dim) will automatically fall back to default.</HintText>
           </Fieldset>
         </Body>

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -205,7 +205,7 @@ const Spacer = styled.span`
 /* ---- component ---- */
 
 export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
-  const { fullConfig, configPath, loading, saving, error, fetchConfig, saveFullConfig } = useConfig();
+  const { fullConfig, effective, configPath, loading, saving, error, fetchConfig, saveFullConfig } = useConfig();
   const [draft, setDraft] = useState<StoreConfig | null>(null);
   const [kvBackend, setKvBackend] = useState('default');
 
@@ -214,11 +214,14 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
     if (open) fetchConfig();
   }, [open, fetchConfig]);
 
-  // Seed draft from fetched config
+  // Seed draft from fetched config — use effective value for KV backend
+  const envOverride = effective != null
+    && effective.kv_cache_backend !== 'default'
+    && effective.kv_cache_backend !== (fullConfig?.inference?.kv_cache_backend ?? 'default');
   useEffect(() => {
     if (fullConfig?.model_store) setDraft({ ...fullConfig.model_store });
-    setKvBackend(fullConfig?.inference?.kv_cache_backend ?? 'default');
-  }, [fullConfig]);
+    setKvBackend(effective?.kv_cache_backend ?? fullConfig?.inference?.kv_cache_backend ?? 'default');
+  }, [fullConfig, effective]);
 
   const update = useCallback((patch: Partial<StoreConfig>) => {
     setDraft((prev) => prev ? { ...prev, ...patch } : prev);
@@ -413,14 +416,18 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
                 }
               />
             </FieldLabel>
-            <Select value={kvBackend} onChange={(e) => setKvBackend(e.target.value)}>
+            <Select value={kvBackend} onChange={(e) => setKvBackend(e.target.value)} disabled={!!envOverride}>
               <option value="default">Default (no quantization)</option>
               <option value="optiq">OptiQ (rotation-based)</option>
               <option value="turboquant_adaptive">TurboQuant Adaptive</option>
               <option value="turboquant">TurboQuant</option>
               <option value="mlx_quantized">MLX Quantized</option>
             </Select>
-            <HintText>Changes take effect on the next model launch. Models with incompatible architectures (GQA, non-power-of-two head_dim) will automatically fall back to default.</HintText>
+            {envOverride ? (
+              <HintText>Overridden by EXO_KV_CACHE_BACKEND environment variable. Remove the env var to configure here.</HintText>
+            ) : (
+              <HintText>Changes take effect on the next model launch. Models with incompatible architectures (GQA, non-power-of-two head_dim) will automatically fall back to default.</HintText>
+            )}
           </Fieldset>
         </Body>
 

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -236,7 +236,8 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
   }, []);
 
   const handleSave = useCallback(async () => {
-    const updated: FullConfig = {};
+    // Base on the last fetched config to avoid dropping sections
+    const updated: FullConfig = { ...(fullConfig ?? {}) };
     if (draft) updated.model_store = draft;
     updated.inference = { kv_cache_backend: kvBackend };
     const ok = await saveFullConfig(updated);
@@ -434,7 +435,7 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
         <Footer>
           <Spacer />
           <Button variant="outline" size="md" onClick={onClose}>Cancel</Button>
-          <Button variant="primary" size="md" loading={saving} onClick={handleSave}>
+          <Button variant="primary" size="md" loading={saving} onClick={handleSave} disabled={loading}>
             Save
           </Button>
         </Footer>

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -219,7 +219,7 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
     && effective.kv_cache_backend !== 'default'
     && effective.kv_cache_backend !== (fullConfig?.inference?.kv_cache_backend ?? 'default');
   useEffect(() => {
-    if (fullConfig?.model_store) setDraft({ ...fullConfig.model_store });
+    setDraft(fullConfig?.model_store ? { ...fullConfig.model_store } : null);
     setKvBackend(effective?.kv_cache_backend ?? fullConfig?.inference?.kv_cache_backend ?? 'default');
   }, [fullConfig, effective]);
 
@@ -421,7 +421,7 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
               <option value="optiq">OptiQ (rotation-based)</option>
               <option value="turboquant_adaptive">TurboQuant Adaptive</option>
               <option value="turboquant">TurboQuant</option>
-              <option value="mlx_quantized">MLX Quantized</option>
+              <option value="mlx_quantized">MLX Quantized (requires EXO_KV_CACHE_BITS env)</option>
             </Select>
             {envOverride ? (
               <HintText>Overridden by EXO_KV_CACHE_BACKEND environment variable. Remove the env var to configure here.</HintText>
@@ -434,7 +434,7 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
         <Footer>
           <Spacer />
           <Button variant="outline" size="md" onClick={onClose}>Cancel</Button>
-          <Button variant="primary" size="md" loading={saving} onClick={handleSave} disabled={!draft}>
+          <Button variant="primary" size="md" loading={saving} onClick={handleSave}>
             Save
           </Button>
         </Footer>

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
-import { useConfig, type StoreConfig } from '../../hooks/useConfig';
+import { useConfig, type StoreConfig, type FullConfig } from '../../hooks/useConfig';
 import { Button } from '../common/Button';
 import { Field } from '../common/Field';
 import { InfoTooltip } from '../common/InfoTooltip';
@@ -148,6 +148,34 @@ const StyledField = styled(Field)`
   min-width: 0;
 `;
 
+const Select = styled.select`
+  background: ${({ theme }) => theme.colors.bg};
+  color: ${({ theme }) => theme.colors.text};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.radii.sm};
+  padding: 4px 8px;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.body};
+  outline: none;
+  cursor: pointer;
+
+  &:focus {
+    border-color: ${({ theme }) => theme.colors.goldDim};
+  }
+
+  option {
+    background: ${({ theme }) => theme.colors.surface};
+    color: ${({ theme }) => theme.colors.text};
+  }
+`;
+
+const HintText = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-style: italic;
+`;
+
 const ConfigPath = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
@@ -177,8 +205,9 @@ const Spacer = styled.span`
 /* ---- component ---- */
 
 export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
-  const { config, configPath, loading, saving, error, fetchConfig, saveConfig } = useConfig();
+  const { fullConfig, configPath, loading, saving, error, fetchConfig, saveFullConfig } = useConfig();
   const [draft, setDraft] = useState<StoreConfig | null>(null);
+  const [kvBackend, setKvBackend] = useState('default');
 
   // Fetch config when panel opens
   useEffect(() => {
@@ -187,8 +216,9 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
 
   // Seed draft from fetched config
   useEffect(() => {
-    if (config) setDraft({ ...config });
-  }, [config]);
+    if (fullConfig?.model_store) setDraft({ ...fullConfig.model_store });
+    setKvBackend(fullConfig?.inference?.kv_cache_backend ?? 'default');
+  }, [fullConfig]);
 
   const update = useCallback((patch: Partial<StoreConfig>) => {
     setDraft((prev) => prev ? { ...prev, ...patch } : prev);
@@ -203,15 +233,17 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
   }, []);
 
   const handleSave = useCallback(async () => {
-    if (!draft) return;
-    const ok = await saveConfig(draft);
+    const updated: FullConfig = {};
+    if (draft) updated.model_store = draft;
+    updated.inference = { kv_cache_backend: kvBackend };
+    const ok = await saveFullConfig(updated);
     if (ok) {
-      addToast({ type: 'success', message: 'Settings saved' });
+      addToast({ type: 'success', message: 'Settings saved — KV cache change takes effect on next model launch' });
       onClose();
     } else {
       addToast({ type: 'error', message: 'Failed to save settings' });
     }
-  }, [draft, saveConfig, onClose]);
+  }, [draft, kvBackend, saveFullConfig, onClose]);
 
   // ESC to close
   useEffect(() => {
@@ -363,6 +395,28 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
               {configPath && <ConfigPath>Config: {configPath}</ConfigPath>}
             </>
           )}
+
+          {/* Inference — always shown, not gated on model_store config */}
+          <Fieldset>
+            <Legend>Inference</Legend>
+            <Row>
+              <FieldLabel>
+                KV Cache Backend
+                <InfoTooltip
+                  filled
+                  content="Select the KV cache quantization strategy. OptiQ uses rotation-based quantization for best quality. TurboQuant Adaptive is a proven stable alternative. Default uses no cache quantization. Takes effect on next model launch."
+                />
+              </FieldLabel>
+              <Select value={kvBackend} onChange={(e) => setKvBackend(e.target.value)}>
+                <option value="default">Default (no quantization)</option>
+                <option value="optiq">OptiQ (rotation-based)</option>
+                <option value="turboquant_adaptive">TurboQuant Adaptive</option>
+                <option value="turboquant">TurboQuant</option>
+                <option value="mlx_quantized">MLX Quantized</option>
+              </Select>
+            </Row>
+            <HintText>Changes take effect on the next model launch. Models with incompatible architectures (GQA, non-power-of-two head_dim) will automatically fall back to default.</HintText>
+          </Fieldset>
         </Body>
 
         <Footer>

--- a/dashboard-react/src/hooks/useConfig.ts
+++ b/dashboard-react/src/hooks/useConfig.ts
@@ -25,15 +25,21 @@ export interface FullConfig {
   inference?: InferenceConfig;
 }
 
+export interface EffectiveConfig {
+  kv_cache_backend: string;
+}
+
 export interface ConfigResponse {
   config: FullConfig;
   configPath: string;
   fileExists: boolean;
+  effective?: EffectiveConfig;
 }
 
 export interface UseConfigReturn {
   config: StoreConfig | null;
   fullConfig: FullConfig | null;
+  effective: EffectiveConfig | null;
   configPath: string | null;
   loading: boolean;
   saving: boolean;
@@ -44,6 +50,7 @@ export interface UseConfigReturn {
 
 export function useConfig(): UseConfigReturn {
   const [fullConfig, setFullConfig] = useState<FullConfig | null>(null);
+  const [effective, setEffective] = useState<EffectiveConfig | null>(null);
   const [configPath, setConfigPath] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -57,6 +64,7 @@ export function useConfig(): UseConfigReturn {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data: ConfigResponse = await res.json();
       setFullConfig(data.config);
+      setEffective(data.effective ?? null);
       setConfigPath(data.configPath);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to fetch config');
@@ -87,5 +95,5 @@ export function useConfig(): UseConfigReturn {
 
   const config = fullConfig?.model_store ?? null;
 
-  return { config, fullConfig, configPath, loading, saving, error, fetchConfig, saveFullConfig };
+  return { config, fullConfig, effective, configPath, loading, saving, error, fetchConfig, saveFullConfig };
 }

--- a/dashboard-react/src/hooks/useConfig.ts
+++ b/dashboard-react/src/hooks/useConfig.ts
@@ -16,26 +16,34 @@ export interface StoreConfig {
   };
 }
 
+export interface InferenceConfig {
+  kv_cache_backend: string;
+}
+
+export interface FullConfig {
+  model_store?: StoreConfig;
+  inference?: InferenceConfig;
+}
+
 export interface ConfigResponse {
-  config: {
-    model_store: StoreConfig;
-  };
+  config: FullConfig;
   configPath: string;
   fileExists: boolean;
 }
 
 export interface UseConfigReturn {
   config: StoreConfig | null;
+  fullConfig: FullConfig | null;
   configPath: string | null;
   loading: boolean;
   saving: boolean;
   error: string | null;
   fetchConfig: () => Promise<void>;
-  saveConfig: (config: StoreConfig) => Promise<boolean>;
+  saveFullConfig: (config: FullConfig) => Promise<boolean>;
 }
 
 export function useConfig(): UseConfigReturn {
-  const [config, setConfig] = useState<StoreConfig | null>(null);
+  const [fullConfig, setFullConfig] = useState<FullConfig | null>(null);
   const [configPath, setConfigPath] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -48,7 +56,7 @@ export function useConfig(): UseConfigReturn {
       const res = await fetch('/config');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data: ConfigResponse = await res.json();
-      setConfig(data.config.model_store);
+      setFullConfig(data.config);
       setConfigPath(data.configPath);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to fetch config');
@@ -57,17 +65,17 @@ export function useConfig(): UseConfigReturn {
     }
   }, []);
 
-  const saveConfig = useCallback(async (updated: StoreConfig): Promise<boolean> => {
+  const saveFullConfig = useCallback(async (updated: FullConfig): Promise<boolean> => {
     setSaving(true);
     setError(null);
     try {
       const res = await fetch('/config', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model_store: updated }),
+        body: JSON.stringify({ config: updated }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setConfig(updated);
+      setFullConfig(updated);
       return true;
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to save config');
@@ -77,5 +85,7 @@ export function useConfig(): UseConfigReturn {
     }
   }, []);
 
-  return { config, configPath, loading, saving, error, fetchConfig, saveConfig };
+  const config = fullConfig?.model_store ?? null;
+
+  return { config, fullConfig, configPath, loading, saving, error, fetchConfig, saveFullConfig };
 }

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -1961,6 +1961,9 @@ class API:
                     "config": {},
                     "configPath": str(self._config_path),
                     "fileExists": False,
+                    "effective": {
+                        "kv_cache_backend": os.environ.get("EXO_KV_CACHE_BACKEND", "default"),
+                    },
                 }
             )
         with self._config_path.open() as f:
@@ -1968,7 +1971,14 @@ class API:
         if raw is None:
             raw = {}
         return JSONResponse(
-            {"config": raw, "configPath": str(self._config_path), "fileExists": True}
+            {
+                "config": raw,
+                "configPath": str(self._config_path),
+                "fileExists": True,
+                "effective": {
+                    "kv_cache_backend": os.environ.get("EXO_KV_CACHE_BACKEND", "default"),
+                },
+            }
         )
 
     async def update_config(self, request: Request) -> JSONResponse:

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2002,15 +2002,21 @@ class API:
         from exo.shared.types.commands import SyncConfig
 
         await self._send_download(SyncConfig(config_yaml=config_yaml))
-        # Apply inference config to env var immediately so next model launch uses it
+        # Apply inference config to env var immediately so next model launch uses it.
+        # Don't overwrite if user provided the env var at launch.
         inference = config_data.get("inference")
         if isinstance(inference, dict) and "kv_cache_backend" in inference:
-            os.environ["EXO_KV_CACHE_BACKEND"] = str(inference["kv_cache_backend"])
+            if not os.environ.get("_EXO_KV_BACKEND_USER_SET"):
+                os.environ["EXO_KV_CACHE_BACKEND"] = str(inference["kv_cache_backend"])
+        # model_store changes still require restart; inference-only changes don't
+        has_store_changes = "model_store" in config_data
         return JSONResponse(
             {
                 "success": True,
-                "message": "Config saved and synced to cluster. KV cache backend takes effect on next model launch.",
-                "requiresRestart": False,
+                "message": "Config saved and synced to cluster."
+                + (" KV cache backend takes effect on next model launch." if inference else "")
+                + (" Restart required for model store changes." if has_store_changes else ""),
+                "requiresRestart": has_store_changes,
             }
         )
 

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2002,11 +2002,15 @@ class API:
         from exo.shared.types.commands import SyncConfig
 
         await self._send_download(SyncConfig(config_yaml=config_yaml))
+        # Apply inference config to env var immediately so next model launch uses it
+        inference = config_data.get("inference")
+        if isinstance(inference, dict) and "kv_cache_backend" in inference:
+            os.environ["EXO_KV_CACHE_BACKEND"] = str(inference["kv_cache_backend"])
         return JSONResponse(
             {
                 "success": True,
-                "message": "Config saved and synced to cluster. Restart exo for changes to take effect.",
-                "requiresRestart": True,
+                "message": "Config saved and synced to cluster. KV cache backend takes effect on next model launch.",
+                "requiresRestart": False,
             }
         )
 

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -1,6 +1,7 @@
 import base64
 import contextlib
 import json
+import os
 import random
 import socket
 import time

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -181,10 +181,16 @@ class DownloadCoordinator:
             if raw and isinstance(raw, dict):
                 inference = raw.get("inference")
                 if isinstance(inference, dict) and "kv_cache_backend" in inference:
-                    os.environ["EXO_KV_CACHE_BACKEND"] = str(inference["kv_cache_backend"])
-                    logger.info(
-                        f"DownloadCoordinator: updated EXO_KV_CACHE_BACKEND={inference['kv_cache_backend']}"
-                    )
+                    # Don't overwrite if user provided the env var at launch
+                    if not os.environ.get("_EXO_KV_BACKEND_USER_SET"):
+                        os.environ["EXO_KV_CACHE_BACKEND"] = str(inference["kv_cache_backend"])
+                        logger.info(
+                            f"DownloadCoordinator: updated EXO_KV_CACHE_BACKEND={inference['kv_cache_backend']}"
+                        )
+                    else:
+                        logger.info(
+                            f"DownloadCoordinator: skipping KV backend update (user env var override active)"
+                        )
         except Exception as exc:
             logger.warning(f"DownloadCoordinator: failed to sync exo.yaml: {exc}")
 

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -166,13 +167,24 @@ class DownloadCoordinator:
             )
 
     async def _sync_config(self, config_yaml: str) -> None:
-        """Write received config YAML to the local exo.yaml file."""
+        """Write received config YAML to the local exo.yaml file and
+        apply runtime-effective settings (e.g., KV cache backend)."""
         config_path = Path("exo.yaml")
         try:
             config_path.write_text(config_yaml)
             logger.info(
                 f"DownloadCoordinator: synced exo.yaml from cluster ({len(config_yaml)} bytes)"
             )
+            # Apply inference config to env var so next runner spawn picks it up
+            import yaml
+            raw = yaml.safe_load(config_yaml)
+            if raw and isinstance(raw, dict):
+                inference = raw.get("inference")
+                if isinstance(inference, dict) and "kv_cache_backend" in inference:
+                    os.environ["EXO_KV_CACHE_BACKEND"] = str(inference["kv_cache_backend"])
+                    logger.info(
+                        f"DownloadCoordinator: updated EXO_KV_CACHE_BACKEND={inference['kv_cache_backend']}"
+                    )
         except Exception as exc:
             logger.warning(f"DownloadCoordinator: failed to sync exo.yaml: {exc}")
 

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -81,6 +81,19 @@ class Node:
         # when exo.yaml is missing, all store references stay None and exo
         # behaves identically to the upstream default).
         exo_config = load_exo_config(Path("exo.yaml"))
+
+        # Apply inference config (kv_cache_backend) to env var so runner
+        # subprocesses inherit it.  Env var takes precedence if already set.
+        if (
+            exo_config is not None
+            and exo_config.inference is not None
+            and not os.environ.get("EXO_KV_CACHE_BACKEND")
+        ):
+            os.environ["EXO_KV_CACHE_BACKEND"] = exo_config.inference.kv_cache_backend
+            logger.info(
+                f"Inference config: kv_cache_backend={exo_config.inference.kv_cache_backend}"
+            )
+
         store_client: ModelStoreClient | None = None
         store_server: ModelStoreServer | None = None
 

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -82,12 +82,17 @@ class Node:
         # behaves identically to the upstream default).
         exo_config = load_exo_config(Path("exo.yaml"))
 
-        # Apply inference config (kv_cache_backend) to env var so runner
-        # subprocesses inherit it.  Env var takes precedence if already set.
+        # Track whether user provided EXO_KV_CACHE_BACKEND at launch —
+        # if so, config syncs must not overwrite it.
+        _user_set_kv_backend = "EXO_KV_CACHE_BACKEND" in os.environ
+        os.environ["_EXO_KV_BACKEND_USER_SET"] = "1" if _user_set_kv_backend else ""
+
+        # Apply inference config to env var so runner subprocesses inherit it.
+        # Env var takes precedence if user set it at launch.
         if (
             exo_config is not None
             and exo_config.inference is not None
-            and "EXO_KV_CACHE_BACKEND" not in os.environ
+            and not _user_set_kv_backend
         ):
             os.environ["EXO_KV_CACHE_BACKEND"] = exo_config.inference.kv_cache_backend
             logger.info(

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -87,7 +87,7 @@ class Node:
         if (
             exo_config is not None
             and exo_config.inference is not None
-            and not os.environ.get("EXO_KV_CACHE_BACKEND")
+            and "EXO_KV_CACHE_BACKEND" not in os.environ
         ):
             os.environ["EXO_KV_CACHE_BACKEND"] = exo_config.inference.kv_cache_backend
             logger.info(

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -68,7 +68,7 @@ from __future__ import annotations
 
 import socket
 from pathlib import Path
-from typing import final
+from typing import Literal, final
 
 import yaml
 
@@ -199,11 +199,12 @@ class InferenceConfig(FrozenModel):
     """Inference-related configuration.
 
     Attributes:
-        kv_cache_backend: KV cache backend to use. One of: default,
-            mlx_quantized, turboquant, turboquant_adaptive, optiq.
+        kv_cache_backend: KV cache backend to use.
     """
 
-    kv_cache_backend: str = "default"
+    kv_cache_backend: Literal[
+        "default", "mlx_quantized", "turboquant", "turboquant_adaptive", "optiq"
+    ] = "default"
 
 
 def load_exo_config(

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -191,6 +191,19 @@ class ExoConfig(FrozenModel):
     """
 
     model_store: ModelStoreConfig | None = None
+    inference: "InferenceConfig | None" = None
+
+
+@final
+class InferenceConfig(FrozenModel):
+    """Inference-related configuration.
+
+    Attributes:
+        kv_cache_backend: KV cache backend to use. One of: default,
+            mlx_quantized, turboquant, turboquant_adaptive, optiq.
+    """
+
+    kv_cache_backend: str = "default"
 
 
 def load_exo_config(


### PR DESCRIPTION
## Summary
Expose KV cache backend selection in the dashboard settings panel so users can switch between Default, OptiQ, TurboQuant Adaptive, TurboQuant, and MLX Quantized without env vars.

## Changes

**Backend:**
- Add `InferenceConfig` to `ExoConfig` with `kv_cache_backend` field
- Read inference config at startup, set `EXO_KV_CACHE_BACKEND` env var (env var override still takes precedence)
- Config synced to all nodes via gossipsub

**Frontend:**
- Settings panel: KV Cache Backend dropdown under new "Inference" fieldset
- Bulleted tooltip describing each option
- useConfig hook updated to handle full config (model_store + inference)
- InfoTooltip supports multiline text via white-space: pre-line

## How it works
1. User selects backend in Settings → Inference → KV Cache Backend
2. Saves to exo.yaml, synced to all nodes via gossipsub
3. Next model launch picks up the new backend
4. `EXO_KV_CACHE_BACKEND` env var still overrides config for power users

## Test plan
- [ ] Open settings, see Inference fieldset with KV Cache Backend dropdown
- [ ] Select OptiQ, save, launch model — verify optiq cache in logs
- [ ] Select Default, save, launch model — verify default cache
- [ ] Tooltip shows bulleted descriptions for each option
- [ ] Env var override: set EXO_KV_CACHE_BACKEND=default, verify it overrides settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)