### PR TITLE
Docs: refresh onboarding and add generated docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,79 @@
+name: docs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: dashboard-react/package-lock.json
+
+      - name: Install Python dependencies
+        run: uv sync --group dev
+
+      - name: Install dashboard dependencies
+        working-directory: dashboard-react
+        run: npm ci
+
+      - name: Build dashboard
+        working-directory: dashboard-react
+        run: npm run build
+
+      - name: Generate OpenAPI docs
+        run: uv run python scripts/export_openapi.py
+
+      - name: Generate TypeDoc
+        working-directory: dashboard-react
+        run: npm run docs:typedoc
+
+      - name: Build MkDocs site
+        run: uv run mkdocs build --strict
+
+      - name: Upload docs artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy-docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-docs
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,15 +40,8 @@ jobs:
         working-directory: dashboard-react
         run: npm run build
 
-      - name: Generate OpenAPI docs
-        run: uv run python scripts/export_openapi.py
-
-      - name: Generate TypeDoc
-        working-directory: dashboard-react
-        run: npm run docs:typedoc
-
-      - name: Build MkDocs site
-        run: uv run mkdocs build --strict
+      - name: Build docs site
+        run: uv run python scripts/build_docs.py
 
       - name: Upload docs artifact
         if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ dashboard-react/dist/
 dashboard-react/storybook-static/
 **/.vite/
 
+# generated docs
+docs/generated/
+site/
+
 # host config snapshots
 hosts_*.json
 .swp

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Skulk is a fork of EXO for running AI models across one or more machines as a cluster.
 It keeps EXO's distributed inference foundation, then extends it with a central model store,
