### PR TITLE
Fix stale native vision images after prefix cache hits

### DIFF
--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -184,8 +184,10 @@ class ExoBatchGenerator:
             top_k=task_params.top_k if task_params.top_k is not None else 0,
         )
 
+        is_native_vision = vision is not None and vision.pixel_values is not None
         native_pixel_values: mx.array | list[mx.array] | None = None
-        if vision is not None and vision.pixel_values is not None:
+        if is_native_vision:
+            assert vision is not None
             native_pixel_values = _slice_native_pixel_values_for_uncached_suffix(
                 vision.pixel_values,
                 media_regions,
@@ -198,7 +200,7 @@ class ExoBatchGenerator:
             else:
                 self.model._pixel_values = native_pixel_values  # type: ignore[attr-defined]
             vision_ctx = contextlib.nullcontext()
-        elif vision is not None:
+        elif vision is not None and not is_native_vision:
             vision_ctx = patch_embed_tokens(
                 self.model, vision.embeddings, prefix_hit_length, len(prompt_tokens) - 1
             )

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -34,6 +34,7 @@ from exo.worker.engines.mlx.cache import (
 )
 from exo.worker.engines.mlx.constants import DEFAULT_TOP_LOGPROBS, MAX_TOKENS
 from exo.worker.engines.mlx.generator.generate import (
+    _slice_native_pixel_values_for_uncached_suffix,
     ban_token_ids,
     eos_ids_from_tokenizer,
     extract_top_logprobs,
@@ -183,11 +184,19 @@ class ExoBatchGenerator:
             top_k=task_params.top_k if task_params.top_k is not None else 0,
         )
 
+        native_pixel_values: mx.array | list[mx.array] | None = None
         if vision is not None and vision.pixel_values is not None:
+            native_pixel_values = _slice_native_pixel_values_for_uncached_suffix(
+                vision.pixel_values,
+                media_regions,
+                prefix_hit_length,
+            )
+
+        if native_pixel_values is not None:
             if hasattr(self.model, "set_pixel_values"):
-                self.model.set_pixel_values(vision.pixel_values)  # type: ignore[attr-defined]
+                self.model.set_pixel_values(native_pixel_values)  # type: ignore[attr-defined]
             else:
-                self.model._pixel_values = vision.pixel_values  # type: ignore[attr-defined]
+                self.model._pixel_values = native_pixel_values  # type: ignore[attr-defined]
             vision_ctx = contextlib.nullcontext()
         elif vision is not None:
             vision_ctx = patch_embed_tokens(

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -115,10 +115,13 @@ def _slice_native_pixel_values_for_uncached_suffix(
     if prefix_hit_length <= 0 or not media_regions:
         return pixel_values
 
+    available_images = (
+        len(pixel_values) if isinstance(pixel_values, list) else int(pixel_values.shape[0])
+    )
     remaining_indices = [
         idx
         for idx, region in enumerate(media_regions)
-        if region.end_pos > prefix_hit_length
+        if idx < available_images and region.end_pos > prefix_hit_length
     ]
     if not remaining_indices:
         logger.info(
@@ -127,12 +130,18 @@ def _slice_native_pixel_values_for_uncached_suffix(
         )
         return None
 
-    if remaining_indices == list(range(len(media_regions))):
+    if available_images != len(media_regions):
+        logger.warning(
+            "Native vision pixel_values/media_regions length mismatch: "
+            f"{available_images} image tensor(s) for {len(media_regions)} media region(s)"
+        )
+
+    if remaining_indices == list(range(available_images)):
         return pixel_values
 
     logger.info(
         "Native vision prefix cache hit trimmed pixel_values from "
-        f"{len(media_regions)} to {len(remaining_indices)} image(s) "
+        f"{available_images} to {len(remaining_indices)} image(s) "
         f"(restore_pos={prefix_hit_length})"
     )
 
@@ -140,7 +149,7 @@ def _slice_native_pixel_values_for_uncached_suffix(
         return [pixel_values[idx] for idx in remaining_indices]
 
     first_idx = remaining_indices[0]
-    expected_suffix = list(range(first_idx, len(media_regions)))
+    expected_suffix = list(range(first_idx, available_images))
     if remaining_indices == expected_suffix:
         return pixel_values[first_idx:]
 
@@ -867,8 +876,10 @@ def mlx_generate(
             "mlx/mlx-vlm stack"
         )
 
+    is_native_vision = vision is not None and vision.pixel_values is not None
     native_pixel_values: mx.array | list[mx.array] | None = None
-    if vision is not None and vision.pixel_values is not None:
+    if is_native_vision:
+        assert vision is not None
         native_pixel_values = _slice_native_pixel_values_for_uncached_suffix(
             vision.pixel_values,
             media_regions,
@@ -881,7 +892,7 @@ def mlx_generate(
         else:
             model._pixel_values = native_pixel_values  # type: ignore[attr-defined]
         maybe_vision_ctx = contextlib.nullcontext()
-    elif vision is not None:
+    elif vision is not None and not is_native_vision:
         maybe_vision_ctx = patch_embed_tokens(
             model, vision.embeddings, prefix_hit_length, len(prompt_tokens) - 1
         )

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -100,6 +100,53 @@ def _should_use_native_vision_reference_path() -> bool:
     )
 
 
+def _slice_native_pixel_values_for_uncached_suffix(
+    pixel_values: mx.array | list[mx.array],
+    media_regions: list[MediaRegion],
+    prefix_hit_length: int,
+) -> mx.array | list[mx.array] | None:
+    """Keep only native vision pixel values still referenced by uncached tokens.
+
+    Prefix-cache hits can reuse earlier image regions from the KV cache. Native
+    vision models consume raw pixel values in prompt order, so after a prefix
+    hit we must drop any already-cached images from ``pixel_values`` or the
+    first stale image will be paired with the next uncached image token span.
+    """
+    if prefix_hit_length <= 0 or not media_regions:
+        return pixel_values
+
+    remaining_indices = [
+        idx
+        for idx, region in enumerate(media_regions)
+        if region.end_pos > prefix_hit_length
+    ]
+    if not remaining_indices:
+        logger.info(
+            "Native vision prefix cache hit reused all image regions; "
+            "skipping pixel-value injection for cached images"
+        )
+        return None
+
+    if remaining_indices == list(range(len(media_regions))):
+        return pixel_values
+
+    logger.info(
+        "Native vision prefix cache hit trimmed pixel_values from "
+        f"{len(media_regions)} to {len(remaining_indices)} image(s) "
+        f"(restore_pos={prefix_hit_length})"
+    )
+
+    if isinstance(pixel_values, list):
+        return [pixel_values[idx] for idx in remaining_indices]
+
+    first_idx = remaining_indices[0]
+    expected_suffix = list(range(first_idx, len(media_regions)))
+    if remaining_indices == expected_suffix:
+        return pixel_values[first_idx:]
+
+    return mx.stack([pixel_values[idx] for idx in remaining_indices], axis=0)
+
+
 @contextlib.contextmanager
 def patch_embed_tokens(
     model: Model, embeddings: mx.array, start_offset: int = 0, token_count: int = 0
@@ -820,11 +867,19 @@ def mlx_generate(
             "mlx/mlx-vlm stack"
         )
 
+    native_pixel_values: mx.array | list[mx.array] | None = None
     if vision is not None and vision.pixel_values is not None:
+        native_pixel_values = _slice_native_pixel_values_for_uncached_suffix(
+            vision.pixel_values,
+            media_regions,
+            prefix_hit_length,
+        )
+
+    if native_pixel_values is not None:
         if hasattr(model, "set_pixel_values"):
-            model.set_pixel_values(vision.pixel_values)  # type: ignore[attr-defined]
+            model.set_pixel_values(native_pixel_values)  # type: ignore[attr-defined]
         else:
-            model._pixel_values = vision.pixel_values  # type: ignore[attr-defined]
+            model._pixel_values = native_pixel_values  # type: ignore[attr-defined]
         maybe_vision_ctx = contextlib.nullcontext()
     elif vision is not None:
         maybe_vision_ctx = patch_embed_tokens(

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -114,6 +114,53 @@ def _should_use_native_vision_reference_path() -> bool:
     )
 
 
+def _slice_native_pixel_values_for_uncached_suffix(
+    pixel_values: mx.array | list[mx.array],
+    media_regions: list[MediaRegion],
+    prefix_hit_length: int,
+) -> mx.array | list[mx.array] | None:
+    """Keep only native vision pixel values still referenced by uncached tokens.
+
+    Prefix-cache hits can reuse earlier image regions from the KV cache. Native
+    vision models consume raw pixel values in prompt order, so after a prefix
+    hit we must drop any already-cached images from ``pixel_values`` or the
+    first stale image will be paired with the next uncached image token span.
+    """
+    if prefix_hit_length <= 0 or not media_regions:
+        return pixel_values
+
+    remaining_indices = [
+        idx
+        for idx, region in enumerate(media_regions)
+        if region.end_pos > prefix_hit_length
+    ]
+    if not remaining_indices:
+        logger.info(
+            "Native vision prefix cache hit reused all image regions; "
+            "skipping pixel-value injection for cached images"
+        )
+        return None
+
+    if remaining_indices == list(range(len(media_regions))):
+        return pixel_values
+
+    logger.info(
+        "Native vision prefix cache hit trimmed pixel_values from "
+        f"{len(media_regions)} to {len(remaining_indices)} image(s) "
+        f"(restore_pos={prefix_hit_length})"
+    )
+
+    if isinstance(pixel_values, list):
+        return [pixel_values[idx] for idx in remaining_indices]
+
+    first_idx = remaining_indices[0]
+    expected_suffix = list(range(first_idx, len(media_regions)))
+    if remaining_indices == expected_suffix:
+        return pixel_values[first_idx:]
+
+    return mx.stack([pixel_values[idx] for idx in remaining_indices], axis=0)
+
+
 @contextlib.contextmanager
 def patch_embed_tokens(
     model: Model, embeddings: mx.array, start_offset: int = 0, token_count: int = 0
@@ -834,11 +881,19 @@ def mlx_generate(
             "mlx/mlx-vlm stack"
         )
 
+    native_pixel_values: mx.array | list[mx.array] | None = None
     if vision is not None and vision.pixel_values is not None:
+        native_pixel_values = _slice_native_pixel_values_for_uncached_suffix(
+            vision.pixel_values,
+            media_regions,
+            prefix_hit_length,
+        )
+
+    if native_pixel_values is not None:
         if hasattr(model, "set_pixel_values"):
-            model.set_pixel_values(vision.pixel_values)  # type: ignore[attr-defined]
+            model.set_pixel_values(native_pixel_values)  # type: ignore[attr-defined]
         else:
-            model._pixel_values = vision.pixel_values  # type: ignore[attr-defined]
+            model._pixel_values = native_pixel_values  # type: ignore[attr-defined]
         maybe_vision_ctx = contextlib.nullcontext()
     elif vision is not None:
         maybe_vision_ctx = patch_embed_tokens(

--- a/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -317,6 +317,26 @@ def test_slice_native_pixel_values_for_uncached_suffix_drops_cached_images() -> 
     assert result[0].tolist() == [20.0]
 
 
+def test_slice_native_pixel_values_for_uncached_suffix_returns_none_when_fully_cached() -> (
+    None
+):
+    """Fully cached follow-up turns should not inject any native pixel values."""
+
+    pixel_values = [mx.array([10.0]), mx.array([20.0])]
+    media_regions = [
+        MediaRegion("first", 1, 4),
+        MediaRegion("second", 5, 8),
+    ]
+
+    result = _slice_native_pixel_values_for_uncached_suffix(
+        pixel_values,
+        media_regions,
+        prefix_hit_length=8,
+    )
+
+    assert result is None
+
+
 def test_mlx_generate_slices_native_pixel_values_after_prefix_hit(
     monkeypatch,
 ) -> None:
@@ -423,3 +443,114 @@ def test_mlx_generate_slices_native_pixel_values_after_prefix_hit(
     assert [response.text for response in responses] == ["ok"]
     assert model.seen_pixel_values is not None
     assert model.pixel_values is None
+
+
+def test_mlx_generate_skips_embedding_patch_when_native_images_are_fully_cached(
+    monkeypatch,
+) -> None:
+    """Fully cached native images should fall back to plain text prefill only."""
+
+    class _FakePrefixCache:
+        def get_kv_cache(self, _model, _prompt_tokens, media_regions=None):
+            assert media_regions is not None
+            return [], mx.array([7, 8]), 0
+
+        def add_kv_cache(self, *args, **kwargs) -> None:
+            return None
+
+        def update_kv_cache(self, *args, **kwargs) -> None:
+            return None
+
+    class _FakeModel:
+        def __init__(self) -> None:
+            self.pixel_values = None
+            self.seen_pixel_values = "unset"
+
+        def set_pixel_values(self, pixel_values) -> None:
+            self.pixel_values = pixel_values
+            self.seen_pixel_values = pixel_values
+
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3, 4, 5, 6, 7, 8]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[
+            MediaRegion("first", 1, 4),
+            MediaRegion("second", 5, 6),
+        ],
+        pixel_values=[mx.array([10.0]), mx.array([20.0])],
+    )
+
+    def _fake_prepare_vision(**_kwargs: object) -> VisionResult:
+        return vision
+
+    def _fake_prefill(model, *_args, **_kwargs):
+        assert model.pixel_values is None
+        return 0.0, 2, []
+
+    def _fake_stream_generate(*_args: object, **_kwargs: object):
+        yield GenerationResponse(text="ok", token=101, usage=None)
+
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prepare_vision",
+        _fake_prepare_vision,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._should_use_native_vision_reference_path",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prefill",
+        _fake_prefill,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.stream_generate",
+        _fake_stream_generate,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.patch_embed_tokens",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("native fully-cached requests should not patch embeddings")
+        ),
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        chat_template_messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "first"},
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "second"},
+                ],
+            },
+        ],
+        images=["ignored-a", "ignored-b"],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+
+    model = _FakeModel()
+    responses = list(
+        mlx_generate(
+            model=model,  # type: ignore[arg-type]
+            tokenizer=_FakeTokenizer(),  # type: ignore[arg-type]
+            task=task,
+            prompt="<bos>",
+            kv_prefix_cache=_FakePrefixCache(),  # type: ignore[arg-type]
+            group=None,
+            vision_processor=object(),  # type: ignore[arg-type]
+        )
+    )
+
+    assert [response.text for response in responses] == ["ok"]
+    assert model.seen_pixel_values is None

--- a/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -10,9 +10,10 @@ from exo.shared.types.worker.runner_response import GenerationResponse
 from exo.worker.engines.mlx.generator.generate import (
     _mlx_generate_native_vision,
     _should_use_native_vision_reference_path,
+    _slice_native_pixel_values_for_uncached_suffix,
     mlx_generate,
 )
-from exo.worker.engines.mlx.vision import VisionResult
+from exo.worker.engines.mlx.vision import MediaRegion, VisionResult
 
 
 class _FakeDetokenizer:
@@ -282,3 +283,131 @@ def test_native_vision_reference_path_version_gate(monkeypatch) -> None:
     )
 
     assert _should_use_native_vision_reference_path() is False
+
+
+def test_slice_native_pixel_values_for_uncached_suffix_drops_cached_images() -> None:
+    """Prefix hits should remove already-cached native images from pixel_values."""
+
+    pixel_values = [mx.array([10.0]), mx.array([20.0])]
+    media_regions = [
+        MediaRegion("first", 1, 4),
+        MediaRegion("second", 5, 8),
+    ]
+
+    result = _slice_native_pixel_values_for_uncached_suffix(
+        pixel_values,
+        media_regions,
+        prefix_hit_length=5,
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].tolist() == [20.0]
+
+
+def test_mlx_generate_slices_native_pixel_values_after_prefix_hit(
+    monkeypatch,
+) -> None:
+    """Follow-up turns should not reuse stale pixel values from cached images."""
+
+    class _FakePrefixCache:
+        def get_kv_cache(self, _model, _prompt_tokens, media_regions=None):
+            assert media_regions is not None
+            return [], mx.array([6, 7, 8]), 0
+
+        def add_kv_cache(self, *args, **kwargs) -> None:
+            return None
+
+        def update_kv_cache(self, *args, **kwargs) -> None:
+            return None
+
+    class _FakeModel:
+        def __init__(self) -> None:
+            self.pixel_values = None
+            self.seen_pixel_values = None
+
+        def set_pixel_values(self, pixel_values) -> None:
+            self.pixel_values = pixel_values
+
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3, 4, 5, 6, 7, 8]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[
+            MediaRegion("first", 1, 4),
+            MediaRegion("second", 5, 8),
+        ],
+        pixel_values=[mx.array([10.0]), mx.array([20.0])],
+    )
+
+    def _fake_prepare_vision(**_kwargs: object) -> VisionResult:
+        return vision
+
+    def _fake_prefill(model, *_args, **_kwargs):
+        assert isinstance(model.pixel_values, list)
+        assert len(model.pixel_values) == 1
+        assert model.pixel_values[0].tolist() == [20.0]
+        model.seen_pixel_values = model.pixel_values
+        return 0.0, 2, []
+
+    def _fake_stream_generate(*_args: object, **_kwargs: object):
+        yield GenerationResponse(text="ok", token=101, usage=None)
+
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prepare_vision",
+        _fake_prepare_vision,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._should_use_native_vision_reference_path",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prefill",
+        _fake_prefill,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.stream_generate",
+        _fake_stream_generate,
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        chat_template_messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "first"},
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "second"},
+                ],
+            },
+        ],
+        images=["ignored-a", "ignored-b"],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+
+    model = _FakeModel()
+    responses = list(
+        mlx_generate(
+            model=model,  # type: ignore[arg-type]
+            tokenizer=_FakeTokenizer(),  # type: ignore[arg-type]
+            task=task,
+            prompt="<bos>",
+            kv_prefix_cache=_FakePrefixCache(),  # type: ignore[arg-type]
+            group=None,
+            vision_processor=object(),  # type: ignore[arg-type]
+        )
+    )
+
+    assert [response.text for response in responses] == ["ok"]
+    assert model.seen_pixel_values is not None
+    assert model.pixel_values is None

