### PR TITLE
fix: inject pixel_values via wrapper for Gemma 4 native vision

### DIFF
--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -179,13 +179,15 @@ class ExoBatchGenerator:
             top_k=task_params.top_k if task_params.top_k is not None else 0,
         )
 
-        vision_ctx = (
-            patch_embed_tokens(
+        if vision is not None and vision.pixel_values is not None:
+            self.model._pixel_values = vision.pixel_values  # type: ignore
+            vision_ctx = contextlib.nullcontext()
+        elif vision is not None:
+            vision_ctx = patch_embed_tokens(
                 self.model, vision.embeddings, prefix_hit_length, len(prompt_tokens) - 1
             )
-            if vision is not None
-            else contextlib.nullcontext()
-        )
+        else:
+            vision_ctx = contextlib.nullcontext()
         with vision_ctx:
             _prefill_tps, _prefill_tokens, cache_snapshots = prefill(
                 self.model,
@@ -197,6 +199,8 @@ class ExoBatchGenerator:
                 on_prefill_progress,
                 distributed_prompt_progress_callback,
             )
+        if hasattr(self.model, "_pixel_values"):
+            self.model._pixel_values = None  # type: ignore
 
         # We need to clamp rotating kv caches to max size so that mlx lm's _merge_caches behaves
         for c in cache:

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -587,13 +587,19 @@ def mlx_generate(
     )
     max_stop_len = max((len(s) for s in stop_sequences), default=0)
 
-    maybe_vision_ctx = (
-        patch_embed_tokens(
+    if vision is not None and vision.pixel_values is not None:
+        # Native vision: inject pixel_values into the wrapper so the model's
+        # own __call__ handles vision tower → projector → masked_scatter.
+        model._pixel_values = vision.pixel_values  # type: ignore
+        maybe_vision_ctx = contextlib.nullcontext()
+    elif vision is not None:
+        # Legacy path: splice pre-computed embeddings via monkey-patched
+        # embed_tokens (Qwen-VL, Kimi, etc.).
+        maybe_vision_ctx = patch_embed_tokens(
             model, vision.embeddings, prefix_hit_length, len(prompt_tokens) - 1
         )
-        if vision is not None
-        else contextlib.nullcontext()
-    )
+    else:
+        maybe_vision_ctx = contextlib.nullcontext()
     with maybe_vision_ctx:
         prefill_tps, prefill_tokens, ssm_snapshots_list = prefill(
             model,
@@ -605,6 +611,10 @@ def mlx_generate(
             on_prefill_progress,
             distributed_prompt_progress_callback,
         )
+    # Clear pixel_values after prefill — image features are now in the KV
+    # cache. Subsequent decode steps must not re-process the image.
+    if hasattr(model, "_pixel_values"):
+        model._pixel_values = None  # type: ignore
     cache_snapshots: list[CacheSnapshot] | None = ssm_snapshots_list or None
 
     # stream_generate starts from the last token

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -84,8 +84,14 @@ class _VlmModelWrapper(nn.Module):
     def __init__(self, inner: nn.Module) -> None:
         super().__init__()
         self._inner = inner
+        # Set by the vision pipeline before prefill for models with native
+        # vision support (e.g. Gemma 4).  Cleared after prefill so decode
+        # steps don't re-process images.
+        self._pixel_values: mx.array | list[mx.array] | None = None
 
     def __call__(self, *args: object, **kwargs: object) -> mx.array:
+        if self._pixel_values is not None:
+            kwargs["pixel_values"] = self._pixel_values
         result = self._inner(*args, **kwargs)
         if hasattr(result, "logits"):
             return result.logits  # type: ignore

--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -169,6 +169,9 @@ class VisionResult:
     prompt_tokens: mx.array
     embeddings: mx.array
     media_regions: list[MediaRegion]
+    # For native-vision models (e.g. Gemma 4): raw pixel tensors passed
+    # directly to the model's __call__ during prefill.
+    pixel_values: mx.array | list[mx.array] | None = None
 
 
 _QUANTIZATION_SUFFIXES = (".biases", ".scales")
@@ -872,12 +875,11 @@ class VisionProcessor:
     ) -> VisionResult:
         """Process images for models with native vision support (e.g. Gemma 4).
 
-        Instead of running a separate vision tower and projector, this calls
-        the model's own ``get_input_embeddings`` which uses its built-in
-        vision tower, projector, and ``masked_scatter`` to produce fused
-        text+vision embeddings.  These pre-computed embeddings are then
-        injected during prefill via the existing ``patch_embed_tokens``
-        mechanism — matching how mlx-vlm's own generate flow works."""
+        Instead of running a separate vision tower and projector, this
+        preprocesses images into ``pixel_values`` tensors.  During prefill
+        the wrapper injects ``pixel_values`` into the model's ``__call__``
+        so its built-in vision tower, projector, and ``masked_scatter``
+        handle everything — exactly matching mlx-vlm's own generate flow."""
         logger.info("Using native vision pipeline (model has built-in vision tower)")
         self._encoder.ensure_loaded()
 
@@ -918,19 +920,6 @@ class VisionProcessor:
             f"Encoded prompt: {len(prompt_tokens)} tokens, {n_image_tokens} image pad tokens"
         )
 
-        # Call the model's native get_input_embeddings to fuse text + vision.
-        # This runs the built-in vision tower → projector → masked_scatter,
-        # producing embeddings where image-token positions contain real
-        # vision features instead of text-token embeddings.
-        inner: Any = getattr(model, "_inner", model)
-        embedding_output: Any = inner.get_input_embeddings(  # pyright: ignore[reportAny]
-            input_ids=prompt_tokens[None],
-            pixel_values=pixel_values,
-        )
-        embeddings: mx.array = embedding_output.inputs_embeds  # pyright: ignore[reportAny]
-        mx.eval(embeddings)
-        logger.info(f"Native vision: fused embeddings shape {embeddings.shape}")
-
         media_regions = _find_media_regions(
             prompt_tokens,
             images,
@@ -939,11 +928,16 @@ class VisionProcessor:
             eoi_token_id=self.vision_config.eoi_token_id,
         )
 
+        # Empty embeddings — the model handles vision internally via
+        # pixel_values injected by _VlmModelWrapper during prefill.
+        empty_embeddings = mx.zeros((1, 0, 1))
+
         return VisionResult(
             prompt=prompt,
             prompt_tokens=prompt_tokens,
-            embeddings=embeddings,
+            embeddings=empty_embeddings,
             media_regions=media_regions,
+            pixel_values=pixel_values,
         )
 
 


### PR DESCRIPTION
## Summary
- **Root cause**: Pre-computing fused embeddings and injecting via `patch_embed_tokens` doesn't work because the model's `__call__` re-invokes `get_input_embeddings` on each prefill chunk, creating a mismatch between pre-computed full-prompt embeddings and per-chunk `per_layer_inputs`.
- **Fix**: Inject `pixel_values` directly into the model's forward pass via `_VlmModelWrapper._pixel_values`. The model's own `__call__` → `get_input_embeddings(input_ids, pixel_values)` → vision tower → `masked_scatter` handles everything natively — exactly matching mlx-vlm's generate flow.
- Set before prefill, cleared after. Legacy path (Qwen-VL) unchanged.

## Test plan
- [x] `uv run basedpyright` — 0 new errors
- [x] `uv run ruff check` — passes
- [x] `uv run pytest` — 344 passed
- [ ] Load Gemma 4, send image → model describes actual image content
- [ ] Verify Qwen-VL still works via legacy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)