### PR TITLE
feat: centralized logging via Vector + VictoriaLogs + Grafana

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ Skulk supports shipping structured logs from all cluster nodes to a central [Vic
      grafana_user: admin
      grafana_password: <your-password>
    ```
-   Settings are synced to all nodes automatically via gossipsub.
+   Non-secret settings are synced to all nodes via gossipsub. Passwords and tokens stay on the local node only.
 
 3. **Install Vector** on each node:
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Skulk is built with a mix of Rust, Python, TypeScript (React for the dashboard),
 - `dashboard/` — Legacy Svelte dashboard (upstream EXO)
 - `rust/` — Rust components (networking, libp2p, PyO3 bindings)
 - `resources/inference_model_cards/` — Model metadata TOML files
+- `deployment/logging/` — VictoriaLogs + Grafana stack and Vector config
 - `docs/` — Technical documentation
 
 ### Dashboard (React)
@@ -157,9 +158,47 @@ Skulk uses `exo.yaml` for cluster configuration. Key sections:
 
 - `model_store` — Store host, paths, staging, download settings
 - `inference` — KV cache backend selection (`default`, `optiq`, `turboquant_adaptive`, etc.)
+- `logging` — Centralized log aggregation (`structured_stdout` toggle)
 - `hf_token` — HuggingFace API token
 
 Configuration can be edited directly in `exo.yaml` or through the dashboard Settings panel. Changes made via the dashboard are synced to all nodes automatically via gossipsub.
+
+## Centralized Logging
+
+Skulk supports shipping structured logs from all cluster nodes to a central [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) instance via [Vector](https://vector.dev/).
+
+### Setup
+
+1. **Deploy the logging stack** on a central server (e.g. via Portainer):
+   ```bash
+   docker compose -f deployment/logging/docker-compose.yml up -d
+   ```
+   This starts VictoriaLogs (port 9428) and Grafana (port 3000).
+
+2. **Enable structured stdout** in `exo.yaml` on each node:
+   ```yaml
+   logging:
+     structured_stdout: true
+   ```
+
+3. **Install Vector** on each node:
+   ```bash
+   brew install vectordotdev/brew/vector
+   ```
+   (Vector is also available via `nix develop` if using the nix dev shell.)
+
+4. **Run exo piped through Vector**:
+   ```bash
+   uv run exo 2>/dev/tty | vector --config deployment/logging/vector.yaml
+   ```
+   stderr goes to the terminal (human-readable), stdout goes to Vector → VictoriaLogs.
+
+5. **Update the VictoriaLogs URL** in `deployment/logging/vector.yaml` if your logging server is not at `192.168.0.118:9428`.
+
+### Browsing Logs
+
+- **VictoriaLogs VMUI**: `http://<logging-server>:9428/select/vmui/`
+- **Grafana**: `http://<logging-server>:3000` (default login: admin/admin)
 
 ## API Adapters
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,10 +181,8 @@ Skulk supports shipping structured logs from all cluster nodes to a central [Vic
      enabled: true
      ingest_url: http://<logging-server>:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
      grafana_url: http://<logging-server>:3000
-     grafana_user: admin
-     grafana_password: <your-password>
    ```
-   Non-secret settings are synced to all nodes via gossipsub. Passwords and tokens stay on the local node only.
+   Settings are synced to all nodes via gossipsub.
 
 3. **Install Vector** on each node:
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Skulk uses `exo.yaml` for cluster configuration. Key sections:
 
 - `model_store` — Store host, paths, staging, download settings
 - `inference` — KV cache backend selection (`default`, `optiq`, `turboquant_adaptive`, etc.)
-- `logging` — Centralized log aggregation (ingest URL, Grafana credentials)
+- `logging` — Centralized log aggregation (enabled toggle, ingest URL)
 - `hf_token` — HuggingFace API token
 
 Configuration can be edited directly in `exo.yaml` or through the dashboard Settings panel. Changes made via the dashboard are synced to all nodes automatically via gossipsub.
@@ -180,7 +180,6 @@ Skulk supports shipping structured logs from all cluster nodes to a central [Vic
    logging:
      enabled: true
      ingest_url: http://<logging-server>:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
-     grafana_url: http://<logging-server>:3000
    ```
    Settings are synced to all nodes via gossipsub.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,7 @@ Skulk supports shipping structured logs from all cluster nodes to a central [Vic
 ### Browsing Logs
 
 - **VictoriaLogs VMUI**: `http://<logging-server>:9428/select/vmui/`
-- **Grafana**: `http://<logging-server>:3000` (default login: admin/admin)
+- **Grafana**: `http://<logging-server>:3000` (login with the credentials configured in your exo.yaml logging section or set during stack deployment)
 
 ## API Adapters
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Skulk uses `exo.yaml` for cluster configuration. Key sections:
 
 - `model_store` — Store host, paths, staging, download settings
 - `inference` — KV cache backend selection (`default`, `optiq`, `turboquant_adaptive`, etc.)
-- `logging` — Centralized log aggregation (`structured_stdout` toggle)
+- `logging` — Centralized log aggregation (ingest URL, Grafana credentials)
 - `hf_token` — HuggingFace API token
 
 Configuration can be edited directly in `exo.yaml` or through the dashboard Settings panel. Changes made via the dashboard are synced to all nodes automatically via gossipsub.
@@ -175,11 +175,16 @@ Skulk supports shipping structured logs from all cluster nodes to a central [Vic
    ```
    This starts VictoriaLogs (port 9428) and Grafana (port 3000).
 
-2. **Enable structured stdout** in `exo.yaml` on each node:
+2. **Configure logging** in the dashboard Settings panel, or in `exo.yaml`:
    ```yaml
    logging:
-     structured_stdout: true
+     enabled: true
+     ingest_url: http://<logging-server>:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
+     grafana_url: http://<logging-server>:3000
+     grafana_user: admin
+     grafana_password: <your-password>
    ```
+   Settings are synced to all nodes automatically via gossipsub.
 
 3. **Install Vector** on each node:
    ```bash

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -212,7 +212,7 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
   const [kvBackend, setKvBackend] = useState('default');
   const [hfToken, setHfToken] = useState('');
   const [loggingDraft, setLoggingDraft] = useState<LoggingConfig>({
-    enabled: false, ingest_url: '', grafana_url: '', grafana_user: '',
+    enabled: false, ingest_url: '', grafana_url: '',
   });
 
   // Fetch config when panel opens
@@ -232,8 +232,6 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
       enabled: fullConfig?.logging?.enabled ?? false,
       ingest_url: fullConfig?.logging?.ingest_url ?? '',
       grafana_url: fullConfig?.logging?.grafana_url ?? '',
-      grafana_user: fullConfig?.logging?.grafana_user ?? '',
-      has_grafana_password: fullConfig?.logging?.has_grafana_password,
     });
   }, [fullConfig, effective]);
 
@@ -507,27 +505,8 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
                     placeholder="http://host:3000"
                   />
                 </Row>
-                <Row>
-                  <FieldLabel>Grafana user</FieldLabel>
-                  <StyledField
-                    size="sm"
-                    value={loggingDraft.grafana_user}
-                    onChange={(e) => setLoggingDraft(prev => ({ ...prev, grafana_user: (e.target as HTMLInputElement).value }))}
-                    placeholder="admin"
-                  />
-                </Row>
-                <Row>
-                  <FieldLabel>Grafana password</FieldLabel>
-                  <StyledField
-                    size="sm"
-                    type="password"
-                    value={loggingDraft.grafana_password ?? ''}
-                    onChange={(e) => setLoggingDraft(prev => ({ ...prev, grafana_password: (e.target as HTMLInputElement).value }))}
-                    placeholder={loggingDraft.has_grafana_password ? "Password is set — enter new to replace" : "password"}
-                  />
-                </Row>
                 <HintText>
-                  Non-secret settings are synced to all nodes. Grafana password stays local. Nodes will start shipping logs when saved.
+                  Settings are synced to all nodes. Nodes will start shipping logs when saved.
                 </HintText>
               </>
             )}

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -527,7 +527,7 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
                   />
                 </Row>
                 <HintText>
-                  Settings are synced to all nodes. Nodes will start shipping logs when saved.
+                  Non-secret settings are synced to all nodes. Grafana password stays local. Nodes will start shipping logs when saved.
                 </HintText>
               </>
             )}

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -212,7 +212,7 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
   const [kvBackend, setKvBackend] = useState('default');
   const [hfToken, setHfToken] = useState('');
   const [loggingDraft, setLoggingDraft] = useState<LoggingConfig>({
-    enabled: false, ingest_url: '', grafana_url: '',
+    enabled: false, ingest_url: '',
   });
 
   // Fetch config when panel opens
@@ -231,7 +231,6 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
     setLoggingDraft({
       enabled: fullConfig?.logging?.enabled ?? false,
       ingest_url: fullConfig?.logging?.ingest_url ?? '',
-      grafana_url: fullConfig?.logging?.grafana_url ?? '',
     });
   }, [fullConfig, effective]);
 
@@ -494,15 +493,6 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
                     value={loggingDraft.ingest_url}
                     onChange={(e) => setLoggingDraft(prev => ({ ...prev, ingest_url: (e.target as HTMLInputElement).value }))}
                     placeholder="http://host:9428/insert/jsonline?_stream_fields=..."