--- a/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -10,9 +10,10 @@ from exo.shared.types.worker.runner_response import GenerationResponse
 from exo.worker.engines.mlx.generator.generate import (
     _mlx_generate_native_vision,
     _should_use_native_vision_reference_path,
+    _slice_native_pixel_values_for_uncached_suffix,
     mlx_generate,
 )
-from exo.worker.engines.mlx.vision import VisionResult
+from exo.worker.engines.mlx.vision import MediaRegion, VisionResult
 
 
 class _FakeDetokenizer:
@@ -296,3 +297,131 @@ def test_native_vision_reference_path_keeps_prereleases_on_safe_path(
     )
 
     assert _should_use_native_vision_reference_path() is True
+
+
+def test_slice_native_pixel_values_for_uncached_suffix_drops_cached_images() -> None:
+    """Prefix hits should remove already-cached native images from pixel_values."""
+
+    pixel_values = [mx.array([10.0]), mx.array([20.0])]
+    media_regions = [
+        MediaRegion("first", 1, 4),
+        MediaRegion("second", 5, 8),
+    ]
+
+    result = _slice_native_pixel_values_for_uncached_suffix(
+        pixel_values,
+        media_regions,
+        prefix_hit_length=5,
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].tolist() == [20.0]
+
+
+def test_mlx_generate_slices_native_pixel_values_after_prefix_hit(
+    monkeypatch,
+) -> None:
+    """Follow-up turns should not reuse stale pixel values from cached images."""
+
+    class _FakePrefixCache:
+        def get_kv_cache(self, _model, _prompt_tokens, media_regions=None):
+            assert media_regions is not None
+            return [], mx.array([6, 7, 8]), 0
+
+        def add_kv_cache(self, *args, **kwargs) -> None:
+            return None
+
+        def update_kv_cache(self, *args, **kwargs) -> None:
+            return None
+
+    class _FakeModel:
+        def __init__(self) -> None:
+            self.pixel_values = None
+            self.seen_pixel_values = None
+
+        def set_pixel_values(self, pixel_values) -> None:
+            self.pixel_values = pixel_values
+
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3, 4, 5, 6, 7, 8]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[
+            MediaRegion("first", 1, 4),
+            MediaRegion("second", 5, 8),
+        ],
+        pixel_values=[mx.array([10.0]), mx.array([20.0])],
+    )
+
+    def _fake_prepare_vision(**_kwargs: object) -> VisionResult:
+        return vision
+
+    def _fake_prefill(model, *_args, **_kwargs):
+        assert isinstance(model.pixel_values, list)
+        assert len(model.pixel_values) == 1
+        assert model.pixel_values[0].tolist() == [20.0]
+        model.seen_pixel_values = model.pixel_values
+        return 0.0, 2, []
+
+    def _fake_stream_generate(*_args: object, **_kwargs: object):
+        yield GenerationResponse(text="ok", token=101, usage=None)
+
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prepare_vision",
+        _fake_prepare_vision,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._should_use_native_vision_reference_path",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prefill",
+        _fake_prefill,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.stream_generate",
+        _fake_stream_generate,
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        chat_template_messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "first"},
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "second"},
+                ],
+            },
+        ],
+        images=["ignored-a", "ignored-b"],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+
+    model = _FakeModel()
+    responses = list(
+        mlx_generate(
+            model=model,  # type: ignore[arg-type]
+            tokenizer=_FakeTokenizer(),  # type: ignore[arg-type]
+            task=task,
+            prompt="<bos>",
+            kv_prefix_cache=_FakePrefixCache(),  # type: ignore[arg-type]
+            group=None,
+            vision_processor=object(),  # type: ignore[arg-type]
+        )
+    )
+
+    assert [response.text for response in responses] == ["ok"]
+    assert model.seen_pixel_values is not None
+    assert model.pixel_values is None


### PR DESCRIPTION
## Summary
- trim native vision `pixel_values` after KV prefix-cache hits so only uncached image regions are passed into generation
- fix both sequential and batch MLX generation paths
- add regression tests covering cached-image follow-up turns and native pixel-value slicing

## Why
When a chat already contained an image, Gemma 4 follow-up turns could hit the KV prefix cache while still carrying the full historical native `pixel_values` list. That let a new uncached image slot get paired with an older cached image tensor, so the model kept answering as if the first image were still on screen.

## Validation
- `uv run python -m ruff check src/exo/worker/engines/mlx/generator/generate.py src/exo/worker/engines/mlx/generator/batch_generate.py src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py`
- `uv run python -m pytest src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py -q`
- manual cluster validation after reboot: image A followed by image B in the same chat now answers about image B instead of reusing image A

## Notes
- This branch was rebased onto the merged Gemma 4 vision baseline from PR #89.
- The branch history includes a merge commit because repository rules prevented force-pushing the rebased branch.
