### PR TITLE
feat: node restart from dashboard (local + remote)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,18 @@ These rules apply to every change. No exceptions.
 - **Use `@final` and immutability wherever applicable.**
 - **Comments explain why, not what.** Every non-obvious decision, workaround, or architectural choice gets a comment explaining the reasoning.
 
+### Handling Review Comments
+
+Evaluate each review comment on a 1–5 severity scale:
+
+- **1 — Nitpick**: Style preferences, minor wording, subjective suggestions. Ignore.
+- **2 — Low**: Nice-to-have improvements, minor refactors, cosmetic. Ignore.
+- **3 — Medium**: Valid point but not blocking. Note for future work, do not fix in this PR.
+- **4 — High**: Real bug, meaningful correctness issue, missing test coverage for critical path. **Fix.**
+- **5 — Critical**: Security vulnerability, data loss risk, will break production. **Fix immediately.**
+
+Only fix comments rated 4 or 5. Do not iterate on minor wording, style, or speculative improvements from automated reviewers (e.g., Copilot). Time spent on low-severity feedback is time not spent on real work.
+
 ### Before Every Commit
 
 1. Run the pre-commit checks (type check, lint, format, test) as documented above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,18 +103,40 @@ Rust code in `rust/` provides:
 - `system_custodian`: System-level operations
 
 ### Dashboard
-Svelte 5 + TypeScript frontend in `dashboard/`. Build output goes to `dashboard/build/` and is served by the API.
+React + TypeScript + styled-components frontend in `dashboard-react/`. Build output goes to `dashboard-react/dist/` and is served by the API. The legacy Svelte dashboard in `dashboard/` is from upstream exo and is not actively used.
 
-## Code Style Requirements
+## Mandatory Workflow Rules
 
-From .cursorrules:
-- Strict, exhaustive typing - never bypass the type-checker
-- Use `Literal[...]` for enum-like sets, `typing.NewType` for primitives
-- Pydantic models with `frozen=True` and `strict=True`
-- Pure functions with injectable effect handlers for side-effects
-- Descriptive names - no abbreviations or 3-letter acronyms
-- Catch exceptions only where you can handle them meaningfully
-- Use `@final` and immutability wherever applicable
+These rules apply to every change. No exceptions.
+
+### Documentation
+
+- **Every API endpoint must be documented** in `docs/api.md` with method, path, parameters, and behavior. If you add or modify an endpoint, update the docs in the same commit or PR.
+- **Every API endpoint must appear in the OpenAPI spec.** FastAPI auto-generates this from route decorators — ensure every route has `tags`, `summary`, and `description` set. Verify with `uv run python scripts/export_openapi.py` (output is gitignored but CI regenerates it).
+- **All public Python functions, classes, and methods must have docstrings** that are clear enough for generative documentation tools (mkdocs, pdoc, sphinx) to produce useful output. Describe what it does, parameters, return value, and any side effects.
+- **All Pydantic models and their fields must have descriptions** via docstrings or `Field(description=...)` for anything non-obvious. These flow into the OpenAPI spec.
+- **TypeScript components and hooks must have JSDoc comments** on exported interfaces, props, and non-trivial functions.
+- **Update CLAUDE.md** if you change architecture, add new topics/channels, or modify the build/test workflow.
+- **Update CONTRIBUTING.md** if you change project structure, add new directories, or modify development setup.
+
+### Code Quality
+
+- **Strict, exhaustive typing** — never bypass the type-checker. Use `Literal[...]` for enum-like sets, `typing.NewType` for primitives.
+- **Pydantic models** with `frozen=True` and `strict=True`.
+- **Pure functions** with injectable effect handlers for side-effects.
+- **Descriptive names** — no abbreviations or 3-letter acronyms.
+- **Catch exceptions only where you can handle them meaningfully.**
+- **Use `@final` and immutability wherever applicable.**
+- **Comments explain why, not what.** Every non-obvious decision, workaround, or architectural choice gets a comment explaining the reasoning.
+
+### Before Every Commit
+
+1. Run the pre-commit checks (type check, lint, format, test) as documented above.
+2. Verify that all new or modified API endpoints are documented in `docs/api.md`.
+3. Verify that all new or modified API endpoints have proper FastAPI decorators (`tags`, `summary`, `description`).
+4. Verify that all new or modified public functions have docstrings.
+5. If the dashboard was changed, run `npm run build` in `dashboard-react/` to confirm it builds.
+6. Stage any files changed by formatters before committing.
 
 ## Testing
 

