### PR TITLE
fix: use native vision pipeline for Gemma 4

### DIFF
--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -38,6 +38,7 @@ from exo.worker.engines.mlx.generator.generate import (
     eos_ids_from_tokenizer,
     extract_top_logprobs,
     patch_embed_tokens,
+    patch_native_vision,
     prefill,
 )
 from exo.worker.engines.mlx.utils_mlx import (
@@ -179,13 +180,14 @@ class ExoBatchGenerator:
             top_k=task_params.top_k if task_params.top_k is not None else 0,
         )
 
-        vision_ctx = (
-            patch_embed_tokens(
+        if vision is not None and vision.pixel_values is not None:
+            vision_ctx = patch_native_vision(self.model, vision.pixel_values)
+        elif vision is not None:
+            vision_ctx = patch_embed_tokens(
                 self.model, vision.embeddings, prefix_hit_length, len(prompt_tokens) - 1
             )
-            if vision is not None
-            else contextlib.nullcontext()
-        )
+        else:
+            vision_ctx = contextlib.nullcontext()
         with vision_ctx:
             _prefill_tps, _prefill_tokens, cache_snapshots = prefill(
                 self.model,

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -111,6 +111,35 @@ def patch_embed_tokens(
         inner.embed_tokens = original_embed
 
 
+@contextlib.contextmanager
+def patch_native_vision(
+    model: Model, pixel_values: mx.array | list[mx.array]
+) -> Generator[None]:
+    """Inject ``pixel_values`` into the model's forward pass during prefill.
+
+    For models with native vision support (e.g. Gemma 4), ``Model.__call__``
+    accepts ``pixel_values`` and handles vision encoding internally via its
+    own vision tower, projector, and ``masked_scatter``.
+
+    Since ``mlx_lm.generate_step._model_call`` doesn't pass extra kwargs,
+    we monkey-patch the inner model's ``__call__`` to inject ``pixel_values``
+    for the duration of prefill.  After the context manager exits, the
+    original ``__call__`` is restored so decode steps don't re-process images.
+    """
+    inner: object = getattr(model, "_inner", model)
+    original_call: object = type(inner).__call__
+
+    def _injected_call(*args: object, **kwargs: object) -> object:
+        kwargs["pixel_values"] = pixel_values
+        return original_call(*args, **kwargs)  # pyright: ignore[reportAny]
+
+    type(inner).__call__ = _injected_call
+    try:
+        yield
+    finally:
+        type(inner).__call__ = original_call
+
+
 class PrefillCancelled(BaseException):
     """Raised when prefill is cancelled via the progress callback."""
 
@@ -587,13 +616,18 @@ def mlx_generate(
     )
     max_stop_len = max((len(s) for s in stop_sequences), default=0)
 
-    maybe_vision_ctx = (
-        patch_embed_tokens(
+    if vision is not None and vision.pixel_values is not None:
+        # Native vision path: inject pixel_values into the model's forward
+        # pass. The model handles vision encoding internally (e.g. Gemma 4).
+        maybe_vision_ctx = patch_native_vision(model, vision.pixel_values)
+    elif vision is not None:
+        # Legacy path: splice pre-computed embeddings via monkey-patched
+        # embed_tokens (Qwen-VL, Kimi, etc.).
+        maybe_vision_ctx = patch_embed_tokens(
             model, vision.embeddings, prefix_hit_length, len(prompt_tokens) - 1
         )
-        if vision is not None
-        else contextlib.nullcontext()
-    )
+    else:
+        maybe_vision_ctx = contextlib.nullcontext()
     with maybe_vision_ctx:
         prefill_tps, prefill_tokens, ssm_snapshots_list = prefill(
             model,

--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -475,6 +475,7 @@ class VisionEncoder:
         self, pil_images: list[Image.Image]
     ) -> tuple[mx.array | list[mx.array], mx.array | None, list[int]]:
         """Public interface to image preprocessing (pixel_values + token counts)."""
+        self.ensure_loaded()
         return self._preprocess_images(pil_images)
 
     def encode_images(self, images: list[str]) -> tuple[mx.array, list[int]]:

--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -157,6 +157,10 @@ class VisionResult:
     prompt_tokens: mx.array
     embeddings: mx.array
     media_regions: list[MediaRegion]
+    # For native-vision models (e.g. Gemma 4) that handle vision internally
+    # via their own vision tower + projector. When set, pixel_values are
+    # injected into the model's forward pass instead of using patch_embed_tokens.
+    pixel_values: mx.array | list[mx.array] | None = None
 
 
 _QUANTIZATION_SUFFIXES = (".biases", ".scales")
@@ -467,6 +471,12 @@ class VisionEncoder:
             + (f", projector: {n_proj / 1e6:.1f}M params" if n_proj else "")
         )
 
+    def preprocess_images(
+        self, pil_images: list[Image.Image]
+    ) -> tuple[mx.array | list[mx.array], mx.array | None, list[int]]:
+        """Public interface to image preprocessing (pixel_values + token counts)."""
+        return self._preprocess_images(pil_images)
+
     def encode_images(self, images: list[str]) -> tuple[mx.array, list[int]]:
         """Encode base64 images into feature tensors and per-image token counts."""
         self.ensure_loaded()
@@ -617,6 +627,17 @@ class VisionEncoder:
         return out
 
 
+def has_native_vision(model: nn.Module) -> bool:
+    """Check if the model has built-in vision processing (e.g. Gemma 4).
+
+    Models with both a ``vision_tower`` and ``embed_vision`` (projector)
+    handle image encoding internally via their ``__call__`` accepting
+    ``pixel_values``.  For these models we pass preprocessed tensors
+    directly instead of running a separate VisionEncoder."""
+    inner: object = getattr(model, "_inner", model)
+    return hasattr(inner, "vision_tower") and hasattr(inner, "embed_vision")
+
+
 def get_inner_model(model: nn.Module) -> Any:  # type: ignore
     """Traverse the model tree to find the inner transformer with ``embed_tokens``."""
     for candidate in (
@@ -761,6 +782,10 @@ class VisionProcessor:
     ) -> VisionResult:
         logger.info(f"Vision pipeline: {len(images)} image(s)")
 
+        native = has_native_vision(model)
+        if native:
+            return self._process_native(images, chat_template_messages, tokenizer)
+
         cache_key = self._image_cache_key(images)
         cached = self._feature_cache.pop(cache_key, None)
         if cached is not None:
@@ -825,6 +850,76 @@ class VisionProcessor:
             prompt_tokens=prompt_tokens,
             embeddings=embeddings,
             media_regions=media_regions,
+        )
+
+    def _process_native(
+        self,
+        images: list[str],
+        chat_template_messages: list[dict[str, Any]],
+        tokenizer: TokenizerWrapper,
+    ) -> VisionResult:
+        """Process images for models with native vision support (e.g. Gemma 4).
+
+        Instead of running a separate vision tower and producing embeddings,
+        this preprocesses images into ``pixel_values`` tensors and returns them
+        in ``VisionResult``.  The model's own ``__call__`` will handle vision
+        encoding via its built-in vision tower and ``masked_scatter``."""
+        logger.info("Using native vision pipeline (model has built-in vision tower)")
+        self._encoder.ensure_loaded()
+
+        pil_images = [decode_base64_image(b64) for b64 in images]
+        for idx, img in enumerate(pil_images):
+            logger.info(f"Image {idx}: {img.width}x{img.height} mode={img.mode}")
+
+        pixel_values, _grid_thw, n_tokens_per_image = self._encoder.preprocess_images(
+            pil_images
+        )
+        logger.info(
+            f"Native vision: preprocessed {len(images)} image(s), "
+            f"tokens per image: {n_tokens_per_image}"
+        )
+
+        image_token = self.vision_config.image_token
+        if image_token is None:
+            image_token = tokenizer.decode([self.vision_config.image_token_id])
+
+        formatted_messages = _format_vlm_messages(
+            chat_template_messages, self.vision_config.model_type
+        )
+        prompt = build_vision_prompt(
+            tokenizer,
+            formatted_messages,
+            n_tokens_per_image,
+            image_token,
+        )
+
+        prompt_tokens: mx.array = encode_prompt(tokenizer, prompt)
+        prompt_tokens = fix_unmatched_think_end_tokens(prompt_tokens, tokenizer)
+        n_image_tokens = int(
+            mx.sum(mx.equal(prompt_tokens, self.vision_config.image_token_id)).item()
+        )
+        logger.info(
+            f"Encoded prompt: {len(prompt_tokens)} tokens, {n_image_tokens} image pad tokens"
+        )
+
+        media_regions = _find_media_regions(
+            prompt_tokens,
+            images,
+            self.vision_config.image_token_id,
+            boi_token_id=self.vision_config.boi_token_id,
+            eoi_token_id=self.vision_config.eoi_token_id,
+        )
+
+        # Return empty embeddings — native models handle vision in their
+        # forward pass via pixel_values, not via pre-computed embeddings.
+        empty_embeddings = mx.zeros((1, 0, 1))
+
+        return VisionResult(
+            prompt=prompt,
+            prompt_tokens=prompt_tokens,
+            embeddings=empty_embeddings,
+            media_regions=media_regions,
+            pixel_values=pixel_values,
         )
 
 

--- a/tests/test_gemma_vision.py
+++ b/tests/test_gemma_vision.py
@@ -177,3 +177,43 @@ class TestLoadProjectorWeights:
         _load_projector_weights(target, flat, config)
         # After loading, the module should have quantized weight shape.
         assert target.weight.shape == ref.weight.shape
+
+
+class TestHasNativeVision:
+    """has_native_vision should detect models with built-in vision support."""
+
+    def test_model_with_vision_tower_and_embed_vision(self):
+        from exo.worker.engines.mlx.vision import has_native_vision
+
+        class _FakeInner(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.vision_tower = nn.Linear(4, 4)
+                self.embed_vision = nn.Linear(4, 4)
+
+        class _FakeWrapper(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._inner = _FakeInner()
+
+        assert has_native_vision(_FakeWrapper()) is True
+
+    def test_model_without_vision_tower(self):
+        from exo.worker.engines.mlx.vision import has_native_vision
+
+        class _Plain(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.some_layer = nn.Linear(4, 4)
+
+        assert has_native_vision(_Plain()) is False
+
+    def test_model_with_only_vision_tower(self):
+        from exo.worker.engines.mlx.vision import has_native_vision
+
+        class _Partial(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.vision_tower = nn.Linear(4, 4)
+
+        assert has_native_vision(_Partial()) is False

--- a/tests/test_gemma_vision.py
+++ b/tests/test_gemma_vision.py
@@ -217,3 +217,37 @@ class TestHasNativeVision:
                 self.vision_tower = nn.Linear(4, 4)
 
         assert has_native_vision(_Partial()) is False
+
+
+class TestPatchNativeVision:
+    """patch_native_vision should inject pixel_values during prefill and restore after."""
+
+    def test_injects_pixel_values_and_restores(self):
+        from exo.worker.engines.mlx.generator.generate import patch_native_vision
+
+        class _Inner(nn.Module):
+            def __call__(self, input_ids, **kwargs):
+                return kwargs
+
+        class _Wrapper(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._inner = _Inner()
+
+        wrapper = _Wrapper()
+        inner = wrapper._inner
+        pv = mx.ones((1, 3, 4))
+
+        # Before patch: no pixel_values injected
+        result_before = inner(mx.array([1, 2, 3]))
+        assert "pixel_values" not in result_before
+
+        # During patch: pixel_values injected
+        with patch_native_vision(wrapper, pv):
+            result_during = inner(mx.array([1, 2, 3]))
+            assert "pixel_values" in result_during
+            assert result_during["pixel_values"] is pv
+
+        # After patch: restored, no pixel_values
+        result_after = inner(mx.array([1, 2, 3]))
+        assert "pixel_values" not in result_after


### PR DESCRIPTION
## Summary
- **Root cause**: Our separate `VisionEncoder` loaded its own copy of vision tower + projector weights, which produced garbage features due to quantization differences. Gemma 4 treated images as text.
- **Fix**: For models with native vision support (built-in `vision_tower` + `embed_vision`), preprocess images into `pixel_values` tensors and inject them into the model's forward pass via `patch_native_vision()` context manager during prefill. The model handles vision encoding internally via `masked_scatter`.
- Legacy path (Qwen-VL, Kimi) remains unchanged via `patch_embed_tokens`.

## Test plan
- [x] `uv run basedpyright` — 0 new errors
- [x] `uv run ruff check` — passes
- [x] `uv run pytest` — 344 passed (14 vision tests including 3 new `has_native_vision` tests)
- [ ] Load `mlx-community/gemma-4-26b-a4b-it-4bit`, send image → model describes image content (not "text strings")
- [ ] Load a Qwen-VL model → vision still works via legacy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)