### PR TITLE
fix: handle quantization params when loading projector weights

### DIFF
--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -159,6 +159,27 @@ class VisionResult:
     media_regions: list[MediaRegion]
 
 
+_QUANTIZATION_SUFFIXES = (".biases", ".scales")
+
+
+def _load_projector_weights(
+    projector: nn.Module, weights: dict[str, mx.array]
+) -> None:
+    """Load projector weights, filtering out quantization-only tensors.
+
+    Quantized checkpoints include auxiliary tensors (biases, scales) that
+    the projector module doesn't define. We drop only those known extras
+    and keep strict loading so genuine incompatibilities are not masked."""
+    dropped = [k for k in weights if k.endswith(_QUANTIZATION_SUFFIXES)]
+    if dropped:
+        logger.info(
+            "Dropping quantization-only projector tensors: "
+            + ", ".join(sorted(dropped))
+        )
+    filtered = {k: v for k, v in weights.items() if k not in dropped}
+    projector.load_weights(list(filtered.items()))
+
+
 def _instantiate_projector(
     cls: type,
     model_config: Any,  # pyright: ignore[reportAny]
@@ -358,9 +379,7 @@ class VisionEncoder:
         mx.eval(self._vision_tower.parameters())
 
         if self._projector is not None and projector_weights:
-            # strict=False: quantized models include extra params (biases,
-            # scales) that the projector module doesn't define.
-            self._projector.load_weights(list(projector_weights.items()), strict=False)
+            _load_projector_weights(self._projector, projector_weights)
             mx.eval(self._projector.parameters())
 
         n_vision = sum(v.size for _, v in vision_weights.items())
@@ -413,9 +432,7 @@ class VisionEncoder:
         mx.eval(self._vision_tower.parameters())
 
         if self._projector is not None and projector_weights:
-            # strict=False: quantized models include extra params (biases,
-            # scales) that the projector module doesn't define.
-            self._projector.load_weights(list(projector_weights.items()), strict=False)
+            _load_projector_weights(self._projector, projector_weights)
             mx.eval(self._projector.parameters())
 
         n_vision = sum(v.size for _, v in vision_weights.items())  # type: ignore

--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -358,7 +358,9 @@ class VisionEncoder:
         mx.eval(self._vision_tower.parameters())
 
         if self._projector is not None and projector_weights:
-            self._projector.load_weights(list(projector_weights.items()))
+            # strict=False: quantized models include extra params (biases,
+            # scales) that the projector module doesn't define.
+            self._projector.load_weights(list(projector_weights.items()), strict=False)
             mx.eval(self._projector.parameters())
 
         n_vision = sum(v.size for _, v in vision_weights.items())
@@ -411,7 +413,9 @@ class VisionEncoder:
         mx.eval(self._vision_tower.parameters())
 
         if self._projector is not None and projector_weights:
-            self._projector.load_weights(list(projector_weights.items()))
+            # strict=False: quantized models include extra params (biases,
+            # scales) that the projector module doesn't define.
+            self._projector.load_weights(list(projector_weights.items()), strict=False)
             mx.eval(self._projector.parameters())
 
         n_vision = sum(v.size for _, v in vision_weights.items())  # type: ignore


### PR DESCRIPTION
## Summary
- Quantized models (e.g. 4-bit Gemma 4) include extra parameters (`biases`, `scales`) in the projector/embedder weights that the `MultimodalEmbedder` module doesn't define
- `load_weights` is strict by default and raises `ValueError` for unknown params
- Fix: pass `strict=False` to both weight loading paths (bundled and separate repo)

## Error before fix
```
ValueError: Received 2 parameters not in model:
embedding_projection.biases,
embedding_projection.scales.
```

This caused vision to silently fall back to text-only, producing garbled output for image inputs.

## Test plan
- [x] All 184 tests pass
- [ ] Verify on-device with `mlx-community/gemma-4-26b-a4b-it-4bit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)