### PR TITLE
fix: serve docs at site root instead of /docs/ prefix

### DIFF
--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -145,7 +145,7 @@ If this fails with `404 No instance found for model ...`, the placement is not r
 - `GET /v1/traces/{task_id}/stats`
 - `GET /v1/traces/{task_id}/raw`
 
-For the full interactive reference with request/response schemas, see the [API Reference](/docs/api/skulk-api).
+For the full interactive reference with request/response schemas, see the [API Reference](/api/skulk-api).
 
 ## OpenAI Chat Completions
 
@@ -656,4 +656,4 @@ Use these endpoints when you are debugging generation behavior, cluster executio
 - [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md)
 - [Model store guide](model-store)
 - [Architecture overview](architecture)
-- [API Reference](/docs/api/skulk-api)
+- [API Reference](/api/skulk-api)

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -26,7 +26,7 @@ If you are getting oriented, start with these pages:
 
 ## Common Jobs
 
-- I want to browse the backend API: [API Reference](/docs/api/skulk-api)
+- I want to browse the backend API: [API Reference](/api/skulk-api)
 - I want frontend and TypeScript symbols: [TypeScript API](https://foxlight-foundation.github.io/Skulk/typedoc/)
 - I want implementation context before I integrate: [Architecture overview](architecture)
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -29,6 +29,9 @@ const config: Config = {
       {
         docs: {
           sidebarPath: "./sidebars.ts",
+          // Serve docs at the site root (/Skulk/) instead of /Skulk/docs/
+          // so URLs match the README (e.g. /Skulk/architecture/).
+          routeBasePath: "/",
           // Required by docusaurus-plugin-openapi-docs so API pages render
           // with the interactive request/response UI rather than plain MDX.
           docItemComponent: "@theme/ApiItem",
@@ -130,16 +133,16 @@ const config: Config = {
         {
           title: "Guides",
           items: [
-            { label: "API Guide", to: "/docs/api-guide" },
-            { label: "Architecture", to: "/docs/architecture" },
-            { label: "Model Store", to: "/docs/model-store" },
-            { label: "KV Cache Backends", to: "/docs/kv-cache-backends" },
+            { label: "API Guide", to: "/api-guide" },
+            { label: "Architecture", to: "/architecture" },
+            { label: "Model Store", to: "/model-store" },
+            { label: "KV Cache Backends", to: "/kv-cache-backends" },
           ],
         },
         {
           title: "Reference",
           items: [
-            { label: "API Reference", to: "/docs/api/skulk-api" },
+            { label: "API Reference", to: "/api/skulk-api" },
             {
               label: "TypeScript API",
               href: "https://foxlight-foundation.github.io/Skulk/typedoc/",


### PR DESCRIPTION
## Summary
- Sets `routeBasePath: "/"` in the Docusaurus docs plugin so pages are served at `/Skulk/architecture/`, `/Skulk/api/`, etc. instead of `/Skulk/docs/architecture/`
- Updates all internal links (footer, intro.md, api-guide.md) to drop the `/docs/` prefix
- Fixes the live site to match URLs expected by the README

## Test plan
- [x] `npm run build` passes locally with `onBrokenLinks: "throw"`
- [ ] CI build-docs passes
- [ ] After merge + deploy, verify https://foxlight-foundation.github.io/Skulk/ redirects to /Skulk/intro
- [ ] Verify https://foxlight-foundation.github.io/Skulk/architecture/ loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)