--- a/dashboard-react/src/components/topology/ClusterNode.tsx
+++ b/dashboard-react/src/components/topology/ClusterNode.tsx
@@ -18,6 +18,8 @@ export interface ClusterNodeProps {
   edges?: TopologyEdge[];
   /** All nodes (needed for interface name resolution). */
   allNodes?: Record<string, NodeInfo>;
+  /** Called when the user confirms a node restart. */
+  onRestart?: () => void;
 }
 
 function buildDebugContent(
@@ -105,6 +107,7 @@ export function ClusterNode({
   scale = 1,
   edges = [],
   allNodes = {},
+  onRestart,
 }: ClusterNodeProps) {
   const model = detectDeviceModel(nodeInfo.system_info?.model_id);
 
@@ -156,6 +159,7 @@ export function ClusterNode({
         nameY={iconTop - nameOffset}
         memoryY={iconTop + iconH + memoryOffset}
         debugContent={debugContent}
+        onRestart={onRestart}
       />
 
       {/* Device icon — centered at origin */}

--- a/dashboard-react/src/components/topology/NodeLabel.tsx
+++ b/dashboard-react/src/components/topology/NodeLabel.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback } from 'react';
 import { formatBytes } from '../../utils/format';
 import { InfoTooltip } from '../common/InfoTooltip';
 
@@ -15,6 +16,8 @@ export interface NodeLabelProps {
   memoryY?: number;
   /** When set, shows an info icon next to the name with this content in a tooltip. */
   debugContent?: React.ReactNode;
+  /** When set, shows a restart icon before the name. */
+  onRestart?: () => void;
 }
 
 export function NodeLabel({
@@ -26,16 +29,56 @@ export function NodeLabel({
   nameY = 0,
   memoryY = 20,
   debugContent,
+  onRestart,
 }: NodeLabelProps) {
   const ramPercent = ramTotal > 0 ? ((ramUsed / ramTotal) * 100).toFixed(0) : '0';
   const usedStr = formatBytes(ramUsed);
   const totalStr = formatBytes(ramTotal);
 
-  // Estimate name width for positioning the info icon after it
+  // Estimate name width for positioning icons around the name text
   const nameWidth = name.length * fontSize * 0.62;
+
+  const [confirming, setConfirming] = useState(false);
+  const handleRestartClick = useCallback(() => {
+    if (!confirming) {
+      setConfirming(true);
+      setTimeout(() => setConfirming(false), 3000);
+      return;
+    }
+    setConfirming(false);
+    onRestart?.();
+  }, [confirming, onRestart]);
 
   return (
     <g>
+      {/* Restart icon — positioned left of the name text */}
+      {onRestart && (
+        <foreignObject
+          x={cx - nameWidth / 2 - 24}
+          y={nameY - 10}
+          width={20}
+          height={20}
+          style={{ overflow: 'visible' }}
+        >
+          <InfoTooltip
+            placement="left"
+            content={confirming ? 'Click again to confirm restart' : 'Restart this node — releases GPU memory and rejoins the cluster'}
+          >
+            <svg
+              width="16" height="16" viewBox="0 0 16 16" fill="none"
+              style={{ cursor: 'pointer', opacity: confirming ? 1 : 0.5, transition: 'opacity 0.15s' }}
+              onClick={handleRestartClick}
+              onMouseEnter={(e) => { (e.target as SVGElement).style.opacity = '1'; }}
+              onMouseLeave={(e) => { (e.target as SVGElement).style.opacity = confirming ? '1' : '0.5'; }}
+            >
+              <path
+                d="M13.65 2.35A7.96 7.96 0 0 0 8 0a8 8 0 1 0 8 8h-2a6 6 0 1 1-1.76-4.24L9 7h7V0l-2.35 2.35z"
+                fill={confirming ? '#f59e0b' : '#999'}
+              />
+            </svg>
+          </InfoTooltip>
+        </foreignObject>
+      )}
       {/* Name above */}
       <text x={cx} y={nameY} textAnchor="middle" dominantBaseline="middle"
         fill="#FFD700" fontSize={fontSize} fontWeight={700}

--- a/dashboard-react/src/components/topology/NodeLabel.tsx
+++ b/dashboard-react/src/components/topology/NodeLabel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { formatBytes } from '../../utils/format';
 import { InfoTooltip } from '../common/InfoTooltip';
 
@@ -39,12 +39,23 @@ export function NodeLabel({
   const nameWidth = name.length * fontSize * 0.62;
 
   const [confirming, setConfirming] = useState(false);
+  const confirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the confirmation timeout on unmount to avoid stale state updates
+  useEffect(() => {
+    return () => {
+      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+    };
+  }, []);
+
   const handleRestartClick = useCallback(() => {
     if (!confirming) {
       setConfirming(true);
-      setTimeout(() => setConfirming(false), 3000);
+      confirmTimerRef.current = setTimeout(() => setConfirming(false), 3000);
       return;
     }
+    if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+    confirmTimerRef.current = null;
     setConfirming(false);
     onRestart?.();
   }, [confirming, onRestart]);
@@ -68,8 +79,8 @@ export function NodeLabel({
               width="16" height="16" viewBox="0 0 16 16" fill="none"
               style={{ cursor: 'pointer', opacity: confirming ? 1 : 0.5, transition: 'opacity 0.15s' }}
               onClick={handleRestartClick}
-              onMouseEnter={(e) => { (e.target as SVGElement).style.opacity = '1'; }}
-              onMouseLeave={(e) => { (e.target as SVGElement).style.opacity = confirming ? '1' : '0.5'; }}
+              onMouseEnter={(e) => { (e.currentTarget as SVGElement).style.opacity = '1'; }}
+              onMouseLeave={(e) => { (e.currentTarget as SVGElement).style.opacity = confirming ? '1' : '0.5'; }}
             >
               <path
                 d="M13.65 2.35A7.96 7.96 0 0 0 8 0a8 8 0 1 0 8 8h-2a6 6 0 1 1-1.76-4.24L9 7h7V0l-2.35 2.35z"

--- a/dashboard-react/src/components/topology/NodeLabel.tsx
+++ b/dashboard-react/src/components/topology/NodeLabel.tsx
@@ -78,7 +78,11 @@ export function NodeLabel({
             <svg
               width="16" height="16" viewBox="0 0 16 16" fill="none"
               style={{ cursor: 'pointer', opacity: confirming ? 1 : 0.5, transition: 'opacity 0.15s' }}
+              role="button"
+              tabIndex={0}
+              aria-label={confirming ? 'Confirm restart of this node' : 'Restart this node'}
               onClick={handleRestartClick}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleRestartClick(); } }}
               onMouseEnter={(e) => { (e.currentTarget as SVGElement).style.opacity = '1'; }}
               onMouseLeave={(e) => { (e.currentTarget as SVGElement).style.opacity = confirming ? '1' : '0.5'; }}
             >

--- a/dashboard-react/src/components/topology/TopologyGraph.tsx
+++ b/dashboard-react/src/components/topology/TopologyGraph.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import type { TopologyData, TopologyEdge } from '../../types/topology';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
@@ -97,17 +97,9 @@ const Container = styled.div`
 
 export function TopologyGraph({ data }: TopologyGraphProps) {
   const [svgRef, { width, height }] = useResizeObserver<SVGSVGElement>();
-  const [localNodeId, setLocalNodeId] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetch('/node_id')
-      .then((r) => r.json())
-      .then((id) => setLocalNodeId(String(id)))
-      .catch(() => {});
-  }, []);
-
-  const handleRestart = useCallback(() => {
-    fetch('/admin/restart', { method: 'POST' }).catch(() => {});
+  const handleRestart = useCallback((nodeId: string) => {
+    fetch(`/admin/restart?node_id=${encodeURIComponent(nodeId)}`, { method: 'POST' }).catch(() => {});
   }, []);
 
   const nodeIds = useMemo(() => Object.keys(data.nodes), [data.nodes]);
@@ -241,7 +233,7 @@ export function TopologyGraph({ data }: TopologyGraphProps) {
               scale={nodeScale}
               edges={data.edges}
               allNodes={data.nodes}
-              onRestart={pos.id === localNodeId ? handleRestart : undefined}
+              onRestart={() => handleRestart(pos.id)}
             />
           ))}
         </g>

--- a/dashboard-react/src/components/topology/TopologyGraph.tsx
+++ b/dashboard-react/src/components/topology/TopologyGraph.tsx
@@ -99,7 +99,9 @@ export function TopologyGraph({ data }: TopologyGraphProps) {
   const [svgRef, { width, height }] = useResizeObserver<SVGSVGElement>();
 
   const handleRestart = useCallback((nodeId: string) => {
-    fetch(`/admin/restart?node_id=${encodeURIComponent(nodeId)}`, { method: 'POST' }).catch(() => {});
+    fetch(`/admin/restart?node_id=${encodeURIComponent(nodeId)}`, { method: 'POST' }).catch((error) => {
+      console.error('Failed to restart node', nodeId, error);
+    });
   }, []);
 
   const nodeIds = useMemo(() => Object.keys(data.nodes), [data.nodes]);

--- a/dashboard-react/src/components/topology/TopologyGraph.tsx
+++ b/dashboard-react/src/components/topology/TopologyGraph.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import type { TopologyData, TopologyEdge } from '../../types/topology';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
@@ -97,6 +97,18 @@ const Container = styled.div`
 
 export function TopologyGraph({ data }: TopologyGraphProps) {
   const [svgRef, { width, height }] = useResizeObserver<SVGSVGElement>();
+  const [localNodeId, setLocalNodeId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/node_id')
+      .then((r) => r.json())
+      .then((id) => setLocalNodeId(String(id)))
+      .catch(() => {});
+  }, []);
+
+  const handleRestart = useCallback(() => {
+    fetch('/admin/restart', { method: 'POST' }).catch(() => {});
+  }, []);
 
   const nodeIds = useMemo(() => Object.keys(data.nodes), [data.nodes]);
 
@@ -229,6 +241,7 @@ export function TopologyGraph({ data }: TopologyGraphProps) {
               scale={nodeScale}
               edges={data.edges}
               allNodes={data.nodes}
+              onRestart={pos.id === localNodeId ? handleRestart : undefined}
             />
           ))}
         </g>

--- a/docs/api.md
+++ b/docs/api.md
@@ -560,9 +560,9 @@ Returns hostname, preferred IP, and node identity information used by the dashbo
 
 **POST** `/admin/restart?node_id=<optional node id>`
 
-Gracefully restart the exo process on this or a remote node. When `node_id` is omitted or matches the local node, restarts directly by spawning a replacement process and exiting. When `node_id` targets a remote node, sends a `RestartNode` command via pub/sub.
+Gracefully restart the exo process on this or a remote node. When `node_id` is omitted or matches the local node, replaces the current process image in-place via `os.execv` (same PID). When `node_id` targets a remote node, sends a `RestartNode` command via pub/sub.
 
-- GPU memory is fully released when the old process exits
+- GPU/Metal memory is released when the process image is replaced
 - the node rejoins the cluster automatically on startup
 - active inference is interrupted
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -556,6 +556,18 @@ Used by the dashboard to browse a safe subset of the filesystem when selecting c
 
 Returns hostname, preferred IP, and node identity information used by the dashboard.
 
+### Restart a node
+
+**POST** `/admin/restart?node_id=<optional node id>`
+
+Gracefully restart the exo process on this or a remote node. When `node_id` is omitted or matches the local node, restarts directly by spawning a replacement process and exiting. When `node_id` targets a remote node, sends a `RestartNode` command via pub/sub.
+
+- GPU memory is fully released when the old process exits
+- the node rejoins the cluster automatically on startup
+- active inference is interrupted
+
+Returns `{"status": "restarting", "node_id": "..."}` for local restarts, or `{"status": "restart_sent", "node_id": "..."}` for remote restarts.
+
 ## State, Events, and Tracing
 
 ### Cluster state

--- a/docs/api.md
+++ b/docs/api.md
@@ -567,6 +567,7 @@ Gracefully restart the exo process on this or a remote node. When `node_id` is o
 - active inference is interrupted
 
 Returns `{"status": "restarting", "node_id": "..."}` for local restarts, or `{"status": "restart_sent", "node_id": "..."}` for remote restarts.
+If a local restart is already scheduled, returns HTTP 409 with `{"status": "restart_already_pending"}`.
 
 ## State, Events, and Tracing
 

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -763,9 +763,10 @@ class API:
         self.app.post(
             "/admin/restart",
             tags=["Admin"],
-            summary="Restart this node",
+            summary="Restart a node",
             description=(
-                "Gracefully restart the exo process on this node. "
+                "Gracefully restart the exo process on this or a remote node. "
+                "Pass node_id query param to target a specific node. "
                 "Active inference is interrupted, GPU memory is fully released, "
                 "and the node rejoins the cluster automatically on startup."
             ),
@@ -2811,31 +2812,40 @@ class API:
             if command_id in self._embedding_queues:
                 del self._embedding_queues[command_id]
 
-    async def restart_node(self) -> JSONResponse:
-        """Restart the exo process on this node.
+    async def restart_node(self, node_id: NodeId | None = None) -> JSONResponse:
+        """Restart the exo process on this or a remote node.
 
-        Spawns a new exo process and then exits the current one. The OS
-        reclaims all GPU memory when the old process exits, and the new
-        process takes over the port after a brief delay."""
-        import subprocess
-        import sys
-        import threading
+        If node_id is omitted or matches this node, restarts locally by
+        spawning a new process and exiting. Otherwise, sends a RestartNode
+        command via pub/sub to the target node."""
+        target = node_id or self.node_id
 
-        logger.info("Node restart requested via API — spawning replacement and exiting")
+        if target == self.node_id:
+            import subprocess
+            import sys
+            import threading
 
-        def _do_restart() -> None:
-            import time
+            logger.info("Node restart requested via API — spawning replacement and exiting")
 
-            time.sleep(1)  # Allow the JSON response to flush
-            # Spawn a new exo process that will take over once we exit
-            subprocess.Popen(
-                [sys.executable, *sys.argv],
-                start_new_session=True,
-            )
-            time.sleep(0.5)  # Brief pause to let the new process start binding
-            import os
+            def _do_restart() -> None:
+                import time
 
-            os._exit(0)  # Hard exit — releases all GPU/Metal memory
+                time.sleep(1)  # Allow the JSON response to flush
+                subprocess.Popen(
+                    [sys.executable, *sys.argv],
+                    start_new_session=True,
+                )
+                time.sleep(0.5)
+                import os
 
-        threading.Thread(target=_do_restart, daemon=True).start()
-        return JSONResponse({"status": "restarting", "node_id": str(self.node_id)})
+                os._exit(0)  # Hard exit — releases all GPU/Metal memory
+
+            threading.Thread(target=_do_restart, daemon=True).start()
+            return JSONResponse({"status": "restarting", "node_id": str(self.node_id)})
+
+        # Remote restart — send command via download commands channel
+        from exo.shared.types.commands import RestartNode
+
+        logger.info(f"Remote node restart requested for {target}")
+        await self._send_download(RestartNode(target_node_id=target))
+        return JSONResponse({"status": "restart_sent", "node_id": str(target)})

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2814,20 +2814,28 @@ class API:
     async def restart_node(self) -> JSONResponse:
         """Restart the exo process on this node.
 
-        Schedules a process restart via os.execv after a brief delay to allow
-        the HTTP response to be sent. The OS reclaims all GPU memory when the
-        process is replaced."""
-        import os
+        Spawns a new exo process and then exits the current one. The OS
+        reclaims all GPU memory when the old process exits, and the new
+        process takes over the port after a brief delay."""
+        import subprocess
         import sys
         import threading
 
-        logger.info("Node restart requested via API — restarting in 1 second")
+        logger.info("Node restart requested via API — spawning replacement and exiting")
 
         def _do_restart() -> None:
             import time
 
             time.sleep(1)  # Allow the JSON response to flush
-            os.execv(sys.executable, [sys.executable, *sys.argv])
+            # Spawn a new exo process that will take over once we exit
+            subprocess.Popen(
+                [sys.executable, *sys.argv],
+                start_new_session=True,
+            )
+            time.sleep(0.5)  # Brief pause to let the new process start binding
+            import os
+
+            os._exit(0)  # Hard exit — releases all GPU/Metal memory
 
         threading.Thread(target=_do_restart, daemon=True).start()
         return JSONResponse({"status": "restarting", "node_id": str(self.node_id)})

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -760,6 +760,16 @@ class API:
                 "Use this for workflows such as OptiQ conversion or alternate artifact generation."
             ),
         )(self.optimize_model)
+        self.app.post(
+            "/admin/restart",
+            tags=["Admin"],
+            summary="Restart this node",
+            description=(
+                "Gracefully restart the exo process on this node. "
+                "Active inference is interrupted, GPU memory is fully released, "
+                "and the node rejoins the cluster automatically on startup."
+            ),
+        )(self.restart_node)
         self.app.get(
             "/store/models/{model_id:path}/optimize/status",
             tags=["Store"],
@@ -2800,3 +2810,24 @@ class API:
             await self._send(TaskFinished(finished_command_id=command_id))
             if command_id in self._embedding_queues:
                 del self._embedding_queues[command_id]
+
+    async def restart_node(self) -> JSONResponse:
+        """Restart the exo process on this node.
+
+        Schedules a process restart via os.execv after a brief delay to allow
+        the HTTP response to be sent. The OS reclaims all GPU memory when the
+        process is replaced."""
+        import os
+        import sys
+        import threading
+
+        logger.info("Node restart requested via API — restarting in 1 second")
+
+        def _do_restart() -> None:
+            import time
+
+            time.sleep(1)  # Allow the JSON response to flush
+            os.execv(sys.executable, [sys.executable, *sys.argv])
+
+        threading.Thread(target=_do_restart, daemon=True).start()
+        return JSONResponse({"status": "restarting", "node_id": str(self.node_id)})

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -769,10 +769,10 @@ class API:
             tags=["Admin"],
             summary="Restart a node",
             description=(
-                "Gracefully restart the exo process on this or a remote node. "
+                "Restart the exo process on this or a remote node. "
                 "Pass node_id query param to target a specific node. "
-                "Active inference is interrupted, GPU memory is fully released, "
-                "and the node rejoins the cluster automatically on startup."
+                "Active inference is interrupted, and the process is replaced; "
+                "the node rejoins the cluster automatically on startup."
             ),
         )(self.restart_node)
         self.app.get(

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2819,9 +2819,9 @@ class API:
     async def restart_node(self, node_id: NodeId | None = None) -> JSONResponse:
         """Restart the exo process on this or a remote node.
 
-        If node_id is omitted or matches this node, restarts locally by
-        spawning a new process and exiting. Otherwise, sends a RestartNode
-        command via pub/sub to the target node."""
+        If node_id is omitted or matches this node, replaces the current
+        process image via os.execv (in-place restart, same PID). Otherwise,
+        sends a RestartNode command via pub/sub to the target node."""
         target = node_id or self.node_id
 
         if target == self.node_id:

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2812,6 +2812,8 @@ class API:
             if command_id in self._embedding_queues:
                 del self._embedding_queues[command_id]
 
+    _restart_pending: bool = False
+
     async def restart_node(self, node_id: NodeId | None = None) -> JSONResponse:
         """Restart the exo process on this or a remote node.
 
@@ -2821,26 +2823,17 @@ class API:
         target = node_id or self.node_id
 
         if target == self.node_id:
-            import subprocess
-            import sys
-            import threading
+            if self._restart_pending:
+                return JSONResponse(
+                    {"status": "restart_already_pending", "node_id": str(self.node_id)},
+                    status_code=409,
+                )
+            self._restart_pending = True
+
+            from exo.utils.restart import schedule_restart
 
             logger.info("Node restart requested via API — spawning replacement and exiting")
-
-            def _do_restart() -> None:
-                import time
-
-                time.sleep(1)  # Allow the JSON response to flush
-                subprocess.Popen(
-                    [sys.executable, *sys.argv],
-                    start_new_session=True,
-                )
-                time.sleep(0.5)
-                import os
-
-                os._exit(0)  # Hard exit — releases all GPU/Metal memory
-
-            threading.Thread(target=_do_restart, daemon=True).start()
+            schedule_restart()
             return JSONResponse({"status": "restarting", "node_id": str(self.node_id)})
 
         # Remote restart — send command via download commands channel

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -233,6 +233,10 @@ API_TAGS_METADATA = [
         "name": "Images",
         "description": "Image generation, editing, retrieval, and benchmarking endpoints.",
     },
+    {
+        "name": "Admin",
+        "description": "Administrative operations such as node restart.",
+    },
 ]
 
 
@@ -2812,8 +2816,6 @@ class API:
             if command_id in self._embedding_queues:
                 del self._embedding_queues[command_id]
 
-    _restart_pending: bool = False
-
     async def restart_node(self, node_id: NodeId | None = None) -> JSONResponse:
         """Restart the exo process on this or a remote node.
 
@@ -2823,17 +2825,15 @@ class API:
         target = node_id or self.node_id
 
         if target == self.node_id:
-            if self._restart_pending:
+            from exo.utils.restart import schedule_restart
+
+            logger.info("Node restart requested via API — scheduling process replacement")
+            scheduled = schedule_restart()
+            if not scheduled:
                 return JSONResponse(
                     {"status": "restart_already_pending", "node_id": str(self.node_id)},
                     status_code=409,
                 )
-            self._restart_pending = True
-
-            from exo.utils.restart import schedule_restart
-
-            logger.info("Node restart requested via API — spawning replacement and exiting")
-            schedule_restart()
             return JSONResponse({"status": "restarting", "node_id": str(self.node_id)})
 
         # Remote restart — send command via download commands channel

--- a/src/exo/api/tests/test_admin_restart.py
+++ b/src/exo/api/tests/test_admin_restart.py
@@ -59,18 +59,15 @@ def test_restart_local_node_with_explicit_id() -> None:
 
 
 def test_restart_idempotent_returns_409() -> None:
-    """Second local restart call should return 409."""
+    """If schedule_restart returns False (already pending), API returns 409."""
     api = _build_api()
     client = TestClient(api.app)
 
-    with patch("exo.utils.restart.schedule_restart", return_value=True):
-        response1 = client.post("/admin/restart")
-    assert response1.status_code == 200
+    with patch("exo.utils.restart.schedule_restart", return_value=False):
+        response = client.post("/admin/restart")
 
-    # The API's _restart_pending flag is now True
-    response2 = client.post("/admin/restart")
-    assert response2.status_code == 409
-    data: dict[str, Any] = response2.json()
+    assert response.status_code == 409
+    data: dict[str, Any] = response.json()
     assert data["status"] == "restart_already_pending"
 
 

--- a/src/exo/api/tests/test_admin_restart.py
+++ b/src/exo/api/tests/test_admin_restart.py
@@ -1,0 +1,96 @@
+# pyright: reportUnusedFunction=false, reportAny=false, reportPrivateUsage=false
+"""Tests for the POST /admin/restart API endpoint."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from exo.api.main import API
+from exo.shared.types.common import NodeId
+from exo.utils.channels import channel
+
+
+def _build_api(node_id: str = "test-node") -> API:
+    """Create a minimal API instance for testing."""
+    command_sender, _ = channel()
+    download_sender, _ = channel()
+    _, event_receiver = channel()
+    _, election_receiver = channel()
+    return API(
+        NodeId(node_id),
+        port=52415,
+        event_receiver=event_receiver,
+        command_sender=command_sender,
+        download_command_sender=download_sender,
+        election_receiver=election_receiver,
+        enable_event_log=False,
+        mount_dashboard=False,
+    )
+
+
+def test_restart_local_node() -> None:
+    """POST /admin/restart without node_id should trigger a local restart."""
+    api = _build_api()
+    client = TestClient(api.app)
+
+    with patch("exo.utils.restart.schedule_restart", return_value=True) as mock:
+        response = client.post("/admin/restart")
+
+    assert response.status_code == 200
+    data: dict[str, Any] = response.json()
+    assert data["status"] == "restarting"
+    assert data["node_id"] == "test-node"
+    mock.assert_called_once()
+
+
+def test_restart_local_node_with_explicit_id() -> None:
+    """POST /admin/restart?node_id=<self> should also trigger local restart."""
+    api = _build_api()
+    client = TestClient(api.app)
+
+    with patch("exo.utils.restart.schedule_restart", return_value=True) as mock:
+        response = client.post("/admin/restart?node_id=test-node")
+
+    assert response.status_code == 200
+    data: dict[str, Any] = response.json()
+    assert data["status"] == "restarting"
+    mock.assert_called_once()
+
+
+def test_restart_idempotent_returns_409() -> None:
+    """Second local restart call should return 409."""
+    api = _build_api()
+    client = TestClient(api.app)
+
+    with patch("exo.utils.restart.schedule_restart", return_value=True):
+        response1 = client.post("/admin/restart")
+    assert response1.status_code == 200
+
+    # The API's _restart_pending flag is now True
+    response2 = client.post("/admin/restart")
+    assert response2.status_code == 409
+    data: dict[str, Any] = response2.json()
+    assert data["status"] == "restart_already_pending"
+
+
+def test_restart_remote_node() -> None:
+    """POST /admin/restart?node_id=<other> should send RestartNode via pub/sub."""
+    api = _build_api("local-node")
+    client = TestClient(api.app)
+
+    with patch.object(api, "_send_download", new_callable=AsyncMock) as mock_send:
+        response = client.post("/admin/restart?node_id=remote-node")
+
+    assert response.status_code == 200
+    data: dict[str, Any] = response.json()
+    assert data["status"] == "restart_sent"
+    assert data["node_id"] == "remote-node"
+    mock_send.assert_called_once()
+
+    # Verify the command type and target
+    from exo.shared.types.commands import RestartNode
+
+    cmd = mock_send.call_args[0][0]
+    assert isinstance(cmd, RestartNode)
+    assert cmd.target_node_id == NodeId("remote-node")

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -22,6 +22,7 @@ from exo.shared.types.commands import (
     DeleteDownload,
     ForwarderDownloadCommand,
     PurgeStagingCache,
+    RestartNode,
     StartDownload,
     SyncConfig,
 )
@@ -150,6 +151,8 @@ class DownloadCoordinator:
                         await self._delete_download(model_id)
                     case CancelDownload(model_id=model_id):
                         await self._cancel_download(model_id)
+                    case RestartNode():
+                        await self._restart_node()
 
     async def _cancel_download(self, model_id: ModelId) -> None:
         if model_id in self.active_downloads and model_id in self.download_status:
@@ -165,6 +168,27 @@ class DownloadCoordinator:
             await self.event_sender.send(
                 NodeDownloadProgress(download_progress=pending)
             )
+
+    async def _restart_node(self) -> None:
+        """Restart this node by spawning a replacement process and exiting."""
+        import subprocess
+        import sys
+        import threading
+
+        logger.info("RestartNode command received — spawning replacement and exiting")
+
+        def _do_restart() -> None:
+            import time
+
+            time.sleep(1)  # Allow in-flight operations to settle
+            subprocess.Popen(
+                [sys.executable, *sys.argv],
+                start_new_session=True,
+            )
+            time.sleep(0.5)
+            os._exit(0)  # Hard exit — releases all GPU/Metal memory
+
+        threading.Thread(target=_do_restart, daemon=True).start()
 
     async def _sync_config(self, config_yaml: str) -> None:
         """Write received config YAML to the local exo.yaml file and

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -170,10 +170,10 @@ class DownloadCoordinator:
             )
 
     async def _restart_node(self) -> None:
-        """Restart this node by spawning a replacement process and exiting."""
+        """Restart this node by replacing the current process image (in-place restart)."""
         from exo.utils.restart import schedule_restart
 
-        logger.info("RestartNode command received — spawning replacement and exiting")
+        logger.info("RestartNode command received — scheduling in-place process restart")
         schedule_restart()
 
     async def _sync_config(self, config_yaml: str) -> None:

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -171,24 +171,10 @@ class DownloadCoordinator:
 
     async def _restart_node(self) -> None:
         """Restart this node by spawning a replacement process and exiting."""
-        import subprocess
-        import sys
-        import threading
+        from exo.utils.restart import schedule_restart
 
         logger.info("RestartNode command received — spawning replacement and exiting")
-
-        def _do_restart() -> None:
-            import time
-
-            time.sleep(1)  # Allow in-flight operations to settle
-            subprocess.Popen(
-                [sys.executable, *sys.argv],
-                start_new_session=True,
-            )
-            time.sleep(0.5)
-            os._exit(0)  # Hard exit — releases all GPU/Metal memory
-
-        threading.Thread(target=_do_restart, daemon=True).start()
+        schedule_restart()
 
     async def _sync_config(self, config_yaml: str) -> None:
         """Write received config YAML to the local exo.yaml file and

--- a/src/exo/shared/types/commands.py
+++ b/src/exo/shared/types/commands.py
@@ -98,6 +98,12 @@ class PurgeStagingCache(BaseCommand):
     model_id: ModelId | None = None
 
 
+class RestartNode(BaseCommand):
+    """Command to restart a specific node in the cluster."""
+
+    target_node_id: NodeId
+
+
 class AddCustomModelCard(BaseCommand):
     model_card: ModelCard
 
@@ -107,7 +113,7 @@ class DeleteCustomModelCard(BaseCommand):
 
 
 DownloadCommand = (
-    StartDownload | DeleteDownload | CancelDownload | SyncConfig | PurgeStagingCache
+    StartDownload | DeleteDownload | CancelDownload | SyncConfig | PurgeStagingCache | RestartNode
 )
 
 CustomModelCardCommand = AddCustomModelCard | DeleteCustomModelCard

--- a/src/exo/utils/restart.py
+++ b/src/exo/utils/restart.py
@@ -41,7 +41,7 @@ def schedule_restart(delay: float = 1.0) -> bool:
         except Exception as exc:
             # If we can't exec the replacement, keep the current process alive
             global _restart_scheduled
-            logger.error(f"Failed to exec replacement process: {exc}")
+            logger.exception(f"Failed to exec replacement process: {exc}")
             with _restart_lock:
                 _restart_scheduled = False
 

--- a/src/exo/utils/restart.py
+++ b/src/exo/utils/restart.py
@@ -1,12 +1,11 @@
 """Utility for cleanly restarting the current exo process.
 
-Spawns a replacement process and exits the current one. The OS reclaims
-all GPU/Metal memory when the old process exits, and the new process
-takes over the port after a brief delay.
+Uses os.execv to replace the current process image with a fresh one.
+This guarantees the old process releases its port before the new one
+binds, and the OS reclaims all GPU/Metal memory.
 """
 
 import os
-import subprocess
 import sys
 import threading
 
@@ -20,9 +19,8 @@ def schedule_restart(delay: float = 1.0) -> bool:
     """Schedule a process restart after *delay* seconds.
 
     Returns True if a restart was scheduled, False if one is already pending.
-    The restart spawns a new exo process, waits briefly for it to start,
-    then hard-exits the current process. If spawning the replacement fails,
-    the current process is left running.
+    After the delay, replaces the current process via os.execv. If execv
+    fails, the current process is left running and the guard is reset.
     """
     global _restart_scheduled
     with _restart_lock:
@@ -35,19 +33,16 @@ def schedule_restart(delay: float = 1.0) -> bool:
 
         time.sleep(delay)
         try:
-            subprocess.Popen(
-                [sys.executable, *sys.argv],
-                start_new_session=True,
-            )
+            # Replace the current process image. This never returns on
+            # success — the OS releases the port and all GPU memory as
+            # part of the exec, then the new process binds fresh.
+            os.execv(sys.executable, [sys.executable, *sys.argv])
         except Exception as exc:
-            # If we can't spawn the replacement, don't kill the current process
+            # If we can't exec the replacement, keep the current process alive
             global _restart_scheduled
-            logger.error(f"Failed to spawn replacement process: {exc}")
+            logger.error(f"Failed to exec replacement process: {exc}")
             with _restart_lock:
                 _restart_scheduled = False
-            return
-        time.sleep(0.5)
-        os._exit(0)
 
     threading.Thread(target=_do_restart, daemon=True).start()
     return True

--- a/src/exo/utils/restart.py
+++ b/src/exo/utils/restart.py
@@ -1,8 +1,9 @@
-"""Utility for cleanly restarting the current exo process.
+"""Utility for restarting the current exo process in-place.
 
 Uses os.execv to replace the current process image with a fresh one.
-This guarantees the old process releases its port before the new one
-binds, and the OS reclaims all GPU/Metal memory.
+Because exec replaces the image within the same PID, bound sockets are
+closed (assuming non-inheritable, which is Python's default) and Metal/GPU
+allocations are released by the OS. The new process then binds fresh.
 """
 
 import os
@@ -16,7 +17,7 @@ _restart_lock = threading.Lock()
 
 
 def schedule_restart(delay: float = 1.0) -> bool:
-    """Schedule a process restart after *delay* seconds.
+    """Schedule an in-place process restart after *delay* seconds.
 
     Returns True if a restart was scheduled, False if one is already pending.
     After the delay, replaces the current process via os.execv. If execv
@@ -33,10 +34,10 @@ def schedule_restart(delay: float = 1.0) -> bool:
 
         time.sleep(delay)
         try:
-            # Replace the current process image. This never returns on
-            # success — the OS releases the port and all GPU memory as
-            # part of the exec, then the new process binds fresh.
-            os.execv(sys.executable, [sys.executable, *sys.argv])
+            # Use `python -m exo` so restart works even when invoked via the
+            # `exo` console script (where sys.argv[0] is just "exo", not a
+            # valid Python file path). Preserve all original arguments.
+            os.execv(sys.executable, [sys.executable, "-m", "exo", *sys.argv[1:]])
         except Exception as exc:
             # If we can't exec the replacement, keep the current process alive
             global _restart_scheduled

--- a/src/exo/utils/restart.py
+++ b/src/exo/utils/restart.py
@@ -1,0 +1,53 @@
+"""Utility for cleanly restarting the current exo process.
+
+Spawns a replacement process and exits the current one. The OS reclaims
+all GPU/Metal memory when the old process exits, and the new process
+takes over the port after a brief delay.
+"""
+
+import os
+import subprocess
+import sys
+import threading
+
+from loguru import logger
+
+_restart_scheduled = False
+_restart_lock = threading.Lock()
+
+
+def schedule_restart(delay: float = 1.0) -> bool:
+    """Schedule a process restart after *delay* seconds.
+
+    Returns True if a restart was scheduled, False if one is already pending.
+    The restart spawns a new exo process, waits briefly for it to start,
+    then hard-exits the current process. If spawning the replacement fails,
+    the current process is left running.
+    """
+    global _restart_scheduled
+    with _restart_lock:
+        if _restart_scheduled:
+            return False
+        _restart_scheduled = True
+
+    def _do_restart() -> None:
+        import time
+
+        time.sleep(delay)
+        try:
+            subprocess.Popen(
+                [sys.executable, *sys.argv],
+                start_new_session=True,
+            )
+        except Exception as exc:
+            # If we can't spawn the replacement, don't kill the current process
+            global _restart_scheduled
+            logger.error(f"Failed to spawn replacement process: {exc}")
+            with _restart_lock:
+                _restart_scheduled = False
+            return
+        time.sleep(0.5)
+        os._exit(0)
+
+    threading.Thread(target=_do_restart, daemon=True).start()
+    return True

--- a/src/exo/utils/tests/test_restart.py
+++ b/src/exo/utils/tests/test_restart.py
@@ -1,0 +1,80 @@
+# pyright: reportUnusedFunction=false, reportAny=false, reportPrivateUsage=false
+"""Tests for exo.utils.restart — process restart scheduling."""
+
+from unittest.mock import MagicMock, patch
+
+from exo.utils import restart
+
+
+def _reset_restart_state() -> None:
+    """Reset the module-level restart guard between tests."""
+    with restart._restart_lock:
+        restart._restart_scheduled = False
+
+
+def test_schedule_restart_spawns_process_and_exits() -> None:
+    """schedule_restart should Popen a new process and call os._exit."""
+    _reset_restart_state()
+
+    with (
+        patch.object(restart.subprocess, "Popen") as mock_popen,
+        patch.object(restart.os, "_exit") as mock_exit,
+        patch.object(restart.threading, "Thread") as mock_thread_cls,
+    ):
+        # Capture the target function so we can run it synchronously
+        mock_thread = MagicMock()
+        mock_thread_cls.return_value = mock_thread
+
+        result = restart.schedule_restart(delay=0)
+        assert result is True
+        mock_thread.start.assert_called_once()
+
+        # Extract and run the restart function directly (skip the sleep)
+        target_fn = mock_thread_cls.call_args[1]["target"]
+        with patch("time.sleep"):
+            target_fn()
+
+        mock_popen.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+
+def test_schedule_restart_idempotent() -> None:
+    """Calling schedule_restart twice should return False the second time."""
+    _reset_restart_state()
+
+    with patch.object(restart.threading, "Thread") as mock_thread_cls:
+        mock_thread = MagicMock()
+        mock_thread_cls.return_value = mock_thread
+
+        assert restart.schedule_restart(delay=0) is True
+        assert restart.schedule_restart(delay=0) is False
+        # Only one thread should have been created
+        assert mock_thread_cls.call_count == 1
+
+
+def test_schedule_restart_recovers_on_popen_failure() -> None:
+    """If Popen fails, os._exit should NOT be called and the guard should reset."""
+    _reset_restart_state()
+
+    with (
+        patch.object(
+            restart.subprocess, "Popen", side_effect=OSError("spawn failed")
+        ) as mock_popen,
+        patch.object(restart.os, "_exit") as mock_exit,
+        patch.object(restart.threading, "Thread") as mock_thread_cls,
+    ):
+        mock_thread = MagicMock()
+        mock_thread_cls.return_value = mock_thread
+
+        restart.schedule_restart(delay=0)
+
+        # Run the target function
+        target_fn = mock_thread_cls.call_args[1]["target"]
+        with patch("time.sleep"):
+            target_fn()
+
+        mock_popen.assert_called_once()
+        mock_exit.assert_not_called()
+
+        # Guard should be reset so we can schedule again
+        assert not restart._restart_scheduled

--- a/src/exo/utils/tests/test_restart.py
+++ b/src/exo/utils/tests/test_restart.py
@@ -35,6 +35,30 @@ def test_schedule_restart_calls_execv() -> None:
         mock_execv.assert_called_once()
 
 
+def test_schedule_restart_uses_python_m_exo() -> None:
+    """Restart argv should use 'python -m exo' so console scripts work."""
+    _reset_restart_state()
+
+    with (
+        patch.object(restart.os, "execv") as mock_execv,
+        patch.object(restart.sys, "executable", "/usr/bin/python3"),
+        patch.object(restart.sys, "argv", ["exo", "--port", "8080"]),
+        patch.object(restart.threading, "Thread") as mock_thread_cls,
+    ):
+        mock_thread = MagicMock()
+        mock_thread_cls.return_value = mock_thread
+
+        restart.schedule_restart(delay=0)
+        target_fn = mock_thread_cls.call_args[1]["target"]
+        with patch("time.sleep"):
+            target_fn()
+
+        mock_execv.assert_called_once_with(
+            "/usr/bin/python3",
+            ["/usr/bin/python3", "-m", "exo", "--port", "8080"],
+        )
+
+
 def test_schedule_restart_idempotent() -> None:
     """Calling schedule_restart twice should return False the second time."""
     _reset_restart_state()

--- a/src/exo/utils/tests/test_restart.py
+++ b/src/exo/utils/tests/test_restart.py
@@ -12,16 +12,14 @@ def _reset_restart_state() -> None:
         restart._restart_scheduled = False
 
 
-def test_schedule_restart_spawns_process_and_exits() -> None:
-    """schedule_restart should Popen a new process and call os._exit."""
+def test_schedule_restart_calls_execv() -> None:
+    """schedule_restart should call os.execv to replace the process."""
     _reset_restart_state()
 
     with (
-        patch.object(restart.subprocess, "Popen") as mock_popen,
-        patch.object(restart.os, "_exit") as mock_exit,
+        patch.object(restart.os, "execv") as mock_execv,
         patch.object(restart.threading, "Thread") as mock_thread_cls,
     ):
-        # Capture the target function so we can run it synchronously
         mock_thread = MagicMock()
         mock_thread_cls.return_value = mock_thread
 
@@ -34,8 +32,7 @@ def test_schedule_restart_spawns_process_and_exits() -> None:
         with patch("time.sleep"):
             target_fn()
 
-        mock_popen.assert_called_once()
-        mock_exit.assert_called_once_with(0)
+        mock_execv.assert_called_once()
 
 
 def test_schedule_restart_idempotent() -> None:
@@ -52,15 +49,14 @@ def test_schedule_restart_idempotent() -> None:
         assert mock_thread_cls.call_count == 1
 
 
-def test_schedule_restart_recovers_on_popen_failure() -> None:
-    """If Popen fails, os._exit should NOT be called and the guard should reset."""
+def test_schedule_restart_recovers_on_execv_failure() -> None:
+    """If execv fails, the guard should reset so restart can be retried."""
     _reset_restart_state()
 
     with (
         patch.object(
-            restart.subprocess, "Popen", side_effect=OSError("spawn failed")
-        ) as mock_popen,
-        patch.object(restart.os, "_exit") as mock_exit,
+            restart.os, "execv", side_effect=OSError("exec failed")
+        ) as mock_execv,
         patch.object(restart.threading, "Thread") as mock_thread_cls,
     ):
         mock_thread = MagicMock()
@@ -73,8 +69,7 @@ def test_schedule_restart_recovers_on_popen_failure() -> None:
         with patch("time.sleep"):
             target_fn()
 
-        mock_popen.assert_called_once()
-        mock_exit.assert_not_called()
+        mock_execv.assert_called_once()
 
         # Guard should be reset so we can schedule again
         assert not restart._restart_scheduled


### PR DESCRIPTION
## Summary

Adds the ability to restart any node in the cluster from the dashboard cluster view.

- **`POST /admin/restart?node_id=<id>`** — restarts the target node. If omitted or local, replaces the current process image in-place via `os.execv` (same PID, ports and GPU memory released). If remote, sends a `RestartNode` command via the `DOWNLOAD_COMMANDS` pub/sub channel.
- **`RestartNode` command** — new targeted command in the download commands channel, handled by each node's `DownloadCoordinator`. Uses the same `target_node_id` filtering pattern as `StartDownload`/`DeleteDownload`.
- **Dashboard** — restart icon appears on **all** nodes in the topology. Two-click confirmation UX. Keyboard accessible (`role="button"`, `tabIndex`, Enter/Space support).
- **Idempotency** — duplicate restart requests return 409. If `os.execv` fails, the guard resets so retry is possible.
- **Console script safe** — uses `python -m exo` in the execv argv so restarts work when invoked via the `exo` console script entry point.

Uses `DOWNLOAD_COMMANDS` (not `COMMANDS`) so it works even when restarting the master node — no master relay needed.

Closes #68

## Test plan

- [ ] Manual: click restart icon on local node, verify exo restarts and rejoins cluster
- [ ] Manual: click restart icon on a remote node, verify remote node restarts
- [x] `npm run build` — dashboard builds cleanly
- [x] `uv run ruff check` — all checks passed
- [x] `uv run basedpyright` — no new errors
- [x] `uv run pytest` — 314 passed, 1 skipped (8 new restart tests)
- [x] Unit tests: execv called with correct argv, idempotency guard, execv failure recovery, console script argv, local/remote API routing, 409 on duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)