-                  />
-                </Row>
-                <Row>
-                  <FieldLabel>Grafana URL</FieldLabel>
-                  <StyledField
-                    size="sm"
-                    value={loggingDraft.grafana_url}
-                    onChange={(e) => setLoggingDraft(prev => ({ ...prev, grafana_url: (e.target as HTMLInputElement).value }))}
-                    placeholder="http://host:3000"
                   />
                 </Row>
                 <HintText>

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
-import { useConfig, type StoreConfig, type FullConfig } from '../../hooks/useConfig';
+import { useConfig, type StoreConfig, type FullConfig, type LoggingConfig } from '../../hooks/useConfig';
 import { Button } from '../common/Button';
 import { Field } from '../common/Field';
 import { InfoTooltip } from '../common/InfoTooltip';
@@ -211,6 +211,9 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
   const [draft, setDraft] = useState<StoreConfig | null>(null);
   const [kvBackend, setKvBackend] = useState('default');
   const [hfToken, setHfToken] = useState('');
+  const [loggingDraft, setLoggingDraft] = useState<LoggingConfig>({
+    enabled: false, ingest_url: '', grafana_url: '', grafana_user: '',
+  });
 
   // Fetch config when panel opens
   useEffect(() => {
@@ -225,6 +228,13 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
     setDraft(fullConfig?.model_store ? { ...fullConfig.model_store } : null);
     setKvBackend(effective?.kv_cache_backend ?? fullConfig?.inference?.kv_cache_backend ?? 'default');
     setHfToken(fullConfig?.hf_token ?? '');
+    setLoggingDraft({
+      enabled: fullConfig?.logging?.enabled ?? false,
+      ingest_url: fullConfig?.logging?.ingest_url ?? '',
+      grafana_url: fullConfig?.logging?.grafana_url ?? '',
+      grafana_user: fullConfig?.logging?.grafana_user ?? '',
+      has_grafana_password: fullConfig?.logging?.has_grafana_password,
+    });
   }, [fullConfig, effective]);
 
   const update = useCallback((patch: Partial<StoreConfig>) => {
@@ -244,6 +254,8 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
     const updated: FullConfig = { ...(fullConfig ?? {}) };
     if (draft) updated.model_store = draft;
     updated.inference = { kv_cache_backend: kvBackend };
+    // Include logging config
+    updated.logging = { ...loggingDraft };
     // Only send hf_token when user entered a new one
     if (hfToken && hfToken !== '') updated.hf_token = hfToken;
     const ok = await saveFullConfig(updated);
@@ -460,6 +472,65 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
               {effective?.has_hf_token ? 'Token is configured. ' : ''}
               Synced to all nodes. Env var HF_TOKEN takes precedence if set.
             </HintText>
+          </Fieldset>
+
+          {/* Logging */}
+          <Fieldset>
+            <Legend>Logging</Legend>
+            <Row>
+              <FieldLabel>
+                Enabled
+                <InfoTooltip
+                  filled
+                  content="When enabled, nodes emit structured JSON logs on stdout for collection by Vector. Requires an ingest URL to be set."
+                />
+              </FieldLabel>
+              <Toggle $on={loggingDraft.enabled} onClick={() => setLoggingDraft(prev => ({ ...prev, enabled: !prev.enabled }))} />
+            </Row>
+            {loggingDraft.enabled && (
+              <>
+                <Row>
+                  <FieldLabel>Ingest URL</FieldLabel>
+                  <StyledField
+                    size="sm"
+                    value={loggingDraft.ingest_url}
+                    onChange={(e) => setLoggingDraft(prev => ({ ...prev, ingest_url: (e.target as HTMLInputElement).value }))}
+                    placeholder="http://host:9428/insert/jsonline?_stream_fields=..."
+                  />
+                </Row>
+                <Row>
+                  <FieldLabel>Grafana URL</FieldLabel>
+                  <StyledField
+                    size="sm"
+                    value={loggingDraft.grafana_url}
+                    onChange={(e) => setLoggingDraft(prev => ({ ...prev, grafana_url: (e.target as HTMLInputElement).value }))}
+                    placeholder="http://host:3000"
+                  />
+                </Row>
+                <Row>
+                  <FieldLabel>Grafana user</FieldLabel>
+                  <StyledField
+                    size="sm"
+                    value={loggingDraft.grafana_user}
+                    onChange={(e) => setLoggingDraft(prev => ({ ...prev, grafana_user: (e.target as HTMLInputElement).value }))}
+                    placeholder="admin"
+                  />
+                </Row>
+                <Row>
+                  <FieldLabel>Grafana password</FieldLabel>
+                  <StyledField
+                    size="sm"
+                    type="password"
+                    value={loggingDraft.grafana_password ?? ''}
+                    onChange={(e) => setLoggingDraft(prev => ({ ...prev, grafana_password: (e.target as HTMLInputElement).value }))}
+                    placeholder={loggingDraft.has_grafana_password ? "Password is set — enter new to replace" : "password"}
+                  />
+                </Row>
+                <HintText>
+                  Settings are synced to all nodes. Nodes will start shipping logs when saved.
+                </HintText>
+              </>
+            )}
           </Fieldset>
         </Body>
 

--- a/dashboard-react/src/hooks/useConfig.ts
+++ b/dashboard-react/src/hooks/useConfig.ts
@@ -27,10 +27,6 @@ export interface LoggingConfig {
   enabled: boolean;
   ingest_url: string;
   grafana_url: string;
-  grafana_user: string;
-  grafana_password?: string;
-  /** Set by GET /config — true when a password is saved on disk. */
-  has_grafana_password?: boolean;
 }
 
 /** Full editable config document as read from or written to `/config`. */

--- a/dashboard-react/src/hooks/useConfig.ts
+++ b/dashboard-react/src/hooks/useConfig.ts
@@ -26,7 +26,6 @@ export interface InferenceConfig {
 export interface LoggingConfig {
   enabled: boolean;
   ingest_url: string;
-  grafana_url: string;
 }
 
 /** Full editable config document as read from or written to `/config`. */

--- a/dashboard-react/src/hooks/useConfig.ts
+++ b/dashboard-react/src/hooks/useConfig.ts
@@ -22,10 +22,22 @@ export interface InferenceConfig {
   kv_cache_backend: string;
 }
 
+/** Logging / observability config synced across the cluster. */
+export interface LoggingConfig {
+  enabled: boolean;
+  ingest_url: string;
+  grafana_url: string;
+  grafana_user: string;
+  grafana_password?: string;
+  /** Set by GET /config — true when a password is saved on disk. */
+  has_grafana_password?: boolean;
+}
+
 /** Full editable config document as read from or written to `/config`. */
 export interface FullConfig {
   model_store?: StoreConfig;
   inference?: InferenceConfig;
+  logging?: LoggingConfig;
   hf_token?: string;
 }
 

--- a/deployment/logging/docker-compose.yml
+++ b/deployment/logging/docker-compose.yml
@@ -1,0 +1,64 @@
+# EXO Cluster Logging Stack
+# Deploy as a Portainer stack on the R720 — single file, no external mounts.
+#
+# VictoriaLogs: log ingestion & storage (port 9428)
+#   - Push JSON logs to: http://<r720>:9428/insert/jsonline
+#   - Built-in VMUI at:  http://<r720>:9428/select/vmui/
+#
+# Grafana: dashboards & alerting (port 3000)
+#   - Default login: admin / admin (change on first login)
+#   - VictoriaLogs is pre-configured as a data source
+
+services:
+  victorialogs:
+    image: victoriametrics/victoria-logs:latest
+    container_name: victorialogs
+    restart: unless-stopped
+    ports:
+      - "9428:9428"
+    volumes:
+      - vlogs-data:/victoria-logs-data
+    command:
+      - -retentionPeriod=90d
+      - -storageDataPath=/victoria-logs-data
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9428/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_INSTALL_PLUGINS=https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/v0.14.0/victoriametrics-logs-datasource-v0.14.0.zip;victorialogs-datasource
+      - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=victorialogs-datasource
+    entrypoint:
+      - sh
+      - -c
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat > /etc/grafana/provisioning/datasources/victorialogs.yml <<'EOF'
+        apiVersion: 1
+        datasources:
+          - name: VictoriaLogs
+            type: victorialogs-datasource
+            access: proxy
+            url: http://victorialogs:9428
+            isDefault: true
+            editable: true
+        EOF
+        exec /run.sh
+    depends_on:
+      victorialogs:
+        condition: service_healthy
+
+volumes:
+  vlogs-data:
+  grafana-data:

--- a/deployment/logging/docker-compose.yml
+++ b/deployment/logging/docker-compose.yml
@@ -6,7 +6,7 @@
 #   - Built-in VMUI at:  http://<r720>:9428/select/vmui/
 #
 # Grafana: dashboards & alerting (port 3000)
-#   - Default login: admin / admin (change on first login)
+#   - Set GF_SECURITY_ADMIN_PASSWORD in your environment or .env file
 #   - VictoriaLogs is pre-configured as a data source
 
 services:
@@ -36,7 +36,7 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:?Set GF_SECURITY_ADMIN_PASSWORD in .env or environment}
       - GF_INSTALL_PLUGINS=https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/v0.14.0/victoriametrics-logs-datasource-v0.14.0.zip;victorialogs-datasource
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=victorialogs-datasource
     entrypoint:

--- a/deployment/logging/docker-compose.yml
+++ b/deployment/logging/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
     environment:
+      - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:?Set GF_SECURITY_ADMIN_PASSWORD in .env or environment}
       - GF_INSTALL_PLUGINS=https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/v0.14.0/victoriametrics-logs-datasource-v0.14.0.zip;victorialogs-datasource
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=victorialogs-datasource

--- a/deployment/logging/vector.yaml
+++ b/deployment/logging/vector.yaml
@@ -20,7 +20,7 @@ sinks:
     type: http
     inputs:
       - exo_stdout
-    uri: http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
+    uri: ${EXO_LOGGING_INGEST_URL:-http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts}
     encoding:
       codec: json
     framing:

--- a/deployment/logging/vector.yaml
+++ b/deployment/logging/vector.yaml
@@ -3,11 +3,11 @@
 # Vector reads structured JSON from exo's stdout and ships it to
 # VictoriaLogs.  Run exo piped through Vector:
 #
-#   uv run exo 2>&1 | vector --config deployment/logging/vector.yaml
+#   uv run exo 2>/dev/tty | vector --config deployment/logging/vector.yaml
 #
-# Or more typically, Vector wraps exo:
-#
-#   vector --config deployment/logging/vector.yaml
+# Vector's disk buffer lives under data_dir (defaults to ~/.exo/vector/).
+
+data_dir: ${EXO_VECTOR_DATA_DIR:-~/.exo/vector}
 
 sources:
   exo_stdout:
@@ -32,5 +32,5 @@ sinks:
       timeout_secs: 2
     buffer:
       type: disk
-      max_size: 268435456  # 256 MB — survives VictoriaLogs downtime
+      max_size: 536870912  # 512 MB — survives VictoriaLogs downtime
       when_full: drop_newest

--- a/deployment/logging/vector.yaml
+++ b/deployment/logging/vector.yaml
@@ -1,0 +1,36 @@
+# Vector configuration for exo log shipping.
+#
+# Vector reads structured JSON from exo's stdout and ships it to
+# VictoriaLogs.  Run exo piped through Vector:
+#
+#   uv run exo 2>&1 | vector --config deployment/logging/vector.yaml
+#
+# Or more typically, Vector wraps exo:
+#
+#   vector --config deployment/logging/vector.yaml
+
+sources:
+  exo_stdout:
+    type: stdin
+    decoding:
+      codec: json
+
+sinks:
+  victorialogs:
+    type: http
+    inputs:
+      - exo_stdout
+    uri: http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
+    encoding:
+      codec: json
+    framing:
+      method: newline_delimited
+    request:
+      timeout_secs: 5
+    batch:
+      max_bytes: 1048576
+      timeout_secs: 2
+    buffer:
+      type: disk
+      max_size: 268435456  # 256 MB — survives VictoriaLogs downtime
+      when_full: drop_newest

--- a/docs/api.md
+++ b/docs/api.md
@@ -532,7 +532,7 @@ Use this for workflows such as model optimization or alternate artifact generati
 
 **GET** `/config`
 
-Returns the current cluster config and config path. Sensitive values (`hf_token`, `logging.grafana_password`) are stripped from the response. A `logging.has_grafana_password` boolean indicates whether a password is stored.
+Returns the current cluster config and config path. Sensitive values (`hf_token`) are stripped from the response.
 
 ### Update config
 
@@ -542,8 +542,7 @@ Updates cluster-wide config. Important behavior:
 
 - if you omit `hf_token`, Skulk preserves the existing value
 - if you omit `logging`, Skulk preserves the existing logging config
-- if you include `logging` but omit `grafana_password`, the existing password is preserved
-- secrets (`hf_token`, `grafana_password`) are not broadcast over gossipsub — they stay on the local node's `exo.yaml`
+- `hf_token` is not broadcast over gossipsub — it stays on the local node's `exo.yaml`
 - logging changes (enable/disable) take effect immediately on all nodes
 - inference changes affect future launches
 - model-store location changes generally require restart

--- a/docs/api.md
+++ b/docs/api.md
@@ -532,7 +532,7 @@ Use this for workflows such as model optimization or alternate artifact generati
 
 **GET** `/config`
 
-Returns the current cluster config and config path. Sensitive values such as `hf_token` are stripped from the returned config.
+Returns the current cluster config and config path. Sensitive values (`hf_token`, `logging.grafana_password`) are stripped from the response. A `logging.has_grafana_password` boolean indicates whether a password is stored.
 
 ### Update config
 
@@ -541,6 +541,10 @@ Returns the current cluster config and config path. Sensitive values such as `hf
 Updates cluster-wide config. Important behavior:
 
 - if you omit `hf_token`, Skulk preserves the existing value
+- if you omit `logging`, Skulk preserves the existing logging config
+- if you include `logging` but omit `grafana_password`, the existing password is preserved
+- secrets (`hf_token`, `grafana_password`) are not broadcast over gossipsub — they stay on the local node's `exo.yaml`
+- logging changes (enable/disable) take effect immediately on all nodes
 - inference changes affect future launches
 - model-store location changes generally require restart
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,21 @@ It is the main operator interface for the same Skulk runtime:
 
 That is why the docs often describe dashboard and API flows as parallel ways of driving the same underlying system.
 
+## Where Logging Fits
+
+Skulk supports centralized log aggregation for the cluster.
+
+Each node can emit structured JSON on stdout alongside the human-readable stderr output. A local Vector agent reads stdout and ships logs to a central VictoriaLogs instance, where they can be queried via Grafana or VictoriaLogs' built-in VMUI.
+
+The key pieces:
+
+- `src/exo/shared/logging.py` — loguru setup with a JSON stdout sink
+- `deployment/logging/vector.yaml` — Vector config (stdin → VictoriaLogs)
+- `deployment/logging/docker-compose.yml` — VictoriaLogs + Grafana stack
+- `exo.yaml` `logging.structured_stdout` — enables the JSON sink
+
+This is opt-in. Without the logging config, exo behaves identically to before.
+
 ## When to Read More
 
 If you are:
@@ -174,3 +189,4 @@ If you are:
 - trying to get started, go back to the [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md)
 - integrating against the API, read the [API guide](api.md)
 - setting up shared storage, read the [model store guide](model-store.md)
+- setting up cluster logging, read `deployment/logging/` and the [CONTRIBUTING guide](https://github.com/Foxlight-Foundation/Skulk/blob/main/CONTRIBUTING.md#centralized-logging)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,7 +178,7 @@ The key pieces:
 - `src/exo/shared/logging.py` — loguru setup with a JSON stdout sink
 - `deployment/logging/vector.yaml` — Vector config (stdin → VictoriaLogs)
 - `deployment/logging/docker-compose.yml` — VictoriaLogs + Grafana stack
-- `exo.yaml` `logging.structured_stdout` — enables the JSON sink
+- `exo.yaml` `logging.enabled` + `logging.ingest_url` — enables the JSON sink (configurable via dashboard Settings, synced to all nodes)
 
 This is opt-in. Without the logging config, exo behaves identically to before.
 

--- a/exo.yaml.example
+++ b/exo.yaml.example
@@ -75,8 +75,6 @@ logging:
   enabled: true
   ingest_url: http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
   grafana_url: http://192.168.0.118:3000
-  grafana_user: admin
-  grafana_password: changeme
 
 # Optional Hugging Face token.
 # The dashboard Settings UI can manage this too.

--- a/exo.yaml.example
+++ b/exo.yaml.example
@@ -74,7 +74,6 @@ logging:
   # See deployment/logging/ for the Vector + VictoriaLogs + Grafana stack.
   enabled: true
   ingest_url: http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
-  grafana_url: http://192.168.0.118:3000
 
 # Optional Hugging Face token.
 # The dashboard Settings UI can manage this too.

--- a/exo.yaml.example
+++ b/exo.yaml.example
@@ -68,6 +68,18 @@ inference:
   # before launch.
   kv_cache_backend: default
 
+logging:
+  # Ship structured JSON logs to a central VictoriaLogs instance.
+  # Deploy the stack: deployment/logging/docker-compose.yml
+  enabled: true
+  url: http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
+
+  # Max seconds between HTTP flushes (lower = less log loss on hard crash).
+  flush_interval_seconds: 2.0
+
+  # Flush immediately when the buffer reaches this many entries.
+  batch_size: 64
+
 # Optional Hugging Face token.
 # The dashboard Settings UI can manage this too.
 # hf_token: hf_xxxxxxxxxxxxxxxxxxxx

--- a/exo.yaml.example
+++ b/exo.yaml.example
@@ -69,10 +69,14 @@ inference:
   kv_cache_backend: default
 
 logging:
-  # Emit structured JSON on stdout for Vector (or any log shipper).
-  # Human-readable logs still go to stderr.
+  # Centralized log aggregation — configure via the dashboard Settings panel
+  # or directly here. Settings are synced to all nodes via gossipsub.
   # See deployment/logging/ for the Vector + VictoriaLogs + Grafana stack.
-  structured_stdout: true
+  enabled: true
+  ingest_url: http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
+  grafana_url: http://192.168.0.118:3000
+  grafana_user: admin
+  grafana_password: changeme
 
 # Optional Hugging Face token.
 # The dashboard Settings UI can manage this too.

--- a/exo.yaml.example
+++ b/exo.yaml.example
@@ -69,16 +69,10 @@ inference:
   kv_cache_backend: default
 
 logging:
-  # Ship structured JSON logs to a central VictoriaLogs instance.
-  # Deploy the stack: deployment/logging/docker-compose.yml
-  enabled: true
-  url: http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
-
-  # Max seconds between HTTP flushes (lower = less log loss on hard crash).
-  flush_interval_seconds: 2.0
-
-  # Flush immediately when the buffer reaches this many entries.
-  batch_size: 64
+  # Emit structured JSON on stdout for Vector (or any log shipper).
+  # Human-readable logs still go to stderr.
+  # See deployment/logging/ for the Vector + VictoriaLogs + Grafana stack.
+  structured_stdout: true
 
 # Optional Hugging Face token.
 # The dashboard Settings UI can manage this too.

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,9 @@
                 # SVELTE
                 nodejs
 
+                # LOGGING
+                vector
+
                 # MISC
                 just
                 jq

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2514,15 +2514,6 @@ class API:
         # Remove sensitive fields — tokens/passwords managed separately
         safe_raw = dict(raw) if raw else {}
         has_hf_token = bool(safe_raw.pop("hf_token", None))
-        # Strip grafana_password but preserve the rest of logging config
-        logging_cfg = safe_raw.get("logging")
-        if isinstance(logging_cfg, dict):
-            safe_raw["logging"] = {
-                k: v for k, v in logging_cfg.items() if k != "grafana_password"
-            }
-            safe_raw["logging"]["has_grafana_password"] = bool(
-                logging_cfg.get("grafana_password")
-            )
         return JSONResponse(
             {
                 "config": safe_raw,
@@ -2548,24 +2539,8 @@ class API:
                     existing = yaml.safe_load(f) or {}
                 if "hf_token" not in config_data and "hf_token" in existing:
                     config_data["hf_token"] = existing["hf_token"]
-                # Preserve logging config: only merge when the request
-                # explicitly includes a logging section. If omitted, keep
-                # the entire existing logging config intact.
-                if "logging" in config_data:
-                    existing_logging = existing.get("logging", {})
-                    update_logging = config_data["logging"]
-                    if isinstance(update_logging, dict):
-                        # Strip the has_grafana_password flag from dashboard
-                        update_logging.pop("has_grafana_password", None)
-                        if (
-                            isinstance(existing_logging, dict)
-                            and "grafana_password" not in update_logging
-                            and "grafana_password" in existing_logging
-                        ):
-                            update_logging["grafana_password"] = existing_logging[
-                                "grafana_password"
-                            ]
-                elif "logging" in existing:
+                # Preserve logging config when omitted from the request
+                if "logging" not in config_data and "logging" in existing:
                     config_data["logging"] = existing["logging"]
             except Exception:
                 pass
@@ -2582,18 +2557,13 @@ class API:
         # Write locally
         with self._config_path.open("w") as f:
             f.write(config_yaml)
-        # Broadcast to all nodes via the download commands topic (gossipsub).
-        # Strip secrets from the broadcast — grafana_password and hf_token
-        # stay on disk but are not transmitted over the network.
+        # Broadcast to all nodes via gossipsub — strip hf_token (secret).
         import copy
 
         from exo.shared.types.commands import SyncConfig
 
         broadcast_data = copy.deepcopy(config_data)
         broadcast_data.pop("hf_token", None)
-        broadcast_logging = broadcast_data.get("logging")
-        if isinstance(broadcast_logging, dict):
-            broadcast_logging.pop("grafana_password", None)
         broadcast_yaml = yaml.safe_dump(
             broadcast_data, default_flow_style=False, sort_keys=False
         )

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -20,7 +20,7 @@ from fastapi import FastAPI, File, Form, HTTPException, Query, Request, UploadFi
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
-from hypercorn.asyncio import serve  # pyright: ignore[reportUnknownVariableType]
+from hypercorn.asyncio import serve
 from hypercorn.config import Config
 from hypercorn.typing import ASGIFramework
 from loguru import logger
@@ -328,7 +328,7 @@ class API:
         self.app = _create_fastapi_app()
 
         @self.app.middleware("http")
-        async def _log_requests(  # pyright: ignore[reportUnusedFunction]
+        async def _log_requests(
             request: Request,
             call_next: Callable[[Request], Awaitable[StreamingResponse]],
         ) -> StreamingResponse:
@@ -2515,14 +2515,14 @@ class API:
         safe_raw = dict(raw) if raw else {}
         has_hf_token = bool(safe_raw.pop("hf_token", None))
         # Strip grafana_password but preserve the rest of logging config
-        logging_cfg = safe_raw.get("logging")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        logging_cfg = safe_raw.get("logging")
         if isinstance(logging_cfg, dict):
             safe_raw["logging"] = {
                 k: v for k, v in logging_cfg.items() if k != "grafana_password"
-            }  # pyright: ignore[reportUnknownVariableType]
+            }
             safe_raw["logging"]["has_grafana_password"] = bool(
                 logging_cfg.get("grafana_password")
-            )  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+            )
         return JSONResponse(
             {
                 "config": safe_raw,
@@ -2548,23 +2548,25 @@ class API:
                     existing = yaml.safe_load(f) or {}
                 if "hf_token" not in config_data and "hf_token" in existing:
                     config_data["hf_token"] = existing["hf_token"]
-                # Preserve grafana_password if not in this update
-                existing_logging = existing.get("logging", {})  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
-                update_logging = config_data.get("logging", {})  # pyright: ignore[reportAny]
-                if isinstance(update_logging, dict) and isinstance(
-                    existing_logging, dict
-                ):
-                    # Strip the has_grafana_password flag from dashboard
-                    update_logging.pop("has_grafana_password", None)  # pyright: ignore[reportUnknownMemberType]
-                    if (
-                        "grafana_password" not in update_logging
-                        and "grafana_password" in existing_logging
-                    ):
-                        update_logging["grafana_password"] = existing_logging[
-                            "grafana_password"
-                        ]
-                    if update_logging:
-                        config_data["logging"] = update_logging
+                # Preserve logging config: only merge when the request
+                # explicitly includes a logging section. If omitted, keep
+                # the entire existing logging config intact.
+                if "logging" in config_data:
+                    existing_logging = existing.get("logging", {})
+                    update_logging = config_data["logging"]
+                    if isinstance(update_logging, dict):
+                        # Strip the has_grafana_password flag from dashboard
+                        update_logging.pop("has_grafana_password", None)
+                        if (
+                            isinstance(existing_logging, dict)
+                            and "grafana_password" not in update_logging
+                            and "grafana_password" in existing_logging
+                        ):
+                            update_logging["grafana_password"] = existing_logging[
+                                "grafana_password"
+                            ]
+                elif "logging" in existing:
+                    config_data["logging"] = existing["logging"]
             except Exception:
                 pass
         # Validate by attempting to parse with Pydantic
@@ -2580,10 +2582,22 @@ class API:
         # Write locally
         with self._config_path.open("w") as f:
             f.write(config_yaml)
-        # Broadcast to all nodes via the download commands topic (gossipsub)
+        # Broadcast to all nodes via the download commands topic (gossipsub).
+        # Strip secrets from the broadcast — grafana_password and hf_token
+        # stay on disk but are not transmitted over the network.
+        import copy
+
         from exo.shared.types.commands import SyncConfig
 
-        await self._send_download(SyncConfig(config_yaml=config_yaml))
+        broadcast_data = copy.deepcopy(config_data)
+        broadcast_data.pop("hf_token", None)
+        broadcast_logging = broadcast_data.get("logging")
+        if isinstance(broadcast_logging, dict):
+            broadcast_logging.pop("grafana_password", None)
+        broadcast_yaml = yaml.safe_dump(
+            broadcast_data, default_flow_style=False, sort_keys=False
+        )
+        await self._send_download(SyncConfig(config_yaml=broadcast_yaml))
         # Apply inference config to env var immediately so next model launch uses it.
         # Don't overwrite if user provided the env var at launch.
         inference = config_data.get("inference")
@@ -2598,13 +2612,13 @@ class API:
         if hf_token and "HF_TOKEN" not in os.environ:
             os.environ["HF_TOKEN"] = str(hf_token)
         # Apply logging config immediately
-        logging_cfg_update = config_data.get("logging")  # pyright: ignore[reportAny]
+        logging_cfg_update = config_data.get("logging")
         if isinstance(logging_cfg_update, dict):
             from exo.shared.logging import set_structured_stdout
 
             log_on = bool(logging_cfg_update.get("enabled", False)) and bool(
                 logging_cfg_update.get("ingest_url")
-            )  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+            )
             set_structured_stdout(log_on)
         # model_store changes still require restart; inference-only changes don't
         has_store_changes = "model_store" in config_data

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2511,9 +2511,18 @@ class API:
             raw = yaml.safe_load(f)
         if raw is None:
             raw = {}
-        # Remove sensitive fields — token is managed separately
+        # Remove sensitive fields — tokens/passwords managed separately
         safe_raw = dict(raw) if raw else {}
         has_hf_token = bool(safe_raw.pop("hf_token", None))
+        # Strip grafana_password but preserve the rest of logging config
+        logging_cfg = safe_raw.get("logging")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        if isinstance(logging_cfg, dict):
+            safe_raw["logging"] = {
+                k: v for k, v in logging_cfg.items() if k != "grafana_password"
+            }  # pyright: ignore[reportUnknownVariableType]
+            safe_raw["logging"]["has_grafana_password"] = bool(
+                logging_cfg.get("grafana_password")
+            )  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
         return JSONResponse(
             {
                 "config": safe_raw,
@@ -2531,14 +2540,31 @@ class API:
     async def update_config(self, request: Request) -> JSONResponse:
         body = await request.json()
         config_data = body.get("config", body)
-        # Preserve existing hf_token if not provided in this update
-        # (GET /config strips it for security, so saves won't have it)
-        if "hf_token" not in config_data and self._config_path.exists():
+        # Preserve existing secrets if not provided in this update
+        # (GET /config strips them for security, so saves won't have them)
+        if self._config_path.exists():
             try:
                 with self._config_path.open() as f:
                     existing = yaml.safe_load(f) or {}
-                if "hf_token" in existing:
+                if "hf_token" not in config_data and "hf_token" in existing:
                     config_data["hf_token"] = existing["hf_token"]
+                # Preserve grafana_password if not in this update
+                existing_logging = existing.get("logging", {})  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+                update_logging = config_data.get("logging", {})  # pyright: ignore[reportAny]
+                if isinstance(update_logging, dict) and isinstance(
+                    existing_logging, dict
+                ):
+                    # Strip the has_grafana_password flag from dashboard
+                    update_logging.pop("has_grafana_password", None)  # pyright: ignore[reportUnknownMemberType]
+                    if (
+                        "grafana_password" not in update_logging
+                        and "grafana_password" in existing_logging
+                    ):
+                        update_logging["grafana_password"] = existing_logging[
+                            "grafana_password"
+                        ]
+                    if update_logging:
+                        config_data["logging"] = update_logging
             except Exception:
                 pass
         # Validate by attempting to parse with Pydantic
@@ -2571,6 +2597,15 @@ class API:
         hf_token = config_data.get("hf_token")
         if hf_token and "HF_TOKEN" not in os.environ:
             os.environ["HF_TOKEN"] = str(hf_token)
+        # Apply logging config immediately
+        logging_cfg_update = config_data.get("logging")  # pyright: ignore[reportAny]
+        if isinstance(logging_cfg_update, dict):
+            from exo.shared.logging import set_structured_stdout
+
+            log_on = bool(logging_cfg_update.get("enabled", False)) and bool(
+                logging_cfg_update.get("ingest_url")
+            )  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+            set_structured_stdout(log_on)
         # model_store changes still require restart; inference-only changes don't
         has_store_changes = "model_store" in config_data
         return JSONResponse(
@@ -2827,7 +2862,9 @@ class API:
         if target == self.node_id:
             from exo.utils.restart import schedule_restart
 
-            logger.info("Node restart requested via API — scheduling process replacement")
+            logger.info(
+                "Node restart requested via API — scheduling process replacement"
+            )
             scheduled = schedule_restart()
             if not scheduled:
                 return JSONResponse(

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -214,13 +214,13 @@ class DownloadCoordinator:
                         "DownloadCoordinator: updated HF_TOKEN from config sync"
                     )
                 # Apply logging config — enable/disable structured stdout
-                logging_cfg = raw.get("logging")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+                logging_cfg = raw.get("logging")
                 if isinstance(logging_cfg, dict):
                     from exo.shared.logging import set_structured_stdout
 
                     log_enabled = bool(logging_cfg.get("enabled", False)) and bool(
                         logging_cfg.get("ingest_url")
-                    )  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                    )
                     set_structured_stdout(log_enabled)
         except Exception as exc:
             logger.warning(f"DownloadCoordinator: failed to sync exo.yaml: {exc}")

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -173,7 +173,9 @@ class DownloadCoordinator:
         """Restart this node by replacing the current process image (in-place restart)."""
         from exo.utils.restart import schedule_restart
 
-        logger.info("RestartNode command received — scheduling in-place process restart")
+        logger.info(
+            "RestartNode command received — scheduling in-place process restart"
+        )
         schedule_restart()
 
     async def _sync_config(self, config_yaml: str) -> None:
@@ -211,6 +213,15 @@ class DownloadCoordinator:
                     logger.info(
                         "DownloadCoordinator: updated HF_TOKEN from config sync"
                     )
+                # Apply logging config — enable/disable structured stdout
+                logging_cfg = raw.get("logging")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+                if isinstance(logging_cfg, dict):
+                    from exo.shared.logging import set_structured_stdout
+
+                    log_enabled = bool(logging_cfg.get("enabled", False)) and bool(
+                        logging_cfg.get("ingest_url")
+                    )  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+                    set_structured_stdout(log_enabled)
         except Exception as exc:
             logger.warning(f"DownloadCoordinator: failed to sync exo.yaml: {exc}")
 

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -516,8 +516,22 @@ def main():
     resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
 
     mp.set_start_method("spawn", force=True)
-    # TODO: Refactor the current verbosity system
-    logger_setup(EXO_LOG, args.verbosity)
+
+    # Load config early so the logging section is available before anything
+    # else runs.  The full config is loaded again inside Node.create() for
+    # the model store and inference sections.
+    _early_config = load_exo_config(Path("exo.yaml"))
+    _log_cfg = _early_config.logging if _early_config else None
+
+    logger_setup(
+        EXO_LOG,
+        args.verbosity,
+        victorialogs_url=_log_cfg.url if _log_cfg and _log_cfg.enabled else None,
+        victorialogs_flush_interval=_log_cfg.flush_interval_seconds
+        if _log_cfg
+        else 2.0,
+        victorialogs_batch_size=_log_cfg.batch_size if _log_cfg else 64,
+    )
     logger.info("Starting EXO")
     logger.info(f"EXO_LIBP2P_NAMESPACE: {os.getenv('EXO_LIBP2P_NAMESPACE')}")
 

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -361,10 +361,22 @@ class Node:
         except Exception as exc:
             logger.warning(f"Failed to update local exo.yaml: {exc}")
 
+        # Strip secrets before broadcasting over gossipsub
+        import copy
+
+        broadcast_dict = copy.deepcopy(config_dict)
+        broadcast_dict.pop("hf_token", None)
+        logging_section = broadcast_dict.get("logging")
+        if isinstance(logging_section, dict):
+            logging_section.pop("grafana_password", None)
+        broadcast_yaml = yaml.safe_dump(
+            broadcast_dict, default_flow_style=False, sort_keys=False
+        )
+
         await self.router.sender(topics.DOWNLOAD_COMMANDS).send(
             ForwarderDownloadCommand(
                 origin=SystemId(),
-                command=SyncConfig(config_yaml=config_yaml),
+                command=SyncConfig(config_yaml=broadcast_yaml),
             )
         )
         logger.info(
@@ -519,9 +531,15 @@ def main():
 
     # Load config early so the logging section is available before anything
     # else runs.  The full config is loaded again inside Node.create() for
-    # the model store and inference sections.
-    _early_config = load_exo_config(Path("exo.yaml"))
-    _log_cfg = _early_config.logging if _early_config else None
+    # the model store and inference sections.  If the file is malformed we
+    # fall back gracefully — logging will start without the JSON sink and
+    # the validation error is logged once the logger is up.
+    _log_cfg = None
+    try:
+        _early_config = load_exo_config(Path("exo.yaml"))
+        _log_cfg = _early_config.logging if _early_config else None
+    except Exception:
+        pass  # Logged after logger_setup below
 
     logger_setup(
         EXO_LOG,

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -366,9 +366,6 @@ class Node:
 
         broadcast_dict = copy.deepcopy(config_dict)
         broadcast_dict.pop("hf_token", None)
-        logging_section = broadcast_dict.get("logging")
-        if isinstance(logging_section, dict):
-            logging_section.pop("grafana_password", None)
         broadcast_yaml = yaml.safe_dump(
             broadcast_dict, default_flow_style=False, sort_keys=False
         )

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -526,11 +526,7 @@ def main():
     logger_setup(
         EXO_LOG,
         args.verbosity,
-        victorialogs_url=_log_cfg.url if _log_cfg and _log_cfg.enabled else None,
-        victorialogs_flush_interval=_log_cfg.flush_interval_seconds
-        if _log_cfg
-        else 2.0,
-        victorialogs_batch_size=_log_cfg.batch_size if _log_cfg else 64,
+        structured_stdout=_log_cfg.structured_stdout if _log_cfg else False,
     )
     logger.info("Starting EXO")
     logger.info(f"EXO_LIBP2P_NAMESPACE: {os.getenv('EXO_LIBP2P_NAMESPACE')}")

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -526,7 +526,7 @@ def main():
     logger_setup(
         EXO_LOG,
         args.verbosity,
-        structured_stdout=_log_cfg.structured_stdout if _log_cfg else False,
+        structured_stdout=bool(_log_cfg and _log_cfg.enabled and _log_cfg.ingest_url),
     )
     logger.info("Starting EXO")
     logger.info(f"EXO_LIBP2P_NAMESPACE: {os.getenv('EXO_LIBP2P_NAMESPACE')}")

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -1,12 +1,24 @@
+from __future__ import annotations
+
+import atexit
+import json
 import logging
+import socket
 import sys
+import threading
+import urllib.error
+import urllib.request
 from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import zstandard
 from hypercorn import Config
 from hypercorn.logging import Logger as HypercornLogger
 from loguru import logger
+
+if TYPE_CHECKING:
+    from loguru import Message
 
 _MAX_LOG_ARCHIVES = 5
 
@@ -43,8 +55,142 @@ class _InterceptHandler(logging.Handler):
         logger.opt(depth=3, exception=record.exc_info).log(level, record.getMessage())
 
 
-def logger_setup(log_file: Path | None, verbosity: int = 0):
-    """Set up logging for this process - formatting, file handles, verbosity and output"""
+# ---------------------------------------------------------------------------
+# VictoriaLogs sink — batches structured JSON and ships over HTTP
+# ---------------------------------------------------------------------------
+
+
+class _VictoriaLogsSink:
+    """Loguru sink that pushes newline-delimited JSON to VictoriaLogs.
+
+    The sink accumulates log entries in memory and flushes them either when
+    the buffer hits ``batch_size`` or every ``flush_interval`` seconds,
+    whichever comes first.  Flushes happen on the loguru background thread
+    (``enqueue=True``), so they never block the event loop.
+
+    For ERROR/CRITICAL messages the sink flushes immediately — these are
+    the lines most likely to precede a hard crash where the periodic timer
+    would never fire.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        node_id: str,
+        flush_interval: float = 2.0,
+        batch_size: int = 64,
+    ) -> None:
+        self._url = url
+        self._node_id = node_id
+        self._batch_size = batch_size
+        self._buffer: list[str] = []
+        self._lock = threading.Lock()
+
+        # Periodic flush timer
+        self._flush_interval = flush_interval
+        self._timer: threading.Timer | None = None
+        self._closed = False
+        self._schedule_flush()
+
+        atexit.register(self.close)
+
+    # -- loguru sink interface ------------------------------------------------
+
+    def __call__(self, message: Message) -> None:
+        record = message.record
+        entry = {
+            "ts": record["time"].strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+            "level": record["level"].name,
+            "node_id": self._node_id,
+            "component": (name.split(".")[1] if "." in name else name)
+            if (name := record["name"])
+            else "unknown",
+            "module": name or "unknown",
+            "function": record["function"],
+            "line": record["line"],
+            "msg": str(record["message"]),
+        }
+        if record["exception"] is not None:
+            entry["exception"] = str(record["exception"])
+
+        line = json.dumps(entry, default=str)
+
+        flush_now = False
+        with self._lock:
+            self._buffer.append(line)
+            if (
+                len(self._buffer) >= self._batch_size
+                or record["level"].no >= logging.ERROR
+            ):
+                flush_now = True
+
+        if flush_now:
+            self._flush()
+
+    # -- flush mechanics ------------------------------------------------------
+
+    def _schedule_flush(self) -> None:
+        if self._closed:
+            return
+        self._timer = threading.Timer(self._flush_interval, self._timer_flush)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _timer_flush(self) -> None:
+        self._flush()
+        self._schedule_flush()
+
+    def _flush(self) -> None:
+        with self._lock:
+            if not self._buffer:
+                return
+            payload = "\n".join(self._buffer) + "\n"
+            self._buffer.clear()
+
+        try:
+            req = urllib.request.Request(
+                self._url,
+                data=payload.encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            urllib.request.urlopen(req, timeout=5)  # noqa: S310 — URL is operator-configured
+        except (urllib.error.URLError, OSError):
+            # Remote logger is down — drop silently rather than cascade.
+            # Local file and console sinks still capture everything.
+            pass
+
+    def close(self) -> None:
+        """Flush remaining entries and stop the timer."""
+        self._closed = True
+        if self._timer is not None:
+            self._timer.cancel()
+        self._flush()
+
+
+# Keep a module-level reference so logger_cleanup can flush it.
+_victorialogs_sink: _VictoriaLogsSink | None = None
+
+
+def logger_setup(
+    log_file: Path | None,
+    verbosity: int = 0,
+    victorialogs_url: str | None = None,
+    victorialogs_flush_interval: float = 2.0,
+    victorialogs_batch_size: int = 64,
+):
+    """Set up logging for this process — formatting, file handles, verbosity, output, and optional remote shipping.
+
+    Args:
+        log_file: Path to the local log file. ``None`` disables file logging.
+        verbosity: 0 = INFO on console, >=1 = DEBUG with source locations.
+        victorialogs_url: Full VictoriaLogs ingest URL (e.g.
+            ``http://host:9428/insert/jsonline?_stream_fields=...``).
+            ``None`` disables remote log shipping.
+        victorialogs_flush_interval: Seconds between periodic HTTP flushes.
+        victorialogs_batch_size: Buffer size that triggers an immediate flush.
+    """
+    global _victorialogs_sink  # noqa: PLW0603
 
     logging.getLogger("exo_pyo3_bindings").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -84,10 +230,27 @@ def logger_setup(log_file: Path | None, verbosity: int = 0):
             compression=_zstd_compress,
         )
 
+    if victorialogs_url:
+        node_name = socket.gethostname()
+        _victorialogs_sink = _VictoriaLogsSink(
+            url=victorialogs_url,
+            node_id=node_name,
+            flush_interval=victorialogs_flush_interval,
+            batch_size=victorialogs_batch_size,
+        )
+        logger.add(
+            _victorialogs_sink,
+            level="DEBUG",
+            enqueue=True,
+        )
+        logger.info(f"Remote logging enabled: {victorialogs_url}")
+
 
 def logger_cleanup():
     """Flush all queues before shutting down so any in-flight logs are written to disk"""
     logger.complete()
+    if _victorialogs_sink is not None:
+        _victorialogs_sink.close()
 
 
 """ --- TODO: Capture MLX Log output:

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -5,6 +5,7 @@ import logging
 import socket
 import sys
 from collections.abc import Iterator
+from datetime import UTC
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -69,7 +70,7 @@ def _json_sink(message: Message) -> None:
     record = message.record
     name = record["name"]
     entry = {
-        "ts": record["time"].strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "ts": record["time"].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
         "level": record["level"].name,
         "node_id": _node_name,
         "component": (name.split(".")[1] if "." in name else name)

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -241,7 +241,7 @@ def logger_setup(
         logger.add(
             _victorialogs_sink,
             level="DEBUG",
-            enqueue=True,
+            enqueue=False,
         )
         logger.info(f"Remote logging enabled: {victorialogs_url}")
 

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -101,9 +101,11 @@ def _json_sink(message: Message) -> None:
         except (BrokenPipeError, OSError):
             # Vector (or whatever reads stdout) has exited — disable the sink
             # to avoid spamming errors. Local file and stderr sinks still work.
+            global _json_sink_id  # noqa: PLW0603
             if _json_sink_id is not None:
                 with contextlib.suppress(ValueError):
                     logger.remove(_json_sink_id)
+                _json_sink_id = None
             logger.warning(
                 "Structured stdout consumer disconnected — JSON sink disabled"
             )

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from loguru import Message
 
 _MAX_LOG_ARCHIVES = 5
+_json_sink_id: int | None = None
 
 _node_name: str = socket.gethostname()
 
@@ -90,12 +91,19 @@ def _json_sink(message: Message) -> None:
                 traceback.format_exception(exc_type, exc_value, exc_tb)
             )
 
-    # Write to the real stdout (not loguru's stderr sink).
-    # Use sys.__stdout__ to bypass any redirections.
+    # Write to the original stdout, bypassing Python-level sys.stdout reassignment.
     stdout = sys.__stdout__
     if stdout is not None:
-        stdout.write(json.dumps(entry, default=str) + "\n")
-        stdout.flush()
+        try:
+            stdout.write(json.dumps(entry, default=str) + "\n")
+            stdout.flush()
+        except (BrokenPipeError, OSError):
+            # Vector (or whatever reads stdout) has exited — disable the sink
+            # to avoid spamming errors. Local file and stderr sinks still work.
+            logger.remove(_json_sink_id)
+            logger.warning(
+                "Structured stdout consumer disconnected — JSON sink disabled"
+            )
 
 
 def logger_setup(
@@ -150,7 +158,8 @@ def logger_setup(
         )
 
     if structured_stdout:
-        logger.add(
+        global _json_sink_id  # noqa: PLW0603
+        _json_sink_id = logger.add(
             _json_sink,
             level="INFO",
             enqueue=False,

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -4,6 +4,7 @@ import json
 import logging
 import socket
 import sys
+import traceback
 from collections.abc import Iterator
 from datetime import UTC
 from pathlib import Path
@@ -70,7 +71,8 @@ def _json_sink(message: Message) -> None:
     record = message.record
     name = record["name"]
     entry = {
-        "ts": record["time"].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "ts": record["time"].astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+        + "Z",
         "level": record["level"].name,
         "node_id": _node_name,
         "component": (name.split(".")[1] if "." in name else name)
@@ -82,7 +84,11 @@ def _json_sink(message: Message) -> None:
         "msg": str(record["message"]),
     }
     if record["exception"] is not None:
-        entry["exception"] = str(record["exception"])
+        exc_type, exc_value, exc_tb = record["exception"]
+        if exc_type is not None:
+            entry["exception"] = "".join(
+                traceback.format_exception(exc_type, exc_value, exc_tb)
+            )
 
     # Write to the real stdout (not loguru's stderr sink).
     # Use sys.__stdout__ to bypass any redirections.
@@ -147,7 +153,7 @@ def logger_setup(
         logger.add(
             _json_sink,
             level="INFO",
-            enqueue=True,
+            enqueue=False,
         )
 
 

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -241,7 +241,7 @@ def logger_setup(
         logger.add(
             _victorialogs_sink,
             level="DEBUG",
-            enqueue=False,
+            enqueue=True,
         )
         logger.info(f"Remote logging enabled: {victorialogs_url}")
 

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -169,6 +169,28 @@ def logger_setup(
         )
 
 
+def set_structured_stdout(enabled: bool) -> None:
+    """Enable or disable the structured JSON stdout sink at runtime.
+
+    Called when logging config is synced across the cluster.  Safe to call
+    repeatedly — adding when already active or removing when already
+    inactive is a no-op.
+    """
+    global _json_sink_id  # noqa: PLW0603
+    if enabled and _json_sink_id is None:
+        _json_sink_id = logger.add(
+            _json_sink,
+            level="INFO",
+            enqueue=False,
+        )
+        logger.info("Structured JSON stdout sink enabled")
+    elif not enabled and _json_sink_id is not None:
+        with contextlib.suppress(ValueError):
+            logger.remove(_json_sink_id)
+        _json_sink_id = None
+        logger.info("Structured JSON stdout sink disabled")
+
+
 def logger_cleanup():
     """Flush all queues before shutting down so any in-flight logs are written to disk"""
     logger.complete()

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-import atexit
 import json
 import logging
 import socket
 import sys
-import threading
-import urllib.error
-import urllib.request
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -21,6 +17,8 @@ if TYPE_CHECKING:
     from loguru import Message
 
 _MAX_LOG_ARCHIVES = 5
+
+_node_name: str = socket.gethostname()
 
 
 def _zstd_compress(filepath: str) -> None:
@@ -56,142 +54,56 @@ class _InterceptHandler(logging.Handler):
 
 
 # ---------------------------------------------------------------------------
-# VictoriaLogs sink — batches structured JSON and ships over HTTP
+# Structured JSON sink — writes one JSON object per line to stdout.
+# Vector (or any log shipper) reads stdout and forwards to VictoriaLogs.
 # ---------------------------------------------------------------------------
 
 
-class _VictoriaLogsSink:
-    """Loguru sink that pushes newline-delimited JSON to VictoriaLogs.
+def _json_sink(message: Message) -> None:
+    """Loguru sink that writes newline-delimited JSON to stdout.
 
-    The sink accumulates log entries in memory and flushes them either when
-    the buffer hits ``batch_size`` or every ``flush_interval`` seconds,
-    whichever comes first.  Flushes happen on the loguru background thread
-    (``enqueue=True``), so they never block the event loop.
-
-    For ERROR/CRITICAL messages the sink flushes immediately — these are
-    the lines most likely to precede a hard crash where the periodic timer
-    would never fire.
+    Each log entry is a single JSON object with fields that map directly
+    to VictoriaLogs stream fields (``node_id``, ``component``) and the
+    message field (``msg``).  Vector consumes this on stdin and ships it.
     """
+    record = message.record
+    name = record["name"]
+    entry = {
+        "ts": record["time"].strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "level": record["level"].name,
+        "node_id": _node_name,
+        "component": (name.split(".")[1] if "." in name else name)
+        if name
+        else "unknown",
+        "module": name or "unknown",
+        "function": record["function"],
+        "line": record["line"],
+        "msg": str(record["message"]),
+    }
+    if record["exception"] is not None:
+        entry["exception"] = str(record["exception"])
 
-    def __init__(
-        self,
-        url: str,
-        node_id: str,
-        flush_interval: float = 2.0,
-        batch_size: int = 64,
-    ) -> None:
-        self._url = url
-        self._node_id = node_id
-        self._batch_size = batch_size
-        self._buffer: list[str] = []
-        self._lock = threading.Lock()
-
-        # Periodic flush timer
-        self._flush_interval = flush_interval
-        self._timer: threading.Timer | None = None
-        self._closed = False
-        self._schedule_flush()
-
-        atexit.register(self.close)
-
-    # -- loguru sink interface ------------------------------------------------
-
-    def __call__(self, message: Message) -> None:
-        record = message.record
-        entry = {
-            "ts": record["time"].strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
-            "level": record["level"].name,
-            "node_id": self._node_id,
-            "component": (name.split(".")[1] if "." in name else name)
-            if (name := record["name"])
-            else "unknown",
-            "module": name or "unknown",
-            "function": record["function"],
-            "line": record["line"],
-            "msg": str(record["message"]),
-        }
-        if record["exception"] is not None:
-            entry["exception"] = str(record["exception"])
-
-        line = json.dumps(entry, default=str)
-
-        flush_now = False
-        with self._lock:
-            self._buffer.append(line)
-            if (
-                len(self._buffer) >= self._batch_size
-                or record["level"].no >= logging.ERROR
-            ):
-                flush_now = True
-
-        if flush_now:
-            self._flush()
-
-    # -- flush mechanics ------------------------------------------------------
-
-    def _schedule_flush(self) -> None:
-        if self._closed:
-            return
-        self._timer = threading.Timer(self._flush_interval, self._timer_flush)
-        self._timer.daemon = True
-        self._timer.start()
-
-    def _timer_flush(self) -> None:
-        self._flush()
-        self._schedule_flush()
-
-    def _flush(self) -> None:
-        with self._lock:
-            if not self._buffer:
-                return
-            payload = "\n".join(self._buffer) + "\n"
-            self._buffer.clear()
-
-        try:
-            req = urllib.request.Request(
-                self._url,
-                data=payload.encode("utf-8"),
-                headers={"Content-Type": "application/json"},
-                method="POST",
-            )
-            urllib.request.urlopen(req, timeout=5)  # noqa: S310 — URL is operator-configured
-        except (urllib.error.URLError, OSError):
-            # Remote logger is down — drop silently rather than cascade.
-            # Local file and console sinks still capture everything.
-            pass
-
-    def close(self) -> None:
-        """Flush remaining entries and stop the timer."""
-        self._closed = True
-        if self._timer is not None:
-            self._timer.cancel()
-        self._flush()
-
-
-# Keep a module-level reference so logger_cleanup can flush it.
-_victorialogs_sink: _VictoriaLogsSink | None = None
+    # Write to the real stdout (not loguru's stderr sink).
+    # Use sys.__stdout__ to bypass any redirections.
+    stdout = sys.__stdout__
+    if stdout is not None:
+        stdout.write(json.dumps(entry, default=str) + "\n")
+        stdout.flush()
 
 
 def logger_setup(
     log_file: Path | None,
     verbosity: int = 0,
-    victorialogs_url: str | None = None,
-    victorialogs_flush_interval: float = 2.0,
-    victorialogs_batch_size: int = 64,
+    structured_stdout: bool = False,
 ):
-    """Set up logging for this process — formatting, file handles, verbosity, output, and optional remote shipping.
+    """Set up logging for this process — formatting, file handles, verbosity, and structured output.
 
     Args:
         log_file: Path to the local log file. ``None`` disables file logging.
         verbosity: 0 = INFO on console, >=1 = DEBUG with source locations.
-        victorialogs_url: Full VictoriaLogs ingest URL (e.g.
-            ``http://host:9428/insert/jsonline?_stream_fields=...``).
-            ``None`` disables remote log shipping.
-        victorialogs_flush_interval: Seconds between periodic HTTP flushes.
-        victorialogs_batch_size: Buffer size that triggers an immediate flush.
+        structured_stdout: When ``True``, emit structured JSON on stdout for
+            consumption by Vector or another log shipper.
     """
-    global _victorialogs_sink  # noqa: PLW0603
-
     logging.getLogger("exo_pyo3_bindings").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
@@ -230,27 +142,17 @@ def logger_setup(
             compression=_zstd_compress,
         )
 
-    if victorialogs_url:
-        node_name = socket.gethostname()
-        _victorialogs_sink = _VictoriaLogsSink(
-            url=victorialogs_url,
-            node_id=node_name,
-            flush_interval=victorialogs_flush_interval,
-            batch_size=victorialogs_batch_size,
-        )
+    if structured_stdout:
         logger.add(
-            _victorialogs_sink,
+            _json_sink,
             level="DEBUG",
             enqueue=True,
         )
-        logger.info(f"Remote logging enabled: {victorialogs_url}")
 
 
 def logger_cleanup():
     """Flush all queues before shutting down so any in-flight logs are written to disk"""
     logger.complete()
-    if _victorialogs_sink is not None:
-        _victorialogs_sink.close()
 
 
 """ --- TODO: Capture MLX Log output:

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import socket
@@ -100,7 +101,9 @@ def _json_sink(message: Message) -> None:
         except (BrokenPipeError, OSError):
             # Vector (or whatever reads stdout) has exited — disable the sink
             # to avoid spamming errors. Local file and stderr sinks still work.
-            logger.remove(_json_sink_id)
+            if _json_sink_id is not None:
+                with contextlib.suppress(ValueError):
+                    logger.remove(_json_sink_id)
             logger.warning(
                 "Structured stdout consumer disconnected — JSON sink disabled"
             )

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -145,7 +145,7 @@ def logger_setup(
     if structured_stdout:
         logger.add(
             _json_sink,
-            level="DEBUG",
+            level="INFO",
             enqueue=True,
         )
 

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -211,7 +211,7 @@ class LoggingConfig(FrozenModel):
             by Vector or another log shipper.
     """
 
-    structured_stdout: bool = True
+    structured_stdout: bool = False
 
 
 @final

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -212,11 +212,7 @@ class LoggingConfig(FrozenModel):
     human-readable stderr output.  A local log shipper such as Vector
     reads stdout and forwards to the ingest endpoint.
 
-    Grafana credentials are stored locally so the dashboard can link
-    directly to log views.  Non-secret fields (``enabled``, ``ingest_url``,
-    ``grafana_url``, ``grafana_user``) are synced to all nodes via gossipsub.
-    ``grafana_password`` is never broadcast — it stays on the local node's
-    ``exo.yaml`` only.
+    All fields are synced to all nodes via gossipsub.
 
     Attributes:
         enabled: Master switch for centralized logging.  Nodes only emit
@@ -226,15 +222,11 @@ class LoggingConfig(FrozenModel):
             ``http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts``.
         grafana_url: Grafana base URL for dashboard links, e.g.
             ``http://192.168.0.118:3000``.
-        grafana_user: Grafana admin username.
-        grafana_password: Grafana admin password.
     """
 
     enabled: bool = False
     ingest_url: str = ""
     grafana_url: str = ""
-    grafana_user: str = ""
-    grafana_password: str = ""
 
 
 @final

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -191,8 +191,8 @@ class ExoConfig(FrozenModel):
             absent, which means the model store feature is disabled.
         inference: Inference settings (KV cache backend).  ``None`` uses
             defaults.
-        logging: Centralized logging configuration (ingest URL, Grafana
-            credentials).  ``None`` disables remote log shipping.
+        logging: Centralized logging configuration (enabled toggle, ingest
+            URL).  ``None`` disables remote log shipping.
         hf_token: HuggingFace API token.  Stripped from ``GET /config``
             responses for security.
     """
@@ -220,13 +220,10 @@ class LoggingConfig(FrozenModel):
             set.
         ingest_url: Full VictoriaLogs (or compatible) ingest URL, e.g.
             ``http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts``.
-        grafana_url: Grafana base URL for dashboard links, e.g.
-            ``http://192.168.0.118:3000``.
     """
 
     enabled: bool = False
     ingest_url: str = ""
-    grafana_url: str = ""
 
 
 @final

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -193,7 +193,36 @@ class ExoConfig(FrozenModel):
 
     model_store: ModelStoreConfig | None = None
     inference: "InferenceConfig | None" = None
+    logging: "LoggingConfig | None" = None
     hf_token: str | None = None
+
+
+@final
+class LoggingConfig(FrozenModel):
+    """Central log aggregation configuration.
+
+    When ``url`` is set, exo pushes structured JSON logs to a VictoriaLogs
+    (or any newline-delimited JSON endpoint) over HTTP.  The sink batches
+    log entries and flushes periodically to minimise overhead on inference
+    nodes.
+
+    Attributes:
+        enabled: Master switch.  ``False`` disables remote shipping even if
+            ``url`` is set — useful for temporarily pausing without removing
+            the config.
+        url: Full ingest URL including query parameters, e.g.
+            ``http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts``.
+        flush_interval_seconds: Maximum seconds between HTTP flushes.
+            Lower values reduce the window of log loss on hard crashes but
+            increase network chatter.
+        batch_size: Flush when the buffer reaches this many entries,
+            regardless of the timer.
+    """
+
+    enabled: bool = True
+    url: str
+    flush_interval_seconds: float = 2.0
+    batch_size: int = 64
 
 
 @final

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -212,8 +212,11 @@ class LoggingConfig(FrozenModel):
     human-readable stderr output.  A local log shipper such as Vector
     reads stdout and forwards to the ingest endpoint.
 
-    Grafana credentials are stored here so the dashboard can link
-    directly to log views.  These are synced to all nodes via gossipsub.
+    Grafana credentials are stored locally so the dashboard can link
+    directly to log views.  Non-secret fields (``enabled``, ``ingest_url``,
+    ``grafana_url``, ``grafana_user``) are synced to all nodes via gossipsub.
+    ``grafana_password`` is never broadcast — it stays on the local node's
+    ``exo.yaml`` only.
 
     Attributes:
         enabled: Master switch for centralized logging.  Nodes only emit

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -183,12 +183,18 @@ class ExoConfig(FrozenModel):
     """Root configuration model for ``exo.yaml``.
 
     This is the top-level object parsed from the config file.  The design
-    leaves room for future top-level sections (networking, inference, etc.)
-    without breaking existing deployments.
+    leaves room for future top-level sections without breaking existing
+    deployments.
 
     Attributes:
         model_store: Model store configuration.  ``None`` when the section is
             absent, which means the model store feature is disabled.
+        inference: Inference settings (KV cache backend).  ``None`` uses
+            defaults.
+        logging: Centralized logging configuration (ingest URL, Grafana
+            credentials).  ``None`` disables remote log shipping.
+        hf_token: HuggingFace API token.  Stripped from ``GET /config``
+            responses for security.
     """
 
     model_store: ModelStoreConfig | None = None

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -201,28 +201,17 @@ class ExoConfig(FrozenModel):
 class LoggingConfig(FrozenModel):
     """Central log aggregation configuration.
 
-    When ``url`` is set, exo pushes structured JSON logs to a VictoriaLogs
-    (or any newline-delimited JSON endpoint) over HTTP.  The sink batches
-    log entries and flushes periodically to minimise overhead on inference
-    nodes.
+    When ``structured_stdout`` is ``True``, exo emits structured JSON on
+    stdout (one object per line) alongside the human-readable stderr
+    output.  A local log shipper such as Vector reads stdout and forwards
+    to VictoriaLogs (or any newline-delimited JSON endpoint).
 
     Attributes:
-        enabled: Master switch.  ``False`` disables remote shipping even if
-            ``url`` is set — useful for temporarily pausing without removing
-            the config.
-        url: Full ingest URL including query parameters, e.g.
-            ``http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts``.
-        flush_interval_seconds: Maximum seconds between HTTP flushes.
-            Lower values reduce the window of log loss on hard crashes but
-            increase network chatter.
-        batch_size: Flush when the buffer reaches this many entries,
-            regardless of the timer.
+        structured_stdout: Emit structured JSON on stdout for consumption
+            by Vector or another log shipper.
     """
 
-    enabled: bool = True
-    url: str
-    flush_interval_seconds: float = 2.0
-    batch_size: int = 64
+    structured_stdout: bool = True
 
 
 @final

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -201,17 +201,31 @@ class ExoConfig(FrozenModel):
 class LoggingConfig(FrozenModel):
     """Central log aggregation configuration.
 
-    When ``structured_stdout`` is ``True``, exo emits structured JSON on
-    stdout (one object per line) alongside the human-readable stderr
-    output.  A local log shipper such as Vector reads stdout and forwards
-    to VictoriaLogs (or any newline-delimited JSON endpoint).
+    When ``enabled`` is ``True`` and ``ingest_url`` is set, exo emits
+    structured JSON on stdout (one object per line) alongside the
+    human-readable stderr output.  A local log shipper such as Vector
+    reads stdout and forwards to the ingest endpoint.
+
+    Grafana credentials are stored here so the dashboard can link
+    directly to log views.  These are synced to all nodes via gossipsub.
 
     Attributes:
-        structured_stdout: Emit structured JSON on stdout for consumption
-            by Vector or another log shipper.
+        enabled: Master switch for centralized logging.  Nodes only emit
+            structured stdout when this is ``True`` and ``ingest_url`` is
+            set.
+        ingest_url: Full VictoriaLogs (or compatible) ingest URL, e.g.
+            ``http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts``.
+        grafana_url: Grafana base URL for dashboard links, e.g.
+            ``http://192.168.0.118:3000``.
+        grafana_user: Grafana admin username.
+        grafana_password: Grafana admin password.
     """
 
-    structured_stdout: bool = False
+    enabled: bool = False
+    ingest_url: str = ""
+    grafana_url: str = ""
+    grafana_user: str = ""
+    grafana_password: str = ""
 
 
 @final

--- a/src/exo/utils/info_gatherer/info_gatherer.py
+++ b/src/exo/utils/info_gatherer/info_gatherer.py
@@ -500,7 +500,7 @@ class InfoGatherer:
                     # On TB4 hardware, system_profiler reports rdma_* identifiers
                     # but the interfaces are never created — RDMA requires TB5.
                     if idents and not _rdma_interfaces_exist():
-                        logger.info(
+                        logger.debug(
                             "Thunderbolt: rdma_ctl reports RDMA but no rdma_* interfaces "
                             "exist (TB4 hardware?) — suppressing RDMA identifiers"
                         )


### PR DESCRIPTION
## Summary
- Structured JSON logging on stdout (alongside human-readable stderr) for consumption by Vector
- Vector ships logs to a central VictoriaLogs instance on the R720, with disk buffering for resilience
- Grafana pre-configured with VictoriaLogs datasource for dashboards and alerting
- `logging.structured_stdout` toggle in `exo.yaml` — zero-config compatible, off by default

## Architecture
```
exo (each node)
  ├── stderr → human-readable terminal output
  └── stdout → structured JSON (node_id, component, level, msg, ...)
                    ↓
              vector (stdin source, disk-buffered)
                    ↓
              VictoriaLogs (R720, :9428)
                    ↓
              Grafana (R720, :3000)
```

## Files changed
- `src/exo/shared/logging.py` — `_json_sink` function, UTC timestamps, INFO level for stdout
- `src/exo/store/config.py` — `LoggingConfig` model with `structured_stdout` toggle
- `src/exo/main.py` — early config load to wire structured stdout before first log
- `deployment/logging/docker-compose.yml` — Portainer-ready stack (VictoriaLogs + Grafana)
- `deployment/logging/vector.yaml` — Vector config (stdin → VictoriaLogs with disk buffer)
- `exo.yaml.example` — documents the new logging section
- `flake.nix` — Vector added to nix dev shell

## Usage
```bash
# In exo.yaml:
logging:
  structured_stdout: true

# Run:
uv run exo 2>/dev/tty | vector --config deployment/logging/vector.yaml
```

## Test plan
- [x] Type checking passes (basedpyright)
- [x] Linting passes (ruff)
- [x] 314 tests pass
- [x] End-to-end verified: exo → Vector → VictoriaLogs → VMUI/Grafana
- [ ] Test on additional cluster nodes

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)