### PR TITLE
fix: prevent stale vision KV cache from causing hallucination

### DIFF
--- a/src/exo/worker/engines/mlx/cache.py
+++ b/src/exo/worker/engines/mlx/cache.py
@@ -265,7 +265,15 @@ class KVPrefixCache:
                 break
             query_r = query_by_start.get(cached_r.start_pos)
             if query_r is None:
-                continue
+                # Cached entry has an image here but query does not — the KV
+                # cache at these positions encodes stale vision embeddings
+                # that must not be reused.
+                logger.info(
+                    f"Media region at pos {cached_r.start_pos} absent in query — "
+                    f"truncating match from {match_length} to {cached_r.start_pos}"
+                )
+                match_length = cached_r.start_pos
+                break
             if query_r.content_hash != cached_r.content_hash:
                 logger.info(
                     f"Media region mismatch at pos {cached_r.start_pos}: "

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -87,10 +87,17 @@ def patch_embed_tokens(
             return original_embed(input_ids)  # type: ignore
         chunk_len = input_ids.shape[-1]
         end = min(start + chunk_len, end_offset)
-        offset[0] = end
-        if end - start < chunk_len:
-            return original_embed(input_ids)  # type: ignore
-        return embeddings[:, start:end, :]
+        offset[0] = start + chunk_len
+        vision_len = end - start
+        if vision_len == chunk_len:
+            return embeddings[:, start:end, :]
+        # Partial overlap: splice vision embeddings for the covered portion
+        # and fall back to text embeddings for the remainder, so image tokens
+        # at chunk boundaries still get correct vision features.
+        text_embeds: mx.array = original_embed(input_ids)  # type: ignore
+        vision_slice = embeddings[:, start:end, :]
+        text_embeds[:, :vision_len, :] = vision_slice
+        return text_embeds
 
     for attr in dir(original_embed):  # type: ignore
         if not attr.startswith("_") and not hasattr(_inject, attr):

--- a/tests/test_vision_cache.py
+++ b/tests/test_vision_cache.py
@@ -33,8 +33,27 @@ class TestValidateMediaMatch:
         assert validate(4000, cached, query) == 4000
 
     def test_text_followup_no_images_in_query(self):
+        # When the cached entry has an image but the query does not, the match
+        # must truncate before the image region to avoid reusing stale vision
+        # KV states.
         cached = [MediaRegion("hashA", 5000, 8600)]
-        assert validate(9000, cached, []) == 9000
+        assert validate(9000, cached, []) == 5000
+
+    def test_text_followup_match_before_cached_image(self):
+        # If the token-level match already ends before the cached image region,
+        # no truncation is needed — the KV cache doesn't cover the image.
+        cached = [MediaRegion("hashA", 5000, 8600)]
+        assert validate(4000, cached, []) == 4000
+
+    def test_multi_image_second_absent_truncates(self):
+        # Turn 1 had two images; turn 2 only has the first — truncate at the
+        # second image's position.
+        cached = [
+            MediaRegion("hashA", 2000, 4000),
+            MediaRegion("hashB", 6000, 8000),
+        ]
+        query = [MediaRegion("hashA", 2000, 4000)]
+        assert validate(9000, cached, query) == 6000
 
     def test_multiple_images_first_mismatch_truncates(self):
         cached = [


### PR DESCRIPTION
## Summary
- **KV cache media validation**: `_validate_media_match` was skipping (`continue`) when a cached entry had an image region but the query did not, allowing stale vision KV states to bleed into subsequent turns. Now truncates the prefix match at the image boundary — matching ollama's behavior where absent multimodal hashes break the prefix match.
- **Partial-chunk embedding injection**: `patch_embed_tokens` was bailing out to plain text embeddings when a prefill chunk partially overlapped the vision range. Image tokens at chunk boundaries got the raw `image_token_id` embedding (garbage) instead of vision features. Now correctly splices vision and text embeddings on partial-overlap chunks.

## Test plan
- [x] Updated `test_text_followup_no_images_in_query` to assert correct truncation behavior
- [x] Added `test_text_followup_match_before_cached_image` — no truncation when match ends before image region
- [x] Added `test_multi_image_second_absent_truncates` — truncates at second image when only first is in query
- [x] All 126 worker + vision cache tests pass
- [x] Verified fix on-device with vision model: no hallucination or recursion on second image prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)