### PR TITLE
feat: Gemma 4 and Gemma 3n vision + tool calling support

### DIFF
--- a/resources/inference_model_cards/mlx-community--gemma-3n-E2B-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-3n-E2B-it-4bit.toml
@@ -1,0 +1,19 @@
+model_id = "mlx-community/gemma-3n-E2B-it-4bit"
+n_layers = 30
+hidden_size = 2048
+num_key_value_heads = 2
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "gemma"
+quantization = "4bit"
+base_model = "Gemma 3n E2B"
+capabilities = ["text", "vision"]
+
+[vision]
+image_token_id = 262145
+model_type = "gemma3n"
+boi_token_id = 255999
+eoi_token_id = 262144
+
+[storage_size]
+in_bytes = 1800000000

--- a/resources/inference_model_cards/mlx-community--gemma-3n-E4B-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-3n-E4B-it-4bit.toml
@@ -1,0 +1,19 @@
+model_id = "mlx-community/gemma-3n-E4B-it-4bit"
+n_layers = 35
+hidden_size = 2048
+num_key_value_heads = 2
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "gemma"
+quantization = "4bit"
+base_model = "Gemma 3n E4B"
+capabilities = ["text", "vision"]
+
+[vision]
+image_token_id = 262145
+model_type = "gemma3n"
+boi_token_id = 255999
+eoi_token_id = 262144
+
+[storage_size]
+in_bytes = 3200000000

--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
@@ -1,0 +1,19 @@
+model_id = "mlx-community/gemma-4-26b-a4b-it-4bit"
+n_layers = 30
+hidden_size = 2816
+num_key_value_heads = 8
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "gemma"
+quantization = "4bit"
+base_model = "Gemma 4 26B A4B"
+capabilities = ["text", "vision"]
+
+[vision]
+image_token_id = 258880
+model_type = "gemma4"
+boi_token_id = 255999
+eoi_token_id = 258882
+
+[storage_size]
+in_bytes = 15500000000

--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
@@ -7,7 +7,7 @@ tasks = ["TextGeneration"]
 family = "gemma"
 quantization = "4bit"
 base_model = "Gemma 4 26B A4B"
-capabilities = ["text", "vision"]
+capabilities = ["text", "vision", "thinking"]
 
 [vision]
 image_token_id = 258880

--- a/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
@@ -1,0 +1,19 @@
+model_id = "mlx-community/gemma-4-e4b-it-8bit"
+n_layers = 42
+hidden_size = 2560
+num_key_value_heads = 2
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "gemma"
+quantization = "8bit"
+base_model = "Gemma 4 E4B"
+capabilities = ["text", "vision"]
+
+[vision]
+image_token_id = 258880
+model_type = "gemma4"
+boi_token_id = 255999
+eoi_token_id = 258882
+
+[storage_size]
+in_bytes = 7200000000

--- a/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
@@ -7,7 +7,7 @@ tasks = ["TextGeneration"]
 family = "gemma"
 quantization = "8bit"
 base_model = "Gemma 4 E4B"
-capabilities = ["text", "vision"]
+capabilities = ["text", "vision", "thinking"]
 
 [vision]
 image_token_id = 258880

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -130,6 +130,8 @@ class VisionCardConfig(CamelCaseModel):
     weights_repo: str = ""
     image_token: str | None = None
     processor_repo: str | None = None
+    boi_token_id: int | None = None
+    eoi_token_id: int | None = None
 
 
 class ModelCard(CamelCaseModel):
@@ -297,15 +299,22 @@ class ConfigData(BaseModel):
         vision_config = data.get("vision_config")
         image_token_id = data.get("image_token_id")
         if vision_config is not None and image_token_id is not None:
+            # Prefer top-level model_type (e.g. "gemma4") over
+            # vision_config.model_type (e.g. "gemma4_vision") — the top-level
+            # value matches the mlx_vlm.models.{model_type} import path.
             model_type = str(
-                vision_config.get("model_type", data.get("model_type", ""))  # pyright: ignore[reportAny]
+                data.get("model_type", vision_config.get("model_type", ""))  # pyright: ignore[reportAny]
             )
             assert info.context is not None
 
