### PR TITLE
Fix Gemma 4 native pixel value wrapper

### DIFF
--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -180,7 +180,10 @@ class ExoBatchGenerator:
         )
 
         if vision is not None and vision.pixel_values is not None:
-            self.model._pixel_values = vision.pixel_values  # type: ignore[attr-defined]
+            if hasattr(self.model, "set_pixel_values"):
+                self.model.set_pixel_values(vision.pixel_values)  # type: ignore[attr-defined]
+            else:
+                self.model._pixel_values = vision.pixel_values  # type: ignore[attr-defined]
             vision_ctx = contextlib.nullcontext()
         elif vision is not None:
             vision_ctx = patch_embed_tokens(
@@ -201,7 +204,9 @@ class ExoBatchGenerator:
                     distributed_prompt_progress_callback,
                 )
         finally:
-            if hasattr(self.model, "_pixel_values"):
+            if hasattr(self.model, "set_pixel_values"):
+                self.model.set_pixel_values(None)  # type: ignore[attr-defined]
+            elif hasattr(self.model, "_pixel_values"):
                 self.model._pixel_values = None  # type: ignore[attr-defined]
 
         # We need to clamp rotating kv caches to max size so that mlx lm's _merge_caches behaves

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -588,7 +588,10 @@ def mlx_generate(
     max_stop_len = max((len(s) for s in stop_sequences), default=0)
 
     if vision is not None and vision.pixel_values is not None:
-        model._pixel_values = vision.pixel_values  # type: ignore[attr-defined]
+        if hasattr(model, "set_pixel_values"):
+            model.set_pixel_values(vision.pixel_values)  # type: ignore[attr-defined]
+        else:
+            model._pixel_values = vision.pixel_values  # type: ignore[attr-defined]
         maybe_vision_ctx = contextlib.nullcontext()
     elif vision is not None:
         maybe_vision_ctx = patch_embed_tokens(
@@ -609,7 +612,9 @@ def mlx_generate(
                 distributed_prompt_progress_callback,
             )
     finally:
-        if hasattr(model, "_pixel_values"):
+        if hasattr(model, "set_pixel_values"):
+            model.set_pixel_values(None)  # type: ignore[attr-defined]
+        elif hasattr(model, "_pixel_values"):
             model._pixel_values = None  # type: ignore[attr-defined]
     cache_snapshots: list[CacheSnapshot] | None = ssm_snapshots_list or None
 

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -86,11 +86,19 @@ class _VlmModelWrapper(nn.Module):
         self._inner = inner
         # Set by the vision pipeline before prefill for native-vision models
         # like Gemma 4, then cleared once prefill has populated the KV cache.
-        self._pixel_values: mx.array | list[mx.array] | None = None
+        object.__setattr__(self, "_pixel_values", None)
+
+    def set_pixel_values(self, pixel_values: mx.array | list[mx.array] | None) -> None:
+        """Cache native vision pixel values for the next prefill call only."""
+        object.__setattr__(self, "_pixel_values", pixel_values)
 
     def __call__(self, *args: object, **kwargs: object) -> mx.array:
-        if self._pixel_values is not None:
-            kwargs["pixel_values"] = self._pixel_values
+        pixel_values = cast(
+            mx.array | list[mx.array] | None,
+            object.__getattribute__(self, "__dict__").get("_pixel_values"),
+        )
+        if pixel_values is not None:
+            kwargs["pixel_values"] = pixel_values
         result = self._inner(*args, **kwargs)
         if hasattr(result, "logits"):
             return result.logits  # type: ignore
@@ -99,6 +107,8 @@ class _VlmModelWrapper(nn.Module):
     def __getattr__(self, name: str) -> object:
         # Delegate attribute access to the inner model so layer iteration,
         # parameter access, etc. all work transparently.
+        if name == "_pixel_values":
+            return object.__getattribute__(self, "__dict__").get("_pixel_values")
         if name == "_inner":
             return super().__getattr__(name)
         return getattr(self._inner, name)

--- a/src/exo/worker/tests/unittests/test_mlx/test_vlm_wrapper.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_vlm_wrapper.py
@@ -1,0 +1,51 @@
+"""Tests for the MLX VLM compatibility wrapper."""
+
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from exo.worker.engines.mlx.utils_mlx import _VlmModelWrapper
+
+
+class _FakeOutput:
+    """Minimal logits container matching mlx-vlm output shape."""
+
+    def __init__(self, logits: mx.array) -> None:
+        self.logits = logits
+
+
+class _FakeInner(nn.Module):
+    """Inner model stub that records keyword arguments."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.last_kwargs: dict[str, Any] = {}
+
+    def __call__(self, *_args: object, **kwargs: object) -> _FakeOutput:
+        self.last_kwargs = dict(kwargs)
+        return _FakeOutput(mx.array([1.0]))
+
+
+def test_vlm_wrapper_tolerates_missing_pixel_values_attr() -> None:
+    """Missing transient pixel values should behave like a text-only call."""
+    inner = _FakeInner()
+    wrapper = _VlmModelWrapper(inner)
+    del wrapper.__dict__["_pixel_values"]
+
+    result = wrapper(mx.array([1]))
+
+    assert "pixel_values" not in inner.last_kwargs
+    assert result.tolist() == [1.0]
+
+
+def test_vlm_wrapper_injects_pixel_values_when_present() -> None:
+    """Native vision pixel values should be forwarded exactly once per call."""
+    inner = _FakeInner()
+    wrapper = _VlmModelWrapper(inner)
+    pixel_values = mx.array([2.0])
+    wrapper.set_pixel_values(pixel_values)
+
+    _ = wrapper(mx.array([1]))
+
+    assert inner.last_kwargs["pixel_values"] is pixel_values


### PR DESCRIPTION
## Summary
- fix native Gemma 4 vision prefill wrapper access to transient 
- use an explicit wrapper setter in both sequential and batch generation paths
- add regression coverage for the missing-attribute crash case

## Validation
- uv run python -m ruff check src/exo/worker/engines/mlx/utils_mlx.py src/exo/worker/engines/mlx/generator/generate.py src/exo/worker/engines/mlx/generator/batch_generate.py src/exo/worker/tests/unittests/test_mlx/test_vlm_wrapper.py
- uv run python -m pytest src/exo/worker/tests/unittests/test_mlx/test_vlm_wrapper.py tests/test_gemma_vision.py src/exo/api/tests/test_chat_completions_adapter.py src/exo/api/tests/test_claude_api.py