-a more modern dashboard, richer API workflows, sophisticated cache quantization, support for more model families such as embedding, TTS, etc. and cluster-friendly configuration management.
+a more modern dashboard, richer API workflows, sophisticated cache quantization, support for more model families such as embeddings and TTS, and cluster-friendly configuration management.
 
 > Skulk is maintained by [Foxlight Foundation](https://github.com/foxlight-foundation) and forked from [exo](https://github.com/exo-explore/exo).
 
@@ -19,9 +19,9 @@ a more modern dashboard, richer API workflows, sophisticated cache quantization,
 - Use a central model store so the cluster downloads once and stages locally.
 - Talk to the cluster through OpenAI Chat Completions, OpenAI Responses, Claude Messages, or Ollama-compatible APIs.
 - Experiment with advanced placement modes, RDMA, and KV cache backends when you are ready.
-- Place non-generative models such as embedding.
-- Implement TTS workflows
-- Actually use your cluster for inference workloads.
+- Run non-chat workloads such as embeddings and other specialized model flows.
+- Build TTS-oriented and other API-driven workflows on top of the cluster.
+- Actually use your cluster for real inference workloads instead of treating it as a demo.
 
 ## Prerequisites
 
@@ -53,7 +53,7 @@ rustup toolchain install nightly
 
 ## Getting Started
 
-If you are brand new to Skulk, this is the best order to follow:
+If you are brand new to Skulk, follow this order:
 
 1. Install the prerequisites for your platform.
 2. Clone the repo.
@@ -65,6 +65,14 @@ If you are brand new to Skulk, this is the best order to follow:
 8. Launch a model from the Model Store view, or place one through the API.
 9. Wait until the model is placed and ready.
 10. Then chat in the dashboard or send API requests.
+
+Skulk's core runtime flow is:
+
+1. start one or more nodes
+2. confirm topology
+3. place a model
+4. wait for it to become ready
+5. then use the dashboard or API
 
 Important behavior:
 
@@ -132,7 +140,8 @@ Use the instructions in [Prerequisites](#prerequisites).
 ```bash
 git clone https://github.com/foxlight-foundation/Skulk.git
 cd Skulk
-cd dashboard-react && npm install && npm run build && cd ..
+npm --prefix dashboard-react install
+npm --prefix dashboard-react run build
 uv sync
 uv run exo
 ```
@@ -153,12 +162,7 @@ From there:
 
 ### 4. Launch a Model with the API Instead
 
-If you would rather use the API directly, here is the simplest flow:
-
-You have two easy options:
-
-- Open the dashboard, go to the Model Store view, launch a model there, and wait for it to become ready before opening chat.
-- Use the API directly.
+If you would rather use the API directly, this is the simplest flow.
 
 1. Preview placements:
 
@@ -310,7 +314,7 @@ Remember: that model must already be placed and running.
 
 Skulk supports both environment variables and `exo.yaml`.
 
-Today, `exo.yaml` is especially useful for:
+`exo.yaml` is especially useful for:
 
 - `model_store`
 - `inference.kv_cache_backend`

--- a/README.md
+++ b/README.md
@@ -6,609 +6,426 @@
   <img src="docs/imgs/skulk-logo.svg" width="200" height="200" alt="Skulk logo">
 </div>
 
----
-### **Skulk** (*noun*): A group of foxes.
->*A skulk moves together without a central authority telling each fox what to do; the skulk coordinates naturally, quietly, with each member contributing to the whole.*
----
-
-### **What is it?**
-
-**Skulk is a fork of EXO.** It extends upstream exo with a **model store** allowing a node in your cluster to hold all model files and serve them to every other node over the local network. This prevents wasted storage and allows for the use of either locally or network attached storage, and also provides for full offline capability after the first download.
+Skulk is a fork of EXO for running AI models across one or more machines as a cluster.
+It keeps EXO's distributed inference foundation, then extends it with a central model store,
+a more modern dashboard, richer API workflows, sophisticated cache quantization, support for more model families such as embedding, TTS, etc. and cluster-friendly configuration management.
 
 > Skulk is maintained by [Foxlight Foundation](https://github.com/foxlight-foundation) and forked from [exo](https://github.com/exo-explore/exo).
 
-### **What else does Skulk do?**
-- **Store-first downloads:** when a model is launched that isn't in the store, Skulk downloads it once and then locally distributes it to the nodes at time of invokation.
-- **Settings panel:** you can configure the store from the dashboard with a one-click "this node is the store host" toggle and a filesystem browser for selecting the store path.
-- **Store Registry:** you can browse models in the store, see download progress, find and download new models, delete models, and see which models are active.
-- **Cluster-wide config sync:** config changes made from the dashboard are broadcast to all skulk nodes automatically via gossipsub.
+## What Skulk Is Good At
 
-- **Auto-detect existing models:** Skulk can scan a selected store path for existing model directories and auto-register them.
-- **Skulk Dashboard:** Full-featured React dashboard with cluster topology visualization, model store management, chat interface with streaming, thinking support, conversation persistence, and placement manager.
-- **Chat Interface:** Stream chat with models directly from the dashboard with real-time TTFT/TPS/ms-per-tok stats, thinking block rendering, conversation history with per-model scoping, and session recovery on refresh.
-- **Placement Manager:** Visual cluster placement configurator — select node count, sharding mode (Pipeline/Tensor), and networking (Ring/Jaccl) with real-time availability validation and error explanations.
-- **OptiQ Integration:** Integrated mlx-optiq for rotation-based KV cache quantization (configurable in Settings) and mixed-precision weight optimization via sensitivity analysis.
-- **HuggingFace Token Management:** Configure your HF API token from the settings panel — synced to all nodes automatically.
-- **Smart Model Tags:** Models tagged with OptiQ, Thinking, and Tensor badges in the store registry.
-- **Context Window Display:** Model context window size shown in chat header, derived from config.json.
-- **Cluster Warnings:** Consolidated warning indicator in header for version mismatches and RDMA issues.
-- **Static Peer Discovery:** `--bootstrap-peers` CLI arg for fixed cluster topology.
+- Run a model on a single machine through the dashboard or API.
+- Form a small cluster of Macs and split larger models across them.
+- Use a central model store so the cluster downloads once and stages locally.
+- Talk to the cluster through OpenAI Chat Completions, OpenAI Responses, Claude Messages, or Ollama-compatible APIs.
+- Experiment with advanced placement modes, RDMA, and KV cache backends when you are ready.
+- Place non-generative models such as embedding.
+- Implement TTS workflows
+- Actually use your cluster for inference workloads.
 
-### **Coming Soon**
+## Prerequisites
 
-- **Store failover:** Skulk can automatically failover to a new store host when the current store host goes offline with automated store host and registry replication.
-- **Shard-aware staging:** Skulk only stages the safetensors files needed for a node's assigned layers, reducing local storage requirements and enabling models on nodes with less RAM.
-- **Offline/air-gapped hardening:** Skulk adds CLI commands for store management (`skulk store list`, `skulk store pull`), adds store integrity checks with hash verification, and cleaner error messaging.
-- **Storage recommendations:** Skulk can show available disk space per volume in the directory browser, highlight the best option, and warn on low space.
-- **Manual shard placement:** Skulk allows youu to control which layers run on which nodes, and you can adjust sharding to target specific machines and manage memory pressure on a per-node basis.
-- **Sub-cluster definitions:** Skulk allows you to define node groups so a model can be targeted to only certain nodes, enabling model-specific sub-clusters within a single physical cluster (e.g. dedicate 2 nodes to a coding model and 2 to a chat model simultaneously).
-- **macOS App:** A native macOS menu bar app for running Skulk in the background — start/stop your cluster, monitor status, and manage models without the terminal.
-- **Conversation sync:** Conversation history synced across all nodes in the cluster so every node has access to the full chat history.
-- **Context compaction:** Intelligent context window management with sliding window and summarization for long conversations.
-- **Voice input:** Voice-to-text input for the chat interface.
+### macOS
 
-## **Features**
+- [Xcode](https://developer.apple.com/xcode/)
+- [uv](https://github.com/astral-sh/uv)
+- [node](https://github.com/nodejs/node)
+- [rustup](https://rustup.rs/)
+- `macmon` for Apple Silicon monitoring
 
-- **Automatic Device Discovery**: Devices running Skulk automatically discover each other - no manual configuration.
-- **RDMA over Thunderbolt**: Skulk ships with [day-0 support for RDMA over Thunderbolt 5](https://x.com/exolabs/status/2001817749744476256?s=20), enabling 99% reduction in latency between devices.
-- **Topology-Aware Auto Parallel**: Skulk figures out the best way to split your model across all available devices based on a realtime view of your device topology. It takes into account device resources and network latency/bandwidth between each link.
-- **Tensor Parallelism**: Skulk supports sharding models, for up to 1.8x speedup on 2 devices and 3.2x speedup on 4 devices.
-- **MLX Support**: Skulk uses [MLX](https://github.com/ml-explore/mlx) as an inference backend and [MLX distributed](https://ml-explore.github.io/mlx/build/html/usage/distributed.html) for distributed communication.
-- **Multiple API Compatibility**: Compatible with OpenAI Chat Completions API, Claude Messages API, OpenAI Responses API, and Ollama API - use your existing tools and clients.
-- **Custom Model Support**: Load custom models from HuggingFace hub to expand the range of available models.
-- **Experimental KV Cache Backends**: Skulk includes opt-in MLX quantized and TurboQuant-inspired KV cache backends for long-context memory experiments. See [docs/kv-cache-backends.md](docs/kv-cache-backends.md).
+```bash
+brew install uv macmon node
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup toolchain install nightly
+```
 
-## **Dashboard**
+### Linux
 
-Skulk includes a built-in dashboard for managing your cluster and chatting with models.
+- [uv](https://github.com/astral-sh/uv)
+- Node 18+
+- [rustup](https://rustup.rs/)
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup toolchain install nightly
+```
+
+## Getting Started
+
+If you are brand new to Skulk, this is the best order to follow:
+
+1. Install the prerequisites for your platform.
+2. Clone the repo.
+3. Build the dashboard.
+4. Run `uv sync`.
+5. Start Skulk with `uv run exo`.
+6. Open the dashboard at `http://localhost:52415`.
+7. Confirm your node or cluster appears in the topology view.
+8. Launch a model from the Model Store view, or place one through the API.
+9. Wait until the model is placed and ready.
+10. Then chat in the dashboard or send API requests.
+
+Important behavior:
+
+- The dashboard will not let you chat unless a model is already placed and ready.
+- The API behaves the same way in practice. If you send a chat request too early, you will usually get `404 No instance found for model ...`.
+
+## Choose Your Path
+
+- **I want the fastest first success**: follow [Single-Node Quick Start](#single-node-quick-start).
+- **I want a multi-node cluster**: follow [Cluster Quick Start](#cluster-quick-start).
+- **I want shared storage and fewer duplicate downloads**: read [Model Store](#model-store) after the cluster quick start.
+- **I want to integrate with code**: jump to [API Guide](#api-guide) and then [docs/api.md](docs/api.md).
+
+## Platform Support
+
+| Platform | Current state |
+|----------|---------------|
+| macOS on Apple Silicon | Primary target. Best experience today. |
+| Multi-Mac clusters | Supported. Best results on matched macOS versions and fast networking. |
+| RDMA over Thunderbolt 5 | Supported on eligible macOS 26.2+ hardware after OS-level setup. |
+| Linux | Supported, but currently CPU-oriented in this fork. |
+
+## Core Features
+
+- **Distributed inference**: split work across devices instead of treating each machine as an island.
+- **Skulk Dashboard**: React dashboard for topology, model store, chat, settings, and placement workflows.
+- **Model Store**: centralize model files on one node and stage them to the rest of the cluster over the LAN.
+- **Cluster-wide config sync**: update config from the dashboard and sync it across nodes.
+- **Placement previews**: inspect valid placements before launching a model.
+- **Thinking-aware chat UI**: chat with compatible models and surface reasoning content.
+- **Alternative API compatibility**: OpenAI Chat Completions, OpenAI Responses, Claude Messages, and Ollama.
+- **Experimental inference tuning**: OptiQ and other KV cache backends for long-context and memory experiments.
+
+## Dashboard
+
+Skulk serves a built-in dashboard at `http://localhost:52415`.
+The React dashboard is the default UI. The legacy Svelte dashboard is kept only as a fallback in the repo.
+The normal dashboard flow is: confirm topology, launch a model, wait for it to become ready, then open chat.
 
 <p align="center">
   <img src="docs/imgs/dash-1.png" alt="Skulk dashboard showing cluster topology and currently running models" width="80%" />
 </p>
-<p align="center"><em>The Skulk dashboard showing cluster topology and currently running models.</em></p>
+<p align="center"><em>Start here: confirm the node or cluster looks healthy in the cluster view.</em></p>
 
 <p align="center">
   <img src="docs/imgs/dash-2.png" alt="Skulk dashboard model store" width="80%" />
 </p>
-<p align="center"><em>The Skulk dashboard model store, allowing local network staging from a centralized store.</em></p>
+<p align="center"><em>Next: launch or download a model from the Model Store view.</em></p>
 
 <p align="center">
   <img src="docs/imgs/dash-3.png" alt="Skulk dashboard chat view" width="80%" />
 </p>
-<p align="center"><em>The Skulk dashboard chat view, showing current chat and chat history.</em></p>
+<p align="center"><em>Then: chat once a model is placed and ready.</em></p>
 
-## **Benchmarks**
+## Single-Node Quick Start
+
+This path is for getting one machine working end-to-end from zero.
+
+### 1. Install Prerequisites
+
+Use the instructions in [Prerequisites](#prerequisites).
+
+### 2. Clone the Repo, Build the Dashboard, and Start Skulk
+
+```bash
+git clone https://github.com/foxlight-foundation/Skulk.git
+cd Skulk
+cd dashboard-react && npm install && npm run build && cd ..
+uv sync
+uv run exo
+```
+
+This starts the dashboard and API at `http://localhost:52415`.
+
+### 3. Open the Dashboard
+
+Go to `http://localhost:52415`.
+
+From there:
+
+1. Confirm your node appears in the topology view.
+2. Open the Model Store view.
+3. Launch a model.
+4. Wait for the model to become ready.
+5. Open chat and start using it.
+
+### 4. Launch a Model with the API Instead
+
+If you would rather use the API directly, here is the simplest flow:
+
+You have two easy options:
+
+- Open the dashboard, go to the Model Store view, launch a model there, and wait for it to become ready before opening chat.
+- Use the API directly.
+
+1. Preview placements:
+
+```bash
+curl "http://localhost:52415/instance/previews?model_id=mlx-community/Llama-3.2-1B-Instruct-4bit"
+```
+
+2. Quick-launch a placement:
+
+```bash
+curl -X POST http://localhost:52415/place_instance \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "sharding": "Pipeline",
+    "instance_meta": "MlxRing",
+    "min_nodes": 1
+  }'
+```
+
+3. Send a chat request:
+
+```bash
+curl -X POST http://localhost:52415/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "messages": [{"role": "user", "content": "Hello from Skulk"}]
+  }'
+```
+
+If you get `404 No instance found for model ...`, the model has not been placed yet or is not running.
+
+## Cluster Quick Start
+
+Use this path when you want more than one machine in the cluster.
+
+1. Install Skulk on each node.
+2. Build the dashboard on each node if you are running from source.
+3. Start `uv run exo` on each machine.
+4. Open the dashboard on one node and confirm the cluster topology looks correct.
+5. Use placement preview or the placement manager to launch a model.
+6. Send chat requests through the dashboard or API.
+
+Skulk can discover peers automatically in many local setups. If you want a fixed cluster topology, use `--bootstrap-peers` or the `EXO_BOOTSTRAP_PEERS` environment variable.
+
+Example:
+
+```bash
+uv run exo --bootstrap-peers /ip4/192.168.1.20/tcp/5678/p2p/12D3KooW...
+```
+
+## Model Store
+
+The model store is one of Skulk's biggest additions over upstream EXO.
+
+Without it, each node may download model data independently.
+With it, one node acts as the store host and the rest of the cluster stages from that machine over the LAN.
+
+Use the model store when:
+
+- your models are large
+- you have multiple nodes
+- you want cleaner offline behavior after the first download
+- you want model files to live on a large local or network-attached volume
+
+Recommended path:
+
+1. Start Skulk on all nodes.
+2. Open the dashboard on the node that should hold the model store.
+3. Go to **Settings**.
+4. Toggle **This node is the store host**.
+5. Choose the store path.
+6. Save.
+7. Restart Skulk on all nodes if the UI tells you the change requires restart.
+
+For the full guide, see [docs/model-store.md](docs/model-store.md).
+
+## API Guide
+
+Skulk exposes several API surfaces:
+
+- **OpenAI Chat Completions**: `/v1/chat/completions`
+- **OpenAI Responses**: `/v1/responses`
+- **Claude Messages**: `/v1/messages`
+- **Ollama-compatible endpoints**: `/ollama/api/...`
+- **Skulk control endpoints**: placement, model store, config, tracing, downloads, cluster state
+
+The most important API doc lives here:
+
+- [docs/api.md](docs/api.md)
+
+That guide is written to be both newcomer-friendly and integration-friendly. It includes:
+
+- a first-success launch flow
+- exact endpoint behavior
+- copy-paste examples
+- common failure cases
+- store and config endpoints
+
+## Common Workflows
+
+### List Known Models
+
+```bash
+curl http://localhost:52415/v1/models
+```
+
+### List Downloaded Models Only
+
+```bash
+curl "http://localhost:52415/v1/models?status=downloaded"
+```
+
+### Search Hugging Face
+
+```bash
+curl "http://localhost:52415/models/search?query=qwen3&limit=5"
+```
+
+### Add a Custom Model Card
+
+```bash
+curl -X POST http://localhost:52415/models/add \
+  -H 'Content-Type: application/json' \
+  -d '{"model_id": "mlx-community/my-custom-model"}'
+```
+
+### Use the OpenAI Python SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:52415/v1",
+    api_key="unused",
+)
+
+response = client.chat.completions.create(
+    model="mlx-community/Llama-3.2-1B-Instruct-4bit",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)
+```
+
+Remember: that model must already be placed and running.
+
+## Configuration
+
+Skulk supports both environment variables and `exo.yaml`.
+
+Today, `exo.yaml` is especially useful for:
+
+- `model_store`
+- `inference.kv_cache_backend`
+- `hf_token`
+
+The dashboard Settings UI can write and sync config for you.
+
+See:
+
+- [exo.yaml.example](exo.yaml.example)
+- [docs/model-store.md](docs/model-store.md)
+- [docs/kv-cache-backends.md](docs/kv-cache-backends.md)
+
+## Useful CLI Options
+
+Current common options:
+
+- `--no-api`
+- `--api-port`
+- `--no-worker`
+- `--no-downloads`
+- `--offline`
+- `--no-batch`
+- `--bootstrap-peers`
+- `--libp2p-port`
+- `--fast-synch`
+- `--no-fast-synch`
+
+Examples:
+
+```bash
+uv run exo --offline
+uv run exo --no-worker
+uv run exo --api-port 52416
+uv run exo --bootstrap-peers /ip4/192.168.1.20/tcp/5678/p2p/12D3KooW...
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `EXO_MODELS_PATH` | Extra colon-separated search paths for local or shared models | None |
+| `EXO_MODELS_DIR` | Primary downloaded-model directory | platform-specific |
+| `EXO_OFFLINE` | Use only local or pre-staged models | `false` |
+| `EXO_ENABLE_IMAGE_MODELS` | Enable image model cards and image workflows | `false` |
+| `EXO_LIBP2P_NAMESPACE` | Custom namespace for cluster isolation | None |
+| `EXO_FAST_SYNCH` | Control MLX fast synch behavior | Auto |
+| `EXO_TRACING_ENABLED` | Enable distributed tracing | `false` |
+| `EXO_KV_CACHE_BACKEND` | KV cache backend selection | `default` |
+| `EXO_KV_CACHE_BITS` | Bit width for `mlx_quantized` | None |
+| `EXO_TQ_K_BITS` | Key-cache bits for TurboQuant backends | `3` |
+| `EXO_TQ_V_BITS` | Value-cache bits for TurboQuant backends | `4` |
+| `EXO_TQ_FP16_LAYERS` | Edge FP16 layers for `turboquant_adaptive` | `4` |
+| `EXO_NO_BATCH` | Force sequential generation | `false` |
+| `EXO_OPTIQ_BITS` | Bit width for `optiq` | `4` |
+| `EXO_OPTIQ_FP16_LAYERS` | Edge FP16 layers for `optiq` | `4` |
+| `EXO_BOOTSTRAP_PEERS` | Comma-separated static peers to dial on startup | None |
+| `HF_TOKEN` | Hugging Face token | None |
+
+Examples:
+
+```bash
+EXO_OFFLINE=true uv run exo
+EXO_ENABLE_IMAGE_MODELS=true uv run exo
+EXO_KV_CACHE_BACKEND=optiq EXO_OPTIQ_BITS=4 EXO_OPTIQ_FP16_LAYERS=4 uv run exo
+```
+
+## RDMA on macOS
+
+RDMA is relevant only if you are building a multi-node Mac cluster on supported Thunderbolt 5 hardware.
+
+High-level process:
+
+1. Boot into Recovery.
+2. Run `rdma_ctl enable`.
+3. Reboot.
+4. Make sure your cabling and macOS versions are appropriate.
+
+Important caveats:
+
+- RDMA clusters need the right hardware and cabling.
+- Matching macOS versions matter.
+- On Mac Studio, avoid the Thunderbolt 5 port next to Ethernet for this setup.
+- If running from source, the repo contains `tmp/set_rdma_network_config.sh` for network setup help.
+
+## Benchmarks
 
 <details>
   <summary>Qwen3-235B (8-bit) on 4 × M3 Ultra Mac Studio with Tensor Parallel RDMA</summary>
   <img src="docs/benchmarks/jeffgeerling/mac-studio-cluster-ai-full-1-qwen3-235b.jpeg" alt="Benchmark - Qwen3-235B (8-bit) on 4 × M3 Ultra Mac Studio with Tensor Parallel RDMA" width="80%" />
-  <p>
-    <strong>Source:</strong> <a href="https://www.jeffgeerling.com/blog/2025/15-tb-vram-on-mac-studio-rdma-over-thunderbolt-5">Jeff Geerling: 15 TB VRAM on Mac Studio – RDMA over Thunderbolt 5</a>
-  </p>
 </details>
 
 <details>
   <summary>DeepSeek v3.1 671B (8-bit) on 4 × M3 Ultra Mac Studio with Tensor Parallel RDMA</summary>
   <img src="docs/benchmarks/jeffgeerling/mac-studio-cluster-ai-full-2-deepseek-3.1-671b.jpeg" alt="Benchmark - DeepSeek v3.1 671B (8-bit) on 4 × M3 Ultra Mac Studio with Tensor Parallel RDMA" width="80%" />
-  <p>
-    <strong>Source:</strong> <a href="https://www.jeffgeerling.com/blog/2025/15-tb-vram-on-mac-studio-rdma-over-thunderbolt-5">Jeff Geerling: 15 TB VRAM on Mac Studio – RDMA over Thunderbolt 5</a>
-  </p>
 </details>
 
 <details>
   <summary>Kimi K2 Thinking (native 4-bit) on 4 × M3 Ultra Mac Studio with Tensor Parallel RDMA</summary>
   <img src="docs/benchmarks/jeffgeerling/mac-studio-cluster-ai-full-3-kimi-k2-thinking.jpeg" alt="Benchmark - Kimi K2 Thinking (native 4-bit) on 4 × M3 Ultra Mac Studio with Tensor Parallel RDMA" width="80%" />
-  <p>
-    <strong>Source:</strong> <a href="https://www.jeffgeerling.com/blog/2025/15-tb-vram-on-mac-studio-rdma-over-thunderbolt-5">Jeff Geerling: 15 TB VRAM on Mac Studio – RDMA over Thunderbolt 5</a>
-  </p>
 </details>
 
----
+## More Documentation
 
-## **Quick Start**
+- [docs/api.md](docs/api.md)
+- [docs/model-store.md](docs/model-store.md)
+- [docs/architecture.md](docs/architecture.md)
+- [docs/kv-cache-backends.md](docs/kv-cache-backends.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
 
-Devices running Skulk automatically discover each other, without needing any manual configuration. Each device provides an API and a dashboard for interacting with your cluster (runs at `http://localhost:52415`).
+## Contributing
 
-There are two ways to run Skulk:
+See [CONTRIBUTING.md](CONTRIBUTING.md) if you want to contribute code, docs, testing help, or design feedback.
 
-### **Run from Source (macOS)**
+## About EXO
 
-If you have [Nix](https://nixos.org/) installed, you can skip most of the steps below and run directly:
-
-```bash
-nix run .#exo
-```
-
-**Note:** To accept the Cachix binary cache (and avoid the Xcode Metal ToolChain), add to `/etc/nix/nix.conf`:
-```
-trusted-users = root    (or your username)
-experimental-features = nix-command flakes
-```
-Then restart the Nix daemon: `sudo launchctl kickstart -k system/org.nixos.nix-daemon`
-
-**Prerequisites:**
-- [Xcode](https://developer.apple.com/xcode/) (provides the Metal ToolChain required for MLX compilation)
-- [brew](https://github.com/Homebrew/brew) (for simple package management on macOS)
-
-  ```bash
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  ```
-- [uv](https://github.com/astral-sh/uv) (for Python dependency management)
-- [macmon](https://github.com/vladkens/macmon) (for hardware monitoring on Apple Silicon)
-- [node](https://github.com/nodejs/node) (for building the dashboard)
-
-  ```bash
-  brew install uv macmon node
-  ```
-- [rust](https://github.com/rust-lang/rustup) (to build Rust bindings, nightly for now)
-
-  ```bash
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-  rustup toolchain install nightly
-  ```
-
-Clone the repo, build the dashboard, and run Skulk:
-
-```bash
-# Clone the repo
-git clone https://github.com/foxlight-foundation/Skulk.git
-
-# Build dashboard
-cd Skulk/dashboard-react && npm install && npm run build && cd ..
-
-# Install Python dependencies
-uv sync
-
-# Run Skulk
-uv run exo
-```
-
-This starts the Skulk dashboard and API at http://localhost:52415/
-
-## **Experimental KV Cache Backends**
-
-Skulk includes opt-in KV cache backends for MLX text generation:
-
-- `default`: current behavior, unchanged unless you explicitly opt in
-- `mlx_quantized`: MLX LM's built-in `QuantizedKVCache`
-- `turboquant`: a correctness-first TurboQuant-inspired KV cache for standard `KVCache` layers
-- `turboquant_adaptive`: keeps the first and last KV layers in FP16 and applies TurboQuant only to middle KV layers
-- `optiq`: rotation-based KV cache quantization via [mlx-optiq](https://github.com/mlx-explore/mlx-optiq)
-
-Current recommended experimental setting:
-
-```bash
-EXO_KV_CACHE_BACKEND=optiq \
-EXO_OPTIQ_BITS=4 \
-EXO_OPTIQ_FP16_LAYERS=4 \
-uv run exo
-```
-
-The `optiq` backend uses mlx-optiq's rotation-based quantization for the best quality-to-memory tradeoff. As a proven alternative, `turboquant_adaptive` remains a solid choice:
-
-```bash
-EXO_KV_CACHE_BACKEND=turboquant_adaptive \
-EXO_TQ_K_BITS=3 \
-EXO_TQ_V_BITS=4 \
-EXO_TQ_FP16_LAYERS=4 \
-uv run exo
-```
-
-**Note:** KV cache backends can now also be configured from the Settings panel in the dashboard without needing to set environment variables.
-
-Important notes:
-
-- These backends are opt-in. If `EXO_KV_CACHE_BACKEND` is unset, behavior remains the same as before.
-- The current implementation is primarily a memory optimization for long-context experiments, not a guaranteed tokens-per-second optimization.
-- Quantized KV cache backends currently force sequential generation because batch/history mode is not supported yet.
-
-More detail, current limitations, and testing guidance live in [docs/kv-cache-backends.md](docs/kv-cache-backends.md).
-
-
-*Please view the section on RDMA to enable this feature on MacOS >=26.2!*
-
-
-### **Run from Source (Linux)**
-
-**Prerequisites:**
-
-- [uv](https://github.com/astral-sh/uv) (for Python dependency management)
-- [node](https://github.com/nodejs/node) (for building the dashboard) - version 18 or higher
-- [rust](https://github.com/rust-lang/rustup) (to build Rust bindings, nightly for now)
-
-**Installation methods:**
-
-**Option 1: Using system package manager (Ubuntu/Debian example):**
-```bash
-# Install Node.js and npm
-sudo apt update
-sudo apt install nodejs npm
-
-# Install uv
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Install Rust (using rustup)
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup toolchain install nightly
-```
-
-**Option 2: Using Homebrew on Linux (if preferred):**
-```bash
-# Install Homebrew on Linux
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-# Install dependencies
-brew install uv node
-
-# Install Rust (using rustup)
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup toolchain install nightly
-```
-
-**Note:** The `macmon` package is macOS-only and not required for Linux.
-
-Clone the repo, build the dashboard, and run Skulk:
-
-```bash
-# Clone the repo
-git clone https://github.com/foxlight-foundation/Skulk.git
-
-# Build dashboard
-cd Skulk/dashboard-react && npm install && npm run build && cd ..
-
-# Install Python dependencies
-uv sync
-
-# Run Skulk
-uv run exo
-```
-
-This starts the Skulk dashboard and API at http://localhost:52415/
-
-**Important note for Linux users:** Currently, Skulk runs on CPU on Linux. GPU support for Linux platforms is under development. If you'd like to see support for your specific Linux hardware, please [search for existing feature requests](https://github.com/foxlight-foundation/Skulk/issues) or create a new one.
-
-**Configuration Options:**
-
-- `--no-worker`: Run Skulk without the worker component. Useful for coordinator-only nodes that handle networking and orchestration but don't execute inference tasks. This is helpful for machines without sufficient GPU resources but with good network connectivity.
-
-  ```bash
-  uv run exo --no-worker
-  ```
-
-**File Locations (Linux):**
-
-Skulk follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) on Linux:
-
-- **Configuration files**: `~/.config/exo/` (or `$XDG_CONFIG_HOME/exo/`)
-- **Data files**: `~/.local/share/exo/` (or `$XDG_DATA_HOME/exo/`)
-- **Cache files**: `~/.cache/exo/` (or `$XDG_CACHE_HOME/exo/`)
-- **Log files**: `~/.cache/exo/exo_log/` (with automatic log rotation)
-- **Custom model cards**: `~/.local/share/exo/custom_model_cards/`
-
-You can override these locations by setting the corresponding XDG environment variables.
-
----
-
-### **Enabling RDMA on macOS**
-
-RDMA is a new capability added to macOS 26.2. It works on any Mac with Thunderbolt 5 (M4 Pro Mac Mini, M4 Max Mac Studio, M4 Max MacBook Pro, M3 Ultra Mac Studio).
-
-Please refer to the caveats for immediate troubleshooting.
-
-To enable RDMA on macOS, follow these steps:
-
-1. Shut down your Mac.
-2. Hold down the power button for 10 seconds until the boot menu appears.
-3. Select "Options" to enter Recovery mode.
-4. When the Recovery UI appears, open the Terminal from the Utilities menu.
-5. In the Terminal, type:
-   ```
-   rdma_ctl enable
-   ```
-   and press Enter.
-6. Reboot your Mac.
-
-After that, RDMA will be enabled in macOS and Skulk will take care of the rest.
-
-**Important Caveats**
-
-1. Devices that wish to be part of an RDMA cluster must be connected to all other devices in the cluster.
-2. The cables must support TB5.
-3. On a Mac Studio, you cannot use the Thunderbolt 5 port next to the Ethernet port.
-4. If running from source, please use the script found at `tmp/set_rdma_network_config.sh`, which will disable Thunderbolt Bridge and set dhcp on each RDMA port.
-5. RDMA ports may be unable to discover each other on different versions of MacOS. Please ensure that OS versions match exactly (even beta version numbers) on all devices.
-
----
-
-## **Environment Variables**
-
-Skulk supports several environment variables for configuration:
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `EXO_MODELS_PATH` | Colon-separated paths to search for pre-downloaded models (e.g., on NFS mounts or shared storage) | None |
-| `EXO_MODELS_DIR` | Directory where Skulk downloads and stores models | `~/.local/share/exo/models` (Linux) or `~/.exo/models` (macOS) |
-| `EXO_OFFLINE` | Run without internet connection (uses only local models) | `false` |
-| `EXO_ENABLE_IMAGE_MODELS` | Enable image model support | `false` |
-| `EXO_LIBP2P_NAMESPACE` | Custom namespace for cluster isolation | None |
-| `EXO_FAST_SYNCH` | Control MLX_METAL_FAST_SYNCH behavior (for JACCL backend) | Auto |
-| `EXO_TRACING_ENABLED` | Enable distributed tracing for performance analysis | `false` |
-| `EXO_KV_CACHE_BACKEND` | Select KV cache backend: `default`, `mlx_quantized`, `turboquant`, `turboquant_adaptive`, or `optiq` | `default` |
-| `EXO_KV_CACHE_BITS` | Bit width for MLX built-in quantized KV cache. Required when `EXO_KV_CACHE_BACKEND=mlx_quantized` | None |
-| `EXO_TQ_K_BITS` | Key-cache bit width for TurboQuant backends | `3` |
-| `EXO_TQ_V_BITS` | Value-cache bit width for TurboQuant backends | `4` |
-| `EXO_TQ_FP16_LAYERS` | Number of KV layers at each edge kept in FP16 for `turboquant_adaptive` | `4` |
-| `EXO_NO_BATCH` | Disable batch generation. Quantized KV backends currently force this behavior automatically as a temporary fallback | `false` |
-| `EXO_OPTIQ_BITS` | Bit width for mlx-optiq KV cache | `4` |
-| `EXO_OPTIQ_FP16_LAYERS` | Edge layers kept in FP16 for optiq | `4` |
-| `EXO_BOOTSTRAP_PEERS` | Comma-separated libp2p multiaddrs for static peer discovery | None |
-| `HF_TOKEN` | HuggingFace API token (can also be set in Settings panel) | None |
-
-**Example usage:**
-
-```bash
-# Use pre-downloaded models from NFS mount
-EXO_MODELS_PATH=/mnt/nfs/models:/opt/ai-models uv run exo
-
-# Run in offline mode
-EXO_OFFLINE=true uv run exo
-
-# Enable image models
-EXO_ENABLE_IMAGE_MODELS=true uv run exo
-
-# Use custom namespace for cluster isolation
-EXO_LIBP2P_NAMESPACE=my-dev-cluster uv run exo
-
-# Use MLX built-in quantized KV cache
-EXO_KV_CACHE_BACKEND=mlx_quantized EXO_KV_CACHE_BITS=4 uv run exo
-
-# Use the current recommended TurboQuant adaptive setting
-EXO_KV_CACHE_BACKEND=turboquant_adaptive EXO_TQ_K_BITS=3 EXO_TQ_V_BITS=4 EXO_TQ_FP16_LAYERS=4 uv run exo
-```
-
-For more detail on KV cache backends, supported model cache layouts, current limitations, and testing guidance, see [docs/kv-cache-backends.md](docs/kv-cache-backends.md).
-
----
-
-### Using the API
-
-Skulk provides multiple API-compatible interfaces for maximum compatibility with existing tools:
-
-- **OpenAI Chat Completions API** - Compatible with OpenAI clients
-- **Claude Messages API** - Compatible with Anthropic's Claude format
-- **OpenAI Responses API** - Compatible with OpenAI's Responses format
-- **Ollama API** - Compatible with Ollama and tools like OpenWebUI
-
-If you prefer to interact with Skulk via the API, here is an example creating an instance of a small model (`mlx-community/Llama-3.2-1B-Instruct-4bit`), sending a chat completions request and deleting the instance.
-
----
-
-**1. Preview instance placements**
-
-The `/instance/previews` endpoint will preview all valid placements for your model.
-
-```bash
-curl "http://localhost:52415/instance/previews?model_id=llama-3.2-1b"
-```
-
-Sample response:
-
-```json
-{
-  "previews": [
-    {
-      "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
-      "sharding": "Pipeline",
-      "instance_meta": "MlxRing",
-      "instance": {...},
-      "memory_delta_by_node": {"local": 729808896},
-      "error": null
-    }
-    // ...possibly more placements...
-  ]
-}
-```
-
-This will return all valid placements for this model. Pick a placement that you like.
-To pick the first one, pipe into `jq`:
-
-```bash
-curl "http://localhost:52415/instance/previews?model_id=llama-3.2-1b" | jq -c '.previews[] | select(.error == null) | .instance' | head -n1
-```
-
----
-
-**2. Create a model instance**
-
-Send a POST to `/instance` with your desired placement in the `instance` field (the full payload must match types as in `CreateInstanceParams`), which you can copy from step 1:
-
-```bash
-curl -X POST http://localhost:52415/instance \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "instance": {...}
-  }'
-```
-
-
-Sample response:
-
-```json
-{
-  "message": "Command received.",
-  "command_id": "e9d1a8ab-...."
-}
-```
-
----
-
-**3. Send a chat completion**
-
-Now, make a POST to `/v1/chat/completions` (the same format as OpenAI's API):
-
-```bash
-curl -N -X POST http://localhost:52415/v1/chat/completions \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
-    "messages": [
-      {"role": "user", "content": "What is Llama 3.2 1B?"}
-    ],
-    "stream": true
-  }'
-```
-
----
-
-**4. Delete the instance**
-
-When you're done, delete the instance by its ID (find it via `/state` or `/instance` endpoints):
-
-```bash
-curl -X DELETE http://localhost:52415/instance/YOUR_INSTANCE_ID
-```
-
-### Claude Messages API Compatibility
-
-Use the Claude Messages API format with the `/v1/messages` endpoint:
-
-```bash
-curl -N -X POST http://localhost:52415/v1/messages \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
-    "messages": [
-      {"role": "user", "content": "Hello"}
-    ],
-    "max_tokens": 1024,
-    "stream": true
-  }'
-```
-
-### **OpenAI Responses API Compatibility**
-
-Use the OpenAI Responses API format with the `/v1/responses` endpoint:
-
-```bash
-curl -N -X POST http://localhost:52415/v1/responses \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
-    "messages": [
-      {"role": "user", "content": "Hello"}
-    ],
-    "stream": true
-  }'
-```
-
-### **Ollama API Compatibility**
-
-Skulk supports Ollama API endpoints for compatibility with tools like OpenWebUI:
-
-```bash
-# Ollama chat
-curl -X POST http://localhost:52415/ollama/api/chat \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
-    "messages": [
-      {"role": "user", "content": "Hello"}
-    ],
-    "stream": false
-  }'
-
-# List models (Ollama format)
-curl http://localhost:52415/ollama/api/tags
-```
-
-### **Custom Model Loading from HuggingFace**
-
-You can add custom models from the HuggingFace hub:
-
-```bash
-curl -X POST http://localhost:52415/models/add \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model_id": "mlx-community/my-custom-model"
-  }'
-```
-
-**Security Note:**
-
-Custom models requiring `trust_remote_code` in their configuration must be explicitly enabled (default is false) for security. Only enable this if you trust the model's remote code execution. Models are fetched from HuggingFace and stored locally as custom model cards.
-
-**Other useful API endpoints*:**
-
-- List all models: `curl http://localhost:52415/models`
-- List downloaded models only: `curl http://localhost:52415/models?status=downloaded`
-- Search HuggingFace: `curl "http://localhost:52415/models/search?query=llama&limit=10"`
-- Inspect instance IDs and deployment state: `curl http://localhost:52415/state`
-
-For further details, see:
-
-- API documentation in [docs/api.md](docs/api.md).
-- API types and endpoints in [src/exo/master/api.py](src/exo/master/api.py).
-
----
-
-## **Benchmarking**
-
-The `exo-bench` tool measures model prefill and token generation speed across different placement configurations. This helps you optimize model performance and validate improvements.
-
-**Prerequisites:**
-- Nodes should be running with `uv run exo` before benchmarking
-- The tool uses the `/bench/chat/completions` endpoint
-
-**Basic usage:**
-
-```bash
-uv run bench/exo_bench.py \
-  --model Llama-3.2-1B-Instruct-4bit \
-  --pp 128,256,512 \
-  --tg 128,256
-```
-
-**Key parameters:**
-
-- `--model`: Model to benchmark (short ID or HuggingFace ID)
-- `--pp`: Prompt size hints (comma-separated integers)
-- `--tg`: Generation lengths (comma-separated integers)
-- `--max-nodes`: Limit placements to N nodes (default: 4)
-- `--instance-meta`: Filter by `ring`, `jaccl`, or `both` (default: both)
-- `--sharding`: Filter by `pipeline`, `tensor`, or `both` (default: both)
-- `--repeat`: Number of repetitions per configuration (default: 1)
-- `--warmup`: Warmup runs per placement (default: 0)
-- `--json-out`: Output file for results (default: bench/results.json)
-
-**Example with filters:**
-
-```bash
-uv run bench/exo_bench.py \
-  --model Llama-3.2-1B-Instruct-4bit \
-  --pp 128,512 \
-  --tg 128 \
-  --max-nodes 2 \
-  --sharding tensor \
-  --repeat 3 \
-  --json-out my-results.json
-```
-
-The tool outputs performance metrics including prompt tokens per second (prompt_tps), generation tokens per second (generation_tps), and peak memory usage for each configuration.
-
----
-
-## **Hardware Accelerator Support**
-
-On macOS, Skulk uses the GPU. On Linux, Skulk currently runs on CPU. We are working on extending hardware accelerator support. If you'd like support for a new hardware platform, please [search for an existing feature request](https://github.com/foxlight-foundation/Skulk/issues) and add a thumbs up so we know what hardware is important to the community.
-
----
-
-## **Contributing**
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to Skulk.
-
---
-
-## **About EXO**
-
-EXO is the upstream project from which Skulk is forked. EXO connects all your devices into an AI cluster. Not only does it enable running models larger than would fit on a single device, but with [day-0 support for RDMA over Thunderbolt](https://x.com/exolabs/status/2001817749744476256?s=20), makes models run faster as you add more devices.
+EXO is the upstream distributed inference project that Skulk builds on top of.
+Skulk keeps that foundation, then pushes further on model-store workflows, dashboard UX, and newcomer-friendly cluster operation.

--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -45,6 +45,7 @@
         "eslint-plugin-storybook": "^10.3.3",
         "globals": "^17.4.0",
         "playwright": "^1.58.2",
+        "redoc": "2.5.2",
         "storybook": "^10.3.3",
         "typedoc": "^0.28.14",
         "typescript": "~5.9.3",
@@ -258,7 +259,6 @@
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1003,6 +1003,13 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/schemasafe": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -1230,6 +1237,82 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.11",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.11.tgz",
+      "integrity": "sha512-V09ayfnb5GyysmvARbt+voFZAjGcf7hSYxOYxSkCc4fbH/DTfq5YWoec8cflvmHHqyIFbqvmGKmYFzqhr9zxDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.11",
@@ -2420,6 +2503,14 @@
       "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -3022,6 +3113,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3045,7 +3146,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3226,6 +3326,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3334,6 +3441,51 @@
         }
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3351,6 +3503,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3388,6 +3547,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cross-spawn": {
@@ -3857,6 +4029,12 @@
         }
       }
     },
+    "node_modules/decko": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decko/-/decko-1.2.0.tgz",
+      "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==",
+      "dev": true
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -3967,12 +4145,29 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.322",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.322.tgz",
       "integrity": "sha512-vFU34OcrvMcH66T+dYC3G4nURmgfDVewMIu6Q2urXpumAPSMmzvcn04KVVV8Opikq8Vs5nUbO/8laNhNRqSzYw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/empathic": {
       "version": "2.0.0",
@@ -4001,6 +4196,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4288,6 +4490,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4318,6 +4527,50 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4398,6 +4651,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreach": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.6.tgz",
+      "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4431,6 +4691,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob": {
@@ -4590,6 +4860,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http2-client": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+      "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4700,6 +4991,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4794,6 +5095,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4833,6 +5144,16 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-pointer": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.2.tgz",
+      "integrity": "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "foreach": "^2.0.4"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5229,6 +5550,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -5315,6 +5649,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/markdown-it": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -5395,6 +5736,70 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mobx": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
+      "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/mobx-react": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-9.2.0.tgz",
+      "integrity": "sha512-dkGWCx+S0/1mfiuFfHRH8D9cplmwhxOV5CkXMp38u6rQGG2Pv3FWYztS0M7ncR6TyPRQKaTG/pnitInoYE9Vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mobx-react-lite": "^4.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mobx-react-lite": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
+      "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.9.0",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5437,12 +5842,171 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch-h2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http2-client": "^1.2.5"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-readfiles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^3.2.1"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oas-kit-common": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/oas-linter": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+      "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@exodus/schemasafe": "^1.0.0-rc.2",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-linter/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oas-resolver": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "node-fetch-h2": "^2.3.0",
+        "oas-kit-common": "^1.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "resolve": "resolve.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-resolver/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oas-schema-walker": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+      "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "oas-kit-common": "^1.0.8",
+        "oas-linter": "^3.2.2",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "reftools": "^1.1.9",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -5472,6 +6036,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-sampler": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.2.tgz",
+      "integrity": "sha512-OKytvqB5XIaTgA9xtw8W8UTar+uymW2xPVpFN0NihMtuHPdPTGxBEhGnfFnJW5g/gOSIvkP+H0Xh3XhVI9/n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.7",
+        "fast-xml-parser": "^5.5.1",
+        "json-pointer": "0.6.2"
       }
     },
     "node_modules/optionator": {
@@ -5537,6 +6113,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5545,6 +6128,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -5607,6 +6206,13 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/perfect-scrollbar": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.6.tgz",
+      "integrity": "sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5674,6 +6280,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/pngjs": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
@@ -5682,6 +6298,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.19.0"
+      }
+    },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/postcss": {
@@ -5766,6 +6395,28 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5894,6 +6545,20 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-tabs": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.1.tgz",
+      "integrity": "sha512-CPiuKoMFf89B7QlbFfdBD9XmUWiE3qudQputMVZB8GQvPJZRX/gqjDaDWOPDwGinEfpJKEuBCkGt83Tt4efeyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -5936,6 +6601,90 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redoc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.5.2.tgz",
+      "integrity": "sha512-sTJfItvRkcDTojB6wdLN4M+Ua6mlZwElV21Tf8Mn7IbQF/1Os6GvgQpZyLWPGZZHbhy7GC1Or1hTMHfz1vKh5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.4.0",
+        "classnames": "^2.3.2",
+        "decko": "^1.2.0",
+        "dompurify": "^3.2.4",
+        "eventemitter3": "^5.0.1",
+        "json-pointer": "^0.6.2",
+        "lunr": "^2.3.9",
+        "mark.js": "^8.11.1",
+        "marked": "^4.3.0",
+        "mobx-react": "9.2.0",
+        "openapi-sampler": "^1.6.2",
+        "path-browserify": "^1.0.1",
+        "perfect-scrollbar": "^1.5.5",
+        "polished": "^4.2.2",
+        "prismjs": "^1.29.0",
+        "prop-types": "^15.8.1",
+        "react-tabs": "^6.0.2",
+        "slugify": "~1.4.7",
+        "stickyfill": "^1.1.1",
+        "swagger2openapi": "^7.0.8",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=6.9",
+        "npm": ">=3.0.0"
+      },
+      "peerDependencies": {
+        "core-js": "^3.1.4",
+        "mobx": "^6.0.4",
+        "react": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "styled-components": "^4.1.1 || ^5.1.1 || ^6.0.5"
+      }
+    },
+    "node_modules/redoc/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/reftools": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+      "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -6092,6 +6841,66 @@
         "node": ">=8"
       }
     },
+    "node_modules/should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "node_modules/should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "node_modules/should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -6112,6 +6921,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.7.tgz",
+      "integrity": "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map": {
@@ -6146,6 +6965,12 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stickyfill": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
+      "integrity": "sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA==",
+      "dev": true
     },
     "node_modules/storybook": {
       "version": "10.3.3",
@@ -6207,6 +7032,34 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -6273,6 +7126,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/styled-components": {
       "version": "6.3.12",
@@ -6367,6 +7233,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger2openapi": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "node-fetch": "^2.6.1",
+        "node-fetch-h2": "^2.3.0",
+        "node-readfiles": "^0.2.0",
+        "oas-kit-common": "^1.0.8",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "oas-validator": "^5.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "boast": "boast.js",
+        "oas-validate": "oas-validate.js",
+        "swagger2openapi": "swagger2openapi.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/swagger2openapi/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -6443,6 +7347,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -6683,6 +7594,20 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "dev": true,
+      "license": "BSD"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -6881,12 +7806,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6931,6 +7874,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -6969,6 +7943,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -6990,6 +7974,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -46,6 +46,7 @@
         "globals": "^17.4.0",
         "playwright": "^1.58.2",
         "storybook": "^10.3.3",
+        "typedoc": "^0.28.14",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1",
@@ -1055,6 +1056,20 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1518,6 +1533,55 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2257,6 +2321,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
@@ -2344,6 +2418,13 @@
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
       "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3903,6 +3984,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
@@ -5102,6 +5196,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5141,6 +5245,13 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
@@ -5204,6 +5315,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/marked": {
       "version": "17.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
@@ -5215,6 +5344,13 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -5635,6 +5771,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6355,6 +6501,69 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.18.tgz",
+      "integrity": "sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6392,6 +6601,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -6759,6 +6975,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-storybook": "^10.3.3",
     "globals": "^17.4.0",
     "playwright": "^1.58.2",
+    "redoc": "2.5.2",
     "storybook": "^10.3.3",
     "typedoc": "^0.28.14",
     "typescript": "~5.9.3",

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "docs:typedoc": "typedoc --options typedoc.json",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
@@ -50,6 +51,7 @@
     "globals": "^17.4.0",
     "playwright": "^1.58.2",
     "storybook": "^10.3.3",
+    "typedoc": "^0.28.14",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",

--- a/dashboard-react/src/docs-entry.ts
+++ b/dashboard-react/src/docs-entry.ts
@@ -1,0 +1,69 @@
+export type {
+  ChatMessage,
+  ChatModelInfo,
+  ChatUploadedFile,
+  Conversation,
+  MessageAttachment,
+} from './types/chat';
+export type {
+  Capability,
+  DownloadAvailability,
+  DownloadProgress,
+  FilterState,
+  HuggingFaceModel,
+  InstanceStatus,
+  ModelFitStatus,
+  ModelGroup,
+  ModelInfo,
+  PickerMode,
+  PlacementPreview,
+} from './types/models';
+export type {
+  DeviceModel,
+  MacmonMemory,
+  MacmonInfo,
+  MacmonTemp,
+  NetworkInterfaceInfo,
+  NodeInfo,
+  SystemInfo,
+  TopologyData,
+  TopologyEdge,
+} from './types/topology';
+
+export {
+  selectActiveConversation,
+  selectActiveMessages,
+  selectAllConversationsSorted,
+  selectConversationsForModel,
+  useChatStore,
+} from './stores/chatStore';
+export type { ChatState } from './stores/chatStore';
+export { useClusterState } from './hooks/useClusterState';
+export type {
+  ConfigResponse,
+  EffectiveConfig,
+  FullConfig,
+  InferenceConfig,
+  StoreConfig,
+  UseConfigReturn,
+} from './hooks/useConfig';
+export { useConfig } from './hooks/useConfig';
+export type {
+  ClusterState,
+  NodeDiskInfo,
+  RawDownloads,
+  RawInstanceInner,
+  RawShardAssignments,
+  RawInstances,
+  RawRunners,
+} from './hooks/useClusterState';
+export { useModelPicker } from './hooks/useModelPicker';
+export type { UseModelPickerOptions, UseModelPickerReturn } from './hooks/useModelPicker';
+export type { Size } from './hooks/useResizeObserver';
+export { useResizeObserver } from './hooks/useResizeObserver';
+export type { Toast, ToastInput, ToastType } from './hooks/useToast';
+export { useToast } from './hooks/useToast';
+export { formatBytes, getTemperatureColor } from './utils/format';
+export { detectDeviceModel } from './types/topology';
+export { formatFileSize, getFileCategory, getFileIcon, truncateFileName } from './types/chat';
+export { CAPABILITIES, EMPTY_FILTERS, SIZE_RANGES, groupModels } from './types/models';

--- a/dashboard-react/src/hooks/useClusterState.ts
+++ b/dashboard-react/src/hooks/useClusterState.ts
@@ -210,25 +210,32 @@ function transformTopology(
 const CONNECTION_LOST_THRESHOLD = 3;
 const POLL_INTERVAL = 1000;
 
+/** Raw downloads map as returned by `/state`. */
 export type RawDownloads = Record<string, unknown[]>;
+
+/** Disk-capacity information keyed by node id. */
 export type NodeDiskInfo = Record<string, { total: { inBytes: number }; available: { inBytes: number } }>;
 
+/** Raw shard-assignment payload returned by the Skulk state API. */
 export interface RawShardAssignments {
   modelId?: string;
   nodeToRunner?: Record<string, string>;
   runnerToShard?: Record<string, Record<string, unknown>>;
 }
 
+/** Raw inner instance shape returned by the Skulk state API. */
 export interface RawInstanceInner {
   instanceId?: string;
   shardAssignments?: RawShardAssignments;
 }
 
+/** Raw instances keyed by instance id with backend-specific tagged variants. */
 export type RawInstances = Record<string, { MlxRingInstance?: RawInstanceInner; MlxJacclInstance?: RawInstanceInner }>;
 
 /** Runner status is a tagged union: e.g. { "RunnerReady": {} } or { "RunnerLoading": { layersLoaded: 5, totalLayers: 32 } } */
 export type RawRunners = Record<string, Record<string, unknown>>;
 
+/** Normalized cluster-state data exposed to the dashboard UI. */
 export interface ClusterState {
   topology: TopologyData | null;
   connected: boolean;
@@ -239,6 +246,7 @@ export interface ClusterState {
   runners: RawRunners;
 }
 
+/** Poll the Skulk `/state` endpoint and normalize it into dashboard-friendly topology and status data. */
 export function useClusterState(): ClusterState {
   const [topology, setTopology] = useState<TopologyData | null>(null);
   const [connected, setConnected] = useState(false);

--- a/dashboard-react/src/hooks/useConfig.ts
+++ b/dashboard-react/src/hooks/useConfig.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+/** Shared model-store configuration returned by the Skulk config API. */
 export interface StoreConfig {
   enabled: boolean;
   store_host: string;
@@ -16,21 +17,25 @@ export interface StoreConfig {
   };
 }
 
+/** Inference-related config surfaced to the dashboard. */
 export interface InferenceConfig {
   kv_cache_backend: string;
 }
 
+/** Full editable config document as read from or written to `/config`. */
 export interface FullConfig {
   model_store?: StoreConfig;
   inference?: InferenceConfig;
   hf_token?: string;
 }
 
+/** Effective runtime values derived from config and environment. */
 export interface EffectiveConfig {
   kv_cache_backend: string;
   has_hf_token?: boolean;
 }
 
+/** Response shape returned by the dashboard config endpoint. */
 export interface ConfigResponse {
   config: FullConfig;
   configPath: string;
@@ -38,6 +43,7 @@ export interface ConfigResponse {
   effective?: EffectiveConfig;
 }
 
+/** State and actions exposed by {@link useConfig}. */
 export interface UseConfigReturn {
   config: StoreConfig | null;
   fullConfig: FullConfig | null;
@@ -50,6 +56,7 @@ export interface UseConfigReturn {
   saveFullConfig: (config: FullConfig) => Promise<boolean>;
 }
 
+/** Load and save cluster config through the Skulk dashboard config API. */
 export function useConfig(): UseConfigReturn {
   const [fullConfig, setFullConfig] = useState<FullConfig | null>(null);
   const [effective, setEffective] = useState<EffectiveConfig | null>(null);

--- a/dashboard-react/src/hooks/useModelPicker.ts
+++ b/dashboard-react/src/hooks/useModelPicker.ts
@@ -10,6 +10,7 @@ import {
   type InstanceStatus,
 } from '../types/models';
 
+/** Inputs used to build the dashboard's model-picker state machine. */
 export interface UseModelPickerOptions {
   models: ModelInfo[];
   favorites: Set<string>;
@@ -20,6 +21,7 @@ export interface UseModelPickerOptions {
   instanceStatuses?: Record<string, InstanceStatus>;
 }
 
+/** State, setters, and derived groups exposed by {@link useModelPicker}. */
 export interface UseModelPickerReturn {
   /* state */
   searchQuery: string;
@@ -50,6 +52,7 @@ export interface UseModelPickerReturn {
   recentGroups: ModelGroup[];
 }
 
+/** Manage model-picker filtering, grouping, favorites, recents, and fit-based recommendations. */
 export function useModelPicker({
   models,
   favorites,

--- a/dashboard-react/src/hooks/useToast.ts
+++ b/dashboard-react/src/hooks/useToast.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 
 export type ToastType = 'success' | 'error' | 'warning' | 'info';
 
+/** Toast record stored in the module-level toast store. */
 export interface Toast {
   id: string;
   type: ToastType;
@@ -11,6 +12,7 @@ export interface Toast {
   createdAt: number;
 }
 
+/** Input accepted when creating a toast. */
 export interface ToastInput {
   type: ToastType;
   message: string;
@@ -41,6 +43,7 @@ function generateId(): string {
   return `toast-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+/** Add a toast to the global toast store and return its generated id. */
 export function addToast(input: ToastInput): string {
   const id = generateId();
   const duration = input.persistent ? 0 : (input.duration ?? DEFAULT_DURATIONS[input.type]);
@@ -55,6 +58,7 @@ export function addToast(input: ToastInput): string {
   return id;
 }
 
+/** Dismiss a toast immediately and clear any scheduled auto-dismiss timer. */
 export function dismissToast(id: string): void {
   const timer = timers.get(id);
   if (timer) { clearTimeout(timer); timers.delete(id); }
@@ -73,6 +77,7 @@ function getSnapshot() {
   return toastList;
 }
 
+/** Subscribe React components to the shared toast store. */
 export function useToast() {
   const toasts = useSyncExternalStore(subscribe, getSnapshot);
   return { toasts, addToast, dismissToast };

--- a/dashboard-react/src/stores/chatStore.ts
+++ b/dashboard-react/src/stores/chatStore.ts
@@ -33,6 +33,7 @@ function autoName(content: string): string {
 
 /* ── Store Interface ──────────────────────────────────── */
 
+/** Persisted chat state keyed by conversation id and selected model. */
 export interface ChatState {
   conversations: Record<string, Conversation>;
   activeConversationId: string | null;
@@ -53,17 +54,21 @@ export interface ChatState {
 
 /* ── Selectors ────────────────────────────────────────── */
 
+/** Return the currently active conversation, if one is selected. */
 export const selectActiveConversation = (state: ChatState): Conversation | null =>
   state.activeConversationId
     ? state.conversations[state.activeConversationId] ?? null
     : null;
 
+/** Return the messages for the active conversation. */
 export const selectActiveMessages = (state: ChatState): ChatMessage[] =>
   selectActiveConversation(state)?.messages ?? [];
 
+/** Return all conversations sorted by last update time, newest first. */
 export const selectAllConversationsSorted = (state: ChatState): Conversation[] =>
   Object.values(state.conversations).sort((a, b) => b.updatedAt - a.updatedAt);
 
+/** Build a selector that returns conversations for one model, newest first. */
 export const selectConversationsForModel = (modelId: string) => (state: ChatState): Conversation[] =>
   Object.values(state.conversations)
     .filter((c) => c.modelId === modelId)
@@ -71,6 +76,7 @@ export const selectConversationsForModel = (modelId: string) => (state: ChatStat
 
 /* ── Store ────────────────────────────────────────────── */
 
+/** Persisted Zustand store that backs the dashboard chat experience. */
 export const useChatStore = create<ChatState>()(
   persist(devtools(
     (set, get) => ({

--- a/dashboard-react/src/types/chat.ts
+++ b/dashboard-react/src/types/chat.ts
@@ -1,3 +1,4 @@
+/** User-selected file staged for chat upload before sending. */
 export interface ChatUploadedFile {
   id: string;
   name: string;
@@ -7,6 +8,7 @@ export interface ChatUploadedFile {
   preview?: string;
 }
 
+/** Attachment persisted on an individual chat message. */
 export interface MessageAttachment {
   id: string;
   name: string;
@@ -16,6 +18,7 @@ export interface MessageAttachment {
   textContent?: string;
 }
 
+/** One chat message in a conversation, including optional reasoning and token metadata. */
 export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant';
@@ -34,6 +37,7 @@ export interface ChatMessage {
   }>;
 }
 
+/** Conversation thread persisted in the dashboard chat store. */
 export interface Conversation {
   id: string;
   name: string;
@@ -45,6 +49,7 @@ export interface Conversation {
   originNodeId?: string;
 }
 
+/** Model metadata needed by the chat UI. */
 export interface ChatModelInfo {
   id: string;
   name: string;
@@ -55,6 +60,7 @@ export interface ChatModelInfo {
   quantization: string;
 }
 
+/** Classify an uploaded file into the coarse categories used by the chat UI. */
 export function getFileCategory(type: string, name: string): 'image' | 'text' | 'pdf' | 'audio' | 'other' {
   if (type.startsWith('image/')) return 'image';
   if (type.startsWith('text/') || name.endsWith('.txt') || name.endsWith('.md') || name.endsWith('.json') || name.endsWith('.csv')) return 'text';
@@ -63,6 +69,7 @@ export function getFileCategory(type: string, name: string): 'image' | 'text' | 
   return 'other';
 }
 
+/** Return a small emoji icon used by the chat attachments UI. */
 export function getFileIcon(type: string, name: string): string {
   switch (getFileCategory(type, name)) {
     case 'image': return '🖼';
@@ -73,6 +80,7 @@ export function getFileIcon(type: string, name: string): string {
   }
 }
 
+/** Format a byte count into a compact human-readable file-size string. */
 export function formatFileSize(bytes: number): string {
   if (bytes === 0) return '0 B';
   const k = 1024;
@@ -81,6 +89,7 @@ export function formatFileSize(bytes: number): string {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 }
 
+/** Shorten long file names while preserving the extension when possible. */
 export function truncateFileName(name: string, maxLen = 20): string {
   if (name.length <= maxLen) return name;
   const dotIdx = name.lastIndexOf('.');

--- a/dashboard-react/src/types/models.ts
+++ b/dashboard-react/src/types/models.ts
@@ -1,3 +1,4 @@
+/** Dashboard-friendly model metadata derived from the Skulk model catalog. */
 export interface ModelInfo {
   id: string;
   name?: string;
@@ -12,6 +13,7 @@ export interface ModelInfo {
   hugging_face_id?: string;
 }
 
+/** Group of related model variants shown as one family in the picker UI. */
 export interface ModelGroup {
   id: string;
   name: string;
@@ -22,6 +24,7 @@ export interface ModelGroup {
   hasMultipleVariants: boolean;
 }
 
+/** Filter state for the dashboard model picker. */
 export interface FilterState {
   capabilities: string[];
   sizeRange: { min: number; max: number } | null;
@@ -38,17 +41,20 @@ export const EMPTY_FILTERS: FilterState = {
 
 export type ModelFitStatus = 'fits_now' | 'fits_cluster_capacity' | 'too_large';
 
+/** Availability of a model across nodes or store-backed downloads. */
 export interface DownloadAvailability {
   available: boolean;
   nodeNames: string[];
   nodeIds: string[];
 }
 
+/** UI-friendly summary of whether a model is already launched and ready. */
 export interface InstanceStatus {
   status: string;
   statusClass: string;
 }
 
+/** Lightweight search result returned by the Hugging Face search API. */
 export interface HuggingFaceModel {
   id: string;
   author: string;
@@ -58,6 +64,7 @@ export interface HuggingFaceModel {
   tags: string[];
 }
 
+/** Progress snapshot for a download shown in the dashboard. */
 export interface DownloadProgress {
   totalBytes: number;
   downloadedBytes: number;
@@ -73,6 +80,7 @@ export interface DownloadProgress {
   }>;
 }
 
+/** Placement preview returned by the Skulk placement preview endpoint. */
 export interface PlacementPreview {
   model_id: string;
   sharding: 'Pipeline' | 'Tensor';
@@ -105,8 +113,8 @@ export const SIZE_RANGES = [
 export type PickerMode = 'launch' | 'store-download';
 
 /**
- * Group ModelInfo[] by base_model (or model id if no base_model).
- * Variants sorted by size ascending; smallest tracked for group display.
+ * Group model variants by base model (or model id if no base model is present).
+ * Variants are sorted by size ascending so the UI can show the smallest representative first.
  */
 export function groupModels(models: ModelInfo[]): ModelGroup[] {
   const map = new Map<string, ModelInfo[]>();

--- a/dashboard-react/src/types/topology.ts
+++ b/dashboard-react/src/types/topology.ts
@@ -1,12 +1,15 @@
+/** Memory sample returned by the topology polling layer. */
 export interface MacmonMemory {
   ram_usage: number;
   ram_total: number;
 }
 
+/** Temperature sample returned by the topology polling layer. */
 export interface MacmonTemp {
   gpu_temp_avg: number;
 }
 
+/** Node monitoring snapshot consumed by dashboard topology components. */
 export interface MacmonInfo {
   memory?: MacmonMemory;
   temp?: MacmonTemp;
@@ -14,17 +17,20 @@ export interface MacmonInfo {
   sys_power?: number;
 }
 
+/** Basic hardware identity information for a node. */
 export interface SystemInfo {
   model_id?: string;
   chip?: string;
   memory?: number;
 }
 
+/** One network interface known for a node. */
 export interface NetworkInterfaceInfo {
   name?: string;
   addresses?: string[];
 }
 
+/** Normalized node record used by the topology graph and cards. */
 export interface NodeInfo {
   system_info?: SystemInfo;
   network_interfaces?: NetworkInterfaceInfo[];
@@ -41,6 +47,7 @@ export interface NodeInfo {
   rdma_interfaces_present?: boolean;
 }
 
+/** Directed edge between two nodes in the cluster topology graph. */
 export interface TopologyEdge {
   source: string;
   target: string;
@@ -50,6 +57,7 @@ export interface TopologyEdge {
   sinkRdmaIface?: string;
 }
 
+/** Complete normalized topology graph returned by the dashboard data layer. */
 export interface TopologyData {
   nodes: Record<string, NodeInfo>;
   edges: TopologyEdge[];
@@ -57,6 +65,7 @@ export interface TopologyData {
 
 export type DeviceModel = 'macbook-pro' | 'mac-studio' | 'mac-mini' | 'unknown';
 
+/** Best-effort device-family classifier used for dashboard hardware icons. */
 export function detectDeviceModel(modelId?: string): DeviceModel {
   if (!modelId) return 'unknown';
   const lower = modelId.toLowerCase();

--- a/dashboard-react/typedoc.json
+++ b/dashboard-react/typedoc.json
@@ -1,0 +1,20 @@
+{
+  "entryPoints": ["src/docs-entry.ts"],
+  "entryPointStrategy": "resolve",
+  "tsconfig": "tsconfig.app.json",
+  "out": "../docs/generated/typedoc",
+  "exclude": [
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
+  "excludePrivate": true,
+  "excludeProtected": false,
+  "excludeInternal": true,
+  "skipErrorChecking": true,
+  "readme": "none",
+  "categorizeByGroup": false,
+  "sort": ["source-order"],
+  "plugin": []
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,18 +2,22 @@
 
 # Skulk API
 
-Skulk exposes an API server at `http://localhost:52415`.
-It serves both compatibility APIs for existing tools and Skulk-specific control endpoints for placement, downloads, store management, config, and debugging.
+Skulk serves an API at `http://localhost:52415`.
 
-## Start Here
+That API has two jobs:
 
-If you are new to Skulk, remember this rule:
+- compatibility endpoints for tools that already speak OpenAI, Claude, or Ollama-style APIs
+- Skulk-specific control endpoints for placement, downloads, config, tracing, and model-store workflows
 
-**A chat request only works after the target model has been placed and is running.**
+## The Most Important Rule
+
+For text generation, Skulk is not just a stateless HTTP server.
+
+**A model has to be placed and running before chat-style requests will work.**
 
 The dashboard enforces this too: it will not let you chat until a model is placed and ready.
 
-If you call `/v1/chat/completions` too early, Skulk will usually return:
+If you call `/v1/chat/completions` too early, Skulk will usually return something like:
 
 ```json
 {
@@ -25,23 +29,26 @@ If you call `/v1/chat/completions` too early, Skulk will usually return:
 }
 ```
 
-The happy path is:
+## Start Here
 
-1. Start Skulk.
-2. Preview or create a placement.
-3. Launch the model.
-4. Then send chat, responses, Claude, or Ollama-style requests.
+If you want your first successful API call, use this flow:
+
+1. Start Skulk with `uv run exo`.
+2. Preview valid placements for a model.
+3. Launch a placement.
+4. Wait for the model to be ready.
+5. Send a chat request.
 
 ## Quick Navigation
 
-- **I want a first successful API call**: [First Success Flow](#first-success-flow)
-- **I want OpenAI SDK compatibility**: [OpenAI Chat Completions](#openai-chat-completions)
-- **I want Claude compatibility**: [Claude Messages API](#claude-messages-api)
-- **I want OpenAI Responses compatibility**: [OpenAI Responses API](#openai-responses-api)
-- **I want Ollama compatibility**: [Ollama API](#ollama-api)
-- **I want placement and launch endpoints**: [Model Placement and Instance Management](#model-placement-and-instance-management)
-- **I want model store or config endpoints**: [Model Store Endpoints](#model-store-endpoints) and [Configuration Endpoints](#configuration-endpoints)
-- **I want debugging endpoints**: [State, Events, and Tracing](#state-events-and-tracing)
+- First working request: [First Success Flow](#first-success-flow)
+- OpenAI-compatible chat: [OpenAI Chat Completions](#openai-chat-completions)
+- OpenAI Responses format: [OpenAI Responses API](#openai-responses-api)
+- Claude format: [Claude Messages API](#claude-messages-api)
+- Ollama compatibility: [Ollama API](#ollama-api)
+- Placement and launch: [Placement and Instance Management](#placement-and-instance-management)
+- Store and config: [Model Store Endpoints](#model-store-endpoints) and [Configuration Endpoints](#configuration-endpoints)
+- Debugging: [State, Events, and Tracing](#state-events-and-tracing)
 
 ## First Success Flow
 
@@ -51,13 +58,15 @@ The happy path is:
 uv run exo
 ```
 
-### 2. Preview placements for a model
+### 2. Preview placements
 
 ```bash
 curl "http://localhost:52415/instance/previews?model_id=mlx-community/Llama-3.2-1B-Instruct-4bit"
 ```
 
-### 3. Launch a simple placement
+This shows what Skulk can actually place on the current node or cluster.
+
+### 3. Launch a placement
 
 ```bash
 curl -X POST http://localhost:52415/place_instance \
@@ -77,9 +86,11 @@ curl -X POST http://localhost:52415/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
-    "messages": [{"role": "user", "content": "Hello!"}]
+    "messages": [{"role": "user", "content": "Hello from Skulk"}]
   }'
 ```
+
+If this fails with `404 No instance found for model ...`, the placement is not ready yet or never launched successfully.
 
 ## Endpoint Overview
 
@@ -95,7 +106,7 @@ curl -X POST http://localhost:52415/v1/chat/completions \
 - `GET /ollama/api/ps`
 - `GET /ollama/api/version`
 
-### Skulk Control Plane APIs
+### Skulk Control APIs
 
 - `GET /v1/models`
 - `GET /models/search`
@@ -181,7 +192,7 @@ for chunk in stream:
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `model` | string | Required. Must match a running instance. |
+| `model` | string | Required. Must match a placed and running model. |
 | `messages` | array | Required. Supports `system`, `user`, `assistant`, `developer`, `tool`, `function`. |
 | `stream` | boolean | Use `true` for SSE streaming. |
 | `temperature` | number | Sampling temperature. |
@@ -201,8 +212,8 @@ for chunk in stream:
 | `tool_choice` | string or object | `auto`, `none`, or a specific tool selection. |
 | `parallel_tool_calls` | boolean | Accepted for compatibility. |
 | `enable_thinking` | boolean | Skulk extension for reasoning-capable models. |
-| `reasoning_effort` | string | Reasoning hint when supported by the model or adapter. |
-| `response_format` | object | Accepted, but not strictly enforced. |
+| `reasoning_effort` | string | Reasoning hint when supported. |
+| `response_format` | object | Accepted for compatibility, not strictly enforced. |
 | `stream_options` | object | Includes `include_usage`. |
 | `user` | string | Optional caller identifier. |
 
@@ -215,7 +226,7 @@ for chunk in stream:
 }
 ```
 
-Assistant messages may also include `tool_calls`.
+Assistant messages may include `tool_calls`.
 Tool response messages should include `tool_call_id`.
 
 ### Finish Reasons
@@ -232,8 +243,6 @@ Tool response messages should include `tool_call_id`.
 ## Tool Use
 
 Skulk supports OpenAI-style function calling.
-
-### Example
 
 ```python
 tools = [{
@@ -318,13 +327,11 @@ curl -X POST http://localhost:52415/v1/responses \
   }'
 ```
 
-Skulk also supports streaming on this endpoint.
-
 ## Claude Messages API
 
 **POST** `/v1/messages`
 
-Use this when you want Anthropic-style request and response shapes.
+Use this when your client expects Anthropic-style request and response shapes.
 
 ```bash
 curl -X POST http://localhost:52415/v1/messages \
@@ -336,11 +343,9 @@ curl -X POST http://localhost:52415/v1/messages \
   }'
 ```
 
-Claude-style streaming events are supported.
-
 ## Ollama API
 
-Skulk supports several Ollama-compatible endpoints to make tools like OpenWebUI easier to connect.
+Skulk supports several Ollama-compatible endpoints so tools like OpenWebUI can connect with minimal glue code.
 
 ### Chat
 
@@ -378,12 +383,6 @@ curl -X POST http://localhost:52415/ollama/api/show \
   -d '{"name": "mlx-community/Llama-3.2-1B-Instruct-4bit"}'
 ```
 
-### Running models
-
-```bash
-curl http://localhost:52415/ollama/api/ps
-```
-
 ## Model Discovery
 
 ### List models
@@ -394,13 +393,7 @@ curl http://localhost:52415/ollama/api/ps
 curl http://localhost:52415/v1/models
 ```
 
-This returns known model cards, not just currently running instances.
-
-### List downloaded models only
-
-```bash
-curl "http://localhost:52415/v1/models?status=downloaded"
-```
+This returns known model cards, not just running instances.
 
 ### Search Hugging Face
 
@@ -415,27 +408,9 @@ Behavior note:
 - Skulk searches `mlx-community` first.
 - If that returns nothing, it falls back to a broader Hugging Face search.
 
-### Add a custom model card
+## Placement and Instance Management
 
-**POST** `/models/add`
-
-```bash
-curl -X POST http://localhost:52415/models/add \
-  -H 'Content-Type: application/json' \
-  -d '{"model_id": "mlx-community/my-custom-model"}'
-```
-
-### Delete a custom model card
-
-**DELETE** `/models/custom/{model_id}`
-
-```bash
-curl -X DELETE http://localhost:52415/models/custom/mlx-community/my-custom-model
-```
-
-## Model Placement and Instance Management
-
-These endpoints are Skulk-specific and matter a lot for first-time users.
+These endpoints are the heart of the Skulk control plane.
 
 ### Quick launch
 
@@ -452,8 +427,6 @@ curl -X POST http://localhost:52415/place_instance \
   }'
 ```
 
-Fields:
-
 | Field | Meaning |
 |-------|---------|
 | `model_id` | Hugging Face-style model ID |
@@ -461,7 +434,7 @@ Fields:
 | `instance_meta` | `MlxRing` or `MlxJaccl` |
 | `min_nodes` | Minimum nodes required for the placement |
 
-### Preview all valid placements
+### Preview valid placements
 
 **GET** `/instance/previews?model_id=...`
 
@@ -469,15 +442,13 @@ Fields:
 curl "http://localhost:52415/instance/previews?model_id=mlx-community/Qwen3.5-9B-4bit"
 ```
 
-This is one of the most useful endpoints in Skulk.
-It shows which combinations of sharding mode, networking mode, and node count are valid.
-Invalid combinations include an error message.
+This is usually the best first Skulk-specific endpoint to call. It shows which combinations of sharding mode, networking mode, and node count are valid, and why invalid combinations fail.
 
 ### Build a placement manually
 
 **GET** `/instance/placement`
 
-Use this if you want to request a specific combination and inspect the exact instance shape.
+Use this when you want a specific combination and want to inspect the exact instance shape before launch.
 
 ### Create an instance from a fully specified placement
 
@@ -493,17 +464,13 @@ Use this when you already have an `instance` object and want exact control.
 
 **DELETE** `/instance/{instance_id}`
 
-```bash
-curl -X DELETE http://localhost:52415/instance/YOUR_INSTANCE_ID
-```
-
 ## Download Management
 
 ### Start a node download
 
 **POST** `/download/start`
 
-This is a lower-level endpoint used when you want explicit download control.
+Lower-level endpoint for explicit node download control.
 
 ### Delete a node download
 
@@ -512,37 +479,34 @@ This is a lower-level endpoint used when you want explicit download control.
 ## Model Store Endpoints
 
 These endpoints are available when the model store is configured.
+
 If it is not configured, Skulk returns `503 Store not configured`.
 
 ### Store health
 
 **GET** `/store/health`
 
-```bash
-curl http://localhost:52415/store/health
-```
+Use this to confirm whether the store is configured and reachable.
 
 ### Store registry
 
 **GET** `/store/registry`
 
-```bash
-curl http://localhost:52415/store/registry
-```
+Use this to inspect which models the shared store knows about.
 
-### Active store downloads
+### Store downloads
 
 **GET** `/store/downloads`
+
+Use this to inspect in-progress shared-store download activity.
 
 ### Request a store download
 
 **POST** `/store/models/{model_id}/download`
 
-```bash
-curl -X POST http://localhost:52415/store/models/mlx-community/Qwen3.5-9B-4bit/download
-```
+Use this when you want the store host to fetch and register a model.
 
-### Check store download status
+### Store download status
 
 **GET** `/store/models/{model_id}/download/status`
 
@@ -554,39 +518,13 @@ curl -X POST http://localhost:52415/store/models/mlx-community/Qwen3.5-9B-4bit/d
 
 **POST** `/store/purge-staging`
 
-```bash
-curl -X POST http://localhost:52415/store/purge-staging \
-  -H 'Content-Type: application/json' \
-  -d '{}'
-```
+Use this to remove staged model artifacts from nodes without deleting the store copy itself.
 
-You can also target one model:
-
-```bash
-curl -X POST http://localhost:52415/store/purge-staging \
-  -H 'Content-Type: application/json' \
-  -d '{"model_id": "mlx-community/Qwen3.5-9B-4bit"}'
-```
-
-### Start OptiQ mixed-precision optimization
+### Start optimization
 
 **POST** `/store/models/{model_id}/optimize`
 
-```bash
-curl -X POST http://localhost:52415/store/models/mlx-community/Qwen3.5-9B-4bit/optimize \
-  -H 'Content-Type: application/json' \
-  -d '{"target_bpw": 4.5, "candidate_bits": [4, 8]}'
-```
-
-### Check optimization status
-
-**GET** `/store/models/{model_id}/optimize/status`
-
-Common responses:
-
-- `404 No optimization job found`
-- `409 ...` if an optimization job is already in progress
-- `503 Model optimizer not available` when the store is not configured
+Use this for workflows such as model optimization or alternate artifact generation.
 
 ## Configuration Endpoints
 
@@ -594,38 +532,29 @@ Common responses:
 
 **GET** `/config`
 
-```bash
-curl http://localhost:52415/config
-```
-
-Behavior:
-
-- Returns the current config file contents.
-- Strips `hf_token` from the visible config for safety.
-- Includes effective runtime values like `kv_cache_backend`.
+Returns the current cluster config and config path. Sensitive values such as `hf_token` are stripped from the returned config.
 
 ### Update config
 
 **PUT** `/config`
 
-```bash
-curl -X PUT http://localhost:52415/config \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "config": {
-      "inference": {"kv_cache_backend": "optiq"},
-      "hf_token": "hf_your_token_here"
-    }
-  }'
-```
+Updates cluster-wide config. Important behavior:
 
-Behavior notes:
+- if you omit `hf_token`, Skulk preserves the existing value
+- inference changes affect future launches
+- model-store location changes generally require restart
 
-- Skulk validates the payload against `exo.yaml` schema.
-- Config is written locally and broadcast to the cluster.
-- If you omit `hf_token`, Skulk preserves the existing saved token.
-- Inference config changes affect future launches.
-- Model store changes still require restart.
+### Filesystem browse
+
+**GET** `/filesystem/browse`
+
+Used by the dashboard to browse a safe subset of the filesystem when selecting config paths.
+
+### Node identity
+
+**GET** `/node/identity`
+
+Returns hostname, preferred IP, and node identity information used by the dashboard.
 
 ## State, Events, and Tracing
 
@@ -633,93 +562,28 @@ Behavior notes:
 
 **GET** `/state`
 
-This is the best general debugging endpoint.
-It includes topology, nodes, instances, runners, and downloads.
+Returns the cluster state as Skulk currently sees it.
 
-### Event stream snapshot
+### Event log
 
 **GET** `/events`
 
-Returns the stored event log as JSON.
+Returns stored events from the API-side event log.
 
 ### Traces
 
 - `GET /v1/traces`
+- `POST /v1/traces/delete`
 - `GET /v1/traces/{task_id}`
 - `GET /v1/traces/{task_id}/stats`
 - `GET /v1/traces/{task_id}/raw`
-- `POST /v1/traces/delete`
 
-Use tracing when you need performance investigation rather than normal day-to-day usage.
+Use these endpoints when you are debugging generation behavior, cluster execution, or performance.
 
-## Filesystem and Identity Helpers
+## Helpful Next Docs
 
-### Browse filesystem
-
-**GET** `/filesystem/browse?path=/Volumes`
-
-Used by the dashboard settings UI for choosing store paths.
-
-Behavior notes:
-
-- Browsing is restricted to allowed roots.
-- Typical allowed roots include `/Volumes`, `/home`, `/mnt`, `/tmp`, and `/opt`.
-- Returns `400` for invalid paths and `403` for permission problems.
-
-### Node identity
-
-**GET** `/node/identity`
-
-Returns:
-
-- `nodeId`
-- `hostname`
-- preferred IPv4 LAN address when available
-
-## Image Endpoints
-
-Skulk also supports image-generation and image-editing APIs.
-These only work when image models are enabled and the relevant image model is already placed.
-
-Endpoints:
-
-- `POST /v1/images/generations`
-- `POST /bench/images/generations`
-- `POST /v1/images/edits`
-- `POST /bench/images/edits`
-- `GET /images`
-- `GET /images/{image_id}`
-
-## Cancellation
-
-**POST** `/v1/cancel/{command_id}`
-
-Use this to cancel an active text or image command when you still know the command ID.
-
-## What Is Not Implemented Yet
-
-| Feature | Status |
-|---------|--------|
-| `/v1/embeddings` | Not implemented |
-| Strict JSON mode enforcement | Not implemented |
-| JSON schema enforcement | Not implemented |
-| API key authentication | Not implemented |
-| Rate limiting | Not implemented |
-| `/v1/audio` | Not implemented |
-| `/v1/files` | Not implemented |
-| `/v1/fine_tuning` | Not implemented |
-| `/v1/batches` | Not implemented |
-
-## Practical Tips
-
-- Use `/instance/previews` early and often. It explains why a placement is invalid.
-- Use `/state` when you are not sure what the cluster thinks is running.
-- Use `/v1/models?status=downloaded` to see what is locally available.
-- Use streaming for better UX in chat clients.
-- Use the dashboard if you are learning the system and the API if you are integrating code.
-
-## Related Docs
-
-- [docs/model-store.md](model-store.md)
-- [docs/kv-cache-backends.md](kv-cache-backends.md)
-- [docs/architecture.md](architecture.md)
+- [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md)
+- [Model store guide](model-store.md)
+- [Architecture overview](architecture.md)
+- [OpenAPI schema](reference/openapi.md)
+- [API Reference (ReDoc)](reference/api-reference.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,267 +2,391 @@
 
 # Skulk API
 
-Skulk exposes an OpenAI-compatible API at `http://localhost:52415`. You can use it with the OpenAI Python/JS SDK, curl, or any tool that speaks the OpenAI API.
+Skulk exposes an API server at `http://localhost:52415`.
+It serves both compatibility APIs for existing tools and Skulk-specific control endpoints for placement, downloads, store management, config, and debugging.
 
-## Quick Start
+## Start Here
 
-### Using the OpenAI Python SDK
+If you are new to Skulk, remember this rule:
+
+**A chat request only works after the target model has been placed and is running.**
+
+The dashboard enforces this too: it will not let you chat until a model is placed and ready.
+
+If you call `/v1/chat/completions` too early, Skulk will usually return:
+
+```json
+{
+  "error": {
+    "message": "No instance found for model mlx-community/...",
+    "type": "Not Found",
+    "code": 404
+  }
+}
+```
+
+The happy path is:
+
+1. Start Skulk.
+2. Preview or create a placement.
+3. Launch the model.
+4. Then send chat, responses, Claude, or Ollama-style requests.
+
+## Quick Navigation
+
+- **I want a first successful API call**: [First Success Flow](#first-success-flow)
+- **I want OpenAI SDK compatibility**: [OpenAI Chat Completions](#openai-chat-completions)
+- **I want Claude compatibility**: [Claude Messages API](#claude-messages-api)
+- **I want OpenAI Responses compatibility**: [OpenAI Responses API](#openai-responses-api)
+- **I want Ollama compatibility**: [Ollama API](#ollama-api)
+- **I want placement and launch endpoints**: [Model Placement and Instance Management](#model-placement-and-instance-management)
+- **I want model store or config endpoints**: [Model Store Endpoints](#model-store-endpoints) and [Configuration Endpoints](#configuration-endpoints)
+- **I want debugging endpoints**: [State, Events, and Tracing](#state-events-and-tracing)
+
+## First Success Flow
+
+### 1. Start Skulk
+
+```bash
+uv run exo
+```
+
+### 2. Preview placements for a model
+
+```bash
+curl "http://localhost:52415/instance/previews?model_id=mlx-community/Llama-3.2-1B-Instruct-4bit"
+```
+
+### 3. Launch a simple placement
+
+```bash
+curl -X POST http://localhost:52415/place_instance \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "sharding": "Pipeline",
+    "instance_meta": "MlxRing",
+    "min_nodes": 1
+  }'
+```
+
+### 4. Send a chat request
+
+```bash
+curl -X POST http://localhost:52415/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+## Endpoint Overview
+
+### Compatibility APIs
+
+- `POST /v1/chat/completions`
+- `POST /v1/responses`
+- `POST /v1/messages`
+- `POST /ollama/api/chat`
+- `POST /ollama/api/generate`
+- `GET /ollama/api/tags`
+- `POST /ollama/api/show`
+- `GET /ollama/api/ps`
+- `GET /ollama/api/version`
+
+### Skulk Control Plane APIs
+
+- `GET /v1/models`
+- `GET /models/search`
+- `POST /models/add`
+- `DELETE /models/custom/{model_id}`
+- `POST /place_instance`
+- `POST /instance`
+- `GET /instance/placement`
+- `GET /instance/previews`
+- `GET /instance/{instance_id}`
+- `DELETE /instance/{instance_id}`
+- `GET /state`
+- `GET /events`
+- `POST /download/start`
+- `DELETE /download/{node_id}/{model_id}`
+- `GET /config`
+- `PUT /config`
+- `GET /store/health`
+- `GET /store/registry`
+- `GET /store/downloads`
+- `POST /store/models/{model_id}/download`
+- `GET /store/models/{model_id}/download/status`
+- `DELETE /store/models/{model_id}`
+- `POST /store/purge-staging`
+- `POST /store/models/{model_id}/optimize`
+- `GET /store/models/{model_id}/optimize/status`
+- `GET /filesystem/browse`
+- `GET /node/identity`
+- `GET /v1/traces`
+- `POST /v1/traces/delete`
+- `GET /v1/traces/{task_id}`
+- `GET /v1/traces/{task_id}/stats`
+- `GET /v1/traces/{task_id}/raw`
+
+## OpenAI Chat Completions
+
+**POST** `/v1/chat/completions`
+
+This is the main text-generation endpoint.
+
+### OpenAI Python SDK Example
 
 ```python
 from openai import OpenAI
 
 client = OpenAI(
     base_url="http://localhost:52415/v1",
-    api_key="unused",  # Skulk doesn't require an API key
+    api_key="unused",
 )
 
 response = client.chat.completions.create(
-    model="mlx-community/Qwen3.5-9B-4bit",
+    model="mlx-community/Llama-3.2-1B-Instruct-4bit",
     messages=[{"role": "user", "content": "Hello!"}],
 )
 print(response.choices[0].message.content)
 ```
 
-### Using curl
+### Curl Example
 
 ```bash
 curl -X POST http://localhost:52415/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
-    "model": "mlx-community/Qwen3.5-9B-4bit",
+    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
     "messages": [{"role": "user", "content": "Hello!"}]
   }'
 ```
 
-### Streaming
+### Streaming Example
 
 ```python
 stream = client.chat.completions.create(
-    model="mlx-community/Qwen3.5-9B-4bit",
+    model="mlx-community/Llama-3.2-1B-Instruct-4bit",
     messages=[{"role": "user", "content": "Tell me a story"}],
     stream=True,
 )
 for chunk in stream:
-    if chunk.choices[0].delta.content:
+    if chunk.choices and chunk.choices[0].delta.content:
         print(chunk.choices[0].delta.content, end="")
 ```
 
----
+### Common Request Fields
 
-## Chat Completions
-
-**POST** `/v1/chat/completions`
-
-This is the main inference endpoint. It's compatible with the OpenAI Chat Completions API.
-
-### Request
-
-```json
-{
-  "model": "mlx-community/Qwen3.5-9B-4bit",
-  "messages": [
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "What is 2+2?"}
-  ],
-  "stream": false,
-  "temperature": 0.7,
-  "max_tokens": 1024
-}
-```
-
-### Parameters
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `model` | string | required | Model ID (e.g., `mlx-community/Qwen3.5-9B-4bit`) |
-| `messages` | array | required | Conversation messages (see Message Format below) |
-| `stream` | boolean | `false` | Stream response as Server-Sent Events |
-| `temperature` | float | `1.0` | Sampling temperature (0.0 = deterministic, 2.0 = very random) |
-| `top_p` | float | `1.0` | Nucleus sampling — only consider tokens with cumulative probability above this |
-| `top_k` | integer | `-1` | Only consider the top K tokens. -1 = disabled |
-| `min_p` | float | `0.0` | Minimum probability threshold. 0.0 = disabled |
-| `max_tokens` | integer | null | Maximum tokens to generate. null = model default |
-| `stop` | string/array | null | Stop generation when these strings are encountered |
-| `seed` | integer | null | Random seed for reproducible output |
-| `frequency_penalty` | float | `0.0` | Penalize tokens based on frequency in output so far |
-| `presence_penalty` | float | `0.0` | Penalize tokens that have appeared at all in output so far |
-| `repetition_penalty` | float | null | Alternative repetition penalty (multiplicative) |
-| `logprobs` | boolean | `false` | Return log probabilities for each token |
-| `top_logprobs` | integer | null | Number of top log probabilities to return per token |
-| `tools` | array | null | Tool/function definitions for function calling (see Tool Use below) |
-| `tool_choice` | string/object | null | Control tool selection (`auto`, `none`, or specific tool) |
-| `enable_thinking` | boolean | `false` | Enable thinking/reasoning mode for capable models |
-| `response_format` | object | null | Requested output format (see Structured Output below) |
+| Field | Type | Notes |
+|-------|------|-------|
+| `model` | string | Required. Must match a running instance. |
+| `messages` | array | Required. Supports `system`, `user`, `assistant`, `developer`, `tool`, `function`. |
+| `stream` | boolean | Use `true` for SSE streaming. |
+| `temperature` | number | Sampling temperature. |
+| `top_p` | number | Nucleus sampling. |
+| `top_k` | integer | Top-k sampling. |
+| `min_p` | number | Minimum-probability threshold. |
+| `max_tokens` | integer | Max generated tokens. |
+| `stop` | string or array | Stop sequences. |
+| `seed` | integer | Reproducibility helper. |
+| `frequency_penalty` | number | Frequency penalty. |
+| `presence_penalty` | number | Presence penalty. |
+| `repetition_penalty` | number | Repetition penalty. |
+| `repetition_context_size` | integer | Context window for repetition handling. |
+| `logprobs` | boolean | Return token logprobs when supported. |
+| `top_logprobs` | integer | Number of top logprobs to include. |
+| `tools` | array | OpenAI-style tool definitions. |
+| `tool_choice` | string or object | `auto`, `none`, or a specific tool selection. |
+| `parallel_tool_calls` | boolean | Accepted for compatibility. |
+| `enable_thinking` | boolean | Skulk extension for reasoning-capable models. |
+| `reasoning_effort` | string | Reasoning hint when supported by the model or adapter. |
+| `response_format` | object | Accepted, but not strictly enforced. |
+| `stream_options` | object | Includes `include_usage`. |
+| `user` | string | Optional caller identifier. |
 
 ### Message Format
 
-Each message in the `messages` array has:
-
 ```json
 {
-  "role": "system" | "user" | "assistant" | "tool",
-  "content": "message text",
-  "tool_calls": [...],      // assistant messages with tool calls
-  "tool_call_id": "...",    // tool response messages
-  "name": "..."             // optional function name
+  "role": "user",
+  "content": "hello"
 }
 ```
 
-### Response (Non-Streaming)
-
-```json
-{
-  "id": "chatcmpl-abc123",
-  "object": "chat.completion",
-  "created": 1711500000,
-  "model": "mlx-community/Qwen3.5-9B-4bit",
-  "choices": [
-    {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": "2+2 equals 4."
-      },
-      "finish_reason": "stop"
-    }
-  ],
-  "usage": {
-    "prompt_tokens": 25,
-    "completion_tokens": 8,
-    "total_tokens": 33
-  }
-}
-```
-
-### Response (Streaming)
-
-When `stream: true`, the response is a stream of Server-Sent Events:
-
-```
-data: {"id":"chatcmpl-abc123","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
-
-data: {"id":"chatcmpl-abc123","choices":[{"index":0,"delta":{"content":"2"},"finish_reason":null}]}
-
-data: {"id":"chatcmpl-abc123","choices":[{"index":0,"delta":{"content":"+2"},"finish_reason":null}]}
-
-data: {"id":"chatcmpl-abc123","choices":[{"index":0,"delta":{"content":" equals 4."},"finish_reason":"stop"}]}
-
-data: [DONE]
-```
+Assistant messages may also include `tool_calls`.
+Tool response messages should include `tool_call_id`.
 
 ### Finish Reasons
 
 | Value | Meaning |
 |-------|---------|
-| `stop` | Natural end of response or stop sequence hit |
-| `length` | Hit `max_tokens` limit |
-| `tool_calls` | Model wants to call a tool |
+| `stop` | Natural stop or stop sequence reached |
+| `length` | `max_tokens` limit reached |
+| `tool_calls` | Model is requesting a tool call |
+| `content_filter` | Reserved for compatibility |
+| `function_call` | Reserved for compatibility |
 | `error` | Generation failed |
 
----
+## Tool Use
 
-## Tool Use / Function Calling
+Skulk supports OpenAI-style function calling.
 
-Skulk supports OpenAI-style tool calling. Define tools in the request, and the model can choose to call them.
-
-### Example: Weather Tool
+### Example
 
 ```python
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"}
+            },
+            "required": ["location"]
+        }
+    }
+}]
+
 response = client.chat.completions.create(
     model="mlx-community/Qwen3.5-9B-4bit",
-    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
-    tools=[{
-        "type": "function",
-        "function": {
-            "name": "get_weather",
-            "description": "Get the current weather for a location",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {"type": "string", "description": "City name"},
-                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
-                },
-                "required": ["location"]
-            }
-        }
-    }],
+    messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+    tools=tools,
     tool_choice="auto",
 )
-
-# Check if the model wants to call a tool
-choice = response.choices[0]
-if choice.finish_reason == "tool_calls":
-    for tool_call in choice.message.tool_calls:
-        print(f"Call: {tool_call.function.name}({tool_call.function.arguments})")
 ```
 
-### Tool Response Flow
+Typical flow:
 
-1. Send messages with tool definitions
-2. Model responds with `finish_reason: "tool_calls"` and tool call details
-3. Execute the tool locally
-4. Send the result back as a `tool` message:
+1. Send messages and tool definitions.
+2. Inspect `finish_reason`.
+3. If it is `tool_calls`, execute the tool in your app.
+4. Send the tool result back as a `tool` message.
+5. Request the final model response.
 
-```python
-messages.append(choice.message)  # The assistant's tool call message
-messages.append({
-    "role": "tool",
-    "tool_call_id": tool_call.id,
-    "content": '{"temperature": 22, "condition": "sunny"}',
-})
-# Send again to get the final response
-response = client.chat.completions.create(
-    model="mlx-community/Qwen3.5-9B-4bit",
-    messages=messages,
-    tools=tools,
-)
-```
+## Thinking / Reasoning
 
-**Note:** Tool calling quality depends on the model. Models like Qwen3, DeepSeek V3, and GLM-4 have good tool calling support. Smaller models may produce unreliable tool calls.
-
----
-
-## Thinking / Reasoning Mode
-
-Some models support "thinking" mode where the model shows its reasoning process before answering.
+Skulk supports reasoning-aware chat for compatible models.
 
 ```python
 response = client.chat.completions.create(
     model="mlx-community/Qwen3.5-9B-4bit",
     messages=[{"role": "user", "content": "What is 127 * 43?"}],
-    enable_thinking=True,  # Skulk extension
+    enable_thinking=True,
 )
 
-# Thinking content is in reasoning_content
 msg = response.choices[0].message
-if hasattr(msg, 'reasoning_content') and msg.reasoning_content:
-    print("Thinking:", msg.reasoning_content)
-print("Answer:", msg.content)
+print(msg.reasoning_content)
+print(msg.content)
 ```
 
-**Supported models:** Models with `thinking` or `thinking_toggle` capability (e.g., Qwen3 with thinking_toggle, Nemotron with always-on thinking).
+Notes:
 
----
+- `enable_thinking` is a Skulk extension.
+- Reasoning support depends on model capabilities.
+- Models with `thinking` or `thinking_toggle` metadata are the likeliest candidates.
 
 ## Structured Output
 
-The `response_format` parameter requests structured output:
+`response_format` is accepted for compatibility, but Skulk does not currently enforce strict JSON mode or JSON schema validation.
 
 ```python
 response = client.chat.completions.create(
     model="mlx-community/Qwen3.5-9B-4bit",
-    messages=[{"role": "user", "content": "List 3 colors as JSON"}],
+    messages=[{"role": "user", "content": "Return valid JSON with three colors"}],
     response_format={"type": "json_object"},
 )
 ```
 
-**Current limitations:** The `response_format` field is accepted but not strictly enforced. The model may or may not produce valid JSON depending on the prompt and model capability. For reliable structured output, include explicit JSON formatting instructions in your prompt.
+For the best results, explicitly instruct the model to return valid JSON.
 
----
+## OpenAI Responses API
 
-## Models
+**POST** `/v1/responses`
 
-### List Models
+Use this when your client expects the OpenAI Responses format instead of Chat Completions.
+
+```bash
+curl -X POST http://localhost:52415/v1/responses \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "input": "Hello from the Responses API"
+  }'
+```
+
+Skulk also supports streaming on this endpoint.
+
+## Claude Messages API
+
+**POST** `/v1/messages`
+
+Use this when you want Anthropic-style request and response shapes.
+
+```bash
+curl -X POST http://localhost:52415/v1/messages \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 512
+  }'
+```
+
+Claude-style streaming events are supported.
+
+## Ollama API
+
+Skulk supports several Ollama-compatible endpoints to make tools like OpenWebUI easier to connect.
+
+### Chat
+
+```bash
+curl -X POST http://localhost:52415/ollama/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+### Generate
+
+```bash
+curl -X POST http://localhost:52415/ollama/api/generate \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+    "prompt": "Write a haiku about foxes"
+  }'
+```
+
+### List models
+
+```bash
+curl http://localhost:52415/ollama/api/tags
+```
+
+### Show model details
+
+```bash
+curl -X POST http://localhost:52415/ollama/api/show \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "mlx-community/Llama-3.2-1B-Instruct-4bit"}'
+```
+
+### Running models
+
+```bash
+curl http://localhost:52415/ollama/api/ps
+```
+
+## Model Discovery
+
+### List models
 
 **GET** `/v1/models`
 
@@ -270,41 +394,28 @@ response = client.chat.completions.create(
 curl http://localhost:52415/v1/models
 ```
 
-Returns all known models with metadata:
+This returns known model cards, not just currently running instances.
 
-```json
-{
-  "data": [
-    {
-      "id": "mlx-community/Qwen3.5-9B-4bit",
-      "name": "Qwen3.5-9B-4bit",
-      "storage_size_megabytes": 5977,
-      "context_length": 262144,
-      "capabilities": ["text", "thinking", "thinking_toggle"],
-      "family": "qwen",
-      "quantization": "4bit",
-      "supports_tensor": true,
-      "tags": ["thinking", "tensor"]
-    }
-  ]
-}
-```
-
-### List Downloaded Models Only
+### List downloaded models only
 
 ```bash
 curl "http://localhost:52415/v1/models?status=downloaded"
 ```
 
-### Search HuggingFace
+### Search Hugging Face
 
-**GET** `/models/search?query=llama&limit=10`
+**GET** `/models/search?query=...&limit=...`
 
 ```bash
 curl "http://localhost:52415/models/search?query=qwen3&limit=5"
 ```
 
-### Add Custom Model
+Behavior note:
+
+- Skulk searches `mlx-community` first.
+- If that returns nothing, it falls back to a broader Hugging Face search.
+
+### Add a custom model card
 
 **POST** `/models/add`
 
@@ -314,13 +425,19 @@ curl -X POST http://localhost:52415/models/add \
   -d '{"model_id": "mlx-community/my-custom-model"}'
 ```
 
----
+### Delete a custom model card
 
-## Instance Management
+**DELETE** `/models/custom/{model_id}`
 
-Before you can chat with a model, it needs to be "placed" (loaded onto cluster nodes).
+```bash
+curl -X DELETE http://localhost:52415/models/custom/mlx-community/my-custom-model
+```
 
-### Quick Launch
+## Model Placement and Instance Management
+
+These endpoints are Skulk-specific and matter a lot for first-time users.
+
+### Quick launch
 
 **POST** `/place_instance`
 
@@ -335,22 +452,44 @@ curl -X POST http://localhost:52415/place_instance \
   }'
 ```
 
-| Parameter | Options | Description |
-|-----------|---------|-------------|
-| `model_id` | string | HuggingFace model ID |
-| `sharding` | `Pipeline`, `Tensor` | How to split the model across nodes |
-| `instance_meta` | `MlxRing`, `MlxJaccl` | Networking backend (Ring = TCP, Jaccl = RDMA/TB5) |
-| `min_nodes` | integer | Minimum number of nodes to use |
+Fields:
 
-### Preview Placements
+| Field | Meaning |
+|-------|---------|
+| `model_id` | Hugging Face-style model ID |
+| `sharding` | `Pipeline` or `Tensor` |
+| `instance_meta` | `MlxRing` or `MlxJaccl` |
+| `min_nodes` | Minimum nodes required for the placement |
 
-See what placement options are valid before launching:
+### Preview all valid placements
 
-**GET** `/instance/previews?model_id=mlx-community/Qwen3.5-9B-4bit`
+**GET** `/instance/previews?model_id=...`
 
-Returns an array of placement previews showing which combinations of sharding, networking, and node count will work, with error explanations for invalid combinations.
+```bash
+curl "http://localhost:52415/instance/previews?model_id=mlx-community/Qwen3.5-9B-4bit"
+```
 
-### Delete Instance
+This is one of the most useful endpoints in Skulk.
+It shows which combinations of sharding mode, networking mode, and node count are valid.
+Invalid combinations include an error message.
+
+### Build a placement manually
+
+**GET** `/instance/placement`
+
+Use this if you want to request a specific combination and inspect the exact instance shape.
+
+### Create an instance from a fully specified placement
+
+**POST** `/instance`
+
+Use this when you already have an `instance` object and want exact control.
+
+### Inspect one instance
+
+**GET** `/instance/{instance_id}`
+
+### Delete an instance
 
 **DELETE** `/instance/{instance_id}`
 
@@ -358,61 +497,80 @@ Returns an array of placement previews showing which combinations of sharding, n
 curl -X DELETE http://localhost:52415/instance/YOUR_INSTANCE_ID
 ```
 
-### Check Running Instances
+## Download Management
 
-**GET** `/state`
+### Start a node download
 
-Returns the full cluster state including all running instances, their runners, and download status.
+**POST** `/download/start`
 
----
+This is a lower-level endpoint used when you want explicit download control.
 
-## Cluster State
+### Delete a node download
 
-### Get State
+**DELETE** `/download/{node_id}/{model_id}`
 
-**GET** `/state`
+## Model Store Endpoints
 
-Returns everything about the cluster: topology, nodes, instances, runners, downloads.
+These endpoints are available when the model store is configured.
+If it is not configured, Skulk returns `503 Store not configured`.
 
-### Get Events
-
-**GET** `/events`
-
-Returns the event log (for debugging).
-
----
-
-## Model Store
-
-### Store Registry
-
-**GET** `/store/registry`
-
-Lists all models in the store with sizes and file counts.
-
-### Download a Model
-
-**POST** `/store/models/{model_id}/download`
-
-Triggers a download from HuggingFace to the store.
-
-### Delete a Model
-
-**DELETE** `/store/models/{model_id}`
-
-Removes a model from the store and disk.
-
-### Store Health
+### Store health
 
 **GET** `/store/health`
 
-Returns store disk usage and path info.
+```bash
+curl http://localhost:52415/store/health
+```
 
-### Optimize Model (OptiQ)
+### Store registry
+
+**GET** `/store/registry`
+
+```bash
+curl http://localhost:52415/store/registry
+```
+
+### Active store downloads
+
+**GET** `/store/downloads`
+
+### Request a store download
+
+**POST** `/store/models/{model_id}/download`
+
+```bash
+curl -X POST http://localhost:52415/store/models/mlx-community/Qwen3.5-9B-4bit/download
+```
+
+### Check store download status
+
+**GET** `/store/models/{model_id}/download/status`
+
+### Delete a model from the store
+
+**DELETE** `/store/models/{model_id}`
+
+### Purge staging caches
+
+**POST** `/store/purge-staging`
+
+```bash
+curl -X POST http://localhost:52415/store/purge-staging \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+You can also target one model:
+
+```bash
+curl -X POST http://localhost:52415/store/purge-staging \
+  -H 'Content-Type: application/json' \
+  -d '{"model_id": "mlx-community/Qwen3.5-9B-4bit"}'
+```
+
+### Start OptiQ mixed-precision optimization
 
 **POST** `/store/models/{model_id}/optimize`
-
-Starts an OptiQ mixed-precision optimization job:
 
 ```bash
 curl -X POST http://localhost:52415/store/models/mlx-community/Qwen3.5-9B-4bit/optimize \
@@ -420,27 +578,35 @@ curl -X POST http://localhost:52415/store/models/mlx-community/Qwen3.5-9B-4bit/o
   -d '{"target_bpw": 4.5, "candidate_bits": [4, 8]}'
 ```
 
-### Optimization Status
+### Check optimization status
 
 **GET** `/store/models/{model_id}/optimize/status`
 
-Poll for optimization progress.
+Common responses:
 
----
+- `404 No optimization job found`
+- `409 ...` if an optimization job is already in progress
+- `503 Model optimizer not available` when the store is not configured
 
-## Configuration
+## Configuration Endpoints
 
-### Get Config
+### Get config
 
 **GET** `/config`
 
-Returns the current `exo.yaml` configuration and effective runtime values.
+```bash
+curl http://localhost:52415/config
+```
 
-### Update Config
+Behavior:
+
+- Returns the current config file contents.
+- Strips `hf_token` from the visible config for safety.
+- Includes effective runtime values like `kv_cache_backend`.
+
+### Update config
 
 **PUT** `/config`
-
-Update configuration and sync to all cluster nodes:
 
 ```bash
 curl -X PUT http://localhost:52415/config \
@@ -453,101 +619,108 @@ curl -X PUT http://localhost:52415/config \
   }'
 ```
 
----
+Behavior notes:
 
-## Alternative API Formats
+- Skulk validates the payload against `exo.yaml` schema.
+- Config is written locally and broadcast to the cluster.
+- If you omit `hf_token`, Skulk preserves the existing saved token.
+- Inference config changes affect future launches.
+- Model store changes still require restart.
 
-### Claude Messages API
+## State, Events, and Tracing
 
-**POST** `/v1/messages`
+### Cluster state
 
-Compatible with Anthropic's Claude API format. Supports streaming with Claude-specific event types (`message_start`, `content_block_delta`, etc.) and thinking blocks.
+**GET** `/state`
 
-### OpenAI Responses API
+This is the best general debugging endpoint.
+It includes topology, nodes, instances, runners, and downloads.
 
-**POST** `/v1/responses`
+### Event stream snapshot
 
-Compatible with OpenAI's newer Responses API format. Supports streaming with response-specific events and reasoning items.
+**GET** `/events`
 
-### Ollama API
+Returns the stored event log as JSON.
 
-For tools like OpenWebUI:
+### Traces
 
-```bash
-# Chat
-curl -X POST http://localhost:52415/ollama/api/chat \
-  -H 'Content-Type: application/json' \
-  -d '{"model": "mlx-community/Qwen3.5-9B-4bit", "messages": [{"role": "user", "content": "Hello"}]}'
+- `GET /v1/traces`
+- `GET /v1/traces/{task_id}`
+- `GET /v1/traces/{task_id}/stats`
+- `GET /v1/traces/{task_id}/raw`
+- `POST /v1/traces/delete`
 
-# List models
-curl http://localhost:52415/ollama/api/tags
+Use tracing when you need performance investigation rather than normal day-to-day usage.
 
-# Model info
-curl -X POST http://localhost:52415/ollama/api/show \
-  -d '{"name": "mlx-community/Qwen3.5-9B-4bit"}'
-```
+## Filesystem and Identity Helpers
 
----
+### Browse filesystem
 
-## Image Generation
+**GET** `/filesystem/browse?path=/Volumes`
 
-**POST** `/v1/images/generations`
+Used by the dashboard settings UI for choosing store paths.
 
-```bash
-curl -X POST http://localhost:52415/v1/images/generations \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "prompt": "a fox in a server room",
-    "model": "exolabs/FLUX.1-dev",
-    "size": "1024x1024",
-    "response_format": "b64_json"
-  }'
-```
+Behavior notes:
 
-Requires an image model to be placed. See [README](../README.md) for supported image models.
+- Browsing is restricted to allowed roots.
+- Typical allowed roots include `/Volumes`, `/home`, `/mnt`, `/tmp`, and `/opt`.
+- Returns `400` for invalid paths and `403` for permission problems.
 
----
+### Node identity
 
-## Benchmarking
+**GET** `/node/identity`
 
-**POST** `/bench/chat/completions`
+Returns:
 
-Same as `/v1/chat/completions` but returns performance metrics:
+- `nodeId`
+- `hostname`
+- preferred IPv4 LAN address when available
 
-```json
-{
-  "generation_stats": {
-    "prompt_tps": 245.3,
-    "generation_tps": 42.1,
-    "prompt_tokens": 128,
-    "generation_tokens": 256,
-    "peak_memory_usage": 8589934592
-  }
-}
-```
+## Image Endpoints
 
----
+Skulk also supports image-generation and image-editing APIs.
+These only work when image models are enabled and the relevant image model is already placed.
 
-## What's NOT Supported (Yet)
+Endpoints:
+
+- `POST /v1/images/generations`
+- `POST /bench/images/generations`
+- `POST /v1/images/edits`
+- `POST /bench/images/edits`
+- `GET /images`
+- `GET /images/{image_id}`
+
+## Cancellation
+
+**POST** `/v1/cancel/{command_id}`
+
+Use this to cancel an active text or image command when you still know the command ID.
+
+## What Is Not Implemented Yet
 
 | Feature | Status |
 |---------|--------|
-| `/v1/embeddings` | Not implemented — planned |
-| JSON mode enforcement | `response_format` accepted but not enforced |
-| JSON schema validation | Not implemented — planned |
-| `/v1/batches` | Not implemented |
+| `/v1/embeddings` | Not implemented |
+| Strict JSON mode enforcement | Not implemented |
+| JSON schema enforcement | Not implemented |
+| API key authentication | Not implemented |
+| Rate limiting | Not implemented |
 | `/v1/audio` | Not implemented |
 | `/v1/files` | Not implemented |
 | `/v1/fine_tuning` | Not implemented |
-| API key authentication | Not implemented — all requests accepted |
-| Rate limiting | Not implemented |
+| `/v1/batches` | Not implemented |
 
----
+## Practical Tips
 
-## Tips
+- Use `/instance/previews` early and often. It explains why a placement is invalid.
+- Use `/state` when you are not sure what the cluster thinks is running.
+- Use `/v1/models?status=downloaded` to see what is locally available.
+- Use streaming for better UX in chat clients.
+- Use the dashboard if you are learning the system and the API if you are integrating code.
 
-- **Finding model IDs**: Use `/v1/models?status=downloaded` to see what's available
-- **Streaming is recommended**: For chat use cases, `stream: true` gives much better UX
-- **Cancel stuck requests**: Close the connection or call `/v1/cancel/{command_id}`
-- **Check cluster health**: `GET /state` shows everything — nodes, instances, runners, downloads
-- **HuggingFace token**: Set via Settings panel or `HF_TOKEN` env var for faster downloads and gated model access
+## Related Docs
+
+- [README.md](../README.md)
+- [docs/model-store.md](model-store.md)
+- [docs/kv-cache-backends.md](kv-cache-backends.md)
+- [docs/architecture.md](architecture.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -720,7 +720,6 @@ Use this to cancel an active text or image command when you still know the comma
 
 ## Related Docs
 
-- [README.md](../README.md)
 - [docs/model-store.md](model-store.md)
 - [docs/kv-cache-backends.md](kv-cache-backends.md)
 - [docs/architecture.md](architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,86 +2,175 @@
 
 # Skulk Architecture Overview
 
-Skulk (forked from exo) uses an _Event Sourcing_ architecture, and Erlang-style _message passing_. To facilitate this, we've written a channel library extending anyio channels with inspiration from tokio::sync::mpsc.
+This page is the quick mental model for how Skulk fits together.
 
-Each logical module - designed to be functional independently of the others - communicates with the rest of the system by sending messages on topics.
+You do not need to understand every subsystem to use Skulk, but it helps to know what is happening when you start a node, join a cluster, place a model, and send a request.
 
-## Systems
+## The Short Version
 
-There are currently 5 major systems:
+A single Skulk node runs several cooperating systems:
 
-- Master
+- networking and peer discovery
+- election and master coordination
+- worker execution and model loading
+- the API server
+- the dashboard served by that API server
 
-    Executes placement and orders events through a single writer
+When you add more nodes, Skulk forms a cluster. The master coordinates placement and state, workers do execution, and the API exposes both compatibility endpoints and Skulk-specific control endpoints.
 
-- Worker
+## The Main User Flow
 
-    Schedules work on a node, gathers system information, etc.#
+Most real usage follows this shape:
 
-- Runner
+1. start one or more Skulk nodes
+2. let the cluster discover itself or connect through bootstrap peers
+3. inspect topology in the dashboard or through `/state`
+4. preview or choose a placement for a model
+5. place the model
+6. download or stage the required model files
+7. load the model on the chosen nodes
+8. send chat or other generation requests
 
-    Executes inference jobs (for now) in an isolated process from the worker for fault-tolerance.
-    The runner is also where MLX inference generators and KV cache backends are selected. Experimental KV cache backend selection is process-local and opt-in via environment variables.
+That is why placement is such an important idea in Skulk docs: generation depends on runtime state, not just API calls.
 
-- API
+## The Main Systems
 
-    Runs a python webserver for exposing state and commands to client applications
+### Master
 
-- Election
+The master coordinates cluster state and placement decisions.
 
-    Implements a distributed algorithm for master election in unstable networking conditions
+Responsibilities include:
 
-## API Layer
+- ordering events
+- coordinating placement
+- maintaining the shared view of the cluster
 
-The API system uses multiple adapters to support multiple API formats, converting them to a single request / response type.
+### Worker
 
-### Adapter Pattern
+Each node runs a worker.
 
-Adapters convert between external API formats and Skulk's internal types:
+The worker is responsible for:
 
-```
-Chat Completions → [adapter] → TextGenerationTaskParams → Application
-Claude Messages  → [adapter] → TextGenerationTaskParams → Application
-Responses API    → [adapter] → TextGenerationTaskParams → Application
-Ollama API       → [adapter] → TextGenerationTaskParams → Application
-```
+- gathering node information
+- managing downloads and staging
+- loading and unloading model runners
+- executing inference-related tasks
 
-Each adapter implements two key functions:
-1. **Request conversion**: Converts API-specific requests to `TextGenerationTaskParams`
-2. **Response generation**: Converts internal `TokenChunk` streams back to API-specific formats (streaming and non-streaming)
+### Runner
 
+Runners execute model work in an isolated process.
 
-## Topics
+This is where Skulk selects inference behavior such as:
 
-There are currently 5 topics:
+- model loading strategy
+- MLX execution path
+- KV cache backend choice
 
-- Commands
+### API
 
-    The API and Worker instruct the master when the event log isn't sufficient. Namely placement and catchup requests go through Commands atm.
+The API server exposes:
 
-- Local Events
+- OpenAI-compatible endpoints
+- Claude-compatible endpoints
+- Ollama-compatible endpoints
+- Skulk-specific control endpoints for placement, config, store, state, and tracing
 
-    All nodes write events here, the master reads those events and orders them
+The API server also serves the dashboard.
 
-- Global Events
+### Election
 
-    The master writes events here, all nodes read from this topic and fold the produced events into their `State`
+Election handles who becomes master in a distributed cluster.
 
-- Election Messages
+That lets Skulk keep operating even when connectivity changes or nodes come and go.
 
-    Before establishing a cluster, nodes communicate here to negotiate a master node.
+## Message Flow
 
-- Connection Messages
+Skulk uses explicit message passing between systems.
 
-    The networking system write mdns-discovered hardware connections here.
+At a high level:
 
+- commands ask for something to happen
+- events record what already happened
+- state is rebuilt by applying events in order
+
+This is why the system often feels more like a distributed application platform than a single local inference process.
 
 ## Event Sourcing
 
-Lots has been written about event sourcing, but it lets us centralize faulty connections and message ACKing with the following model.
+Skulk uses an event-sourced state model.
 
-Whenever a device produces side effects, it captures those side effects in an `Event`. `Event`s are then "applied" to their model of `State`, which is globally distributed across the cluster. Whenever a command is received, it is combined with state to produce side effects, captured in yet more events. The rule of thumb is "`Event`s are past tense, `Command`s are imperative". Telling a node to perform some action like "place this model" or "Give me a copy of the event log" is represented by a command (The worker's `Task`s are also commands), while "this node is using 300GB of ram" is an event. Notably, `Event`s SHOULD never cause side effects on their own. There are a few exceptions to this, we're working out the specifics of generalizing the distributed event sourcing model to make it better suit our needs
+In practice, that means:
 
-## Purity
+- cluster changes are represented as events
+- those events are ordered and applied into a shared state object
+- commands and current state together drive future work
 
-A significant goal of the current design is to make data flow explicit. Classes should either represent simple data (`CamelCaseModel`s typically, and `TaggedModel`s for unions) or active `System`s (Erlang `Actor`s), with all transformations of that data being "referentially transparent" - destructure and construct new data, don't mutate in place. We have had varying degrees of success with this, and are still exploring where purity makes sense.
+A simple rule of thumb:
+
+- events are past tense
+- commands are imperative
+
+Examples:
+
+- "place this model" is a command
+- "this instance was created" is an event
+
+## API Adapters
+
+Skulk supports multiple external API styles by adapting them into one internal execution path.
+
+At a high level:
+
+```text
+OpenAI Chat Completions -> adapter -> internal text generation task
+Claude Messages         -> adapter -> internal text generation task
+OpenAI Responses        -> adapter -> internal text generation task
+Ollama APIs             -> adapter -> internal text generation task
+```
+
+This is why one placed model can be accessed through several compatibility formats.
+
+## Topics and Communication
+
+The major communication patterns include:
+
+- command topics for explicit requests
+- local events from workers and nodes
+- global events broadcast by the master
+- election messages for leader coordination
+- connection messages for networking updates
+
+You do not usually need to work with these directly as a user, but they explain why state, placement, and trace behavior look the way they do.
+
+## Where the Model Store Fits
+
+The model store does not replace the cluster architecture.
+
+Instead, it changes how model artifacts are sourced:
+
+- without a store, nodes download independently
+- with a store, one host keeps shared model files and other nodes stage from it
+
+The rest of the system still uses the same master, worker, API, and placement model.
+
+## Where the Dashboard Fits
+
+The dashboard is not a separate product or service.
+
+It is the main operator interface for the same Skulk runtime:
+
+- topology view
+- model store workflows
+- settings and config
+- chat
+- placement workflows
+
+That is why the docs often describe dashboard and API flows as parallel ways of driving the same underlying system.
+
+## When to Read More
+
+If you are:
+
+- trying to get started, go back to the [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md)
+- integrating against the API, read the [API guide](api.md)
+- setting up shared storage, read the [model store guide](model-store.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Skulk is a distributed inference platform, so these docs try to serve both of th
 
 If you are getting oriented, start with these pages:
 
+- [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md) for installation, first run, and quick-start paths
 - [API guide](api.md) for the happy path: place a model, then call the API
 - [Model store guide](model-store.md) for shared model storage and download workflows
 - [KV cache backends](kv-cache-backends.md) for backend and runtime tuning

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,34 @@
 # Skulk Developer Docs
 
-This site combines hand-written guides with generated reference material for Skulk.
+This site combines practical guides with generated reference material for Skulk.
 
-## What lives here
+Skulk is a distributed inference platform, so these docs try to serve both of the audiences that show up most often:
 
-- Human-oriented guides for setup, architecture, and operational workflows
-- Generated OpenAPI output for the FastAPI backend
-- Generated TypeDoc output for selected TypeScript modules in `dashboard-react`
+- people who are new and want a clear path to a first working setup
+- developers who want exact API, type, and integration reference material
 
 ## Start Here
 
-- [API guide](api.md)
-- [Model store guide](model-store.md)
-- [KV cache backends](kv-cache-backends.md)
-- [Architecture overview](architecture.md)
+If you are getting oriented, start with these pages:
 
-## Generated Reference
+- [API guide](api.md) for the happy path: place a model, then call the API
+- [Model store guide](model-store.md) for shared model storage and download workflows
+- [KV cache backends](kv-cache-backends.md) for backend and runtime tuning
+- [Architecture overview](architecture.md) for how the node, cluster, and event model fit together
 
-- [OpenAPI schema](reference/openapi.md)
-- [API Reference (ReDoc)](reference/api-reference.md)
-- [TypeDoc](reference/typedoc.md)
+## Common Jobs
+
+- I want to browse the backend API: [API Reference (ReDoc)](reference/api-reference.md)
+- I want the raw machine-readable schema: [OpenAPI schema](reference/openapi.md)
+- I want frontend and TypeScript symbols: [TypeDoc](reference/typedoc.md)
+- I want implementation context before I integrate: [Architecture overview](architecture.md)
+
+## What Lives Here
+
+- Hand-written guides for setup, architecture, and operational workflows
+- Generated OpenAPI output for the FastAPI backend
+- Generated TypeDoc output for selected TypeScript modules in `dashboard-react`
+
+## Keep In Mind
+
+For text generation, Skulk is not just a stateless HTTP API. A model generally needs to be placed and running before chat-style requests succeed. The dashboard enforces this, and the compatibility APIs reflect the same runtime reality.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# Skulk Developer Docs
+
+This site combines hand-written guides with generated reference material for Skulk.
+
+## What lives here
+
+- Human-oriented guides for setup, architecture, and operational workflows
+- Generated OpenAPI output for the FastAPI backend
+- Generated TypeDoc output for selected TypeScript modules in `dashboard-react`
+
+## Start Here
+
+- [API guide](api.md)
+- [Model store guide](model-store.md)
+- [KV cache backends](kv-cache-backends.md)
+- [Architecture overview](architecture.md)
+
+## Generated Reference
+
+- [OpenAPI schema](reference/openapi.md)
+- [API Reference (ReDoc)](reference/api-reference.md)
+- [TypeDoc](reference/typedoc.md)

--- a/docs/model-store.md
+++ b/docs/model-store.md
@@ -2,613 +2,253 @@
 
 # Skulk Model Store
 
-> **Status:** Phase 1+3 — centralized LAN distribution with dashboard integration
-> **Config file:** `exo.yaml` (optional, zero-config compatible — can be configured via the dashboard)
+The model store is one of the biggest additions Skulk makes on top of upstream EXO.
 
----
+In a normal cluster without a model store, each node may need to download model data for itself.
+With the model store enabled, one node becomes the shared store host and other nodes stage from it over the LAN.
 
-## What problem does this solve?
+## Why You Would Use It
 
-In a standard Skulk cluster every node independently downloads its assigned
-model shard from HuggingFace at inference time.  For a small home cluster
-(2-8 machines) this creates four pain points:
+Use the model store when:
 
-| Pain point | Impact |
-|---|---|
-| Redundant downloads | Every node pulls the same model files; a 30B model may mean 20 GB x N nodes of internet traffic |
-| Slow cold starts | A node that hasn't seen a model yet blocks inference for the whole cluster |
-| Version drift | Each node downloads on its own schedule; model files can diverge |
-| No offline mode | The cluster is dead without an internet connection after the first run |
+- you have more than one node
+- your models are large
+- you want fewer repeated downloads
+- you want a cleaner offline story after the first download
+- you want model files to live on a dedicated large disk or volume
 
-The model store solves all four by introducing a single designated
-**store host** node — typically the machine with the most attached storage —
-that holds all model files.  Every other node pulls its assigned shard from
-the store over the local network (Thunderbolt, 10 GbE, or even fast Wi-Fi)
-instead of from HuggingFace.
+## What Changes When It Is Enabled
 
----
+Without the model store:
 
-## How it extends Skulk
+- nodes download model data independently
+- cold starts can be slower across the cluster
+- repeated downloads are more common
 
-This is a **non-breaking opt-in extension** to the existing architecture.
-If `exo.yaml` is absent (the default for any existing deployment), the model
-store is not active and Skulk behaves identically to the upstream default.
+With the model store:
 
-### What changes when the model store is enabled
+- one node hosts the shared model store
+- other nodes stage needed files from that host
+- Skulk keeps the same cluster and inference architecture, but changes where model artifacts come from
 
-| Component | Without store | With store |
-|---|---|---|
-| `DownloadCoordinator` | Uses `ResumableShardDownloader` -> HuggingFace | Uses `ModelStoreDownloader` wrapping `ResumableShardDownloader` |
-| `ModelStoreDownloader` | n/a | Intercepts `ensure_shard()`, stages from store; falls back to inner downloader if model not present |
-| Store host startup | n/a | `ModelStore` (registry) + `ModelStoreServer` (HTTP) started alongside other node components |
-| Worker shutdown | n/a | `ModelStoreClient.evict_shard()` removes staged files when `cleanup_on_deactivate: true` |
-| MLX / inference | Loads from `~/.exo/models/` | Loads from `~/.exo/staging/` (or `node_cache_path`) — **no change to the inference stack** |
+## What Does Not Change
 
-### What does NOT change
+- the libp2p mesh, election, master, and worker model stay the same
+- the main Skulk API stays the same
+- the dashboard remains your main control surface
+- single-node Skulk still works fine without the model store
 
-- The libp2p routing, election, and master/worker architecture is unchanged.
-- The OpenAI-compatible REST API is unchanged.
-- The MLX inference backend is unchanged.
-- Nodes without `exo.yaml` continue to work normally and can coexist with
-  store-enabled nodes (useful during a phased rollout).
+## Before You Start
 
----
+Make sure:
 
-## Architecture
+- all nodes are running the same Skulk build
+- you know which machine should be the store host
+- that machine has enough storage for the models you want to share
+- the chosen `store_path` is mounted and writable
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│  Cluster                                                            │
-│                                                                     │
-│  ┌───────────────────┐          HTTP :58080            ┌─────────┐ │
-│  │  mac-studio-1     │◄────────────────────────────────│ kite2   │ │
-│  │  (store host)     │  GET /models/{id}/{file}        │         │ │
-│  │                   │                                 │ staging │ │
-│  │  ModelStore       │◄────────────────────────────────│ ~/.exo/ │ │
-│  │  (registry.json)  │                                 │ staging/│ │
-│  │                   │                                 └─────────┘ │
-│  │  ModelStoreServer │                                             │
-│  │  (aiohttp)        │◄────────────────────────────────┌─────────┐ │
-│  │                   │                                 │ kite3   │ │
-│  │  /Volumes/        │                                 │         │ │
-│  │  ModelStore/      │                                 │ staging │ │
-│  │  models/          │                                 │ /Vols/  │ │
-│  │    mlx-comm--.../ │                                 │ FastSSD/│ │
-│  │    ...            │                                 └─────────┘ │
-│  └───────────────────┘                                             │
-│                                                                     │
-│  All nodes: libp2p mesh, election, master/worker unchanged         │
-└─────────────────────────────────────────────────────────────────────┘
-```
+The store server uses port `58080` by default.
 
-### Module layout
+## Recommended Setup: Dashboard First
 
-```
-src/exo/store/
-  __init__.py              (empty — package marker)
-  config.py                ExoConfig, ModelStoreConfig, StagingNodeConfig
-                           load_exo_config(), resolve_node_staging()
-  model_store.py           ModelStore — registry + path resolution (store host only)
-  model_store_server.py    ModelStoreServer — aiohttp HTTP file server (store host only)
-  model_store_client.py    ModelStoreClient — HTTP staging client (all nodes)
-                           ModelStoreDownloader — ShardDownloader wrapper (all nodes)
-```
+This is the simplest path for most people.
 
-### Integration points in the existing codebase
+1. Start Skulk on all nodes with `uv run exo`.
+2. Open the dashboard on the node you want to become the store host.
+3. Go to **Settings**.
+4. Enable the store host toggle.
+5. Choose the store path.
+6. Save the config.
+7. Restart Skulk on all nodes if the dashboard tells you a restart is required.
 
-| File | What was added |
-|---|---|
-| `src/exo/main.py` | Load `exo.yaml`; build `ModelStore`, `ModelStoreServer`, `ModelStoreClient`; wrap `exo_shard_downloader()` with `ModelStoreDownloader`; start server on store host; re-wrap on election transitions; pass `exo_config`/`store_client` to API |
-| `src/exo/api/main.py` | `GET/PUT /config` (read/write `exo.yaml`), `GET /store/health` and `/store/registry` (proxy to store server), `GET /filesystem/browse` (directory browser), `GET /node/identity` (hostname + LAN IP); config saves broadcast to cluster via `SyncConfig` |
-| `src/exo/worker/main.py` | Accept `store_client` and `staging_config` in `Worker.__init__`; call `evict_shard()` in the `Shutdown` task handler |
-| `src/exo/download/coordinator.py` | Handle `SyncConfig` command — write received config to local `exo.yaml` |
-| `src/exo/shared/types/commands.py` | `SyncConfig` command type for cluster-wide config distribution |
-| `pyproject.toml` | Added `pyyaml` and `types-PyYAML` dependencies |
-| `dashboard/src/routes/settings/+page.svelte` | Settings page: store host toggle, directory browser, config form |
-| `dashboard/src/routes/downloads/+page.svelte` | Segmented control toggling between Node Downloads and Store Registry |
-| `dashboard/src/lib/components/DirectoryBrowser.svelte` | Filesystem browser with breadcrumbs for path selection |
-| `dashboard/src/lib/components/StoreRegistryTable.svelte` | Table showing models in the central store |
-| `dashboard/src/lib/components/HeaderNav.svelte` | Settings gear icon + nav link |
+After that, use the dashboard or API normally. When models are available in the store, worker nodes stage from the store host instead of downloading independently.
 
----
+## Manual Setup with `exo.yaml`
 
-## Prerequisites
+If you prefer to configure the model store manually, put the same `exo.yaml` file on each node.
 
-- All nodes running the same Skulk build
-- The store host node has the storage device mounted and accessible at `store_path`
-- Config is distributed automatically when using the dashboard Settings page.
-  If configuring manually, `exo.yaml` must be present at the project root on
-  **every node** (or absent to fall back to standard behaviour on that node)
-
-The store server uses port `58080` for model file transfers over the same
-Thunderbolt/ethernet links that the cluster already uses for the ring network.
-No additional network configuration is needed.
-
----
-
-## Quick start
-
-There are two ways to configure the model store: via the **dashboard** (recommended) or by editing `exo.yaml` manually.
-
-### Option A — Configure via the dashboard (recommended)
-
-1. Start Skulk on all nodes: `uv run exo`
-2. Open the dashboard on the node you want to be the store host: `http://localhost:52415`
-3. Navigate to **Settings** (gear icon in the header)
-4. Toggle **"This node is the store host"** — hostname and IP are filled in automatically
-5. Click the folder icon next to **Store Path** and browse to your storage volume (e.g. `/Volumes/ModelStore/models`)
-6. Click **Save** — the config is written to `exo.yaml` and synced to all nodes in the cluster automatically
-7. Restart Skulk on all nodes for changes to take effect
-
-### Option B — Edit `exo.yaml` manually
-
-The minimum viable config:
+Minimal example:
 
 ```yaml
 model_store:
   enabled: true
-  store_host: mac-studio-1    # change to your store host's hostname
+  store_host: mac-studio-1
   store_path: /Volumes/ModelStore/models
 ```
 
-Copy this to the same path on every node.  Use `node_overrides` to tune
-per-node staging (see [Configuration reference](#configuration-reference)).
+For most users:
 
-### After configuration — run Skulk normally
+- `store_host` should be the hostname of the store machine
+- `store_path` should be an absolute path on that host
 
-```bash
-uv run exo
-```
-
-No new flags or environment variables needed.  On startup:
-
-- **Store host** (`mac-studio-1`): detects that its hostname matches
-  `store_host`, starts `ModelStoreServer` on port `58080`.
-- **Worker nodes**: detect they are not the store host, start a
-  `ModelStoreClient` pointed at `mac-studio-1:58080`.
-
-Watch for these log lines to confirm the store is active:
-
-```
-# Store host
-ModelStore: this node is the store host — store at /Volumes/ModelStore/models, server on port 58080
-ModelStoreServer listening on 0.0.0.0:58080 (store: /Volumes/ModelStore/models)
-
-# Worker nodes
-ModelStoreDownloader: staging mlx-community/Qwen3-30B-A3B-4bit from store → ~/.exo/staging/mlx-community--Qwen3-30B-A3B-4bit
-ModelStoreClient: staged mlx-community/Qwen3-30B-A3B-4bit to ~/.exo/staging/... (21474836480 bytes)
-```
-
-### 3 — Request a model
-
-```bash
-curl http://localhost:52415/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "mlx-community/Qwen3-30B-A3B-4bit",
-    "messages": [{"role": "user", "content": "hi"}]
-  }'
-```
-
-**First request (model not yet in store):** If `allow_hf_fallback: true`,
-nodes download from HuggingFace as normal.  The model lands in `~/.exo/models/`
-on each node.
-
-**Subsequent requests:** Worker nodes stage from `mac-studio-1:58080`.
-HuggingFace is not contacted.
-
----
-
-## Configuration reference
+## Example Full Configuration
 
 ```yaml
 model_store:
-  enabled: true                        # false → store disabled (same as no file)
-
-  store_host: mac-studio-1             # hostname or libp2p node_id of store node
-  store_port: 58080                    # HTTP port — must be open on store host
-  store_path: /Volumes/ModelStore/models  # absolute path on store host
+  enabled: true
+  store_host: mac-studio-1
+  store_port: 58080
+  store_path: /Volumes/ModelStore/models
 
   download:
-    allow_hf_fallback: true            # false → error if model not in store
+    allow_hf_fallback: true
 
   staging:
-    # Default applied to all nodes without a matching node_override
     enabled: true
-    node_cache_path: ~/.exo/staging    # ~ expanded per-node
-    cleanup_on_deactivate: true        # delete staged files on instance shutdown
+    node_cache_path: ~/.exo/staging
+    cleanup_on_deactivate: true
 
   node_overrides:
-    # Keyed by hostname (socket.gethostname()) or libp2p node_id.
-    # First match wins; unspecified fields inherit from the base config.
     mac-studio-1:
       staging:
-        node_cache_path: /Volumes/ModelStore/models  # load directly from store
-        cleanup_on_deactivate: false                 # store IS the cache
+        node_cache_path: /Volumes/ModelStore/models
+        cleanup_on_deactivate: false
 ```
 
-### Field reference
+## How to Think About It
 
-#### `model_store.store_host`
+There are two important paths:
 
-Compared against (in order):
-1. The node's libp2p peer ID (`node_id`)
-2. The node's hostname (`socket.gethostname()`)
+- `store_path`: the shared source of truth on the store host
+- `node_cache_path`: the local staging area where a node prepares files before loading them
 
-Set it to the **hostname** of your store node for simplest configuration.
+For worker nodes, `node_cache_path` is usually a fast local path such as `~/.exo/staging`.
 
-#### `model_store.staging.node_cache_path`
+For the store host, you often point `node_cache_path` at the same directory as `store_path` so the store host can load directly from the shared volume without making another copy.
 
-MLX loads the model from this path.  Default is `~/.exo/staging/`, which
-sits alongside the existing `~/.exo/models/` cache already in use.
+## Important Fields
 
-For the store host, point this at the same directory as `store_path` so that
-no local copy is made — MLX loads directly from the store device:
+### `model_store.enabled`
 
-```yaml
-node_overrides:
-  mac-studio-1:
-    staging:
-      node_cache_path: /Volumes/ModelStore/models
-      cleanup_on_deactivate: false
-```
+Turns the model store on or off without deleting the config file.
 
-#### `model_store.download.allow_hf_fallback`
+### `model_store.store_host`
 
-| Value | Behaviour |
-|---|---|
-| `true` (default) | Model not in store → download from HuggingFace |
-| `false` | Model not in store → raise `ModelNotInStoreError` |
+The hostname or node ID of the store host.
 
-Use `false` for air-gapped clusters to guarantee no unexpected internet traffic.
+For most users, hostname is the easiest and most reliable choice.
 
----
+### `model_store.store_port`
 
-## Store HTTP API
+HTTP port used for store transfers.
 
-The `ModelStoreServer` exposes a small read-only HTTP API on the store host.
-All responses are JSON unless noted.  The API is **not authenticated** — it is
-designed for trusted LAN use.  Do not expose `store_port` to untrusted networks.
+Default: `58080`
 
-| Endpoint | Method | Description |
-|---|---|---|
-| `/health` | GET | Liveness check; returns `store_path`, `free_bytes`, `total_bytes`, `used_bytes` |
-| `/registry` | GET | Full store index — array of model entries with paths, file lists, sizes, timestamps |
-| `/models` | GET | Array of model ID strings in the store |
-| `/models/{id}/files` | GET | File list for one model (`%2F` for `/` in model ID) |
-| `/models/{id}/{path}` | GET | File content; supports `Range` header (HTTP 206) |
+### `model_store.store_path`
 
-```bash
-# Liveness check
-curl http://mac-studio-1:58080/health
+Absolute path on the store host where shared models live.
 
-# List models
-curl http://mac-studio-1:58080/models
+### `model_store.download.allow_hf_fallback`
 
-# File list for a model
-curl http://mac-studio-1:58080/models/mlx-community%2FQwen3-30B-A3B-4bit/files
+Controls what happens if a requested model is not already in the store.
 
-# Manual resumable download of one file
-curl -H "Range: bytes=1073741824-" \
-  http://mac-studio-1:58080/models/mlx-community%2FQwen3-30B-A3B-4bit/model-00001-of-00008.safetensors \
-  -o model-00001.partial
-```
+| Value | Behavior |
+|-------|----------|
+| `true` | Fall back to Hugging Face download when needed |
+| `false` | Fail instead of downloading from Hugging Face |
 
----
+Use `false` if you want stricter offline or air-gapped behavior.
 
-## Dashboard API (FastAPI, port 52415)
+### `model_store.staging.node_cache_path`
 
-These endpoints are served by the main Skulk API alongside all existing
-endpoints.  The dashboard uses them for the Settings page and Store
-Registry view.
+Where a node stages files before loading them.
 
-| Endpoint | Method | Description |
-|---|---|---|
-| `/config` | GET | Read current `exo.yaml` as JSON. Returns `{config, configPath, fileExists}` |
-| `/config` | PUT | Validate and write new config to `exo.yaml`. Broadcasts to all nodes via gossipsub. Body: `{config: {...}}` |
-| `/store/health` | GET | Proxy store server `/health`. Returns `{storePath, freeBytes, totalBytes, usedBytes}`. 503 if store not configured/unreachable |
-| `/store/registry` | GET | Proxy store server `/registry`. Returns `{entries: [...]}`. 503 if store not configured |
-| `/filesystem/browse` | GET | List subdirectories at `?path=/Volumes`. Restricted to `/Volumes`, `/home`, `/mnt`, `/tmp`, `/opt`. Returns `{path, directories: [{name, path}]}` |
-| `/node/identity` | GET | Current node's hostname and LAN IP. Returns `{nodeId, hostname, ipAddress}` |
+### `model_store.staging.cleanup_on_deactivate`
 
-### Config sync across the cluster
+If `true`, staged files are cleaned up when instances are shut down.
 
-When `PUT /config` saves a new config, it also broadcasts the YAML content
-to all nodes in the cluster via a `SyncConfig` command on the
-`DOWNLOAD_COMMANDS` gossipsub topic.  Each node's `DownloadCoordinator`
-receives the message and writes it to its local `exo.yaml`.
+## Typical Flow
 
-This ensures all nodes stay in sync when config is changed from the
-dashboard.  A restart is still required on all nodes for the new config to
-take effect at runtime.
+### First time a model is needed
 
----
+If the model is not already in the store and fallback is enabled:
 
-## Dashboard UI
+1. Skulk requests the model.
+2. The store-aware download path checks the store.
+3. If the model is missing, Skulk falls back to Hugging Face.
+4. The model lands in the appropriate local or store-managed path.
 
-### Settings page (`/#/settings`)
+### Later requests
 
-The settings page provides a visual editor for `exo.yaml`:
+Once the model exists in the store:
 
-- **Store Status**: shows connection status (green/red dot), store path, and disk usage bar
-- **Store Host toggle**: "This node is the store host" — automatically fills hostname and LAN IP. When off, shows manual host/IP fields for pointing at a remote store.
-- **Directory Browser**: click the folder icon next to any path field to browse the filesystem starting at `/Volumes`. Navigate through directories and select one — no need to type paths.
-- **Config form**: all `model_store` fields are editable — enable/disable, port, download policy, staging settings, node overrides with per-node staging toggles.
-- **Save**: validates via Pydantic, writes to disk, syncs to cluster. Shows restart reminder.
+1. worker nodes ask the store host for the needed files
+2. files are staged locally
+3. inference loads from the staged path
 
-### Downloads page — Store Registry tab
+## Useful Store Endpoints
 
-When the model store is configured and reachable, the downloads page shows a
-segmented control: **Node Downloads** (existing grid) and **Store Registry**.
+These are exposed through the main Skulk API:
 
-The Store Registry tab shows all models in the central store with:
-- Model ID
-- Total size
-- File count
-- Date added
+- `GET /store/health`
+- `GET /store/registry`
+- `GET /store/downloads`
+- `POST /store/models/{model_id}/download`
+- `GET /store/models/{model_id}/download/status`
+- `DELETE /store/models/{model_id}`
+- `POST /store/purge-staging`
+- `POST /store/models/{model_id}/optimize`
 
----
+Common meanings:
 
-## Data flow
-
-### First run — model not in store, HF fallback enabled
-
-```
-DownloadCoordinator
-  → ModelStoreDownloader.ensure_shard()
-      → ModelStoreClient.is_model_available()   # HTTP 404
-      → allow_hf_fallback=true
-        → inner.ensure_shard()                  # ResumableShardDownloader
-            → HuggingFace → ~/.exo/models/...
-              → return ~/.exo/models/...
-                → MLX loads from ~/.exo/models/...
-```
-
-### Subsequent runs — model in store
-
-```
-DownloadCoordinator
-  → ModelStoreDownloader.ensure_shard()
-      → ModelStoreClient.is_model_available()   # HTTP 200
-      → ModelStoreClient.stage_shard()
-          → GET mac-studio-1:58080/models/{id}/files
-          → GET mac-studio-1:58080/models/{id}/{file}  (per file, Range resume)
-            → ~/.exo/staging/mlx-community--Qwen3-30B-A3B-4bit/
-              → return staging path
-                → MLX loads from ~/.exo/staging/...
-
-Instance shutdown (Shutdown task in Worker)
-  → ModelStoreClient.evict_shard()
-      → rm -rf ~/.exo/staging/mlx-community--Qwen3-30B-A3B-4bit/
-        (store copy on mac-studio-1 untouched)
-```
-
-### Store host — no network round-trip
-
-```
-ModelStoreDownloader.ensure_shard()
-  → ModelStoreClient.stage_shard()   (local_store_path set)
-      → _stage_local()
-          → shutil.copy2() per file  (or no-op if node_cache_path == store_path)
-            → MLX loads from node_cache_path
-```
-
----
-
-## Registry and store population
-
-### Registry format
-
-`{store_path}/registry.json` is written and read by `ModelStore`:
-
-```json
-{
-  "mlx-community/Qwen3-30B-A3B-4bit": {
-    "model_id": "mlx-community/Qwen3-30B-A3B-4bit",
-    "store_path": "mlx-community--Qwen3-30B-A3B-4bit",
-    "files": ["config.json", "tokenizer.json", "model-00001-of-00008.safetensors"],
-    "downloaded_at": "2026-03-20T14:32:00+00:00",
-    "total_bytes": 21474836480
-  }
-}
-```
-
-### Staging directory layout (worker nodes)
-
-```
-~/.exo/staging/
-  mlx-community--Qwen3-30B-A3B-4bit/
-    config.json
-    tokenizer.json
-    model-00003-of-00008.safetensors   ← only this node's assigned shard
-  mlx-community--Llama-3.1-8B-Instruct-4bit/
-    ...
-```
-
-### Pre-populating the store (Phase 1)
-
-In Phase 1, the registry must be populated manually.  The recommended workflow
-is to download models directly to the store on the store host using
-`huggingface-cli`, then register them:
-
-```bash
-# 1. Download to the store directory on mac-studio-1
-huggingface-cli download mlx-community/Qwen3-30B-A3B-4bit \
-  --local-dir /Volumes/ModelStore/models/mlx-community--Qwen3-30B-A3B-4bit
-
-# 2. Register in the store index
-python - <<'EOF'
-from pathlib import Path
-from exo.store.model_store import ModelStore
-
-store = ModelStore(Path("/Volumes/ModelStore/models"))
-p = Path("/Volumes/ModelStore/models/mlx-community--Qwen3-30B-A3B-4bit")
-files = [str(f.relative_to(p)) for f in p.rglob("*") if f.is_file()]
-total = sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
-store.register_model("mlx-community/Qwen3-30B-A3B-4bit", p, files, total)
-print(f"Registered {len(files)} files, {total:,} bytes")
-EOF
-```
-
-Phase 2 will automate this (see [Roadmap](#roadmap)).
-
----
+- `503 Store not configured`: the cluster is not configured to use a model store
+- `503 Store unreachable`: the store is configured, but the API cannot reach it
+- `404`: the model or job does not exist
+- `409`: a conflicting operation is already in progress
 
 ## Troubleshooting
 
-### Worker can't reach the store host
+### The store host seems unreachable
+
+Check:
+
+- that the store host is running
+- that `store_host` matches the real hostname
+- that port `58080` is reachable on your LAN
+
+Useful check:
 
 ```bash
-curl http://mac-studio-1:58080/health
+curl http://STORE_HOST:58080/health
 ```
 
-If this fails:
-- Check that `ModelStoreServer` started on `mac-studio-1` (look for
-  `ModelStoreServer listening on 0.0.0.0:58080` in the store host's logs)
-- Check that port `58080` is open in any firewall on `mac-studio-1`
-- Confirm `store_host: mac-studio-1` matches the hostname exactly
-  (`hostname` command on the store host)
+### The model is on disk but does not appear in the store registry
 
-### Model shows as unavailable despite being in the store directory
+Check:
+
+- that the model is in the configured `store_path`
+- that the registry knows about it
+- that the dashboard Store Registry view shows it
+
+Useful check:
 
 ```bash
-curl http://mac-studio-1:58080/registry
+curl http://localhost:52415/store/registry
 ```
 
-Check that:
-- A registry entry exists for the model ID
-- The `store_path` in the entry points to the correct subdirectory
-- The subdirectory exists on disk
+### Nodes still download from Hugging Face
 
-If the entry is missing, re-run the registration script above.
+Check:
 
-### Staged files not cleaned up
+- whether the model is already present in the store
+- whether `allow_hf_fallback` is still `true`
+- whether the store host is reachable from worker nodes
 
-Check that `cleanup_on_deactivate: true` is set for the node (and not
-overridden to `false` in `node_overrides`).  Eviction is logged at INFO level:
+### Staged files are not being cleaned up
 
-```
-ModelStoreClient: evicted staged shard for mlx-community/Qwen3-30B-A3B-4bit from ...
-```
+Check `cleanup_on_deactivate` and any `node_overrides` that may disable cleanup for a specific machine.
 
-### Transfer stalls partway through
+## Good Defaults for Most Clusters
 
-Staging is automatically resumable.  Re-request the model — `ModelStoreClient`
-detects `.partial` files and sends a `Range` header to continue from the last
-byte received.  No manual cleanup needed.
+- use the dashboard to manage the store config
+- choose one machine with the most storage as the store host
+- keep `allow_hf_fallback: true` while you are getting started
+- use a fast local staging path on worker nodes
+- point the store host's `node_cache_path` at the store itself
 
-### HuggingFace downloads are being used despite the store being configured
+## Related Docs
 
-1. Check the store host logs — is `ModelStoreServer` running?
-2. `curl http://<store_host>:58080/models` — is the model listed?
-3. If the model isn't listed, it hasn't been registered.  Register it (see above).
-4. Check worker logs for `ModelStoreDownloader: ... not in store, falling back to HuggingFace`.
-
----
-
-## Roadmap
-
-This is a phased feature.  Each phase is a self-contained improvement that
-can be reviewed and merged independently.
-
-### Phase 1 — Centralized LAN distribution *(done)*
-
-- `ModelStore`: registry + path resolution on the store host
-- `ModelStoreServer`: HTTP file server with Range/resume support
-- `ModelStoreClient`: HTTP staging client with `.partial` resume
-- `ModelStoreDownloader`: `ShardDownloader` wrapper; transparent HF fallback
-- `exo.yaml`: optional cluster config file; zero-config when absent
-- Manual store population via `huggingface-cli` + `register_model()`
-
----
-
-### Phase 2 — Automatic store population
-
-When a model is downloaded from HuggingFace via the fallback path, the
-`ModelStoreDownloader` (or the `DownloadCoordinator`) automatically copies the
-completed download into the store and registers it.  After Phase 2, the store
-self-populates as models are first requested — no manual registration needed.
-
-Scope:
-- Hook `DownloadCoordinator`'s `DownloadCompleted` event to trigger a
-  background copy-and-register on the store host.
-- Or: add a post-download hook in `ResumableShardDownloader` that notifies
-  the store client when a file is complete.
-- Registry update is idempotent so concurrent completions are safe.
-
----
-
-### Phase 3 — Dashboard integration *(done)*
-
-- **Settings page** (`/#/settings`): read-write config editor with store health display, "this node is the store host" toggle, filesystem directory browser for path selection, node override management. Config saves are broadcast to all nodes via gossipsub.
-- **Downloads page**: segmented control toggling between node downloads grid and store registry catalog (model list with sizes, file counts, timestamps).
-- **Navigation**: Settings gear icon in header nav.
-- **API endpoints**: `GET/PUT /config`, `GET /store/health`, `GET /store/registry`, `GET /filesystem/browse`, `GET /node/identity`.
-
----
-
-### Phase 4 — Store host failover
-
-If the designated store host goes offline, worker nodes currently cannot stage
-new models (though already-staged models continue to work until evicted).
-
-Scope:
-- Track store host liveness via the existing peer connection events.
-- On store host failure: emit a `StoreHostUnavailable` event; nodes fall back
-  to HuggingFace if `allow_hf_fallback: true`.
-- Optional: allow a secondary store host to be configured.
-- Stretch goal: replicate the store registry to a secondary node and promote
-  it automatically.
-
----
-
-### Phase 5 — Shard-aware staging and heterogeneous clusters
-
-Currently, `ModelStoreClient.stage_shard()` downloads **all** model files to
-every worker, regardless of which layers that node is responsible for.  MLX
-then loads only the relevant shard.  This wastes local staging space.
-
-Scope:
-- Accept a `ShardMetadata` in `stage_shard()` and filter the file list to
-  only the safetensors files that correspond to the assigned layer range.
-- Requires understanding the safetensors index to map layers -> files.
-- Unlocks running models on nodes with less RAM than the full shard.
-- Directly enables "Manual shard control" as a user-facing feature.
-
----
-
-### Phase 6 — Offline / air-gapped mode improvements
-
-`allow_hf_fallback: false` already prevents HuggingFace access.  Phase 6
-hardens the offline story:
-
-- CLI command to list models available in the store (`exo store list`).
-- CLI command to pre-fetch a model into the store without running inference
-  (`exo store pull mlx-community/Qwen3-30B-A3B-4bit`).
-- Store integrity check: verify file hashes on startup and surface
-  corruption via the dashboard.
-- Cleaner error messaging when a model is requested in offline mode and
-  is not in the store.
-
----
-
-## Contributing / upstream considerations
-
-This feature is designed to be proposable to the upstream exo project.
-Key design choices that support that goal:
-
-- **Zero-config compatible**: the feature is entirely opt-in via `exo.yaml`.
-  Existing deployments are unaffected.
-- **No new required dependencies**: `aiohttp` and `aiofiles` are already in
-  the dependency graph; only `pyyaml` was added.
-- **Wrapping, not forking**: `ModelStoreDownloader` wraps the existing
-  `ShardDownloader` interface rather than replacing it, so the existing
-  download stack is preserved intact.
-- **Minimal integration surface**: only two existing files were modified
-  (`main.py` and `worker/main.py`); everything else is new code in
-  `src/exo/store/`.
-- **Typed and strict**: all new code follows the project's `strict=True`
-  Pydantic and `basedpyright` conventions.
-- **`exo.yaml` is extensible**: future cluster-level features (networking
-  tuning, custom backends, resource policies) can add top-level sections
-  without breaking existing configs.
+- [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md)
+- [API guide](api.md)
+- [Architecture overview](architecture.md)
+- [exo.yaml example](https://github.com/Foxlight-Foundation/Skulk/blob/main/exo.yaml.example)

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -1,13 +1,9 @@
 # API Reference
 
-The generated backend API reference is rendered with ReDoc.
+<script>
+window.location.replace("../../generated/api/index.html");
+</script>
 
-<p><a href="../generated/api/index.html">Open full API reference</a></p>
+Redirecting to the generated API reference.
 
-If the embedded renderer below does not display correctly in your browser, use the full-page link above.
-
-<iframe
-  src="../generated/api/index.html"
-  title="Skulk API Reference"
-  style="width: 100%; min-height: 80vh; border: 1px solid #ddd; border-radius: 8px;"
-></iframe>
+If you are not redirected automatically, <a href="../../generated/api/index.html">open the API reference</a>.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -1,0 +1,13 @@
+# API Reference
+
+The generated backend API reference is rendered with ReDoc.
+
+<p><a href="../generated/api/index.html">Open full API reference</a></p>
+
+If the embedded renderer below does not display correctly in your browser, use the full-page link above.
+
+<iframe
+  src="../generated/api/index.html"
+  title="Skulk API Reference"
+  style="width: 100%; min-height: 80vh; border: 1px solid #ddd; border-radius: 8px;"
+></iframe>

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -9,3 +9,5 @@ Use this artifact if you want to:
 - inspect the machine-readable API schema
 - build client-generation workflows later
 - compare API changes over time in CI
+
+If you want a browsable version first, start with the [API Reference (ReDoc)](api-reference.md).

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -2,7 +2,7 @@
 
 The generated OpenAPI schema for the Skulk backend is published as JSON.
 
-<p><a href="../generated/openapi.json">Download <code>openapi.json</code></a></p>
+<p><a href="../../generated/openapi.json">Download <code>openapi.json</code></a></p>
 
 Use this artifact if you want to:
 

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -1,0 +1,11 @@
+# OpenAPI Schema
+
+The generated OpenAPI schema for the Skulk backend is published as JSON.
+
+<p><a href="../generated/openapi.json">Download <code>openapi.json</code></a></p>
+
+Use this artifact if you want to:
+
+- inspect the machine-readable API schema
+- build client-generation workflows later
+- compare API changes over time in CI

--- a/docs/reference/typedoc.md
+++ b/docs/reference/typedoc.md
@@ -1,0 +1,13 @@
+# TypeDoc
+
+The generated TypeDoc output documents the selected public TypeScript surface in `dashboard-react`.
+
+<p><a href="../generated/typedoc/index.html">Open full TypeDoc output</a></p>
+
+If the embedded renderer below does not display correctly in your browser, use the full-page link above.
+
+<iframe
+  src="../generated/typedoc/index.html"
+  title="Skulk TypeDoc"
+  style="width: 100%; min-height: 80vh; border: 1px solid #ddd; border-radius: 8px;"
+></iframe>

--- a/docs/reference/typedoc.md
+++ b/docs/reference/typedoc.md
@@ -1,13 +1,9 @@
 # TypeDoc
 
-The generated TypeDoc output documents the selected public TypeScript surface in `dashboard-react`.
+<script>
+window.location.replace("../../generated/typedoc/index.html");
+</script>
 
-<p><a href="../generated/typedoc/index.html">Open full TypeDoc output</a></p>
+Redirecting to the generated TypeDoc output.
 
-If the embedded renderer below does not display correctly in your browser, use the full-page link above.
-
-<iframe
-  src="../generated/typedoc/index.html"
-  title="Skulk TypeDoc"
-  style="width: 100%; min-height: 80vh; border: 1px solid #ddd; border-radius: 8px;"
-></iframe>
+If you are not redirected automatically, <a href="../../generated/typedoc/index.html">open TypeDoc</a>.

--- a/exo.yaml.example
+++ b/exo.yaml.example
@@ -1,21 +1,20 @@
-# exo.yaml - cluster configuration for Skulk
+# exo.yaml - optional Skulk cluster configuration
 #
-# You can configure much of this from the dashboard at:
+# You can manage much of this from the dashboard at:
 # http://localhost:52415
 #
-# If this file is absent, Skulk keeps its zero-config behavior and runs
-# without model-store features.
+# If this file is absent, Skulk keeps its zero-config behavior.
 #
-# This file is especially useful for:
-# - model_store
-# - inference.kv_cache_backend
-# - hf_token
+# This file is most useful when you want to:
+# - enable the shared model store
+# - choose an inference.kv_cache_backend
+# - persist an hf_token
 #
-# If you edit it manually for a cluster, keep it at the same relative path
-# on every node.
+# If you are using a cluster and editing this manually, keep it at the same
+# relative path on every node.
 
 model_store:
-  # Set false to disable the model store without deleting the file.
+  # Set to false to disable the model store without deleting the file.
   enabled: true
 
   # Hostname or libp2p node ID of the store host.

--- a/exo.yaml.example
+++ b/exo.yaml.example
@@ -1,87 +1,74 @@
-# exo.yaml — cluster configuration for exo
+# exo.yaml - cluster configuration for Skulk
 #
-# TIP: You can configure the model store visually from the dashboard at
-# http://localhost:52415/#/settings — the Settings page writes this file
-# and syncs it to all nodes automatically.
+# You can configure much of this from the dashboard at:
+# http://localhost:52415
 #
-# If editing manually, place this file alongside the exo project root on
-# every node in your cluster.  If this file is absent, exo behaves
-# identically to the upstream default (zero-config compatibility).
+# If this file is absent, Skulk keeps its zero-config behavior and runs
+# without model-store features.
 #
-# NOTE: Experimental KV cache backend controls such as
-# EXO_KV_CACHE_BACKEND, EXO_KV_CACHE_BITS, EXO_TQ_K_BITS,
-# EXO_TQ_V_BITS, and EXO_TQ_FP16_LAYERS are currently environment
-# variables, not exo.yaml settings. See docs/kv-cache-backends.md.
+# This file is especially useful for:
+# - model_store
+# - inference.kv_cache_backend
+# - hf_token
 #
-# ─────────────────────────────────────────────────────────────────────────────
-# MODEL STORE
-# ─────────────────────────────────────────────────────────────────────────────
-# By default, every exo node independently downloads its model shard from
-# HuggingFace at inference time.  For a small home cluster this means:
-#
-#   • Redundant external bandwidth — every node pulls the same files.
-#   • Slow cold starts on large models (30B+).
-#   • No offline capability after the first run.
-#
-# The model store solves this by designating one node as the store host.
-# The store host serves model files to all other nodes over HTTP on the
-# local network.  Worker nodes stage their assigned shard to node-local
-# storage before MLX loads it.  MLX always receives a local filesystem
-# path — it has no knowledge of the store.
-#
-# Minimum required fields: store_host, store_path
-#
-# See docs/model-store.md for full documentation.
-# ─────────────────────────────────────────────────────────────────────────────
+# If you edit it manually for a cluster, keep it at the same relative path
+# on every node.
 
 model_store:
-  # Master switch.  Set false to disable without removing the file.
+  # Set false to disable the model store without deleting the file.
   enabled: true
 
-  # Hostname (or libp2p node_id) of the node that hosts the model store.
-  # This node must have the storage device mounted at store_path.
+  # Hostname or libp2p node ID of the store host.
+  # For most users, hostname is the simplest choice.
   store_host: mac-studio-1
 
-  # HTTP port for the ModelStoreServer on the store host.
-  # Must be reachable from all worker nodes on the local network.
+  # Optional HTTP hostname or IP address used by worker nodes.
+  # Set this if store_host is a peer ID instead of a resolvable hostname.
+  # store_http_host: 192.168.1.10
+
+  # HTTP port used by the model store server.
   store_port: 58080
 
-  # Absolute path to the model store root on the store host.
-  # Model directories live here as <org>--<model>/ (e.g.
-  # mlx-community--Qwen3-30B-A3B-4bit/).
+  # Absolute path to the directory that holds store-managed models.
   store_path: /Volumes/ModelStore/models
 
   download:
-    # When true (default), nodes fall back to HuggingFace if a model is
-    # not yet in the store.  Set false for air-gapped deployments.
+    # If true, Skulk may fall back to Hugging Face when a model is not yet
+    # present in the store.
     allow_hf_fallback: true
 
   staging:
-    # Default staging config applied to all nodes without a node_override.
+    # Staging is where a node prepares model files before MLX loads them.
     enabled: true
-
-    # Local directory where model files are staged before MLX loads them.
-    # ~ is expanded per-node.  Each model occupies a subdirectory named
-    # <org>--<model> (e.g. mlx-community--Qwen3-30B-A3B-4bit/).
     node_cache_path: ~/.exo/staging
-
-    # Delete staged files when the model instance is deactivated.
-    # Keeps node-local storage lean at the cost of re-staging on next use.
     cleanup_on_deactivate: true
 
-  # Per-node overrides (matched by hostname or libp2p node_id).
-  # Use this to tune staging behaviour for nodes with different storage.
   node_overrides:
-
-    # Store host: point node_cache_path at the store itself so MLX loads
-    # directly from the attached storage — no copy needed.
+    # Store-host example: load directly from the store path instead of
+    # making a local copy.
     mac-studio-1:
       staging:
         node_cache_path: /Volumes/ModelStore/models
-        cleanup_on_deactivate: false   # store IS the cache; never delete it
+        cleanup_on_deactivate: false
 
-    # Node with fast NVMe — use it for staging instead of the home dir.
+    # Example worker with a fast local NVMe cache:
     # mac-mini-2:
     #   staging:
     #     node_cache_path: /Volumes/FastNVMe/exo-staging
     #     cleanup_on_deactivate: true
+
+inference:
+  # Valid values:
+  # - default
+  # - mlx_quantized
+  # - turboquant
+  # - turboquant_adaptive
+  # - optiq
+  #
+  # Environment variables still override this if you set them explicitly
+  # before launch.
+  kv_cache_backend: default
+
+# Optional Hugging Face token.
+# The dashboard Settings UI can manage this too.
+# hf_token: hf_xxxxxxxxxxxxxxxxxxxx

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,24 @@
+site_name: Skulk Developer Docs
+site_description: Generated and hand-written developer documentation for Skulk
+repo_url: https://github.com/Foxlight-Foundation/Skulk
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+
+docs_dir: docs
+site_dir: site
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - API Guide: api.md
+      - Model Store: model-store.md
+      - KV Cache Backends: kv-cache-backends.md
+      - Architecture: architecture.md
+  - Reference:
+      - OpenAPI Schema: reference/openapi.md
+      - API Reference (ReDoc): reference/api-reference.md
+      - TypeDoc: reference/typedoc.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,11 +2,7 @@ site_name: Skulk Developer Docs
 site_description: Generated and hand-written developer documentation for Skulk
 repo_url: https://github.com/Foxlight-Foundation/Skulk
 theme:
-  name: material
-  features:
-    - navigation.sections
-    - navigation.expand
-    - content.code.copy
+  name: shadcn
 
 docs_dir: docs
 site_dir: site

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exo = "exo.main:main"
 [dependency-groups]
 dev = [
   "basedpyright>=1.29.0",
-  "mkdocs-material>=9.6.0",
+  "mkdocs-shadcn>=0.10.2",
   "pyinstaller>=6.17.0",
   "pytest>=8.4.0",
   "pytest-asyncio>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ exo = "exo.main:main"
 [dependency-groups]
 dev = [
   "basedpyright>=1.29.0",
+  "mkdocs-material>=9.6.0",
   "pyinstaller>=6.17.0",
   "pytest>=8.4.0",
   "pytest-asyncio>=1.0.0",

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_GENERATED = REPO_ROOT / "docs" / "generated"
+SITE_DIR = REPO_ROOT / "site"
+SITE_GENERATED = SITE_DIR / "generated"
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> None:
+    subprocess.run(cmd, cwd=cwd or REPO_ROOT, check=True)
+
+
+def main() -> None:
+    run(["uv", "run", "python", "scripts/export_openapi.py"])
+    run(["npm", "run", "docs:typedoc"], cwd=REPO_ROOT / "dashboard-react")
+    run(["uv", "run", "mkdocs", "build", "--strict"])
+
+    if SITE_GENERATED.exists():
+        shutil.rmtree(SITE_GENERATED)
+    shutil.copytree(DOCS_GENERATED, SITE_GENERATED)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from urllib.request import urlopen
 
 os.environ.setdefault("EXO_HOME", ".skulk-docs-home")
 
@@ -38,6 +39,10 @@ def write_openapi(output_path: Path) -> None:
 
 def write_redoc_html(output_path: Path, openapi_json_path: str) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    redoc_bundle_path = output_path.parent / "redoc.standalone.js"
+    redoc_bundle_path.write_bytes(
+        urlopen("https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js").read()
+    )
     output_path.write_text(
         f"""<!doctype html>
 <html lang="en">
@@ -46,15 +51,37 @@ def write_redoc_html(output_path: Path, openapi_json_path: str) -> None:
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Skulk API Reference</title>
     <style>
+      html,
       body {{
         margin: 0;
         padding: 0;
+        height: 100%;
+      }}
+      #redoc-container {{
+        min-height: 100vh;
+      }}
+      #redoc-loading {{
+        font-family: system-ui, sans-serif;
+        padding: 1rem;
+        color: #334155;
       }}
     </style>
   </head>
   <body>
-    <redoc spec-url="{openapi_json_path}"></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+    <div id="redoc-loading">Loading API reference...</div>
+    <div id="redoc-container"></div>
+    <script src="./redoc.standalone.js"></script>
+    <script>
+      const loading = document.getElementById("redoc-loading");
+      const container = document.getElementById("redoc-container");
+      if (window.Redoc) {{
+        window.Redoc.init("{openapi_json_path}", {{}}, container, () => {{
+          if (loading) loading.remove();
+        }});
+      }} else if (loading) {{
+        loading.textContent = "Failed to load ReDoc assets.";
+      }}
+    </script>
   </body>
 </html>
 """,

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 from pathlib import Path
-from urllib.request import urlopen
 
 os.environ.setdefault("EXO_HOME", ".skulk-docs-home")
 
@@ -11,10 +11,15 @@ from exo.api.main import API
 from exo.shared.types.common import NodeId
 from exo.utils.channels import channel
 
-REDOC_BUNDLE_URL = (
-    "https://cdn.jsdelivr.net/npm/redoc@2.4.0/bundles/redoc.standalone.js"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REDOC_BUNDLE_SOURCE = (
+    REPO_ROOT
+    / "dashboard-react"
+    / "node_modules"
+    / "redoc"
+    / "bundles"
+    / "redoc.standalone.js"
 )
-REDOC_DOWNLOAD_TIMEOUT_SECONDS = 30
 
 
 def build_docs_api() -> API:
@@ -45,8 +50,12 @@ def write_openapi(output_path: Path) -> None:
 def write_redoc_html(output_path: Path, openapi_json_path: str) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     redoc_bundle_path = output_path.parent / "redoc.standalone.js"
-    with urlopen(REDOC_BUNDLE_URL, timeout=REDOC_DOWNLOAD_TIMEOUT_SECONDS) as response:
-        redoc_bundle_path.write_bytes(response.read())
+    if not REDOC_BUNDLE_SOURCE.exists():
+        raise FileNotFoundError(
+            "ReDoc bundle not found. Install dashboard dependencies first so "
+            f"{REDOC_BUNDLE_SOURCE} exists."
+        )
+    shutil.copy2(REDOC_BUNDLE_SOURCE, redoc_bundle_path)
     output_path.write_text(
         f"""<!doctype html>
 <html lang="en">

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+os.environ.setdefault("EXO_HOME", ".skulk-docs-home")
+
+from exo.api.main import API
+from exo.shared.types.common import NodeId
+from exo.utils.channels import channel
+
+
+def build_docs_api() -> API:
+    command_sender, _ = channel()
+    download_sender, _ = channel()
+    _, event_receiver = channel()
+    _, election_receiver = channel()
+
+    return API(
+        NodeId("docs-node"),
+        port=52415,
+        event_receiver=event_receiver,
+        command_sender=command_sender,
+        download_command_sender=download_sender,
+        election_receiver=election_receiver,
+        enable_event_log=False,
+        mount_dashboard=False,
+    )
+
+
+def write_openapi(output_path: Path) -> None:
+    api = build_docs_api()
+    schema = api.app.openapi()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(schema, indent=2) + "\n")
+
+
+def write_redoc_html(output_path: Path, openapi_json_path: str) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Skulk API Reference</title>
+    <style>
+      body {{
+        margin: 0;
+        padding: 0;
+      }}
+    </style>
+  </head>
+  <body>
+    <redoc spec-url="{openapi_json_path}"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  </body>
+</html>
+""",
+    )
+
+
+def main() -> None:
+    docs_root = Path("docs/generated")
+    openapi_path = docs_root / "openapi.json"
+    api_html_path = docs_root / "api" / "index.html"
+
+    write_openapi(openapi_path)
+    write_redoc_html(api_html_path, "../openapi.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -11,6 +11,11 @@ from exo.api.main import API
 from exo.shared.types.common import NodeId
 from exo.utils.channels import channel
 
+REDOC_BUNDLE_URL = (
+    "https://cdn.jsdelivr.net/npm/redoc@2.4.0/bundles/redoc.standalone.js"
+)
+REDOC_DOWNLOAD_TIMEOUT_SECONDS = 30
+
 
 def build_docs_api() -> API:
     command_sender, _ = channel()
@@ -40,9 +45,8 @@ def write_openapi(output_path: Path) -> None:
 def write_redoc_html(output_path: Path, openapi_json_path: str) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     redoc_bundle_path = output_path.parent / "redoc.standalone.js"
-    redoc_bundle_path.write_bytes(
-        urlopen("https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js").read()
-    )
+    with urlopen(REDOC_BUNDLE_URL, timeout=REDOC_DOWNLOAD_TIMEOUT_SECONDS) as response:
+        redoc_bundle_path.write_bytes(response.read())
     output_path.write_text(
         f"""<!doctype html>
 <html lang="en">

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -194,31 +194,31 @@ ONBOARDING_COMPLETE_FILE = EXO_CACHE_HOME / "onboarding_complete"
 API_TAGS_METADATA = [
     {
         "name": "Compatibility APIs",
-        "description": "OpenAI, Anthropic Claude, and Ollama-compatible endpoints.",
+        "description": "Endpoints that let existing SDKs and tools talk to Skulk using OpenAI, Claude, or Ollama-style request formats.",
     },
     {
         "name": "Models",
-        "description": "Model discovery, search, and custom model-card management.",
+        "description": "Model discovery, search, listing, and custom model-card management.",
     },
     {
         "name": "Instances",
-        "description": "Placement, launch, lookup, and deletion of model instances.",
+        "description": "Placement previews, launch flows, instance lookup, and lifecycle management for running models.",
     },
     {
         "name": "Downloads",
-        "description": "Low-level node download and staging-cache management.",
+        "description": "Low-level node download control and staging-cache management.",
     },
     {
         "name": "Store",
-        "description": "Central model-store health, registry, downloads, and optimization.",
+        "description": "Shared model-store health, registry inspection, download workflows, deletion, and optimization.",
     },
     {
         "name": "Config",
-        "description": "Cluster configuration and filesystem helpers used by the dashboard.",
+        "description": "Cluster configuration, safe filesystem browsing, and node identity helpers used by the dashboard.",
     },
     {
         "name": "State & Tracing",
-        "description": "Cluster state, event log, trace exports, and onboarding helpers.",
+        "description": "Cluster state, event log access, trace inspection/export, and onboarding helpers.",
     },
     {
         "name": "Images",
@@ -256,6 +256,19 @@ def _create_fastapi_app() -> FastAPI:
         redoc_url="/api/redoc",
         openapi_tags=API_TAGS_METADATA,
     )
+
+
+def _json_request_body(schema: dict[str, object]) -> dict[str, object]:
+    return {
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": schema,
+                }
+            },
+        }
+    }
 
 
 class API:
@@ -385,6 +398,7 @@ class API:
             "/instance",
             tags=["Instances"],
             summary="Create an instance from a fully specified placement",
+            description="Create an instance from an already computed placement object when you want exact control instead of Skulk picking the placement for you.",
         )(self.create_instance)
         self.app.post(
             "/place_instance",
@@ -399,6 +413,7 @@ class API:
             "/instance/placement",
             tags=["Instances"],
             summary="Compute a concrete placement for one requested combination",
+            description="Return the exact instance shape Skulk would create for one requested model, sharding mode, instance metadata, and node-count combination.",
         )(self.get_placement)
         self.app.get(
             "/instance/previews",
@@ -419,17 +434,29 @@ class API:
             tags=["Instances"],
             summary="Delete a running instance",
         )(self.delete_instance)
-        self.app.get("/models", tags=["Models"], summary="List known models")(self.get_models)
-        self.app.get("/v1/models", tags=["Models"], summary="List known models")(self.get_models)
+        self.app.get(
+            "/models",
+            tags=["Models"],
+            summary="List known models",
+            description="Return known model cards, including metadata Skulk uses for placement and compatibility decisions.",
+        )(self.get_models)
+        self.app.get(
+            "/v1/models",
+            tags=["Models"],
+            summary="List known models",
+            description="OpenAI-style model listing endpoint backed by Skulk's model catalog rather than only currently running instances.",
+        )(self.get_models)
         self.app.post(
             "/models/add",
             tags=["Models"],
             summary="Fetch and add a custom model card",
+            description="Add a custom model card to Skulk's model catalog so it becomes searchable and launchable through the API or dashboard.",
         )(self.add_custom_model)
         self.app.delete(
             "/models/custom/{model_id:path}",
             tags=["Models"],
             summary="Delete a custom model card",
+            description="Remove a previously added custom model card from Skulk's local catalog.",
         )(self.delete_custom_model)
         self.app.get(
             "/models/search",
@@ -507,6 +534,7 @@ class API:
             "/v1/cancel/{command_id}",
             tags=["Compatibility APIs"],
             summary="Cancel an active text or image command",
+            description="Request cancellation for an in-flight text or image generation command by its command ID.",
         )(self.cancel_command)
 
         # Ollama API
@@ -518,10 +546,18 @@ class API:
             tags=["Compatibility APIs"],
             summary="Ollama chat",
             description="Ollama-compatible chat endpoint backed by Skulk model placement and routing.",
+            openapi_extra=_json_request_body(OllamaChatRequest.model_json_schema()),
         )(self.ollama_chat)
         self.app.post("/ollama/api/api/chat", response_model=None, tags=["Compatibility APIs"], summary="Ollama chat alias")(self.ollama_chat)
         self.app.post("/ollama/api/v1/chat", response_model=None, tags=["Compatibility APIs"], summary="Ollama chat alias")(self.ollama_chat)
-        self.app.post("/ollama/api/generate", response_model=None, tags=["Compatibility APIs"], summary="Ollama generate")(self.ollama_generate)
+        self.app.post(
+            "/ollama/api/generate",
+            response_model=None,
+            tags=["Compatibility APIs"],
+            summary="Ollama generate",
+            description="Ollama-compatible prompt-completion endpoint backed by a placed Skulk model.",
+            openapi_extra=_json_request_body(OllamaGenerateRequest.model_json_schema()),
+        )(self.ollama_generate)
         self.app.get("/ollama/api/tags", tags=["Compatibility APIs"], summary="List Ollama models")(self.ollama_tags)
         self.app.get("/ollama/api/api/tags", tags=["Compatibility APIs"], summary="List Ollama models alias")(self.ollama_tags)
         self.app.get("/ollama/api/v1/tags", tags=["Compatibility APIs"], summary="List Ollama models alias")(self.ollama_tags)
@@ -529,17 +565,72 @@ class API:
         self.app.get("/ollama/api/ps", tags=["Compatibility APIs"], summary="List running Ollama models")(self.ollama_ps)
         self.app.get("/ollama/api/version", tags=["Compatibility APIs"], summary="Get Ollama API version")(self.ollama_version)
 
-        self.app.get("/state", tags=["State & Tracing"], summary="Get cluster state")(lambda: self.state)
-        self.app.get("/events", tags=["State & Tracing"], summary="Get stored event log")(self.stream_events)
-        self.app.post("/download/start", tags=["Downloads"], summary="Start a node download")(self.start_download)
-        self.app.delete("/download/{node_id}/{model_id:path}", tags=["Downloads"], summary="Delete a node download")(self.delete_download)
-        self.app.get("/v1/traces", tags=["State & Tracing"], summary="List saved traces")(self.list_traces)
-        self.app.post("/v1/traces/delete", tags=["State & Tracing"], summary="Delete saved traces")(self.delete_traces)
-        self.app.get("/v1/traces/{task_id}", tags=["State & Tracing"], summary="Get one saved trace")(self.get_trace)
-        self.app.get("/v1/traces/{task_id}/stats", tags=["State & Tracing"], summary="Get one trace summary")(self.get_trace_stats)
-        self.app.get("/v1/traces/{task_id}/raw", tags=["State & Tracing"], summary="Download raw trace JSON")(self.get_trace_raw)
-        self.app.get("/onboarding", tags=["State & Tracing"], summary="Get onboarding completion status")(self.get_onboarding)
-        self.app.post("/onboarding", tags=["State & Tracing"], summary="Mark onboarding complete")(self.complete_onboarding)
+        self.app.get(
+            "/state",
+            tags=["State & Tracing"],
+            summary="Get cluster state",
+            description="Return the current cluster state as seen by this API node, including topology, instances, and node capabilities.",
+        )(lambda: self.state)
+        self.app.get(
+            "/events",
+            tags=["State & Tracing"],
+            summary="Get stored event log",
+            description="Stream or return the API-side event log used for debugging state transitions and cluster behavior.",
+        )(self.stream_events)
+        self.app.post(
+            "/download/start",
+            tags=["Downloads"],
+            summary="Start a node download",
+            description="Start a low-level node download for a specific shard on a specific node.",
+        )(self.start_download)
+        self.app.delete(
+            "/download/{node_id}/{model_id:path}",
+            tags=["Downloads"],
+            summary="Delete a node download",
+            description="Delete or cancel a download associated with a given node and model.",
+        )(self.delete_download)
+        self.app.get(
+            "/v1/traces",
+            tags=["State & Tracing"],
+            summary="List saved traces",
+            description="List saved trace files that can be inspected for debugging and performance analysis.",
+        )(self.list_traces)
+        self.app.post(
+            "/v1/traces/delete",
+            tags=["State & Tracing"],
+            summary="Delete saved traces",
+            description="Delete one or more saved trace artifacts by task ID.",
+        )(self.delete_traces)
+        self.app.get(
+            "/v1/traces/{task_id}",
+            tags=["State & Tracing"],
+            summary="Get one saved trace",
+            description="Return the structured trace events for one saved task trace.",
+        )(self.get_trace)
+        self.app.get(
+            "/v1/traces/{task_id}/stats",
+            tags=["State & Tracing"],
+            summary="Get one trace summary",
+            description="Return aggregated timing statistics for one saved trace.",
+        )(self.get_trace_stats)
+        self.app.get(
+            "/v1/traces/{task_id}/raw",
+            tags=["State & Tracing"],
+            summary="Download raw trace JSON",
+            description="Download the raw Chrome trace JSON artifact for one task.",
+        )(self.get_trace_raw)
+        self.app.get(
+            "/onboarding",
+            tags=["State & Tracing"],
+            summary="Get onboarding completion status",
+            description="Return whether the dashboard onboarding flow has been completed on this node.",
+        )(self.get_onboarding)
+        self.app.post(
+            "/onboarding",
+            tags=["State & Tracing"],
+            summary="Mark onboarding complete",
+            description="Mark the local dashboard onboarding flow as complete.",
+        )(self.complete_onboarding)
 
         # Config & store endpoints
         self.app.get(
@@ -575,14 +666,30 @@ class API:
             summary="List active store downloads",
             description="List in-progress downloads being managed by the shared model store.",
         )(self.get_store_downloads)
-        self.app.delete("/store/models/{model_id:path}", tags=["Store"], summary="Delete a model from the store")(self.delete_store_model)
-        self.app.post("/store/models/{model_id:path}/download", tags=["Store"], summary="Request a store download")(
-            self.request_store_download
-        )
-        self.app.get("/store/models/{model_id:path}/download/status", tags=["Store"], summary="Get store download status")(
-            self.get_store_download_status
-        )
-        self.app.post("/store/purge-staging", tags=["Downloads"], summary="Purge staging caches")(self.purge_staging_caches)
+        self.app.delete(
+            "/store/models/{model_id:path}",
+            tags=["Store"],
+            summary="Delete a model from the store",
+            description="Delete a model and its shared-store artifacts from the configured model store.",
+        )(self.delete_store_model)
+        self.app.post(
+            "/store/models/{model_id:path}/download",
+            tags=["Store"],
+            summary="Request a store download",
+            description="Ask the shared model store to download and register a model by model ID.",
+        )(self.request_store_download)
+        self.app.get(
+            "/store/models/{model_id:path}/download/status",
+            tags=["Store"],
+            summary="Get store download status",
+            description="Return current status for a shared-store download request for one model.",
+        )(self.get_store_download_status)
+        self.app.post(
+            "/store/purge-staging",
+            tags=["Downloads"],
+            summary="Purge staging caches",
+            description="Broadcast a staging-cache purge request to nodes, optionally scoped to one model ID.",
+        )(self.purge_staging_caches)
         self.app.post(
             "/store/models/{model_id:path}/optimize",
             tags=["Store"],
@@ -592,9 +699,24 @@ class API:
                 "Use this for workflows such as OptiQ conversion or alternate artifact generation."
             ),
         )(self.optimize_model)
-        self.app.get("/store/models/{model_id:path}/optimize/status", tags=["Store"], summary="Get model optimization status")(self.get_optimize_status)
-        self.app.get("/filesystem/browse", tags=["Config"], summary="Browse filesystem roots for config selection")(self.browse_filesystem)
-        self.app.get("/node/identity", tags=["Config"], summary="Get node identity and preferred IP")(self.get_node_identity)
+        self.app.get(
+            "/store/models/{model_id:path}/optimize/status",
+            tags=["Store"],
+            summary="Get model optimization status",
+            description="Return the current status of an optimization job for one shared-store model.",
+        )(self.get_optimize_status)
+        self.app.get(
+            "/filesystem/browse",
+            tags=["Config"],
+            summary="Browse filesystem roots for config selection",
+            description="Browse a safe subset of filesystem roots so the dashboard can help users choose store and staging paths.",
+        )(self.browse_filesystem)
+        self.app.get(
+            "/node/identity",
+            tags=["Config"],
+            summary="Get node identity and preferred IP",
+            description="Return the node ID, hostname, and preferred LAN IP address that the dashboard uses during setup.",
+        )(self.get_node_identity)
 
     async def place_instance(self, payload: PlaceInstanceParams):
         command = PlaceInstance(

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -390,6 +390,10 @@ class API:
             "/place_instance",
             tags=["Instances"],
             summary="Quick-launch a model placement",
+            description=(
+                "Place and launch a model with Skulk choosing a valid concrete placement "
+                "from the requested sharding, instance metadata, and minimum-node constraints."
+            ),
         )(self.place_instance)
         self.app.get(
             "/instance/placement",
@@ -400,6 +404,10 @@ class API:
             "/instance/previews",
             tags=["Instances"],
             summary="Preview valid placements for a model",
+            description=(
+                "Return candidate placements for a model before launch. This is the best first "
+                "step when you want to see what Skulk can place on the current node or cluster."
+            ),
         )(self.get_placement_previews)
         self.app.get(
             "/instance/{instance_id}",
@@ -427,12 +435,20 @@ class API:
             "/models/search",
             tags=["Models"],
             summary="Search Hugging Face for models",
+            description=(
+                "Search for models to add or launch. Skulk prefers MLX-friendly results first, "
+                "then falls back to broader Hugging Face search results."
+            ),
         )(self.search_models)
         self.app.post(
             "/v1/chat/completions",
             response_model=None,
             tags=["Compatibility APIs"],
             summary="OpenAI Chat Completions-compatible text generation",
+            description=(
+                "Generate text with an OpenAI Chat Completions-compatible payload. The requested "
+                "model must already be placed and running or Skulk will return a not-found error."
+            ),
         )(
             self.chat_completions
         )
@@ -472,12 +488,20 @@ class API:
             response_model=None,
             tags=["Compatibility APIs"],
             summary="Anthropic Claude Messages-compatible endpoint",
+            description=(
+                "Claude Messages-compatible text generation endpoint. As with chat completions, "
+                "the target model must already be placed and ready."
+            ),
         )(self.claude_messages)
         self.app.post(
             "/v1/responses",
             response_model=None,
             tags=["Compatibility APIs"],
             summary="OpenAI Responses-compatible endpoint",
+            description=(
+                "OpenAI Responses-compatible endpoint for text generation and reasoning-style "
+                "workflows backed by a placed Skulk model."
+            ),
         )(self.openai_responses)
         self.app.post(
             "/v1/cancel/{command_id}",
@@ -488,7 +512,13 @@ class API:
         # Ollama API
         self.app.head("/ollama/", tags=["Compatibility APIs"], summary="Ollama version check")(self.ollama_version)
         self.app.head("/ollama/api/version", tags=["Compatibility APIs"], summary="Ollama version check")(self.ollama_version)
-        self.app.post("/ollama/api/chat", response_model=None, tags=["Compatibility APIs"], summary="Ollama chat")(self.ollama_chat)
+        self.app.post(
+            "/ollama/api/chat",
+            response_model=None,
+            tags=["Compatibility APIs"],
+            summary="Ollama chat",
+            description="Ollama-compatible chat endpoint backed by Skulk model placement and routing.",
+        )(self.ollama_chat)
         self.app.post("/ollama/api/api/chat", response_model=None, tags=["Compatibility APIs"], summary="Ollama chat alias")(self.ollama_chat)
         self.app.post("/ollama/api/v1/chat", response_model=None, tags=["Compatibility APIs"], summary="Ollama chat alias")(self.ollama_chat)
         self.app.post("/ollama/api/generate", response_model=None, tags=["Compatibility APIs"], summary="Ollama generate")(self.ollama_generate)
@@ -512,11 +542,39 @@ class API:
         self.app.post("/onboarding", tags=["State & Tracing"], summary="Mark onboarding complete")(self.complete_onboarding)
 
         # Config & store endpoints
-        self.app.get("/config", tags=["Config"], summary="Get cluster config")(self.get_config)
-        self.app.put("/config", tags=["Config"], summary="Update cluster config")(self.update_config)
-        self.app.get("/store/health", tags=["Store"], summary="Get model-store health")(self.get_store_health)
-        self.app.get("/store/registry", tags=["Store"], summary="Get model-store registry")(self.get_store_registry)
-        self.app.get("/store/downloads", tags=["Store"], summary="List active store downloads")(self.get_store_downloads)
+        self.app.get(
+            "/config",
+            tags=["Config"],
+            summary="Get cluster config",
+            description="Return the current cluster-wide config with sensitive fields such as the HF token removed.",
+        )(self.get_config)
+        self.app.put(
+            "/config",
+            tags=["Config"],
+            summary="Update cluster config",
+            description=(
+                "Update cluster-wide config. Some changes apply to future launches immediately, "
+                "while model-store location changes still require a restart."
+            ),
+        )(self.update_config)
+        self.app.get(
+            "/store/health",
+            tags=["Store"],
+            summary="Get model-store health",
+            description="Check whether the configured shared model store is enabled and reachable.",
+        )(self.get_store_health)
+        self.app.get(
+            "/store/registry",
+            tags=["Store"],
+            summary="Get model-store registry",
+            description="List models and metadata known to the shared store registry.",
+        )(self.get_store_registry)
+        self.app.get(
+            "/store/downloads",
+            tags=["Store"],
+            summary="List active store downloads",
+            description="List in-progress downloads being managed by the shared model store.",
+        )(self.get_store_downloads)
         self.app.delete("/store/models/{model_id:path}", tags=["Store"], summary="Delete a model from the store")(self.delete_store_model)
         self.app.post("/store/models/{model_id:path}/download", tags=["Store"], summary="Request a store download")(
             self.request_store_download
@@ -525,7 +583,15 @@ class API:
             self.get_store_download_status
         )
         self.app.post("/store/purge-staging", tags=["Downloads"], summary="Purge staging caches")(self.purge_staging_caches)
-        self.app.post("/store/models/{model_id:path}/optimize", tags=["Store"], summary="Start model optimization")(self.optimize_model)
+        self.app.post(
+            "/store/models/{model_id:path}/optimize",
+            tags=["Store"],
+            summary="Start model optimization",
+            description=(
+                "Start an optimization job for a model already present in the shared store. "
+                "Use this for workflows such as OptiQ conversion or alternate artifact generation."
+            ),
+        )(self.optimize_model)
         self.app.get("/store/models/{model_id:path}/optimize/status", tags=["Store"], summary="Get model optimization status")(self.get_optimize_status)
         self.app.get("/filesystem/browse", tags=["Config"], summary="Browse filesystem roots for config selection")(self.browse_filesystem)
         self.app.get("/node/identity", tags=["Config"], summary="Get node identity and preferred IP")(self.get_node_identity)

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -191,6 +191,41 @@ if TYPE_CHECKING:
 _API_EVENT_LOG_DIR = EXO_EVENT_LOG_DIR / "api"
 ONBOARDING_COMPLETE_FILE = EXO_CACHE_HOME / "onboarding_complete"
 
+API_TAGS_METADATA = [
+    {
+        "name": "Compatibility APIs",
+        "description": "OpenAI, Anthropic Claude, and Ollama-compatible endpoints.",
+    },
+    {
+        "name": "Models",
+        "description": "Model discovery, search, and custom model-card management.",
+    },
+    {
+        "name": "Instances",
+        "description": "Placement, launch, lookup, and deletion of model instances.",
+    },
+    {
+        "name": "Downloads",
+        "description": "Low-level node download and staging-cache management.",
+    },
+    {
+        "name": "Store",
+        "description": "Central model-store health, registry, downloads, and optimization.",
+    },
+    {
+        "name": "Config",
+        "description": "Cluster configuration and filesystem helpers used by the dashboard.",
+    },
+    {
+        "name": "State & Tracing",
+        "description": "Cluster state, event log, trace exports, and onboarding helpers.",
+    },
+    {
+        "name": "Images",
+        "description": "Image generation, editing, retrieval, and benchmarking endpoints.",
+    },
+]
+
 
 def _format_to_content_type(image_format: Literal["png", "jpeg", "webp"] | None) -> str:
     return f"image/{image_format or 'png'}"
@@ -203,6 +238,24 @@ def _ensure_seed(params: AdvancedImageParams | None) -> AdvancedImageParams:
     if params.seed is None:
         return params.model_copy(update={"seed": random.randint(0, 2**32 - 1)})
     return params
+
+
+def _create_fastapi_app() -> FastAPI:
+    return FastAPI(
+        title="Skulk API",
+        summary="Distributed inference, placement, store, and compatibility APIs for Skulk.",
+        description=(
+            "Skulk exposes OpenAI-compatible inference APIs, cluster placement controls, "
+            "model-store workflows, configuration endpoints, and debugging endpoints. "
+            "Most text-generation requests require the target model to already be placed "
+            "and running on the node or cluster."
+        ),
+        version="0.1.0",
+        openapi_url="/api/openapi.json",
+        docs_url="/api/docs",
+        redoc_url="/api/redoc",
+        openapi_tags=API_TAGS_METADATA,
+    )
 
 
 class API:
@@ -218,9 +271,11 @@ class API:
         election_receiver: Receiver[ElectionMessage],
         exo_config: "ExoConfig | None" = None,
         store_client: "ModelStoreClient | None" = None,
+        enable_event_log: bool = True,
+        mount_dashboard: bool = True,
     ) -> None:
         self.state = State()
-        self._event_log = DiskEventLog(_API_EVENT_LOG_DIR)
+        self._event_log = DiskEventLog(_API_EVENT_LOG_DIR) if enable_event_log else None
         self._system_id = SystemId()
         self.command_sender = command_sender
         self.download_command_sender = download_command_sender
@@ -241,7 +296,7 @@ class API:
         self.paused: bool = False
         self.paused_ev: anyio.Event = anyio.Event()
 
-        self.app = FastAPI()
+        self.app = _create_fastapi_app()
 
         @self.app.middleware("http")
         async def _log_requests(  # pyright: ignore[reportUnusedFunction]
@@ -255,14 +310,15 @@ class API:
         self._setup_cors()
         self._setup_routes()
 
-        self.app.mount(
-            "/",
-            StaticFiles(
-                directory=DASHBOARD_DIR,
-                html=True,
-            ),
-            name="dashboard",
-        )
+        if mount_dashboard:
+            self.app.mount(
+                "/",
+                StaticFiles(
+                    directory=DASHBOARD_DIR,
+                    html=True,
+                ),
+                name="dashboard",
+            )
 
         self._text_generation_queues: dict[
             CommandId,
@@ -276,8 +332,9 @@ class API:
 
     def reset(self, result_clock: int, event_receiver: Receiver[IndexedEvent]):
         logger.info("Resetting API State")
-        self._event_log.close()
-        self._event_log = DiskEventLog(_API_EVENT_LOG_DIR)
+        if self._event_log is not None:
+            self._event_log.close()
+            self._event_log = DiskEventLog(_API_EVENT_LOG_DIR)
         self.state = State()
         self._system_id = SystemId()
         self._text_generation_queues = {}
@@ -319,78 +376,159 @@ class API:
         )
 
     def _setup_routes(self) -> None:
-        self.app.get("/node_id")(lambda: self.node_id)
-        self.app.post("/instance")(self.create_instance)
-        self.app.post("/place_instance")(self.place_instance)
-        self.app.get("/instance/placement")(self.get_placement)
-        self.app.get("/instance/previews")(self.get_placement_previews)
-        self.app.get("/instance/{instance_id}")(self.get_instance)
-        self.app.delete("/instance/{instance_id}")(self.delete_instance)
-        self.app.get("/models")(self.get_models)
-        self.app.get("/v1/models")(self.get_models)
-        self.app.post("/models/add")(self.add_custom_model)
-        self.app.delete("/models/custom/{model_id:path}")(self.delete_custom_model)
-        self.app.get("/models/search")(self.search_models)
-        self.app.post("/v1/chat/completions", response_model=None)(
+        self.app.get(
+            "/node_id",
+            tags=["State & Tracing"],
+            summary="Get this API node's ID",
+        )(lambda: self.node_id)
+        self.app.post(
+            "/instance",
+            tags=["Instances"],
+            summary="Create an instance from a fully specified placement",
+        )(self.create_instance)
+        self.app.post(
+            "/place_instance",
+            tags=["Instances"],
+            summary="Quick-launch a model placement",
+        )(self.place_instance)
+        self.app.get(
+            "/instance/placement",
+            tags=["Instances"],
+            summary="Compute a concrete placement for one requested combination",
+        )(self.get_placement)
+        self.app.get(
+            "/instance/previews",
+            tags=["Instances"],
+            summary="Preview valid placements for a model",
+        )(self.get_placement_previews)
+        self.app.get(
+            "/instance/{instance_id}",
+            tags=["Instances"],
+            summary="Get one running instance",
+        )(self.get_instance)
+        self.app.delete(
+            "/instance/{instance_id}",
+            tags=["Instances"],
+            summary="Delete a running instance",
+        )(self.delete_instance)
+        self.app.get("/models", tags=["Models"], summary="List known models")(self.get_models)
+        self.app.get("/v1/models", tags=["Models"], summary="List known models")(self.get_models)
+        self.app.post(
+            "/models/add",
+            tags=["Models"],
+            summary="Fetch and add a custom model card",
+        )(self.add_custom_model)
+        self.app.delete(
+            "/models/custom/{model_id:path}",
+            tags=["Models"],
+            summary="Delete a custom model card",
+        )(self.delete_custom_model)
+        self.app.get(
+            "/models/search",
+            tags=["Models"],
+            summary="Search Hugging Face for models",
+        )(self.search_models)
+        self.app.post(
+            "/v1/chat/completions",
+            response_model=None,
+            tags=["Compatibility APIs"],
+            summary="OpenAI Chat Completions-compatible text generation",
+        )(
             self.chat_completions
         )
-        self.app.post("/bench/chat/completions")(self.bench_chat_completions)
-        self.app.post("/v1/images/generations", response_model=None)(
+        self.app.post(
+            "/bench/chat/completions",
+            tags=["Compatibility APIs"],
+            summary="Benchmark chat completions",
+        )(self.bench_chat_completions)
+        self.app.post(
+            "/v1/images/generations",
+            response_model=None,
+            tags=["Images"],
+            summary="Generate images",
+        )(
             self.image_generations
         )
-        self.app.post("/bench/images/generations")(self.bench_image_generations)
-        self.app.post("/v1/images/edits", response_model=None)(self.image_edits)
-        self.app.post("/bench/images/edits")(self.bench_image_edits)
-        self.app.get("/images")(self.list_images)
-        self.app.get("/images/{image_id}")(self.get_image)
-        self.app.post("/v1/messages", response_model=None)(self.claude_messages)
-        self.app.post("/v1/responses", response_model=None)(self.openai_responses)
-        self.app.post("/v1/cancel/{command_id}")(self.cancel_command)
+        self.app.post(
+            "/bench/images/generations",
+            tags=["Images"],
+            summary="Benchmark image generation",
+        )(self.bench_image_generations)
+        self.app.post(
+            "/v1/images/edits",
+            response_model=None,
+            tags=["Images"],
+            summary="Edit images",
+        )(self.image_edits)
+        self.app.post(
+            "/bench/images/edits",
+            tags=["Images"],
+            summary="Benchmark image editing",
+        )(self.bench_image_edits)
+        self.app.get("/images", tags=["Images"], summary="List stored images")(self.list_images)
+        self.app.get("/images/{image_id}", tags=["Images"], summary="Fetch one stored image")(self.get_image)
+        self.app.post(
+            "/v1/messages",
+            response_model=None,
+            tags=["Compatibility APIs"],
+            summary="Anthropic Claude Messages-compatible endpoint",
+        )(self.claude_messages)
+        self.app.post(
+            "/v1/responses",
+            response_model=None,
+            tags=["Compatibility APIs"],
+            summary="OpenAI Responses-compatible endpoint",
+        )(self.openai_responses)
+        self.app.post(
+            "/v1/cancel/{command_id}",
+            tags=["Compatibility APIs"],
+            summary="Cancel an active text or image command",
+        )(self.cancel_command)
 
         # Ollama API
-        self.app.head("/ollama/")(self.ollama_version)
-        self.app.head("/ollama/api/version")(self.ollama_version)
-        self.app.post("/ollama/api/chat", response_model=None)(self.ollama_chat)
-        self.app.post("/ollama/api/api/chat", response_model=None)(self.ollama_chat)
-        self.app.post("/ollama/api/v1/chat", response_model=None)(self.ollama_chat)
-        self.app.post("/ollama/api/generate", response_model=None)(self.ollama_generate)
-        self.app.get("/ollama/api/tags")(self.ollama_tags)
-        self.app.get("/ollama/api/api/tags")(self.ollama_tags)
-        self.app.get("/ollama/api/v1/tags")(self.ollama_tags)
-        self.app.post("/ollama/api/show")(self.ollama_show)
-        self.app.get("/ollama/api/ps")(self.ollama_ps)
-        self.app.get("/ollama/api/version")(self.ollama_version)
+        self.app.head("/ollama/", tags=["Compatibility APIs"], summary="Ollama version check")(self.ollama_version)
+        self.app.head("/ollama/api/version", tags=["Compatibility APIs"], summary="Ollama version check")(self.ollama_version)
+        self.app.post("/ollama/api/chat", response_model=None, tags=["Compatibility APIs"], summary="Ollama chat")(self.ollama_chat)
+        self.app.post("/ollama/api/api/chat", response_model=None, tags=["Compatibility APIs"], summary="Ollama chat alias")(self.ollama_chat)
+        self.app.post("/ollama/api/v1/chat", response_model=None, tags=["Compatibility APIs"], summary="Ollama chat alias")(self.ollama_chat)
+        self.app.post("/ollama/api/generate", response_model=None, tags=["Compatibility APIs"], summary="Ollama generate")(self.ollama_generate)
+        self.app.get("/ollama/api/tags", tags=["Compatibility APIs"], summary="List Ollama models")(self.ollama_tags)
+        self.app.get("/ollama/api/api/tags", tags=["Compatibility APIs"], summary="List Ollama models alias")(self.ollama_tags)
+        self.app.get("/ollama/api/v1/tags", tags=["Compatibility APIs"], summary="List Ollama models alias")(self.ollama_tags)
+        self.app.post("/ollama/api/show", tags=["Compatibility APIs"], summary="Show Ollama model details")(self.ollama_show)
+        self.app.get("/ollama/api/ps", tags=["Compatibility APIs"], summary="List running Ollama models")(self.ollama_ps)
+        self.app.get("/ollama/api/version", tags=["Compatibility APIs"], summary="Get Ollama API version")(self.ollama_version)
 
-        self.app.get("/state")(lambda: self.state)
-        self.app.get("/events")(self.stream_events)
-        self.app.post("/download/start")(self.start_download)
-        self.app.delete("/download/{node_id}/{model_id:path}")(self.delete_download)
-        self.app.get("/v1/traces")(self.list_traces)
-        self.app.post("/v1/traces/delete")(self.delete_traces)
-        self.app.get("/v1/traces/{task_id}")(self.get_trace)
-        self.app.get("/v1/traces/{task_id}/stats")(self.get_trace_stats)
-        self.app.get("/v1/traces/{task_id}/raw")(self.get_trace_raw)
-        self.app.get("/onboarding")(self.get_onboarding)
-        self.app.post("/onboarding")(self.complete_onboarding)
+        self.app.get("/state", tags=["State & Tracing"], summary="Get cluster state")(lambda: self.state)
+        self.app.get("/events", tags=["State & Tracing"], summary="Get stored event log")(self.stream_events)
+        self.app.post("/download/start", tags=["Downloads"], summary="Start a node download")(self.start_download)
+        self.app.delete("/download/{node_id}/{model_id:path}", tags=["Downloads"], summary="Delete a node download")(self.delete_download)
+        self.app.get("/v1/traces", tags=["State & Tracing"], summary="List saved traces")(self.list_traces)
+        self.app.post("/v1/traces/delete", tags=["State & Tracing"], summary="Delete saved traces")(self.delete_traces)
+        self.app.get("/v1/traces/{task_id}", tags=["State & Tracing"], summary="Get one saved trace")(self.get_trace)
+        self.app.get("/v1/traces/{task_id}/stats", tags=["State & Tracing"], summary="Get one trace summary")(self.get_trace_stats)
+        self.app.get("/v1/traces/{task_id}/raw", tags=["State & Tracing"], summary="Download raw trace JSON")(self.get_trace_raw)
+        self.app.get("/onboarding", tags=["State & Tracing"], summary="Get onboarding completion status")(self.get_onboarding)
+        self.app.post("/onboarding", tags=["State & Tracing"], summary="Mark onboarding complete")(self.complete_onboarding)
 
         # Config & store endpoints
-        self.app.get("/config")(self.get_config)
-        self.app.put("/config")(self.update_config)
-        self.app.get("/store/health")(self.get_store_health)
-        self.app.get("/store/registry")(self.get_store_registry)
-        self.app.get("/store/downloads")(self.get_store_downloads)
-        self.app.delete("/store/models/{model_id:path}")(self.delete_store_model)
-        self.app.post("/store/models/{model_id:path}/download")(
+        self.app.get("/config", tags=["Config"], summary="Get cluster config")(self.get_config)
+        self.app.put("/config", tags=["Config"], summary="Update cluster config")(self.update_config)
+        self.app.get("/store/health", tags=["Store"], summary="Get model-store health")(self.get_store_health)
+        self.app.get("/store/registry", tags=["Store"], summary="Get model-store registry")(self.get_store_registry)
+        self.app.get("/store/downloads", tags=["Store"], summary="List active store downloads")(self.get_store_downloads)
+        self.app.delete("/store/models/{model_id:path}", tags=["Store"], summary="Delete a model from the store")(self.delete_store_model)
+        self.app.post("/store/models/{model_id:path}/download", tags=["Store"], summary="Request a store download")(
             self.request_store_download
         )
-        self.app.get("/store/models/{model_id:path}/download/status")(
+        self.app.get("/store/models/{model_id:path}/download/status", tags=["Store"], summary="Get store download status")(
             self.get_store_download_status
         )
-        self.app.post("/store/purge-staging")(self.purge_staging_caches)
-        self.app.post("/store/models/{model_id:path}/optimize")(self.optimize_model)
-        self.app.get("/store/models/{model_id:path}/optimize/status")(self.get_optimize_status)
-        self.app.get("/filesystem/browse")(self.browse_filesystem)
-        self.app.get("/node/identity")(self.get_node_identity)
+        self.app.post("/store/purge-staging", tags=["Downloads"], summary="Purge staging caches")(self.purge_staging_caches)
+        self.app.post("/store/models/{model_id:path}/optimize", tags=["Store"], summary="Start model optimization")(self.optimize_model)
+        self.app.get("/store/models/{model_id:path}/optimize/status", tags=["Store"], summary="Get model optimization status")(self.get_optimize_status)
+        self.app.get("/filesystem/browse", tags=["Config"], summary="Browse filesystem roots for config selection")(self.browse_filesystem)
+        self.app.get("/node/identity", tags=["Config"], summary="Get node identity and preferred IP")(self.get_node_identity)
 
     async def place_instance(self, payload: PlaceInstanceParams):
         command = PlaceInstance(
@@ -833,7 +971,9 @@ class API:
             yield "]"
 
         return StreamingResponse(
-            _generate_json_array(self._event_log.read_all()),
+            _generate_json_array(
+                [] if self._event_log is None else self._event_log.read_all()
+            ),
             media_type="application/json",
         )
 
@@ -1729,7 +1869,8 @@ class API:
                     with anyio.CancelScope(shield=True):
                         shutdown_ev.set()
         finally:
-            self._event_log.close()
+            if self._event_log is not None:
+                self._event_log.close()
             self.command_sender.close()
             self.event_receiver.close()
 
@@ -1750,7 +1891,8 @@ class API:
     async def _apply_state(self):
         with self.event_receiver as events:
             async for i_event in events:
-                self._event_log.append(i_event.event)
+                if self._event_log is not None:
+                    self._event_log.append(i_event.event)
                 self.state = apply(self.state, i_event)
                 event = i_event.event
 

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -3,7 +3,7 @@ from collections.abc import Generator
 from typing import Annotated, Any, Literal, get_args
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from exo.shared.models.model_cards import ModelCard, ModelId
 from exo.shared.types.common import CommandId, NodeId
@@ -195,6 +195,17 @@ class StreamOptions(BaseModel):
 
 
 class ChatCompletionRequest(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                "messages": [{"role": "user", "content": "Hello from Skulk"}],
+                "stream": False,
+                "temperature": 0.7,
+            }
+        }
+    )
+
     model: ModelId
     frequency_penalty: float | None = None
     messages: list[ChatCompletionMessage]
@@ -228,6 +239,10 @@ class BenchChatCompletionRequest(ChatCompletionRequest):
 
 
 class AddCustomModelParams(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"model_id": "mlx-community/my-custom-model"}}
+    )
+
     model_id: ModelId
 
 
@@ -241,6 +256,17 @@ class HuggingFaceSearchResult(BaseModel):
 
 
 class PlaceInstanceParams(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                "sharding": "Pipeline",
+                "instance_meta": "MlxRing",
+                "min_nodes": 1,
+            }
+        }
+    )
+
     model_id: ModelId
     sharding: Sharding = Sharding.Pipeline
     instance_meta: InstanceMeta = InstanceMeta.MlxRing
@@ -248,6 +274,18 @@ class PlaceInstanceParams(BaseModel):
 
 
 class CreateInstanceParams(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "instance": {
+                    "shard_assignments": {
+                        "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit"
+                    }
+                }
+            }
+        }
+    )
+
     instance: Instance
 
 
@@ -262,6 +300,23 @@ class PlacementPreview(BaseModel):
 
 
 class PlacementPreviewResponse(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "previews": [
+                    {
+                        "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                        "sharding": "Pipeline",
+                        "instance_meta": "MlxRing",
+                        "instance": None,
+                        "memory_delta_by_node": None,
+                        "error": None,
+                    }
+                ]
+            }
+        }
+    )
+
     previews: list[PlacementPreview]
 
 
@@ -410,6 +465,18 @@ class ImageListResponse(BaseModel, frozen=True):
 
 
 class StartDownloadParams(CamelCaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "targetNodeId": "12D3KooWExampleNodeId",
+                "shardMetadata": {
+                    "type": "tensor",
+                    "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                },
+            }
+        }
+    )
+
     target_node_id: NodeId
     shard_metadata: ShardMetadata
 
@@ -423,6 +490,10 @@ class DeleteDownloadResponse(CamelCaseModel):
 
 
 class PurgeStagingRequest(CamelCaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"modelId": "mlx-community/Llama-3.2-1B-Instruct-4bit"}}
+    )
+
     model_id: str | None = None
 
 
@@ -474,6 +545,10 @@ class TraceListResponse(CamelCaseModel):
 
 
 class DeleteTracesRequest(CamelCaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"taskIds": ["chatcmpl-123", "chatcmpl-456"]}}
+    )
+
     task_ids: list[str]
 
 

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -278,8 +278,37 @@ class CreateInstanceParams(BaseModel):
         json_schema_extra={
             "example": {
                 "instance": {
-                    "shard_assignments": {
-                        "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit"
+                    "MlxRingInstance": {
+                        "instanceId": "00000000-0000-0000-0000-000000000000",
+                        "shardAssignments": {
+                            "modelId": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                            "runnerToShard": {
+                                "runner-1": {
+                                    "PipelineShardMetadata": {
+                                        "modelCard": {
+                                            "modelId": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                                            "storageSize": {"inBytes": 2147483648},
+                                            "nLayers": 32,
+                                            "hiddenSize": 2048,
+                                            "supportsTensor": False,
+                                            "tasks": ["TextGeneration"],
+                                        },
+                                        "deviceRank": 0,
+                                        "worldSize": 1,
+                                        "startLayer": 0,
+                                        "endLayer": 32,
+                                        "nLayers": 32,
+                                    }
+                                }
+                            },
+                            "nodeToRunner": {
+                                "node-1": "runner-1"
+                            }
+                        },
+                        "hostsByNode": {
+                            "node-1": []
+                        },
+                        "ephemeralPort": 52416,
                     }
                 }
             }
@@ -470,8 +499,21 @@ class StartDownloadParams(CamelCaseModel):
             "example": {
                 "targetNodeId": "12D3KooWExampleNodeId",
                 "shardMetadata": {
-                    "type": "tensor",
-                    "model_id": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                    "TensorShardMetadata": {
+                        "modelCard": {
+                            "modelId": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                            "storageSize": {"inBytes": 2147483648},
+                            "nLayers": 32,
+                            "hiddenSize": 2048,
+                            "supportsTensor": True,
+                            "tasks": ["TextGeneration"],
+                        },
+                        "deviceRank": 0,
+                        "worldSize": 1,
+                        "startLayer": 0,
+                        "endLayer": 32,
+                        "nLayers": 32,
+                    }
                 },
             }
         }

--- a/src/exo/api/types/claude_api.py
+++ b/src/exo/api/types/claude_api.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from exo.shared.types.common import ModelId
 
@@ -103,6 +103,17 @@ class ClaudeThinkingConfig(BaseModel, frozen=True):
 
 class ClaudeMessagesRequest(BaseModel):
     """Request body for Claude Messages API."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                "max_tokens": 512,
+                "messages": [{"role": "user", "content": "Hello from Claude-compatible Skulk"}],
+                "stream": False,
+            }
+        }
+    )
 
     model: ModelId
     max_tokens: int

--- a/src/exo/api/types/ollama_api.py
+++ b/src/exo/api/types/ollama_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from exo.shared.models.model_cards import ModelId
 
@@ -45,6 +45,16 @@ class OllamaOptions(BaseModel, frozen=True):
 
 
 class OllamaChatRequest(BaseModel, frozen=True):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                "messages": [{"role": "user", "content": "Hello from Ollama-compatible Skulk"}],
+                "stream": False,
+            }
+        }
+    )
+
     model: ModelId
     messages: list[OllamaMessage]
     stream: bool = True
@@ -56,6 +66,16 @@ class OllamaChatRequest(BaseModel, frozen=True):
 
 
 class OllamaGenerateRequest(BaseModel, frozen=True):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                "prompt": "Write a haiku about foxes",
+                "stream": False,
+            }
+        }
+    )
+
     model: ModelId
     prompt: str = ""
     system: str | None = None

--- a/src/exo/api/types/openai_responses.py
+++ b/src/exo/api/types/openai_responses.py
@@ -9,7 +9,7 @@ task params type used by the inference pipeline, see
 import time
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from exo.shared.types.common import ModelId
 from exo.shared.types.text_generation import ReasoningEffort
@@ -86,6 +86,16 @@ class ResponsesRequest(BaseModel, frozen=True):
     internal task params type is ``TextGenerationTaskParams``; see the
     ``responses_request_to_text_generation`` adapter for conversion.
     """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "model": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+                "input": "Hello from the Responses API",
+                "stream": False,
+            }
+        }
+    )
 
     # --- OpenAI Responses API standard fields ---
     model: ModelId

--- a/uv.lock
+++ b/uv.lock
@@ -182,29 +182,6 @@ wheels = [
 ]
 
 [[package]]
-name = "babel"
-version = "2.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
-]
-
-[[package]]
-name = "backrefs"
-version = "6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
-    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
-]
-
-[[package]]
 name = "basedpyright"
 version = "1.37.1"
 source = { registry = "https://pypi.org/simple" }
@@ -214,6 +191,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/b0/fbba81ea29eed1274e965cd0445f0d6020b467ff4d3393791e4d6ae02e64/basedpyright-1.37.1.tar.gz", hash = "sha256:1f47bc6f45cbcc5d6f8619d60aa42128e4b38942f5118dcd4bc20c3466c5e02f", size = 25235384, upload-time = "2026-01-08T14:42:46.447Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/d6/6b33bb49f08d761d7c958a1e3cecfb3ffbdcf4ba6bbed65b23ab47516b75/basedpyright-1.37.1-py3-none-any.whl", hash = "sha256:caf3adfe54f51623241712f8b4367adb51ef8a8c2288e3e1ec4118319661340d", size = 12297397, upload-time = "2026-01-08T14:42:50.306Z" },
+]
+
+[[package]]
+name = "bottle"
+version = "0.13.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/71/cca6167c06d00c81375fd668719df245864076d284f7cb46a694cbeb5454/bottle-0.13.4.tar.gz", hash = "sha256:787e78327e12b227938de02248333d788cfe45987edca735f8f88e03472c3f47", size = 98717, upload-time = "2025-06-15T10:08:59.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/f6/b55ec74cfe68c6584163faa311503c20b0da4c09883a41e8e00d6726c954/bottle-0.13.4-py2.py3-none-any.whl", hash = "sha256:045684fbd2764eac9cdeb824861d1551d113e8b683d8d26e296898d3dd99a12e", size = 103807, upload-time = "2025-06-15T10:08:57.691Z" },
 ]
 
 [[package]]
@@ -516,7 +502,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs-material", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mkdocs-shadcn", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyinstaller", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest-asyncio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -558,7 +544,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.29.0" },
-    { name = "mkdocs-material", specifier = ">=9.6.0" },
+    { name = "mkdocs-shadcn", specifier = ">=0.10.2" },
     { name = "pyinstaller", specifier = ">=6.17.0" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
@@ -770,6 +756,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
 ]
 
 [[package]]
@@ -1473,34 +1483,18 @@ wheels = [
 ]
 
 [[package]]
-name = "mkdocs-material"
-version = "9.7.6"
+name = "mkdocs-shadcn"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "babel", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "backrefs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "colorama", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "bottle", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "gitpython", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mkdocs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs-material-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "paginate", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pymdown-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/c6/d86f2494c1e1bd80d07d4ccd83862e6b4306dd8a39a97e22c0d15e54156c/mkdocs_shadcn-0.10.2.tar.gz", hash = "sha256:cc37a5a2d998dfec2fbfa24c6b67d20c5bd8b53ad36a17e51ef6e1b865be08a3", size = 3161105, upload-time = "2026-03-19T10:12:32.422Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
-]
-
-[[package]]
-name = "mkdocs-material-extensions"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+    { url = "https://files.pythonhosted.org/packages/15/73/ce6ebaaec752d90e774997e890b7a7cff6a0642c8dec9afd7ee8e047c9e0/mkdocs_shadcn-0.10.2-py3-none-any.whl", hash = "sha256:f3c4c5f7f4bf80506d6cf834c6a4201d0e447980020ad8fca145bdb46c20ede1", size = 1410494, upload-time = "2026-03-19T10:12:30.421Z" },
 ]
 
 [[package]]
@@ -2047,15 +2041,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/55/d0/88784ecdb0e481b39af721f637a60046e6f09ca03553aa71d788062e2012/packaging-26.0rc1.tar.gz", hash = "sha256:2104df24f61f17179ac8459cda8138cd344967d3b4f0934afa582a6826963fc5", size = 142273, upload-time = "2026-01-09T17:41:18.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/35/ddf3a6e8fc754fb939e2ea36fde96c28189184d6115afcf60011bb438ae5/packaging-26.0rc1-py3-none-any.whl", hash = "sha256:ecf921b33c620e357b1eed2ac3bc6313b1582874b0282d0773b6797b79cb0786", size = 74021, upload-time = "2026-01-09T17:41:17.134Z" },
-]
-
-[[package]]
-name = "paginate"
-version = "0.5.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
 ]
 
 [[package]]
@@ -2936,6 +2921,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -182,6 +182,29 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
+]
+
+[[package]]
 name = "basedpyright"
 version = "1.37.1"
 source = { registry = "https://pypi.org/simple" }
@@ -473,7 +496,7 @@ dependencies = [
     { name = "loguru", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mflux", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mlx", version = "0.30.6", source = { registry = "https://pypi.org/simple" }, extra = ["cpu"], marker = "sys_platform == 'linux'" },
-    { name = "mlx", version = "0.30.7.dev20260321+257d5692", source = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git?branch=address-rdma-gpu-locks#257d5692fc7af6bba3b8afaeb63c549b7d1e43d5" }, marker = "sys_platform == 'darwin'" },
+    { name = "mlx", version = "0.30.7.dev20260330+257d5692", source = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git?branch=address-rdma-gpu-locks#257d5692fc7af6bba3b8afaeb63c549b7d1e43d5" }, marker = "sys_platform == 'darwin'" },
     { name = "mlx-lm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mlx-optiq", extra = ["convert"], marker = "sys_platform == 'darwin'" },
     { name = "msgspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -493,6 +516,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mkdocs-material", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyinstaller", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest-asyncio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -534,6 +558,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.29.0" },
+    { name = "mkdocs-material", specifier = ">=9.6.0" },
     { name = "pyinstaller", specifier = ">=6.17.0" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
@@ -733,6 +758,18 @@ wheels = [
 [package.optional-dependencies]
 http = [
     { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
 ]
 
 [[package]]
@@ -1218,6 +1255,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1347,6 +1393,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
 name = "mflux"
 version = "0.16.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1357,7 +1412,7 @@ dependencies = [
     { name = "huggingface-hub", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "matplotlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mlx", version = "0.30.6", source = { registry = "https://pypi.org/simple" }, extra = ["cuda13"], marker = "sys_platform == 'linux'" },
-    { name = "mlx", version = "0.30.7.dev20260321+257d5692", source = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git?branch=address-rdma-gpu-locks#257d5692fc7af6bba3b8afaeb63c549b7d1e43d5" }, marker = "sys_platform == 'darwin'" },
+    { name = "mlx", version = "0.30.7.dev20260330+257d5692", source = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git?branch=address-rdma-gpu-locks#257d5692fc7af6bba3b8afaeb63c549b7d1e43d5" }, marker = "sys_platform == 'darwin'" },
     { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "opencv-python", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "piexif", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1378,6 +1433,74 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/dc/73dfccae395df22623fbb6f748657700fd9372be22904a0dafb825dc42d2/mflux-0.16.9.tar.gz", hash = "sha256:ff35e9386b5f026a6b97c786b3426e5341105de3356e55ec1b0c5951ff0ac8c8", size = 764296, upload-time = "2026-03-07T11:54:45.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/69/091df2d0f4a2677d5e2a8b326d568bd884d7ca37f15d3ff78e574aca2271/mflux-0.16.9-py3-none-any.whl", hash = "sha256:988e925653a024e81b46401fd5a2e423dd283428ba64949af4d9257e7df8ddd9", size = 1018804, upload-time = "2026-03-07T11:54:43.47Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "ghp-import", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "markupsafe", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mergedeep", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mkdocs-get-deps", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pathspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml-env-tag", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "watchdog", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "platformdirs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "backrefs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "colorama", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mkdocs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mkdocs-material-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "paginate", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pymdown-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
 ]
 
 [[package]]
@@ -1405,7 +1528,7 @@ cuda13 = [
 
 [[package]]
 name = "mlx"
-version = "0.30.7.dev20260321+257d5692"
+version = "0.30.7.dev20260330+257d5692"
 source = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git?branch=address-rdma-gpu-locks#257d5692fc7af6bba3b8afaeb63c549b7d1e43d5" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
@@ -1442,7 +1565,7 @@ version = "0.31.0"
 source = { git = "https://github.com/rltakashige/mlx-lm?branch=leo%2Feval-left-padding-in-batched-rotation#5e0c484cfb5c68d281a71409927ee1bb75adaae2" }
 dependencies = [
     { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mlx", version = "0.30.7.dev20260321+257d5692", source = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git?branch=address-rdma-gpu-locks#257d5692fc7af6bba3b8afaeb63c549b7d1e43d5" }, marker = "sys_platform == 'darwin'" },
+    { name = "mlx", version = "0.30.7.dev20260330+257d5692", source = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git?branch=address-rdma-gpu-locks#257d5692fc7af6bba3b8afaeb63c549b7d1e43d5" }, marker = "sys_platform == 'darwin'" },
     { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1455,7 +1578,7 @@ name = "mlx-optiq"
 version = "0.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx", version = "0.30.7.dev20260321+257d5692", source = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git?branch=address-rdma-gpu-locks#257d5692fc7af6bba3b8afaeb63c549b7d1e43d5" }, marker = "sys_platform == 'darwin'" },
+    { name = "mlx", version = "0.30.7.dev20260330+257d5692", source = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git?branch=address-rdma-gpu-locks#257d5692fc7af6bba3b8afaeb63c549b7d1e43d5" }, marker = "sys_platform == 'darwin'" },
     { name = "mlx-lm", marker = "sys_platform == 'darwin'" },
     { name = "numpy", marker = "sys_platform == 'darwin'" },
     { name = "scipy", marker = "sys_platform == 'darwin'" },
@@ -1927,6 +2050,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1960,6 +2092,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/1b/674e89996cc4be74db3c4eb09240c4bb549865c9c3f5d9b086ff8fcfbf00/pandas-3.0.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85fe4c4df62e1e20f9db6ebfb88c844b092c22cd5324bdcf94bfa2fc1b391221", size = 10740055, upload-time = "2026-02-17T22:20:04.328Z" },
     { url = "https://files.pythonhosted.org/packages/d0/f8/e954b750764298c22fa4614376531fe63c521ef517e7059a51f062b87dca/pandas-3.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:331ca75a2f8672c365ae25c0b29e46f5ac0c6551fdace8eec4cd65e4fac271ff", size = 11357632, upload-time = "2026-02-17T22:20:06.647Z" },
     { url = "https://files.pythonhosted.org/packages/6d/02/c6e04b694ffd68568297abd03588b6d30295265176a5c01b7459d3bc35a3/pandas-3.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15860b1fdb1973fffade772fdb931ccf9b2f400a3f5665aef94a00445d7d8dd5", size = 11810974, upload-time = "2026-02-17T22:20:08.946Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -2300,6 +2441,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2422,6 +2576,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
     { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -3129,6 +3295,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- refresh onboarding and API documentation for new adopters
- add generated docs infrastructure for OpenAPI, TypeDoc, and GitHub Pages
- switch the docs shell to mkdocs-shadcn and fix published wrapper/reference paths

## Validation
- `uv run python -m ruff check scripts/export_openapi.py scripts/build_docs.py`
- `uv run python scripts/build_docs.py`
- local browser verification of the generated site, ReDoc, and TypeDoc

## Notes
- `uv run python -m basedpyright` currently fails on preexisting repo issues outside this docs work, including existing unknown/Any typing in `src/exo/api/main.py`, `src/exo/download/coordinator.py`, and `src/exo/store/model_optimizer.py`
- `uv run python -m pytest` currently has one preexisting failure in `rust/exo_pyo3_bindings/tests/test_python.py::test_sleep_on_multiple_items` because `NetworkingHandle.__new__()` now expects additional arguments
- `nix fmt` could not be run in this environment because `nix` is not installed locally