+            boi = data.get("boi_token_id")
+            eoi = data.get("eoi_token_id")
             data["vision"] = VisionCardConfig(
                 image_token_id=int(image_token_id),  # pyright: ignore[reportAny]
                 model_type=model_type,
                 weights_repo=info.context["model_id"],  # type: ignore
+                boi_token_id=int(boi) if boi is not None else None,  # pyright: ignore[reportAny]
+                eoi_token_id=int(eoi) if eoi is not None else None,  # pyright: ignore[reportAny]
             )
 
         return data

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -467,16 +467,21 @@ def load_tokenizer_for_model_id(
         eos_token_ids=eos_token_ids,
     )
 
-    if "gemma-3" in model_id_lower:
-        gemma_3_eos_id = 1
-        gemma_3_end_of_turn_id = 106
+    if "gemma-3" in model_id_lower or "gemma-4" in model_id_lower:
+        gemma_eos_id = 1
+        gemma_end_of_turn_id = 106
         if tokenizer.eos_token_ids is not None:
-            if gemma_3_end_of_turn_id not in tokenizer.eos_token_ids:
+            if gemma_end_of_turn_id not in tokenizer.eos_token_ids:
                 tokenizer.eos_token_ids = list(tokenizer.eos_token_ids) + [
-                    gemma_3_end_of_turn_id
+                    gemma_end_of_turn_id
                 ]
         else:
-            tokenizer.eos_token_ids = [gemma_3_eos_id, gemma_3_end_of_turn_id]
+            tokenizer.eos_token_ids = [gemma_eos_id, gemma_end_of_turn_id]
+
+    if "gemma-4" in model_id_lower:
+        tokenizer.tool_call_start = "<|tool_call>"
+        tokenizer.tool_call_end = "<tool_call|>"
+        tokenizer.tool_parser = _parse_gemma4_tool_calls
 
     return tokenizer
 
@@ -800,6 +805,63 @@ def mx_barrier(group: Group | None):
             mx.array(1.0), group=group, stream=mx.default_stream(mx.Device(mx.cpu))
         )
     )
+
+
+def _parse_gemma4_tool_calls(text: str) -> list[dict[str, Any]]:
+    """Parse Gemma 4 tool calls from model output.
+
+    Gemma 4 emits ``call:FUNCTION{key1:value1,key2:<|"|>string<|"|>}``
+    where ``<|"|>`` delimits string values. Bare values keep their JSON
+    type (number, boolean, null); quoted values are always strings.
+
+    Uses the three-phase approach from ollama PR #15306:
+    1. Extract ``<|"|>``-delimited strings into placeholders
+    2. Quote bare keys
+    3. Restore strings via ``json.dumps()`` for correct escaping
+    """
+    import regex as re
+
+    _call_re = re.compile(r"call:(\w+)\{(.*?)\}", re.DOTALL)
+    _gemma_quote_re = re.compile(r'(?s)<\|"\|>(.*?)<\|"\|>')
+    _bare_key_re = re.compile(r"([,{])(\w+):")
+
+    def _args_to_json(raw_args: str) -> str:
+        # Phase 1: extract <|"|>-quoted strings into placeholders.
+        extracted: list[str] = []
+
+        def _replace_quoted(m: re.Match[str]) -> str:
+            extracted.append(m.group(1))
+            return f"\x00{len(extracted) - 1}\x00"
+
+        skeleton = _gemma_quote_re.sub(_replace_quoted, raw_args)
+
+        # Phase 2: quote bare keys — {key: or ,key: → {"key": or ,"key":
+        skeleton = "{" + skeleton  # ensure leading { for regex
+        skeleton = _bare_key_re.sub(r'\1"\2":', skeleton)
+        skeleton = skeleton[1:]  # remove added {
+
+        # Phase 3: restore extracted strings with proper JSON escaping.
+        for i, value in enumerate(extracted):
+            escaped = json.dumps(value)  # json.dumps handles all escaping
+            skeleton = skeleton.replace(f"\x00{i}\x00", escaped)
+
+        return skeleton
+
+    results: list[dict[str, Any]] = []
+    for match in _call_re.finditer(text):
+        func_name = match.group(1)
+        raw_args = match.group(2)
+        args_json = "{" + _args_to_json(raw_args) + "}"
+        try:
+            args_dict: dict[str, Any] = json.loads(args_json)  # pyright: ignore[reportAny]
+        except json.JSONDecodeError:
+            logger.warning(f"Failed to parse Gemma 4 tool call args: {args_json}")
+            args_dict = {}
+        results.append(dict(name=func_name, arguments=args_dict))  # pyright: ignore[reportAny]
+
+    if not results:
+        raise ValueError(f"No Gemma 4 tool calls found in: {text}")
+    return results
 
 
 def _parse_kimi_tool_calls(text: str):

--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -504,19 +504,29 @@ class VisionEncoder:
         return pixel_values, None, n_tokens_per_image
 
     def _get_soft_tokens_per_image(self) -> int:
-        """Determine the number of soft tokens per image from model config."""
+        """Determine the number of soft tokens per image from model config.
+
+        Caches the result to avoid re-reading config.json on every call."""
+        cached = getattr(self, "_soft_tokens_cache", None)
+        if cached is not None:
+            return int(cached)
+
+        result = 256  # sensible default for SiglipImageProcessor-based models
         config = self._load_config_json()
         if config:
             # Top-level vision_soft_tokens_per_image (gemma3n, gemma4).
             vst = config.get("vision_soft_tokens_per_image")
             if vst is not None:
-                return int(vst)  # pyright: ignore[reportAny]
-            # VisionConfig.default_output_length (gemma4).
-            vc: dict[str, Any] = config.get("vision_config", {})  # pyright: ignore[reportAny]
-            dol = vc.get("default_output_length")
-            if dol is not None:
-                return int(dol)  # pyright: ignore[reportAny]
-        return 256  # sensible default for SiglipImageProcessor-based models
+                result = int(vst)  # pyright: ignore[reportAny]
+            else:
+                # VisionConfig.default_output_length (gemma4).
+                vc: dict[str, Any] = config.get("vision_config", {})  # pyright: ignore[reportAny]
+                dol = vc.get("default_output_length")
+                if dol is not None:
+                    result = int(dol)  # pyright: ignore[reportAny]
+
+        self._soft_tokens_cache = result
+        return result
 
     def _run_vision_tower(
         self, pixel_values: mx.array | list[mx.array], grid_thw: mx.array | None

--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -159,6 +159,45 @@ class VisionResult:
     media_regions: list[MediaRegion]
 
 
+def _instantiate_projector(
+    cls: type,
+    model_config: Any,  # pyright: ignore[reportAny]
+    vision_config: Any,  # pyright: ignore[reportAny]
+    text_config: Any,  # pyright: ignore[reportAny]
+) -> nn.Module:
+    """Try multiple calling conventions for projector/embedder classes.
+
+    Different model families use different constructor signatures:
+    - Qwen/Kimi: ``Projector(model_config)``
+    - Gemma 3n: ``Embedder(vision_config, text_config=text_config)``
+    - Gemma 4: ``Embedder(embedding_dim, text_hidden_size, eps)``
+    """
+    params = set(inspect.signature(cls.__init__).parameters.keys()) - {"self"}
+    # Try single ModelConfig arg first (Qwen/Kimi pattern)
+    if "config" in params or len(params) == 1:
+        try:
+            return cls(model_config)  # type: ignore
+        except TypeError:
+            pass
+    # Try (multimodal_config, text_config) pattern (Gemma 3n)
+    if "multimodal_config" in params or "text_config" in params:
+        try:
+            return cls(vision_config, text_config=text_config)  # type: ignore
+        except TypeError:
+            pass
+    # Try raw dims pattern (Gemma 4: embedding_dim, text_hidden_size, eps)
+    if "embedding_dim" in params:
+        kwargs: dict[str, Any] = {
+            "embedding_dim": getattr(vision_config, "hidden_size", 768),  # pyright: ignore[reportAny]
+            "text_hidden_size": getattr(text_config, "hidden_size", 2048),  # pyright: ignore[reportAny]
+        }
+        if "eps" in params:
+            kwargs["eps"] = getattr(vision_config, "rms_norm_eps", 1e-6)  # pyright: ignore[reportAny]
+        return cls(**kwargs)  # type: ignore
+    # Fallback: pass through _filter_config
+    return cls(**_filter_config(cls, vars(model_config)))  # type: ignore
+
+
 class VisionEncoder:
     """Lazy-loaded vision tower + projector that encodes PIL images into
     feature tensors. Supports both bundled weights (loaded from the main
@@ -221,13 +260,16 @@ class VisionEncoder:
             model_mod = self._import_mlx_vlm(self._config.model_type)  # type: ignore
 
         projector_cls = None
+        # Match common projector class naming conventions across model
+        # families: *Projector (Qwen, Kimi), *Embedder (Gemma 3n/4).
+        _projector_patterns = ("Projector", "Embedder")
         if model_mod is not None:
             for attr_name in dir(model_mod):  # type: ignore
                 obj = getattr(model_mod, attr_name)  # type: ignore
                 if (
                     isinstance(obj, type)
                     and issubclass(obj, nn.Module)
-                    and "Projector" in attr_name
+                    and any(p in attr_name for p in _projector_patterns)
                 ):
                     projector_cls = obj
                     break
@@ -247,7 +289,9 @@ class VisionEncoder:
                 vision_config=vision_config,
                 **_filter_config(config_mod.ModelConfig, extra),  # type: ignore
             )
-            self._projector = projector_cls(model_config)  # type: ignore
+            self._projector = _instantiate_projector(
+                projector_cls, model_config, vision_config, text_config
+            )
 
         processor_repo = self._config.processor_repo
         if processor_repo:
@@ -330,7 +374,11 @@ class VisionEncoder:
             raise FileNotFoundError(f"No safetensors files found in {self._model_path}")
 
         vision_prefixes = ["vision_tower.", "model.visual."]
+        # Gemma 3n/4 store their projector (MultimodalEmbedder) under
+        # "embed_vision." in the same safetensors files as vision weights.
+        projector_prefixes = ["embed_vision."]
         vision_weights: dict[str, mx.array] = {}
+        projector_weights: dict[str, mx.array] = {}
         found_raw_prefix = False
         for sf_path in safetensors_files:
             file_weights: dict[str, mx.array] = mx.load(str(sf_path))  # type: ignore
@@ -342,6 +390,12 @@ class VisionEncoder:
                         if prefix == "model.visual.":
                             found_raw_prefix = True
                         break
+                else:
+                    for prefix in projector_prefixes:
+                        if key.startswith(prefix):
+                            short_key = key[len(prefix) :]
+                            projector_weights[short_key] = val
+                            break
 
         if not vision_weights:
             raise ValueError(
@@ -356,8 +410,16 @@ class VisionEncoder:
         self._vision_tower.load_weights(list(vision_weights.items()))  # type: ignore
         mx.eval(self._vision_tower.parameters())
 
+        if self._projector is not None and projector_weights:
+            self._projector.load_weights(list(projector_weights.items()))
+            mx.eval(self._projector.parameters())
+
         n_vision = sum(v.size for _, v in vision_weights.items())  # type: ignore
-        logger.info(f"Vision encoder loaded: {n_vision / 1e6:.1f}M params")
+        n_proj = sum(v.size for _, v in projector_weights.items())
+        logger.info(
+            f"Vision encoder loaded: {n_vision / 1e6:.1f}M params"
+            + (f", projector: {n_proj / 1e6:.1f}M params" if n_proj else "")
+        )
 
     def encode_images(self, images: list[str]) -> tuple[mx.array, list[int]]:
         """Encode base64 images into feature tensors and per-image token counts."""
@@ -368,6 +430,24 @@ class VisionEncoder:
         pil_images = [decode_base64_image(b64) for b64 in images]
         for idx, img in enumerate(pil_images):
             logger.info(f"Image {idx}: {img.width}x{img.height} mode={img.mode}")
+
+        pixel_values, grid_thw, n_tokens_per_image = self._preprocess_images(
+            pil_images
+        )
+        hidden_states = self._run_vision_tower(pixel_values, grid_thw)
+
+        if self._projector is not None:
+            image_features: mx.array = self._projector(hidden_states)
+        else:
+            image_features = hidden_states
+
+        return image_features, n_tokens_per_image
+
+    def _preprocess_images(
+        self, pil_images: list[Image.Image]
+    ) -> tuple[mx.array | list[mx.array], mx.array | None, list[int]]:
+        """Run the image processor and return pixel values, optional grid, and token counts."""
+        assert self._processor is not None
 
         if self._config.processor_repo:
             processed = self._processor.preprocess(
@@ -382,13 +462,29 @@ class VisionEncoder:
                 int(mx.prod(grid_thw[i]).item()) // merge_length
                 for i in range(grid_thw.shape[0])
             ]
-        else:
-            processed = self._processor(
-                images=pil_images,
-                return_tensors="np",
-            )
-            pixel_values = mx.array(processed["pixel_values"])  # type: ignore
-            grid_thw = mx.array(processed["image_grid_thw"])  # type: ignore
+            return pixel_values, grid_thw, n_tokens_per_image
+
+        raw: Any = self._processor(images=pil_images, return_tensors="np")
+
+        # Gemma 4's processor returns (data_dict, num_soft_tokens_per_image).
+        if isinstance(raw, tuple):
+            data_dict = dict(raw[0])  # type: ignore
+            soft_tokens: list[int] = list(raw[1])  # type: ignore
+            pv_raw = data_dict["pixel_values"]  # pyright: ignore[reportUnknownVariableType]
+            if isinstance(pv_raw, list):
+                # Variable-sized images — keep as list for per-image encoding.
+                pixel_values_list: list[mx.array] = [mx.array(v) for v in pv_raw]  # pyright: ignore[reportUnknownVariableType, reportUnknownArgumentType]
+                return pixel_values_list, None, soft_tokens
+            return mx.array(pv_raw), None, soft_tokens  # pyright: ignore[reportUnknownArgumentType]
+
+        # Standard HuggingFace processor (Qwen, SiglipImageProcessor, etc.)
+        pv_key = "pixel_values"
+        pixel_values = mx.array(raw[pv_key])  # type: ignore
+
+        # Processors that return grid info (Qwen-VL family).
+        grid_key = "image_grid_thw"
+        if grid_key in raw:
+            grid_thw = mx.array(raw[grid_key])  # type: ignore
             merge_unit = self._spatial_merge_size**2
             n_tokens_per_image = [
                 int(
@@ -399,24 +495,65 @@ class VisionEncoder:
                 // merge_unit
                 for i in range(grid_thw.shape[0])
             ]
+            return pixel_values, grid_thw, n_tokens_per_image
+
+        # Gemma 3n / simple processors: no grid info, use config's
+        # vision_soft_tokens_per_image or the vision tower's default_output_length.
+        n_per_image = self._get_soft_tokens_per_image()
+        n_tokens_per_image = [n_per_image] * len(pil_images)
+        return pixel_values, None, n_tokens_per_image
+
+    def _get_soft_tokens_per_image(self) -> int:
+        """Determine the number of soft tokens per image from model config."""
+        config = self._load_config_json()
+        if config:
+            # Top-level vision_soft_tokens_per_image (gemma3n, gemma4).
+            vst = config.get("vision_soft_tokens_per_image")
+            if vst is not None:
+                return int(vst)  # pyright: ignore[reportAny]
+            # VisionConfig.default_output_length (gemma4).
+            vc: dict[str, Any] = config.get("vision_config", {})  # pyright: ignore[reportAny]
+            dol = vc.get("default_output_length")
+            if dol is not None:
+                return int(dol)  # pyright: ignore[reportAny]
+        return 256  # sensible default for SiglipImageProcessor-based models
+
+    def _run_vision_tower(
+        self, pixel_values: mx.array | list[mx.array], grid_thw: mx.array | None
+    ) -> mx.array:
+        """Run the vision tower, dispatching by input format."""
+        assert self._vision_tower is not None
 
         if self._needs_nhwc:
+            assert grid_thw is not None
             grid_hw = grid_thw[:, 1:] if grid_thw.shape[-1] == 3 else grid_thw
-            hidden_states = self._vision_tower(
-                pixel_values.transpose(0, 2, 3, 1),
+            return self._vision_tower(
+                pixel_values.transpose(0, 2, 3, 1),  # type: ignore
                 output_hidden_states=True,
                 grid_thw=grid_hw,
             )
-        else:
+
+        if isinstance(pixel_values, list):
+            # Variable-sized images (Gemma 4): encode each independently and
+            # concatenate features.
+            features: list[mx.array] = []
+            for pv in pixel_values:
+                if pv.ndim == 3:
+                    pv = pv[None]  # add batch dim
+                out: mx.array = self._vision_tower(pv)
+                out = out[0] if isinstance(out, tuple) else out
+                if out.ndim == 3:
+                    out = out.reshape(-1, out.shape[-1])  # flatten batch
+                features.append(out)
+            return mx.concatenate(features, axis=0)
+
+        if grid_thw is not None:
             result = self._vision_tower(pixel_values, grid_thw)
-            hidden_states = result[0] if isinstance(result, tuple) else result
-
-        if self._projector is not None:
-            image_features: mx.array = self._projector(hidden_states)
         else:
-            image_features = hidden_states
-
-        return image_features, n_tokens_per_image
+            # No grid info (Gemma 3n, SiglipImageProcessor) — vision tower
+            # takes just pixel_values.
+            result = self._vision_tower(pixel_values)
+        return result[0] if isinstance(result, tuple) else result
 
 
 def get_inner_model(model: nn.Module) -> Any:  # type: ignore
@@ -479,7 +616,10 @@ def _find_media_regions(
     prompt_tokens: mx.array,
     images: list[str],
     image_token_id: int,
+    boi_token_id: int | None = None,
+    eoi_token_id: int | None = None,
 ) -> list[MediaRegion]:
+    """Find contiguous image-token runs and expand to include BOI/EOI markers."""
     tokens_np = np.array(prompt_tokens)
     is_pad = tokens_np == image_token_id  # type: ignore
 
@@ -499,6 +639,22 @@ def _find_media_regions(
         regions.append(
             MediaRegion(content_hash="", start_pos=run_start, end_pos=len(tokens_np))
         )
+
+    # Expand region boundaries to include surrounding BOI/EOI tokens so
+    # the KV prefix cache invalidates the full image span.
+    for region in regions:
+        if (
+            boi_token_id is not None
+            and region.start_pos > 0
+            and tokens_np[region.start_pos - 1] == boi_token_id
+        ):
+            region.start_pos -= 1
+        if (
+            eoi_token_id is not None
+            and region.end_pos < len(tokens_np)
+            and tokens_np[region.end_pos] == eoi_token_id
+        ):
+            region.end_pos += 1
 
     for i, region in enumerate(regions):
         if i < len(images):
@@ -599,6 +755,8 @@ class VisionProcessor:
             prompt_tokens,
             images,
             self.vision_config.image_token_id,
+            boi_token_id=self.vision_config.boi_token_id,
+            eoi_token_id=self.vision_config.eoi_token_id,
         )
 
         return VisionResult(

--- a/src/exo/worker/tests/unittests/test_runner/test_gemma4_tool_parsing.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_gemma4_tool_parsing.py
@@ -1,0 +1,92 @@
+"""Tests for Gemma 4 tool call parsing.
+
+Covers the ``<|"|>`` quoting format, bare key quoting, type preservation,
+internal quotes, and backslash escaping — matching ollama's test cases."""
+
+import pytest
+
+from exo.worker.engines.mlx.utils_mlx import _parse_gemma4_tool_calls
+
+
+class TestGemma4ToolCallParsing:
+    def test_simple_string_arg(self):
+        text = 'call:get_weather{location:<|"|>San Francisco<|"|>}'
+        result = _parse_gemma4_tool_calls(text)
+        assert len(result) == 1
+        assert result[0]["name"] == "get_weather"
+        assert result[0]["arguments"]["location"] == "San Francisco"
+
+    def test_numeric_arg_unquoted(self):
+        """Bare numeric values should preserve their type."""
+        text = "call:set_temp{value:42}"
+        result = _parse_gemma4_tool_calls(text)
+        assert result[0]["arguments"]["value"] == 42
+
+    def test_numeric_arg_quoted_is_string(self):
+        """Quoted numeric values should be strings, not numbers."""
+        text = 'call:set_temp{value:<|"|>42<|"|>}'
+        result = _parse_gemma4_tool_calls(text)
+        assert result[0]["arguments"]["value"] == "42"
+
+    def test_boolean_unquoted(self):
+        text = "call:toggle{enabled:true}"
+        result = _parse_gemma4_tool_calls(text)
+        assert result[0]["arguments"]["enabled"] is True
+
+    def test_boolean_quoted_is_string(self):
+        text = 'call:toggle{enabled:<|"|>true<|"|>}'
+        result = _parse_gemma4_tool_calls(text)
+        assert result[0]["arguments"]["enabled"] == "true"
+
+    def test_null_unquoted(self):
+        text = "call:clear{field:null}"
+        result = _parse_gemma4_tool_calls(text)
+        assert result[0]["arguments"]["field"] is None
+
+    def test_internal_double_quotes(self):
+        """Strings containing double quotes must be properly escaped."""
+        text = 'call:run{cmd:<|"|>git commit -m "fix bug"<|"|>}'
+        result = _parse_gemma4_tool_calls(text)
+        assert result[0]["arguments"]["cmd"] == 'git commit -m "fix bug"'
+
+    def test_windows_path_backslashes(self):
+        """Backslashes in paths must be properly escaped."""
+        text = 'call:read{path:<|"|>C:\\Temp\\file.txt<|"|>}'
+        result = _parse_gemma4_tool_calls(text)
+        assert result[0]["arguments"]["path"] == "C:\\Temp\\file.txt"
+
+    def test_multiple_args(self):
+        text = 'call:search{query:<|"|>hello world<|"|>,limit:10,exact:true}'
+        result = _parse_gemma4_tool_calls(text)
+        args = result[0]["arguments"]
+        assert args["query"] == "hello world"
+        assert args["limit"] == 10
+        assert args["exact"] is True
+
+    def test_multiple_tool_calls(self):
+        text = (
+            'call:foo{a:<|"|>x<|"|>}\n'
+            'call:bar{b:42}'
+        )
+        result = _parse_gemma4_tool_calls(text)
+        assert len(result) == 2
+        assert result[0]["name"] == "foo"
+        assert result[0]["arguments"]["a"] == "x"
+        assert result[1]["name"] == "bar"
+        assert result[1]["arguments"]["b"] == 42
+
+    def test_no_tool_calls_raises(self):
+        with pytest.raises(ValueError, match="No Gemma 4 tool calls found"):
+            _parse_gemma4_tool_calls("just some text")
+
+    def test_empty_args(self):
+        text = "call:ping{}"
+        result = _parse_gemma4_tool_calls(text)
+        assert result[0]["name"] == "ping"
+        assert result[0]["arguments"] == {}
+
+    def test_string_with_newlines(self):
+        """Newlines inside quoted strings should be preserved."""
+        text = 'call:write{content:<|"|>line1\nline2<|"|>}'
+        result = _parse_gemma4_tool_calls(text)
+        assert result[0]["arguments"]["content"] == "line1\nline2"

--- a/tests/test_gemma_vision.py
+++ b/tests/test_gemma_vision.py
@@ -1,0 +1,141 @@
+"""Tests for Gemma 3n/4 vision model support.
+
+Covers BOI/EOI media region expansion, projector detection patterns,
+model_type auto-detection priority, and VisionCardConfig BOI/EOI fields."""
+
+import base64
+import io
+
+import mlx.core as mx
+from PIL import Image
+
+from exo.shared.models.model_cards import VisionCardConfig
+from exo.worker.engines.mlx.vision import _find_media_regions
+
+
+def _fake_b64_image() -> str:
+    """Create a minimal valid base64-encoded PNG for testing."""
+    img = Image.new("RGB", (4, 4), color=(0, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+class TestFindMediaRegionsBoiEoi:
+    """_find_media_regions should expand region boundaries to include BOI/EOI."""
+
+    def test_no_boi_eoi(self):
+        """Without BOI/EOI config, regions cover only image tokens."""
+        tokens = mx.array([10, 20, 99, 99, 99, 30, 40])
+        b64 = _fake_b64_image()
+        regions = _find_media_regions(tokens, [b64], image_token_id=99)
+        assert len(regions) == 1
+        assert regions[0].start_pos == 2
+        assert regions[0].end_pos == 5
+
+    def test_boi_eoi_expansion(self):
+        """With BOI/EOI, regions expand to include surrounding markers."""
+        boi, img, eoi = 255999, 262145, 262144
+        tokens = mx.array([10, boi, img, img, img, eoi, 20])
+        b64 = _fake_b64_image()
+        regions = _find_media_regions(
+            tokens, [b64], image_token_id=img,
+            boi_token_id=boi, eoi_token_id=eoi,
+        )
+        assert len(regions) == 1
+        assert regions[0].start_pos == 1
+        assert regions[0].end_pos == 6
+
+    def test_boi_only(self):
+        """Only BOI present (no EOI) — expand start only."""
+        boi, img = 255999, 262145
+        tokens = mx.array([boi, img, img, 10])
+        b64 = _fake_b64_image()
+        regions = _find_media_regions(
+            tokens, [b64], image_token_id=img,
+            boi_token_id=boi, eoi_token_id=None,
+        )
+        assert len(regions) == 1
+        assert regions[0].start_pos == 0
+        assert regions[0].end_pos == 3
+
+    def test_no_boi_at_boundary(self):
+        """BOI token not adjacent — no expansion."""
+        boi, img = 255999, 262145
+        tokens = mx.array([10, 20, img, img, 30])
+        b64 = _fake_b64_image()
+        regions = _find_media_regions(
+            tokens, [b64], image_token_id=img,
+            boi_token_id=boi, eoi_token_id=None,
+        )
+        assert len(regions) == 1
+        assert regions[0].start_pos == 2
+        assert regions[0].end_pos == 4
+
+    def test_multiple_images_boi_eoi(self):
+        """Multiple images each wrapped in BOI/EOI."""
+        boi, img, eoi = 255999, 262145, 262144
+        tokens = mx.array([boi, img, img, eoi, 10, boi, img, eoi, 20])
+        b64_a = _fake_b64_image()
+        b64_b = _fake_b64_image()
+        regions = _find_media_regions(
+            tokens, [b64_a, b64_b], image_token_id=img,
+            boi_token_id=boi, eoi_token_id=eoi,
+        )
+        assert len(regions) == 2
+        assert regions[0].start_pos == 0
+        assert regions[0].end_pos == 4
+        assert regions[1].start_pos == 5
+        assert regions[1].end_pos == 8
+
+
+class TestVisionCardConfigBoiEoi:
+    """VisionCardConfig should accept optional BOI/EOI token IDs."""
+
+    def test_defaults_none(self):
+        config = VisionCardConfig(
+            image_token_id=151655, model_type="qwen3_vl"
+        )
+        assert config.boi_token_id is None
+        assert config.eoi_token_id is None
+
+    def test_gemma_config(self):
+        config = VisionCardConfig(
+            image_token_id=262145,
+            model_type="gemma3n",
+            boi_token_id=255999,
+            eoi_token_id=262144,
+        )
+        assert config.boi_token_id == 255999
+        assert config.eoi_token_id == 262144
+
+
+class TestModelTypePriority:
+    """Auto-detection should prefer top-level model_type over vision_config.model_type."""
+
+    def test_top_level_preferred(self):
+        from exo.shared.models.model_cards import ConfigData
+
+        data = {
+            "model_type": "gemma3n",
+            "num_hidden_layers": 30,
+            "hidden_size": 2048,
+            "vision_config": {"model_type": "gemma3n_vision", "hidden_size": 2048},
+            "image_token_id": 262145,
+        }
+        result = ConfigData.model_validate(data, context={"model_id": "test/model"})
+        assert result.vision is not None
+        assert result.vision.model_type == "gemma3n"
+
+    def test_falls_back_to_vision_config(self):
+        from exo.shared.models.model_cards import ConfigData
+
+        data = {
+            "num_hidden_layers": 30,
+            "hidden_size": 2048,
+            "vision_config": {"model_type": "qwen3_vl", "hidden_size": 2560},
+            "image_token_id": 151655,
+        }
+        result = ConfigData.model_validate(data, context={"model_id": "test/model"})
+        assert result.vision is not None
+        assert result.vision.model_type == "qwen3_vl"


### PR DESCRIPTION
## Summary
- Full multimodal vision pipeline support for Gemma 4 (`gemma4`) and Gemma 3n (`gemma3n`) model families
- Gemma 4 tool call parser implementing the `<|"|>` quoting format (three-phase placeholder approach matching ollama's PR #15306)
- Model cards for gemma-3n-E2B/E4B and gemma-4-e4b/26b-a4b

### Vision pipeline changes
- Fix auto-detection `model_type` priority (top-level > `vision_config.model_type`) so `gemma4` resolves correctly instead of `gemma4_vision`
- Expand projector detection to find `MultimodalEmbedder` alongside `*Projector` classes, with flexible instantiation across different constructor signatures
- Load bundled projector weights from `embed_vision.*` prefix
- Handle Gemma's image processor output: tuple returns, variable-sized pixel values, no grid info
- BOI/EOI token support in `VisionCardConfig` and media region detection for correct KV cache invalidation

### Tool calling
- `_parse_gemma4_tool_calls()`: extract `<|"|>` regions, quote bare keys, restore via `json.dumps()` for correct escaping
- Respects type semantics: `<|"|>1<|"|>` = string, bare `1` = number
- Wired into tokenizer with `<|tool_call>`/`<tool_call|>` markers

## Test plan
- [x] 9 new vision tests: BOI/EOI media region expansion, model_type priority, VisionCardConfig fields
- [x] 13 new tool parsing tests: string args, type preservation, internal quotes, backslashes, multi-arg, multi-call
- [x] All 184 existing + new tests pass
- [x] basedpyright: 0 new errors
- [x] ruff: passes
- [ ] Live test with Gemma 4 vision model on-device

🤖 Generated with [Claude Code](https://claude.com/claude-code)