### PR TITLE
Add phase 1 model capability spine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,22 @@ Evaluate each review comment on a 1–5 severity scale:
 
 Only fix comments rated 4 or 5. Do not iterate on minor wording, style, or speculative improvements from automated reviewers (e.g., Copilot). Time spent on low-severity feedback is time not spent on real work.
 
+### PR Review Loop
+
+When working an open pull request, use this review loop until no unresolved
+severity 4 or 5 comments remain:
+
+1. Inspect the PR for new review comments, unresolved threads, and failing checks.
+2. Evaluate each comment using the severity rubric above.
+3. Ignore severity 1–2 comments.
+4. Note severity 3 comments for future work, but do not fix them in the current PR.
+5. Fix severity 4–5 comments with the smallest correct change.
+6. Add or update focused tests for every correctness fix on a critical path.
+7. Run focused validation before replying on the PR.
+8. Reply on each addressed thread with the concrete fix or rationale.
+9. Resolve only threads that are actually addressed by code and validation.
+10. Repeat until there are no unresolved severity 4–5 comments, or stop and escalate if the fix becomes ambiguous, validation fails, or the required change would sprawl beyond the PR scope.
+
 ### Before Every Commit
 
 1. Run the pre-commit checks (type check, lint, format, test) as documented above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,9 @@ The system uses event sourcing for state management:
   - `commands.py`: Command types
   - `tasks.py`: Task types for worker execution
   - `state.py`: Cluster state model
+- `src/exo/shared/models/`: persisted model metadata and capability resolution
+  - `model_cards.py`: declarative model cards, including optional advanced capability sections
+  - `capabilities.py`: normalized runtime capability profiles derived from model cards plus conservative family defaults
 
 ### Rust Components
 Rust code in `rust/` provides:
@@ -128,6 +131,13 @@ Rust code in `rust/` provides:
 
 ### Dashboard
 React + TypeScript + styled-components frontend in `dashboard-react/`. Build output goes to `dashboard-react/dist/` and is served by the API. The legacy Svelte dashboard in `dashboard/` is from upstream exo and is not actively used.
+
+### Model Capability System
+Skulk now treats model capability handling as two layers:
+- **Model cards**: persisted declarative metadata, including optional `reasoning`, `modalities`, `tooling`, and `runtime` sections for refined model support
+- **Resolved capability profiles**: normalized runtime behavior contracts derived from the card plus conservative family defaults
+
+This capability spine is the source of truth for model-aware reasoning defaults, prompt rendering, output parsing, tool-call handling, and additive `/v1/models` metadata consumed by the dashboard.
 
 ### Logging & Observability
 Centralized logging uses a three-layer stack:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ This starts a Vite dev server on port 3000 with hot reload. The dev server proxi
 - `src/exo/worker/` — Worker node (inference, runner management, download coordination)
 - `src/exo/store/` — Model store (registry, downloads, config, model optimizer)
 - `src/exo/shared/` — Shared types, constants, topology
+- `website/docs/` — Docusaurus documentation source, including API guide and model-capability docs
 
 ## Development Guidelines
 
@@ -145,8 +146,42 @@ in_bytes = 729808896
 The `capabilities` field defines what the model can do:
 - `text`: Standard text generation
 - `thinking`: Model supports chain-of-thought reasoning
-- `thinking_toggle`: Thinking can be enabled/disabled via `enable_thinking` parameter
 - `image_edit`: Model supports image-to-image editing (FLUX.1-Kontext)
+
+These coarse capability tags are intentionally broad. They help with catalog
+badges and filtering, but they are not the full runtime behavior contract.
+
+### Extended Capability Sections
+
+Model cards can now optionally declare refined model behavior through structured
+sections:
+
+- `[reasoning]`
+  - `supports_toggle`
+  - `supports_budget`
+  - `format`
+  - `default_effort`
+  - `disabled_effort`
+- `[modalities]`
+  - `supports_audio_input`
+  - `supports_native_multimodal`
+- `[tooling]`
+  - `supports_tool_calling`
+  - `tool_call_format`
+- `[runtime]`
+  - `prompt_renderer`
+  - `output_parser`
+
+These sections are optional. Existing cards still work without them.
+
+At runtime, Skulk resolves the model card plus conservative model-family
+defaults into a normalized capability profile. That resolved profile drives
+model-aware reasoning defaults, prompt rendering, output parsing, and the
+additive `resolved_capabilities` metadata returned by `/v1/models`.
+
+For the full field reference and examples, see:
+- [website/docs/model-cards.md](website/docs/model-cards.md)
+- [website/docs/model-capabilities.md](website/docs/model-capabilities.md)
 
 ### Security Note
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,21 @@ Before starting work:
 
 This makes reviews faster and helps us maintain code quality as the project evolves.
 
+## Pull Request Review Loop
+
+When working an active PR, use this review loop:
+
+1. Inspect the PR for new review comments, unresolved threads, and failing checks.
+2. Rank each comment on the repository's 1–5 severity scale.
+3. Ignore severity 1–2 comments.
+4. Defer severity 3 comments unless maintainers explicitly ask for them in the current PR.
+5. Fix severity 4–5 comments with the smallest correct change.
+6. Add or update focused tests for every correctness fix.
+7. Run focused validation before replying.
+8. Reply on each addressed thread with the concrete fix.
+9. Resolve only threads that are actually addressed.
+10. Repeat until there are no unresolved severity 4–5 comments, or stop and escalate if the change becomes ambiguous, broad, or blocked.
+
 ## Code Style
 
 Write pure functions where possible. Leverage the type systems available to you — Rust's type system, Python type hints, and TypeScript types. Comments should explain why you're doing something, not what the code does — especially for non-obvious decisions.

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -32,6 +32,18 @@ export interface ModelCardInfo {
   supportsTensor?: boolean;
   capabilities?: string[];
   tags?: string[];
+  resolvedCapabilities?: {
+    supportsThinking?: boolean;
+    supportsThinkingToggle?: boolean;
+    supportsThinkingBudget?: boolean;
+    supportsImageInput?: boolean;
+    supportsAudioInput?: boolean;
+    supportsToolCalling?: boolean;
+    thinkingFormat?: string;
+    promptRenderer?: string;
+    outputParser?: string;
+    supportsNativeMultimodal?: boolean;
+  };
 }
 
 export interface StoreRegistryTableProps {
@@ -420,6 +432,7 @@ function ModelInfoContent({ entry, card }: { entry: StoreRegistryEntry; card?: M
   const hfUrl = entry.model_id.includes('/')
     ? `https://huggingface.co/${entry.model_id}`
     : null;
+  const resolved = card?.resolvedCapabilities;
 
   return (
     <div style={{ minWidth: 240 }}>
@@ -470,6 +483,22 @@ function ModelInfoContent({ entry, card }: { entry: StoreRegistryEntry; card?: M
           <>
             <span style={{ color: 'rgba(255,255,255,0.45)' }}>Capabilities</span>
             <span>{card.capabilities.join(', ')}</span>
+          </>
+        )}
+        {resolved && (
+          <>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Thinking toggle</span>
+            <span>{resolved.supportsThinkingToggle ? 'Supported' : 'Not supported'}</span>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Thinking budget</span>
+            <span>{resolved.supportsThinkingBudget ? 'Supported' : 'Not supported'}</span>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Tool calling</span>
+            <span>{resolved.supportsToolCalling ? 'Supported' : 'Not supported'}</span>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Image input</span>
+            <span>{resolved.supportsImageInput ? 'Supported' : 'Not supported'}</span>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Audio input</span>
+            <span>{resolved.supportsAudioInput ? 'Supported' : 'Not supported'}</span>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Reasoning format</span>
+            <span>{resolved.thinkingFormat ?? 'none'}</span>
           </>
         )}
         <span style={{ color: 'rgba(255,255,255,0.45)' }}>Files</span>

--- a/dashboard-react/src/components/models/ModelPickerGroup.tsx
+++ b/dashboard-react/src/components/models/ModelPickerGroup.tsx
@@ -205,6 +205,7 @@ const InfoIconWrapper = styled.span`
 
 function ModelGroupInfo({ group }: { group: ModelGroup }) {
   const v = group.smallestVariant;
+  const resolved = v.resolved_capabilities;
   return (
     <div style={{ minWidth: 220 }}>
       <div style={{ color: '#FFD700', fontWeight: 600, marginBottom: 6 }}>
@@ -229,6 +230,18 @@ function ModelGroupInfo({ group }: { group: ModelGroup }) {
           <>
             <span style={{ color: 'rgba(255,255,255,0.45)' }}>Capabilities</span>
             <span>{group.capabilities.join(', ')}</span>
+          </>
+        )}
+        {resolved && (
+          <>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Thinking toggle</span>
+            <span>{resolved.supports_thinking_toggle ? 'Supported' : 'Not supported'}</span>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Tool calling</span>
+            <span>{resolved.supports_tool_calling ? 'Supported' : 'Not supported'}</span>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Image input</span>
+            <span>{resolved.supports_image_input ? 'Supported' : 'Not supported'}</span>
+            <span style={{ color: 'rgba(255,255,255,0.45)' }}>Audio input</span>
+            <span>{resolved.supports_audio_input ? 'Supported' : 'Not supported'}</span>
           </>
         )}
       </div>

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -4,6 +4,7 @@ import { ChatMessages } from '../chat/ChatMessages';
 import { ChatForm } from '../chat/ChatForm';
 import type { ChatMessage } from '../../types/chat';
 import type { ChatUploadedFile } from '../../types/chat';
+import type { ModelInfo } from '../../types/models';
 import type { InstanceCardData } from '../layout/InstancePanel';
 import { useChatStore } from '../../stores/chatStore';
 import { useUIStore } from '../../stores/uiStore';
@@ -94,7 +95,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
   const [tps, setTps] = useState<number | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [modelCapabilities, setModelCapabilities] = useState<Record<string, string[]>>({});
+  const [modelThinkingToggleSupport, setModelThinkingToggleSupport] = useState<Record<string, boolean>>({});
   const [modelContextLengths, setModelContextLengths] = useState<Record<string, number>>({});
 
   // Restore scroll position after store hydration + DOM render
@@ -138,14 +139,16 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
       try {
         const res = await fetch('/models');
         if (!res.ok) return;
-        const data = await res.json();
-        const caps: Record<string, string[]> = {};
+        const data = await res.json() as { data?: ModelInfo[] };
+        const toggleSupport: Record<string, boolean> = {};
         const ctxLens: Record<string, number> = {};
         for (const m of data.data ?? []) {
-          if (m.id && m.capabilities) caps[m.id] = m.capabilities;
+          if (m.id) {
+            toggleSupport[m.id] = m.resolved_capabilities?.supports_thinking_toggle ?? false;
+          }
           if (m.id && m.context_length) ctxLens[m.id] = m.context_length;
         }
-        setModelCapabilities(caps);
+        setModelThinkingToggleSupport(toggleSupport);
         setModelContextLengths(ctxLens);
       } catch { /* ignore */ }
     })();
@@ -154,7 +157,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
   const contextLength = selectedModelId ? modelContextLengths[selectedModelId] ?? 0 : 0;
 
   const supportsThinking = selectedModelId
-    ? (modelCapabilities[selectedModelId]?.includes('thinking_toggle') ?? false)
+    ? (modelThinkingToggleSupport[selectedModelId] ?? false)
     : false;
 
   // Ready models

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -70,7 +70,8 @@ const ModelSelect = styled.select`
 `;
 
 const EMPTY_MESSAGES: ChatMessage[] = [];
-const STREAM_STALL_TIMEOUT_MS = 60_000;
+const INITIAL_STREAM_STALL_TIMEOUT_MS = 10 * 60_000;
+const ACTIVE_STREAM_STALL_TIMEOUT_MS = 60_000;
 
 /* ── Component ────────────────────────────────────────── */
 
@@ -238,15 +239,19 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     abortRef.current = controller;
     let stallTimer: number | null = null;
     let requestTimedOut = false;
+    let lastStallTimeoutMs = INITIAL_STREAM_STALL_TIMEOUT_MS;
 
     const resetStallTimer = () => {
       if (stallTimer !== null) {
         window.clearTimeout(stallTimer);
       }
+      lastStallTimeoutMs = firstTokenTime === null
+        ? INITIAL_STREAM_STALL_TIMEOUT_MS
+        : ACTIVE_STREAM_STALL_TIMEOUT_MS;
       stallTimer = window.setTimeout(() => {
         requestTimedOut = true;
         controller.abort();
-      }, STREAM_STALL_TIMEOUT_MS);
+      }, lastStallTimeoutMs);
     };
 
     const startTime = performance.now();
@@ -391,7 +396,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
       if ((err as Error).name === 'AbortError') {
         // User cancelled
         if (requestTimedOut) {
-          rawContent = `Error: generation stalled for more than ${Math.round(STREAM_STALL_TIMEOUT_MS / 1000)} seconds.`;
+          rawContent = `Error: generation stalled for more than ${Math.round(lastStallTimeoutMs / 1000)} seconds.`;
         }
       } else {
         rawContent = rawContent || `Error: ${(err as Error).message}`;

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -70,6 +70,7 @@ const ModelSelect = styled.select`
 `;
 
 const EMPTY_MESSAGES: ChatMessage[] = [];
+const STREAM_STALL_TIMEOUT_MS = 60_000;
 
 /* ── Component ────────────────────────────────────────── */
 
@@ -235,6 +236,18 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
 
     const controller = new AbortController();
     abortRef.current = controller;
+    let stallTimer: number | null = null;
+    let requestTimedOut = false;
+
+    const resetStallTimer = () => {
+      if (stallTimer !== null) {
+        window.clearTimeout(stallTimer);
+      }
+      stallTimer = window.setTimeout(() => {
+        requestTimedOut = true;
+        controller.abort();
+      }, STREAM_STALL_TIMEOUT_MS);
+    };
 
     const startTime = performance.now();
     let firstTokenTime: number | null = null;
@@ -244,6 +257,8 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     let lastTps: number | undefined;
 
     try {
+      resetStallTimer();
+
       // Build messages array — use multimodal content format when images are attached
       const apiMessages = allMessages.map((m) => {
         if (m.attachments?.some((a) => a.type.startsWith('image/') && a.preview)) {
@@ -288,6 +303,8 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
+
+        resetStallTimer();
 
         buffer += decoder.decode(value, { stream: true });
 
@@ -373,23 +390,37 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     } catch (err) {
       if ((err as Error).name === 'AbortError') {
         // User cancelled
+        if (requestTimedOut) {
+          rawContent = `Error: generation stalled for more than ${Math.round(STREAM_STALL_TIMEOUT_MS / 1000)} seconds.`;
+        }
       } else {
         rawContent = rawContent || `Error: ${(err as Error).message}`;
+      }
+    } finally {
+      if (stallTimer !== null) {
+        window.clearTimeout(stallTimer);
       }
     }
 
     // Finalize assistant message
-    const assistantMsg: ChatMessage = {
-      id: crypto.randomUUID(),
-      role: 'assistant',
-      content: rawContent.replace(/<think>[\s\S]*?<\/think>/gi, '').replace(/<think>[\s\S]*/i, '').trim(),
-      timestamp: Date.now(),
-      ttftMs: firstTokenTime ? firstTokenTime - startTime : undefined,
-      tps: lastTps,
-      thinkingContent: fullThinking || undefined,
-    };
+    const finalAssistantContent = rawContent
+      .replace(/<think>[\s\S]*?<\/think>/gi, '')
+      .replace(/<think>[\s\S]*/i, '')
+      .trim();
 
-    addMessage(assistantMsg);
+    if (finalAssistantContent || fullThinking) {
+      const assistantMsg: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: 'assistant',
+        content: finalAssistantContent,
+        timestamp: Date.now(),
+        ttftMs: firstTokenTime ? firstTokenTime - startTime : undefined,
+        tps: lastTps,
+        thinkingContent: fullThinking || undefined,
+      };
+
+      addMessage(assistantMsg);
+    }
     setStreamingContent(null);
     setStreamingThinking(null);
     setIsLoading(false);

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -182,6 +182,18 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
             supportsTensor: m.supports_tensor ?? undefined,
             capabilities: m.capabilities ?? undefined,
             tags: m.tags ?? [],
+            resolvedCapabilities: m.resolved_capabilities ? {
+              supportsThinking: m.resolved_capabilities.supports_thinking ?? false,
+              supportsThinkingToggle: m.resolved_capabilities.supports_thinking_toggle ?? false,
+              supportsThinkingBudget: m.resolved_capabilities.supports_thinking_budget ?? false,
+              supportsImageInput: m.resolved_capabilities.supports_image_input ?? false,
+              supportsAudioInput: m.resolved_capabilities.supports_audio_input ?? false,
+              supportsToolCalling: m.resolved_capabilities.supports_tool_calling ?? false,
+              thinkingFormat: m.resolved_capabilities.thinking_format ?? 'none',
+              promptRenderer: m.resolved_capabilities.prompt_renderer ?? 'tokenizer',
+              outputParser: m.resolved_capabilities.output_parser ?? 'generic',
+              supportsNativeMultimodal: m.resolved_capabilities.supports_native_multimodal ?? false,
+            } : undefined,
           };
         }
         setApiModelCards(cards);

--- a/dashboard-react/src/types/models.ts
+++ b/dashboard-react/src/types/models.ts
@@ -1,4 +1,49 @@
 /** Dashboard-friendly model metadata derived from the Skulk model catalog. */
+export interface ReasoningCapabilityInfo {
+  supports_toggle?: boolean;
+  supports_budget?: boolean;
+  format?: string;
+  default_effort?: string;
+  disabled_effort?: string;
+}
+
+/** Optional declarative modality metadata copied from a model card. */
+export interface ModalitiesCapabilityInfo {
+  supports_audio_input?: boolean;
+  supports_native_multimodal?: boolean;
+}
+
+/** Optional declarative tool-calling metadata copied from a model card. */
+export interface ToolingCapabilityInfo {
+  supports_tool_calling?: boolean;
+  tool_call_format?: string;
+}
+
+/** Optional declarative runtime hints copied from a model card. */
+export interface RuntimeCapabilityInfo {
+  prompt_renderer?: string;
+  output_parser?: string;
+}
+
+/** Normalized runtime capability contract returned by `/v1/models`. */
+export interface ResolvedModelCapabilities {
+  family: string;
+  supports_thinking: boolean;
+  supports_thinking_toggle: boolean;
+  supports_thinking_budget: boolean;
+  default_reasoning_effort: string;
+  disabled_reasoning_effort: string;
+  thinking_format: string;
+  supports_image_input: boolean;
+  supports_audio_input: boolean;
+  supports_tool_calling: boolean;
+  tool_call_format: string;
+  prompt_renderer: string;
+  output_parser: string;
+  supports_native_multimodal: boolean;
+}
+
+/** Complete dashboard-facing model metadata entry returned by the model catalog. */
 export interface ModelInfo {
   id: string;
   name?: string;
@@ -11,6 +56,11 @@ export interface ModelInfo {
   is_custom?: boolean;
   tasks?: string[];
   hugging_face_id?: string;
+  reasoning?: ReasoningCapabilityInfo;
+  modalities?: ModalitiesCapabilityInfo;
+  tooling?: ToolingCapabilityInfo;
+  runtime?: RuntimeCapabilityInfo;
+  resolved_capabilities?: ResolvedModelCapabilities;
 }
 
 /** Group of related model variants shown as one family in the picker UI. */

--- a/dashboard-react/src/types/models.ts
+++ b/dashboard-react/src/types/models.ts
@@ -47,6 +47,8 @@ export interface ResolvedModelCapabilities {
 export interface ModelInfo {
   id: string;
   name?: string;
+  context_length?: number;
+  tags?: string[];
   storage_size_megabytes?: number;
   base_model?: string;
   quantization?: string;

--- a/docs/api.md
+++ b/docs/api.md
@@ -319,7 +319,7 @@ Notes:
 
 - `enable_thinking` is a Skulk extension.
 - Reasoning support depends on model capabilities.
-- Models with `thinking` or `thinking_toggle` metadata are the likeliest candidates.
+- Use `/v1/models[].resolved_capabilities` to decide whether a model supports thinking and whether clients should render a thinking toggle.
 
 ## Structured Output
 
@@ -417,6 +417,11 @@ curl http://localhost:52415/v1/models
 ```
 
 This returns known model cards, not just running instances.
+
+The response now includes both:
+
+- the declarative advanced capability sections from the model card when present
+- a normalized `resolved_capabilities` block that the dashboard and API clients can use for model-aware behavior without guessing
 
 ### Search Hugging Face
 
@@ -571,9 +576,29 @@ Important fields:
 | `tags` | array | UI-friendly derived labels such as `vision`, `thinking`, `embedding`, `tensor`, and `optiq` |
 | `supports_tensor` | boolean | Whether tensor parallel launch is supported |
 | `base_model` | string | Base family or upstream source model when known |
+| `reasoning` | object/null | Optional declarative reasoning metadata from the model card |
+| `modalities` | object/null | Optional declarative modality metadata from the model card |
+| `tooling` | object/null | Optional declarative tool-calling metadata from the model card |
+| `runtime` | object/null | Optional declarative runtime integration hints from the model card |
+| `resolved_capabilities` | object/null | Normalized runtime capability view resolved from the model card and model-family defaults |
 
 The dashboard uses `tags` for compact badges and `capabilities` for filtering
 and richer tooltips.
+
+Important `resolved_capabilities` fields include:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `supports_thinking` | boolean | Whether the model family is expected to expose a reasoning or thinking mode |
+| `supports_thinking_toggle` | boolean | Whether clients can safely offer a thinking on/off control |
+| `supports_thinking_budget` | boolean | Whether the runtime expects a thinking-budget style control to exist |
+| `supports_image_input` | boolean | Whether image input is supported |
+| `supports_audio_input` | boolean | Whether audio input is supported |
+| `supports_tool_calling` | boolean | Whether structured tool calling is expected |
+| `thinking_format` | string | The normalized reasoning marker format, such as `none`, `token_delimited`, or `channel_delimited` |
+| `prompt_renderer` | string | The resolved prompt rendering strategy, such as `tokenizer`, `gemma4`, or `dsml` |
+| `output_parser` | string | The resolved output parsing strategy, such as `generic`, `gemma4`, `gpt_oss`, or `deepseek_v32` |
+| `supports_native_multimodal` | boolean | Whether Skulk can use a native multimodal execution path for the model |
 
 ## Configuration Endpoints
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -320,6 +320,7 @@ Notes:
 - `enable_thinking` is a Skulk extension.
 - Reasoning support depends on model capabilities.
 - Use `/v1/models` response `data[].resolved_capabilities` to decide whether a model supports thinking and whether clients should render a thinking toggle.
+- Treat `resolved_capabilities` as the default tool-free request path; request-specific options such as tools can change prompt rendering and related resolved values for mixed-mode model families.
 
 ## Structured Output
 
@@ -580,7 +581,7 @@ Important fields:
 | `modalities` | object/null | Optional declarative modality metadata from the model card |
 | `tooling` | object/null | Optional declarative tool-calling metadata from the model card |
 | `runtime` | object/null | Optional declarative runtime integration hints from the model card |
-| `resolved_capabilities` | object/null | Normalized runtime capability view resolved from the model card and model-family defaults |
+| `resolved_capabilities` | object/null | Normalized runtime capability view resolved from the model card and model-family defaults for the default tool-free request path |
 
 The dashboard uses `tags` for compact badges and `capabilities` for filtering
 and richer tooltips.

--- a/docs/api.md
+++ b/docs/api.md
@@ -319,7 +319,7 @@ Notes:
 
 - `enable_thinking` is a Skulk extension.
 - Reasoning support depends on model capabilities.
-- Use `/v1/models[].resolved_capabilities` to decide whether a model supports thinking and whether clients should render a thinking toggle.
+- Use `/v1/models` response `data[].resolved_capabilities` to decide whether a model supports thinking and whether clients should render a thinking toggle.
 
 ## Structured Output
 

--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
@@ -9,6 +9,22 @@ quantization = "4bit"
 base_model = "Gemma 4 26B A4B"
 capabilities = ["text", "vision", "thinking"]
 
+[reasoning]
+supports_toggle = true
+format = "channel_delimited"
+default_effort = "medium"
+disabled_effort = "none"
+
+[modalities]
+supports_native_multimodal = true
+
+[tooling]
+tool_call_format = "gemma4"
+
+[runtime]
+prompt_renderer = "gemma4"
+output_parser = "gemma4"
+
 [vision]
 image_token_id = 258880
 model_type = "gemma4"

--- a/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
@@ -9,6 +9,22 @@ quantization = "8bit"
 base_model = "Gemma 4 E4B"
 capabilities = ["text", "vision", "thinking"]
 
+[reasoning]
+supports_toggle = true
+format = "channel_delimited"
+default_effort = "medium"
+disabled_effort = "none"
+
+[modalities]
+supports_native_multimodal = true
+
+[tooling]
+tool_call_format = "gemma4"
+
+[runtime]
+prompt_renderer = "gemma4"
+output_parser = "gemma4"
+
 [vision]
 image_token_id = 258880
 model_type = "gemma4"

--- a/resources/inference_model_cards/mlx-community--gpt-oss-120b-MXFP4-Q8.toml
+++ b/resources/inference_model_cards/mlx-community--gpt-oss-120b-MXFP4-Q8.toml
@@ -11,3 +11,10 @@ capabilities = ["text", "thinking"]
 
 [storage_size]
 in_bytes = 70652212224
+
+[tooling]
+supports_tool_calling = true
+tool_call_format = "gpt_oss"
+
+[runtime]
+output_parser = "gpt_oss"

--- a/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
+++ b/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
@@ -12,3 +12,10 @@ context_length = 131072
 
 [storage_size]
 in_bytes = 12025908224
+
+[tooling]
+supports_tool_calling = true
+tool_call_format = "gpt_oss"
+
+[runtime]
+output_parser = "gpt_oss"

--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -59,6 +59,8 @@ async def fetch_image_url(url: str) -> str:
 
 async def chat_request_to_text_generation(
     request: ChatCompletionRequest,
+    *,
+    model_card: ModelCard | None = None,
 ) -> TextGenerationTaskParams:
     instructions: str | None = None
     input_messages: list[InputMessage] = []
@@ -144,7 +146,6 @@ async def chat_request_to_text_generation(
             dumped: dict[str, Any] = msg_copy.model_dump(exclude_none=True)
             chat_template_messages.append(dumped)
 
-    model_card = await ModelCard.load(request.model)
     capability_profile = resolve_model_capability_profile(
         request.model,
         model_card=model_card,

--- a/src/exo/api/adapters/chat_completions.py
+++ b/src/exo/api/adapters/chat_completions.py
@@ -23,6 +23,8 @@ from exo.api.types import (
     Usage,
 )
 from exo.download.download_utils import create_http_session
+from exo.shared.models.capabilities import resolve_model_capability_profile
+from exo.shared.models.model_cards import ModelCard
 from exo.shared.types.chunks import (
     ErrorChunk,
     PrefillProgressChunk,
@@ -142,8 +144,15 @@ async def chat_request_to_text_generation(
             dumped: dict[str, Any] = msg_copy.model_dump(exclude_none=True)
             chat_template_messages.append(dumped)
 
+    model_card = await ModelCard.load(request.model)
+    capability_profile = resolve_model_capability_profile(
+        request.model,
+        model_card=model_card,
+    )
     resolved_effort, resolved_thinking = resolve_reasoning_params(
-        request.reasoning_effort, request.enable_thinking
+        request.reasoning_effort,
+        request.enable_thinking,
+        capability_profile,
     )
 
     return TextGenerationTaskParams(

--- a/src/exo/api/adapters/responses.py
+++ b/src/exo/api/adapters/responses.py
@@ -40,6 +40,8 @@ from exo.api.types.openai_responses import (
     ResponseTextDoneEvent,
     ResponseUsage,
 )
+from exo.shared.models.capabilities import resolve_model_capability_profile
+from exo.shared.models.model_cards import ModelCard
 from exo.shared.types.chunks import (
     ErrorChunk,
     PrefillProgressChunk,
@@ -154,8 +156,15 @@ async def responses_request_to_text_generation(
         built_chat_template = chat_template_messages if chat_template_messages else None
 
     effort_from_reasoning = request.reasoning.effort if request.reasoning else None
+    model_card = await ModelCard.load(request.model)
+    capability_profile = resolve_model_capability_profile(
+        request.model,
+        model_card=model_card,
+    )
     resolved_effort, resolved_thinking = resolve_reasoning_params(
-        effort_from_reasoning, request.enable_thinking
+        effort_from_reasoning,
+        request.enable_thinking,
+        capability_profile,
     )
 
     # The responses API often does not provide tool args nested under a "function" field.

--- a/src/exo/api/adapters/responses.py
+++ b/src/exo/api/adapters/responses.py
@@ -72,6 +72,8 @@ def _extract_content(content: str | list[ResponseContentPart]) -> str:
 
 async def responses_request_to_text_generation(
     request: ResponsesRequest,
+    *,
+    model_card: ModelCard | None = None,
 ) -> TextGenerationTaskParams:
     input_value: list[InputMessage]
     built_chat_template: list[dict[str, Any]] | None = None
@@ -156,7 +158,6 @@ async def responses_request_to_text_generation(
         built_chat_template = chat_template_messages if chat_template_messages else None
 
     effort_from_reasoning = request.reasoning.effort if request.reasoning else None
-    model_card = await ModelCard.load(request.model)
     capability_profile = resolve_model_capability_profile(
         request.model,
         model_card=model_card,

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -92,6 +92,7 @@ from exo.api.types import (
     PlacementPreviewResponse,
     PurgeStagingRequest,
     PurgeStagingResponse,
+    ResolvedModelCapabilities,
     StartDownloadParams,
     StartDownloadResponse,
     ToolCall,
@@ -139,6 +140,7 @@ from exo.shared.constants import (
 )
 from exo.shared.election import ElectionMessage
 from exo.shared.logging import InterceptLogger
+from exo.shared.models.capabilities import resolve_model_capability_profile
 from exo.shared.models.model_cards import (
     ModelCard,
     ModelId,
@@ -2126,6 +2128,37 @@ class API:
             tags.append("embedding")
         return tags
 
+    @staticmethod
+    def _model_list_entry(card: "ModelCard") -> ModelListModel:
+        """Build the public model-list representation for one model card."""
+        resolved_profile = resolve_model_capability_profile(
+            card.model_id,
+            model_card=card,
+        )
+        return ModelListModel(
+            id=card.model_id,
+            hugging_face_id=card.model_id,
+            name=card.model_id.short(),
+            description="",
+            tags=API._model_tags(card),
+            storage_size_megabytes=card.storage_size.in_mb,
+            supports_tensor=card.supports_tensor,
+            tasks=[task.value for task in card.tasks],
+            is_custom=card.is_custom,
+            family=card.family,
+            quantization=card.quantization,
+            base_model=card.base_model,
+            capabilities=card.capabilities,
+            context_length=card.context_length,
+            reasoning=card.reasoning,
+            modalities=card.modalities,
+            tooling=card.tooling,
+            runtime=card.runtime,
+            resolved_capabilities=ResolvedModelCapabilities.from_profile(
+                resolved_profile
+            ),
+        )
+
     async def get_models(self, status: str | None = Query(default=None)) -> ModelList:
         """Returns list of available models, optionally filtered by being downloaded."""
         cards = await get_model_cards()
@@ -2139,25 +2172,7 @@ class API:
             cards = [c for c in cards if c.model_id in downloaded_model_ids]
 
         return ModelList(
-            data=[
-                ModelListModel(
-                    id=card.model_id,
-                    hugging_face_id=card.model_id,
-                    name=card.model_id.short(),
-                    description="",
-                    tags=self._model_tags(card),
-                    storage_size_megabytes=card.storage_size.in_mb,
-                    supports_tensor=card.supports_tensor,
-                    tasks=[task.value for task in card.tasks],
-                    is_custom=card.is_custom,
-                    family=card.family,
-                    quantization=card.quantization,
-                    base_model=card.base_model,
-                    capabilities=card.capabilities,
-                    context_length=card.context_length,
-                )
-                for card in cards
-            ]
+            data=[self._model_list_entry(card) for card in cards]
         )
 
     async def add_custom_model(self, payload: AddCustomModelParams) -> ModelListModel:
@@ -2176,18 +2191,7 @@ class API:
             )
         )
 
-        return ModelListModel(
-            id=card.model_id,
-            hugging_face_id=card.model_id,
-            name=card.model_id.short(),
-            description="",
-            tags=[],
-            storage_size_megabytes=int(card.storage_size.in_mb),
-            supports_tensor=card.supports_tensor,
-            tasks=[task.value for task in card.tasks],
-            is_custom=True,
-            context_length=card.context_length,
-        )
+        return self._model_list_entry(card.model_copy(update={"is_custom": True}))
 
     async def delete_custom_model(self, model_id: ModelId) -> JSONResponse:
         """Delete a user-added custom model card and sync deletion across the cluster."""

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -1241,7 +1241,7 @@ class API:
     ) -> ChatCompletionResponse | StreamingResponse:
         """OpenAI Chat Completions API - adapter."""
         resolved_model = await self._resolve_and_validate_text_model(payload.model)
-        model_card = await ModelCard.load(resolved_model)
+        model_card = await self._get_running_model_card(resolved_model)
         task_params = await chat_request_to_text_generation(
             payload.model_copy(update={"model": resolved_model}),
             model_card=model_card,
@@ -1303,6 +1303,18 @@ class API:
                 detail=f"No instance found for model {model_id}",
             )
         return model_id
+
+    async def _get_running_model_card(self, model_id: ModelId) -> ModelCard:
+        """Return a model card for a running instance without requiring remote lookup.
+
+        Text requests should prefer the in-memory shard metadata once a model is
+        already running so request availability does not depend on model-card
+        cache misses or Hugging Face fetches during normal inference.
+        """
+        for instance in self.state.instances.values():
+            if instance.shard_assignments.model_id == model_id:
+                return instance.shard_assignments.model_card
+        return await ModelCard.load(model_id)
 
     async def _validate_image_model(self, model: ModelId) -> ModelId:
         """Validate model exists and return resolved model ID.
@@ -1914,7 +1926,7 @@ class API:
     ) -> ResponsesResponse | StreamingResponse:
         """OpenAI Responses API."""
         resolved_model = await self._resolve_and_validate_text_model(payload.model)
-        model_card = await ModelCard.load(resolved_model)
+        model_card = await self._get_running_model_card(resolved_model)
         task_params = await responses_request_to_text_generation(
             payload.model_copy(update={"model": resolved_model}),
             model_card=model_card,

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -85,6 +85,7 @@ from exo.api.types import (
     ImageListItem,
     ImageListResponse,
     ImageSize,
+    ModalitiesCapabilitySection,
     ModelList,
     ModelListModel,
     PlaceInstanceParams,
@@ -92,10 +93,13 @@ from exo.api.types import (
     PlacementPreviewResponse,
     PurgeStagingRequest,
     PurgeStagingResponse,
+    ReasoningCapabilitySection,
     ResolvedModelCapabilities,
+    RuntimeCapabilitySection,
     StartDownloadParams,
     StartDownloadResponse,
     ToolCall,
+    ToolingCapabilitySection,
     TraceCategoryStats,
     TraceEventResponse,
     TraceListItem,
@@ -1236,11 +1240,12 @@ class API:
         self, payload: ChatCompletionRequest
     ) -> ChatCompletionResponse | StreamingResponse:
         """OpenAI Chat Completions API - adapter."""
-        task_params = await chat_request_to_text_generation(payload)
-        resolved_model = await self._resolve_and_validate_text_model(
-            ModelId(task_params.model)
+        resolved_model = await self._resolve_and_validate_text_model(payload.model)
+        model_card = await ModelCard.load(resolved_model)
+        task_params = await chat_request_to_text_generation(
+            payload.model_copy(update={"model": resolved_model}),
+            model_card=model_card,
         )
-        task_params = task_params.model_copy(update={"model": resolved_model})
 
         command = await self._send_text_generation_with_images(task_params)
 
@@ -1908,9 +1913,12 @@ class API:
         self, payload: ResponsesRequest
     ) -> ResponsesResponse | StreamingResponse:
         """OpenAI Responses API."""
-        task_params = await responses_request_to_text_generation(payload)
-        resolved_model = await self._resolve_and_validate_text_model(task_params.model)
-        task_params = task_params.model_copy(update={"model": resolved_model})
+        resolved_model = await self._resolve_and_validate_text_model(payload.model)
+        model_card = await ModelCard.load(resolved_model)
+        task_params = await responses_request_to_text_generation(
+            payload.model_copy(update={"model": resolved_model}),
+            model_card=model_card,
+        )
 
         command = await self._send_text_generation_with_images(task_params)
 
@@ -2150,10 +2158,10 @@ class API:
             base_model=card.base_model,
             capabilities=card.capabilities,
             context_length=card.context_length,
-            reasoning=card.reasoning,
-            modalities=card.modalities,
-            tooling=card.tooling,
-            runtime=card.runtime,
+            reasoning=ReasoningCapabilitySection.from_model_card(card),
+            modalities=ModalitiesCapabilitySection.from_model_card(card),
+            tooling=ToolingCapabilitySection.from_model_card(card),
+            runtime=RuntimeCapabilitySection.from_model_card(card),
             resolved_capabilities=ResolvedModelCapabilities.from_profile(
                 resolved_profile
             ),

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -1276,12 +1276,12 @@ class API:
     async def bench_chat_completions(
         self, payload: BenchChatCompletionRequest
     ) -> BenchChatCompletionResponse:
-        task_params = await chat_request_to_text_generation(payload)
-        resolved_model = await self._resolve_and_validate_text_model(
-            ModelId(task_params.model)
+        resolved_model = await self._resolve_and_validate_text_model(payload.model)
+        model_card = await self._get_running_model_card(resolved_model)
+        task_params = await chat_request_to_text_generation(
+            payload.model_copy(update={"model": resolved_model}),
+            model_card=model_card,
         )
-        task_params = task_params.model_copy(update={"model": resolved_model})
-
         task_params = task_params.model_copy(update={"stream": False, "bench": True})
 
         command = await self._send_text_generation_with_images(task_params)

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -2155,11 +2155,16 @@ class API:
             card.model_id,
             model_card=card,
         )
+        description = (
+            "resolved_capabilities reflects the default tool-free request path; "
+            "request-specific options such as tools may change prompt rendering "
+            "and related resolved capability values."
+        )
         return ModelListModel(
             id=card.model_id,
             hugging_face_id=card.model_id,
             name=card.model_id.short(),
-            description="",
+            description=description,
             tags=API._model_tags(card),
             storage_size_megabytes=card.storage_size.in_mb,
             supports_tensor=card.supports_tensor,

--- a/src/exo/api/tests/test_model_tags.py
+++ b/src/exo/api/tests/test_model_tags.py
@@ -139,3 +139,24 @@ def test_model_list_entry_exposes_deepseek_family_defaults_without_card_extensio
     assert entry.resolved_capabilities.supports_thinking_toggle is True
     assert entry.resolved_capabilities.prompt_renderer == "dsml"
     assert entry.resolved_capabilities.output_parser == "deepseek_v32"
+
+
+def test_model_list_entry_honors_coarse_thinking_toggle_capability() -> None:
+    """Legacy coarse capability tags should still drive toggle support in the API contract."""
+    card = ModelCard(
+        model_id=ModelId("mlx-community/Qwen3.5-122B-A10B-4bit"),
+        storage_size=Memory.from_bytes(1024),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text", "thinking", "thinking_toggle"],
+        family="qwen",
+    )
+
+    entry = API._model_list_entry(card)
+
+    assert entry.reasoning is None
+    assert entry.resolved_capabilities is not None
+    assert entry.resolved_capabilities.supports_thinking is True
+    assert entry.resolved_capabilities.supports_thinking_toggle is True

--- a/src/exo/api/tests/test_model_tags.py
+++ b/src/exo/api/tests/test_model_tags.py
@@ -59,7 +59,7 @@ def test_model_list_entry_exposes_declared_and_resolved_capabilities() -> None:
     assert entry.reasoning is not None
     assert entry.reasoning.supports_toggle is True
     assert entry.runtime is not None
-    assert entry.runtime.prompt_renderer == PromptRendererType.Gemma4
+    assert entry.runtime.prompt_renderer == "gemma4"
     assert entry.resolved_capabilities is not None
     assert entry.resolved_capabilities.supports_thinking_toggle is True
     assert entry.resolved_capabilities.prompt_renderer == "gemma4"
@@ -160,3 +160,38 @@ def test_model_list_entry_honors_coarse_thinking_toggle_capability() -> None:
     assert entry.resolved_capabilities is not None
     assert entry.resolved_capabilities.supports_thinking is True
     assert entry.resolved_capabilities.supports_thinking_toggle is True
+
+
+def test_model_list_entry_serializes_declared_capabilities_in_snake_case() -> None:
+    """API JSON should keep declared capability sections in snake_case."""
+    card = ModelCard(
+        model_id=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        storage_size=Memory.from_bytes(1024),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text", "vision", "thinking"],
+        family="gemma",
+        reasoning=ReasoningCardConfig(
+            supports_toggle=True,
+            supports_budget=True,
+            format=ReasoningFormat.ChannelDelimited,
+        ),
+        tooling=ToolingCardConfig(
+            supports_tool_calling=True,
+            tool_call_format=ToolCallFormat.Gemma4,
+        ),
+        runtime=RuntimeCapabilityCardConfig(
+            prompt_renderer=PromptRendererType.Gemma4,
+            output_parser=OutputParserType.Gemma4,
+        ),
+    )
+
+    payload = API._model_list_entry(card).model_dump(by_alias=True)
+
+    assert payload["reasoning"]["supports_toggle"] is True
+    assert payload["reasoning"]["supports_budget"] is True
+    assert payload["tooling"]["supports_tool_calling"] is True
+    assert payload["tooling"]["tool_call_format"] == "gemma4"
+    assert payload["runtime"]["prompt_renderer"] == "gemma4"

--- a/src/exo/api/tests/test_model_tags.py
+++ b/src/exo/api/tests/test_model_tags.py
@@ -137,8 +137,10 @@ def test_model_list_entry_exposes_deepseek_family_defaults_without_card_extensio
     assert entry.runtime is None
     assert entry.resolved_capabilities is not None
     assert entry.resolved_capabilities.supports_thinking_toggle is True
+    assert entry.resolved_capabilities.supports_tool_calling is True
     assert entry.resolved_capabilities.prompt_renderer == "dsml"
     assert entry.resolved_capabilities.output_parser == "deepseek_v32"
+    assert entry.resolved_capabilities.tool_call_format == "dsml"
 
 
 def test_model_list_entry_honors_coarse_thinking_toggle_capability() -> None:

--- a/src/exo/api/tests/test_model_tags.py
+++ b/src/exo/api/tests/test_model_tags.py
@@ -2,7 +2,17 @@
 """Tests for derived model tags exposed by the API."""
 
 from exo.api.main import API
-from exo.shared.models.model_cards import ModelCard, ModelTask
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelTask,
+    OutputParserType,
+    PromptRendererType,
+    ReasoningCardConfig,
+    ReasoningFormat,
+    RuntimeCapabilityCardConfig,
+    ToolCallFormat,
+    ToolingCardConfig,
+)
 from exo.shared.types.common import ModelId
 from exo.shared.types.memory import Memory
 
@@ -21,3 +31,111 @@ def test_model_tags_include_vision() -> None:
     )
 
     assert API._model_tags(card) == ["thinking", "vision", "tensor"]
+
+
+def test_model_list_entry_exposes_declared_and_resolved_capabilities() -> None:
+    """Model list entries should expose refined declared and resolved metadata."""
+    card = ModelCard(
+        model_id=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        storage_size=Memory.from_bytes(1024),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text", "vision", "thinking"],
+        family="gemma",
+        reasoning=ReasoningCardConfig(
+            supports_toggle=True,
+            format=ReasoningFormat.ChannelDelimited,
+        ),
+        runtime=RuntimeCapabilityCardConfig(
+            prompt_renderer=PromptRendererType.Gemma4,
+            output_parser=OutputParserType.Gemma4,
+        ),
+    )
+
+    entry = API._model_list_entry(card)
+
+    assert entry.reasoning is not None
+    assert entry.reasoning.supports_toggle is True
+    assert entry.runtime is not None
+    assert entry.runtime.prompt_renderer == PromptRendererType.Gemma4
+    assert entry.resolved_capabilities is not None
+    assert entry.resolved_capabilities.supports_thinking_toggle is True
+    assert entry.resolved_capabilities.prompt_renderer == "gemma4"
+
+
+def test_model_list_entry_exposes_gpt_oss_runtime_capabilities() -> None:
+    """Model list entries should surface tool/runtime metadata for GPT-OSS cards."""
+    card = ModelCard(
+        model_id=ModelId("mlx-community/gpt-oss-20b-MXFP4-Q8"),
+        storage_size=Memory.from_bytes(1024),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text", "thinking"],
+        family="gpt-oss",
+        tooling=ToolingCardConfig(
+            supports_tool_calling=True,
+            tool_call_format=ToolCallFormat.GptOss,
+        ),
+        runtime=RuntimeCapabilityCardConfig(
+            output_parser=OutputParserType.GptOss,
+        ),
+    )
+
+    entry = API._model_list_entry(card)
+
+    assert entry.tooling is not None
+    assert entry.tooling.supports_tool_calling is True
+    assert entry.resolved_capabilities is not None
+    assert entry.resolved_capabilities.supports_tool_calling is True
+    assert entry.resolved_capabilities.tool_call_format == "gpt_oss"
+    assert entry.resolved_capabilities.output_parser == "gpt_oss"
+
+
+def test_model_list_entry_keeps_legacy_cards_compatible() -> None:
+    """Legacy cards without advanced sections should still serialize cleanly."""
+    card = ModelCard(
+        model_id=ModelId("mlx-community/Qwen3.5-9B-4bit"),
+        storage_size=Memory.from_bytes(1024),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text", "thinking"],
+    )
+
+    entry = API._model_list_entry(card)
+
+    assert entry.reasoning is None
+    assert entry.modalities is None
+    assert entry.tooling is None
+    assert entry.runtime is None
+    assert entry.resolved_capabilities is not None
+    assert entry.resolved_capabilities.prompt_renderer == "tokenizer"
+    assert entry.resolved_capabilities.output_parser == "generic"
+
+
+def test_model_list_entry_exposes_deepseek_family_defaults_without_card_extensions() -> None:
+    """Resolved capabilities should expose DeepSeek family defaults even without advanced card sections."""
+    card = ModelCard(
+        model_id=ModelId("mlx-community/DeepSeek-V3.2-4bit"),
+        storage_size=Memory.from_bytes(1024),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text", "thinking"],
+        family="deepseek-v3.2",
+    )
+
+    entry = API._model_list_entry(card)
+
+    assert entry.reasoning is None
+    assert entry.runtime is None
+    assert entry.resolved_capabilities is not None
+    assert entry.resolved_capabilities.supports_thinking_toggle is True
+    assert entry.resolved_capabilities.prompt_renderer == "dsml"
+    assert entry.resolved_capabilities.output_parser == "deepseek_v32"

--- a/src/exo/api/tests/test_model_validation_order.py
+++ b/src/exo/api/tests/test_model_validation_order.py
@@ -1,0 +1,63 @@
+"""Tests that request validation happens before capability-driven card loading."""
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from exo.api.main import API
+from exo.api.types import ChatCompletionMessage, ChatCompletionRequest
+from exo.api.types.openai_responses import ResponsesRequest
+from exo.shared.types.common import ModelId
+
+
+@pytest.mark.anyio
+async def test_chat_completions_validates_model_before_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid chat models should fail locally before the adapter tries to build task params."""
+
+    async def _fail_if_called(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("chat_request_to_text_generation should not run before validation")
+
+    async def _raise_not_found(self: API, model_id: ModelId) -> ModelId:
+        raise HTTPException(status_code=404, detail=f"No instance found for model {model_id}")
+
+    monkeypatch.setattr("exo.api.main.chat_request_to_text_generation", _fail_if_called)
+    monkeypatch.setattr(API, "_resolve_and_validate_text_model", _raise_not_found)
+
+    api = object.__new__(API)
+    payload = ChatCompletionRequest(
+        model=ModelId("missing/model"),
+        messages=[ChatCompletionMessage(role="user", content="hello")],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await api.chat_completions(payload)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_openai_responses_validates_model_before_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid responses models should fail locally before the adapter tries to build task params."""
+
+    async def _fail_if_called(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError(
+            "responses_request_to_text_generation should not run before validation"
+        )
+
+    async def _raise_not_found(self: API, model_id: ModelId) -> ModelId:
+        raise HTTPException(status_code=404, detail=f"No instance found for model {model_id}")
+
+    monkeypatch.setattr("exo.api.main.responses_request_to_text_generation", _fail_if_called)
+    monkeypatch.setattr(API, "_resolve_and_validate_text_model", _raise_not_found)
+
+    api = object.__new__(API)
+    payload = ResponsesRequest(
+        model=ModelId("missing/model"),
+        input="hello",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await api.openai_responses(payload)
+
+    assert exc_info.value.status_code == 404

--- a/src/exo/api/tests/test_model_validation_order.py
+++ b/src/exo/api/tests/test_model_validation_order.py
@@ -7,7 +7,11 @@ import pytest
 from fastapi import HTTPException
 
 from exo.api.main import API
-from exo.api.types import ChatCompletionMessage, ChatCompletionRequest
+from exo.api.types import (
+    BenchChatCompletionRequest,
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+)
 from exo.api.types.openai_responses import ResponsesRequest
 from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.common import ModelId
@@ -101,3 +105,80 @@ async def test_running_text_requests_use_in_memory_model_card(monkeypatch: pytes
     resolved = await api._get_running_model_card(running_card.model_id)
 
     assert resolved == running_card
+
+
+@pytest.mark.anyio
+async def test_bench_chat_completions_uses_running_model_card(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Benchmark chat should use the same model-aware defaults as normal chat."""
+
+    running_card = ModelCard(
+        model_id=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        storage_size=Memory.from_mb(100),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text", "vision", "thinking"],
+        family="gemma",
+    )
+
+    api = object.__new__(API)
+    api.state = SimpleNamespace(
+        instances={
+            "running": SimpleNamespace(
+                shard_assignments=SimpleNamespace(
+                    model_id=running_card.model_id,
+                    model_card=running_card,
+                )
+            )
+        }
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _capture_adapter(
+        request: BenchChatCompletionRequest,
+        *,
+        model_card: ModelCard | None = None,
+    ):
+        captured["request_model"] = request.model
+        captured["model_card"] = model_card
+        return SimpleNamespace(
+            model=request.model,
+            stream=False,
+            bench=False,
+            model_copy=lambda update: SimpleNamespace(
+                model=update.get("model", request.model),
+                stream=update.get("stream", False),
+                bench=update.get("bench", False),
+                model_copy=lambda nested_update: SimpleNamespace(
+                    model=nested_update.get("model", update.get("model", request.model)),
+                    stream=nested_update.get("stream", update.get("stream", False)),
+                    bench=nested_update.get("bench", update.get("bench", False)),
+                ),
+            ),
+        )
+
+    async def _send_task(task_params):
+        captured["task_params"] = task_params
+        return SimpleNamespace(command_id="cmd-1")
+
+    async def _collect_stats(command_id: str):
+        captured["command_id"] = command_id
+        return SimpleNamespace(model=str(running_card.model_id))
+
+    monkeypatch.setattr("exo.api.main.chat_request_to_text_generation", _capture_adapter)
+    monkeypatch.setattr(api, "_send_text_generation_with_images", _send_task)
+    monkeypatch.setattr(api, "_collect_text_generation_with_stats", _collect_stats)
+
+    payload = BenchChatCompletionRequest(
+        model=running_card.model_id,
+        messages=[ChatCompletionMessage(role="user", content="hello")],
+    )
+
+    response = await api.bench_chat_completions(payload)
+
+    assert captured["request_model"] == running_card.model_id
+    assert captured["model_card"] == running_card
+    assert captured["command_id"] == "cmd-1"
+    assert response.model == str(running_card.model_id)

--- a/src/exo/api/tests/test_model_validation_order.py
+++ b/src/exo/api/tests/test_model_validation_order.py
@@ -1,5 +1,6 @@
 """Tests that request validation happens before capability-driven card loading."""
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -8,7 +9,9 @@ from fastapi import HTTPException
 from exo.api.main import API
 from exo.api.types import ChatCompletionMessage, ChatCompletionRequest
 from exo.api.types.openai_responses import ResponsesRequest
+from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.common import ModelId
+from exo.shared.types.memory import Memory
 
 
 @pytest.mark.anyio
@@ -61,3 +64,40 @@ async def test_openai_responses_validates_model_before_adapter(monkeypatch: pyte
         await api.openai_responses(payload)
 
     assert exc_info.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_running_text_requests_use_in_memory_model_card(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Running text requests should not depend on ModelCard.load cache/fetch behavior."""
+
+    running_card = ModelCard(
+        model_id=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        storage_size=Memory.from_mb(100),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text", "vision", "thinking"],
+        family="gemma",
+    )
+
+    async def _fail_if_called(model_id: ModelId) -> ModelCard:
+        raise AssertionError(f"ModelCard.load should not be called for running model {model_id}")
+
+    monkeypatch.setattr("exo.api.main.ModelCard.load", _fail_if_called)
+
+    api = object.__new__(API)
+    api.state = SimpleNamespace(
+        instances={
+            "running": SimpleNamespace(
+                shard_assignments=SimpleNamespace(
+                    model_id=running_card.model_id,
+                    model_card=running_card,
+                )
+            )
+        }
+    )
+
+    resolved = await api._get_running_model_card(running_card.model_id)
+
+    assert resolved == running_card

--- a/src/exo/api/types/__init__.py
+++ b/src/exo/api/types/__init__.py
@@ -38,6 +38,7 @@ from .api import ImageListResponse as ImageListResponse
 from .api import ImageSize as ImageSize
 from .api import Logprobs as Logprobs
 from .api import LogprobsContentItem as LogprobsContentItem
+from .api import ModalitiesCapabilitySection as ModalitiesCapabilitySection
 from .api import ModelList as ModelList
 from .api import ModelListModel as ModelListModel
 from .api import NodePowerStats as NodePowerStats
@@ -48,12 +49,15 @@ from .api import PowerUsage as PowerUsage
 from .api import PromptTokensDetails as PromptTokensDetails
 from .api import PurgeStagingRequest as PurgeStagingRequest
 from .api import PurgeStagingResponse as PurgeStagingResponse
+from .api import ReasoningCapabilitySection as ReasoningCapabilitySection
 from .api import ResolvedModelCapabilities as ResolvedModelCapabilities
+from .api import RuntimeCapabilitySection as RuntimeCapabilitySection
 from .api import StartDownloadParams as StartDownloadParams
 from .api import StartDownloadResponse as StartDownloadResponse
 from .api import StreamingChoiceResponse as StreamingChoiceResponse
 from .api import ToolCall as ToolCall
 from .api import ToolCallItem as ToolCallItem
+from .api import ToolingCapabilitySection as ToolingCapabilitySection
 from .api import TopLogprobItem as TopLogprobItem
 from .api import TraceCategoryStats as TraceCategoryStats
 from .api import TraceEventResponse as TraceEventResponse

--- a/src/exo/api/types/__init__.py
+++ b/src/exo/api/types/__init__.py
@@ -48,6 +48,7 @@ from .api import PowerUsage as PowerUsage
 from .api import PromptTokensDetails as PromptTokensDetails
 from .api import PurgeStagingRequest as PurgeStagingRequest
 from .api import PurgeStagingResponse as PurgeStagingResponse
+from .api import ResolvedModelCapabilities as ResolvedModelCapabilities
 from .api import StartDownloadParams as StartDownloadParams
 from .api import StartDownloadResponse as StartDownloadResponse
 from .api import StreamingChoiceResponse as StreamingChoiceResponse

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -6,14 +6,7 @@ from uuid import uuid4
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from exo.shared.models.capabilities import ResolvedCapabilityProfile
-from exo.shared.models.model_cards import (
-    ModalitiesCardConfig,
-    ModelCard,
-    ModelId,
-    ReasoningCardConfig,
-    RuntimeCapabilityCardConfig,
-    ToolingCardConfig,
-)
+from exo.shared.models.model_cards import ModelCard, ModelId
 from exo.shared.types.common import CommandId, NodeId
 from exo.shared.types.memory import Memory
 from exo.shared.types.text_generation import ReasoningEffort
@@ -61,19 +54,19 @@ class ModelListModel(BaseModel):
         default_factory=list,
         description="Coarse catalog capability labels such as text, vision, thinking, or embedding.",
     )
-    reasoning: ReasoningCardConfig | None = Field(
+    reasoning: "ReasoningCapabilitySection | None" = Field(
         default=None,
         description="Optional declarative reasoning controls from the model card.",
     )
-    modalities: ModalitiesCardConfig | None = Field(
+    modalities: "ModalitiesCapabilitySection | None" = Field(
         default=None,
         description="Optional declarative modality support details from the model card.",
     )
-    tooling: ToolingCardConfig | None = Field(
+    tooling: "ToolingCapabilitySection | None" = Field(
         default=None,
         description="Optional declarative tool-calling metadata from the model card.",
     )
-    runtime: RuntimeCapabilityCardConfig | None = Field(
+    runtime: "RuntimeCapabilitySection | None" = Field(
         default=None,
         description="Optional declarative runtime integration hints from the model card.",
     )
@@ -159,6 +152,90 @@ class ResolvedModelCapabilities(BaseModel):
             prompt_renderer=profile.prompt_renderer.value,
             output_parser=profile.output_parser.value,
             supports_native_multimodal=profile.supports_native_multimodal,
+        )
+
+
+class ReasoningCapabilitySection(BaseModel):
+    """Snake-case reasoning metadata exposed by the models API."""
+
+    supports_toggle: bool | None = None
+    supports_budget: bool | None = None
+    format: str | None = None
+    default_effort: ReasoningEffort | None = None
+    disabled_effort: ReasoningEffort | None = None
+
+    @classmethod
+    def from_model_card(cls, model_card: ModelCard) -> "ReasoningCapabilitySection | None":
+        config = model_card.reasoning
+        if config is None:
+            return None
+        return cls(
+            supports_toggle=config.supports_toggle,
+            supports_budget=config.supports_budget,
+            format=config.format.value if config.format is not None else None,
+            default_effort=config.default_effort,
+            disabled_effort=config.disabled_effort,
+        )
+
+
+class ModalitiesCapabilitySection(BaseModel):
+    """Snake-case modality metadata exposed by the models API."""
+
+    supports_audio_input: bool | None = None
+    supports_native_multimodal: bool | None = None
+
+    @classmethod
+    def from_model_card(cls, model_card: ModelCard) -> "ModalitiesCapabilitySection | None":
+        config = model_card.modalities
+        if config is None:
+            return None
+        return cls(
+            supports_audio_input=config.supports_audio_input,
+            supports_native_multimodal=config.supports_native_multimodal,
+        )
+
+
+class ToolingCapabilitySection(BaseModel):
+    """Snake-case tool-calling metadata exposed by the models API."""
+
+    supports_tool_calling: bool | None = None
+    tool_call_format: str | None = None
+
+    @classmethod
+    def from_model_card(cls, model_card: ModelCard) -> "ToolingCapabilitySection | None":
+        config = model_card.tooling
+        if config is None:
+            return None
+        return cls(
+            supports_tool_calling=config.supports_tool_calling,
+            tool_call_format=(
+                config.tool_call_format.value
+                if config.tool_call_format is not None
+                else None
+            ),
+        )
+
+
+class RuntimeCapabilitySection(BaseModel):
+    """Snake-case runtime metadata exposed by the models API."""
+
+    prompt_renderer: str | None = None
+    output_parser: str | None = None
+
+    @classmethod
+    def from_model_card(cls, model_card: ModelCard) -> "RuntimeCapabilitySection | None":
+        config = model_card.runtime
+        if config is None:
+            return None
+        return cls(
+            prompt_renderer=(
+                config.prompt_renderer.value
+                if config.prompt_renderer is not None
+                else None
+            ),
+            output_parser=(
+                config.output_parser.value if config.output_parser is not None else None
+            ),
         )
 
 

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -5,7 +5,15 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from exo.shared.models.model_cards import ModelCard, ModelId
+from exo.shared.models.capabilities import ResolvedCapabilityProfile
+from exo.shared.models.model_cards import (
+    ModalitiesCardConfig,
+    ModelCard,
+    ModelId,
+    ReasoningCardConfig,
+    RuntimeCapabilityCardConfig,
+    ToolingCardConfig,
+)
 from exo.shared.types.common import CommandId, NodeId
 from exo.shared.types.memory import Memory
 from exo.shared.types.text_generation import ReasoningEffort
@@ -30,6 +38,8 @@ class ErrorResponse(BaseModel):
 
 
 class ModelListModel(BaseModel):
+    """Public model-catalog entry returned by the models endpoints."""
+
     id: str
     object: str = "model"
     created: int = Field(default_factory=lambda: int(time.time()))
@@ -47,7 +57,109 @@ class ModelListModel(BaseModel):
     family: str = Field(default="")
     quantization: str = Field(default="")
     base_model: str = Field(default="")
-    capabilities: list[str] = Field(default_factory=list)
+    capabilities: list[str] = Field(
+        default_factory=list,
+        description="Coarse catalog capability labels such as text, vision, thinking, or embedding.",
+    )
+    reasoning: ReasoningCardConfig | None = Field(
+        default=None,
+        description="Optional declarative reasoning controls from the model card.",
+    )
+    modalities: ModalitiesCardConfig | None = Field(
+        default=None,
+        description="Optional declarative modality support details from the model card.",
+    )
+    tooling: ToolingCardConfig | None = Field(
+        default=None,
+        description="Optional declarative tool-calling metadata from the model card.",
+    )
+    runtime: RuntimeCapabilityCardConfig | None = Field(
+        default=None,
+        description="Optional declarative runtime integration hints from the model card.",
+    )
+    resolved_capabilities: "ResolvedModelCapabilities | None" = Field(
+        default=None,
+        description="Normalized runtime capabilities resolved from the model card and model-family defaults.",
+    )
+
+
+class ResolvedModelCapabilities(BaseModel):
+    """Normalized runtime behavior that UI and API consumers can safely inspect."""
+
+    family: str = Field(default="", description="Resolved model family used for runtime behavior decisions.")
+    supports_thinking: bool = Field(
+        default=False,
+        description="Whether the runtime expects the model to expose a reasoning or thinking mode.",
+    )
+    supports_thinking_toggle: bool = Field(
+        default=False,
+        description="Whether thinking can be explicitly enabled or disabled for requests.",
+    )
+    supports_thinking_budget: bool = Field(
+        default=False,
+        description="Whether the runtime expects the model to accept a thinking or reasoning budget control.",
+    )
+    default_reasoning_effort: ReasoningEffort = Field(
+        default="medium",
+        description="Reasoning effort used when thinking is enabled without an explicit effort override.",
+    )
+    disabled_reasoning_effort: ReasoningEffort = Field(
+        default="none",
+        description="Reasoning effort used when thinking is explicitly disabled.",
+    )
+    thinking_format: str = Field(
+        default="none",
+        description="Resolved reasoning marker format expected from this model family.",
+    )
+    supports_image_input: bool = Field(
+        default=False,
+        description="Whether the runtime should treat the model as accepting image inputs.",
+    )
+    supports_audio_input: bool = Field(
+        default=False,
+        description="Whether the runtime should treat the model as accepting audio inputs.",
+    )
+    supports_tool_calling: bool = Field(
+        default=False,
+        description="Whether the runtime expects the model to support structured tool calling.",
+    )
+    tool_call_format: str = Field(
+        default="generic",
+        description="Resolved tool-call output format family used for parsing.",
+    )
+    prompt_renderer: str = Field(
+        default="tokenizer",
+        description="Resolved prompt renderer strategy used to prepare requests for this model.",
+    )
+    output_parser: str = Field(
+        default="generic",
+        description="Resolved output parser strategy used to interpret model responses.",
+    )
+    supports_native_multimodal: bool = Field(
+        default=False,
+        description="Whether the runtime can use a native multimodal execution path for the model.",
+    )
+
+    @classmethod
+    def from_profile(
+        cls, profile: ResolvedCapabilityProfile
+    ) -> "ResolvedModelCapabilities":
+        return cls(
+            family=profile.family,
+            supports_thinking=profile.supports_thinking,
+            supports_thinking_toggle=profile.supports_thinking_toggle,
+            supports_thinking_budget=profile.supports_thinking_budget,
+            default_reasoning_effort=profile.default_reasoning_effort,
+            disabled_reasoning_effort=profile.disabled_reasoning_effort,
+            thinking_format=profile.thinking_format.value,
+            supports_image_input=profile.supports_image_input,
+            supports_audio_input=profile.supports_audio_input,
+            supports_tool_calling=profile.supports_tool_calling,
+            tool_call_format=profile.tool_call_format.value,
+            prompt_renderer=profile.prompt_renderer.value,
+            output_parser=profile.output_parser.value,
+            supports_native_multimodal=profile.supports_native_multimodal,
+        )
 
 
 class ModelList(BaseModel):

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -72,7 +72,11 @@ class ModelListModel(BaseModel):
     )
     resolved_capabilities: "ResolvedModelCapabilities | None" = Field(
         default=None,
-        description="Normalized runtime capabilities resolved from the model card and model-family defaults.",
+        description=(
+            "Normalized runtime capabilities resolved from the model card and "
+            "model-family defaults for the default tool-free request path. "
+            "Request-specific options such as tools may change some resolved values."
+        ),
     )
 
 

--- a/src/exo/shared/models/capabilities.py
+++ b/src/exo/shared/models/capabilities.py
@@ -102,6 +102,9 @@ def resolve_model_capability_profile(
         card is not None
         and ("thinking" in card.capabilities or card.reasoning is not None)
     )
+    supports_thinking_toggle = bool(
+        card is not None and "thinking_toggle" in card.capabilities
+    )
     supports_tool_calling = bool(
         (tokenizer is not None and getattr(tokenizer, "has_tool_calling", False))
         or (
@@ -125,6 +128,7 @@ def resolve_model_capability_profile(
     profile = ResolvedCapabilityProfile(
         family=profile_family,
         supports_thinking=supports_thinking,
+        supports_thinking_toggle=supports_thinking_toggle,
         supports_image_input=supports_image_input,
         supports_tool_calling=supports_tool_calling,
         thinking_format=thinking_format,

--- a/src/exo/shared/models/capabilities.py
+++ b/src/exo/shared/models/capabilities.py
@@ -1,0 +1,229 @@
+"""Runtime capability resolution derived from model cards.
+
+This module keeps model cards as the persisted declarative source of truth while
+providing a normalized runtime profile that inference code can consume without
+sprinkling optional-field checks throughout the hot path.
+"""
+
+from typing import TYPE_CHECKING
+
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    OutputParserType,
+    PromptRendererType,
+    ReasoningFormat,
+    ToolCallFormat,
+    get_card,
+)
+from exo.shared.types.text_generation import ReasoningEffort, TextGenerationTaskParams
+from exo.utils.pydantic_ext import FrozenModel
+
+if TYPE_CHECKING:
+    from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+
+class ResolvedCapabilityProfile(FrozenModel):
+    """Normalized runtime behavior derived from a model card and runtime facts."""
+
+    family: str = "generic"
+    supports_thinking: bool = False
+    supports_thinking_toggle: bool = False
+    supports_thinking_budget: bool = False
+    default_reasoning_effort: ReasoningEffort = "medium"
+    disabled_reasoning_effort: ReasoningEffort = "none"
+    thinking_format: ReasoningFormat = ReasoningFormat.None_
+    supports_image_input: bool = False
+    supports_audio_input: bool = False
+    supports_tool_calling: bool = False
+    tool_call_format: ToolCallFormat = ToolCallFormat.Generic
+    prompt_renderer: PromptRendererType = PromptRendererType.Tokenizer
+    output_parser: OutputParserType = OutputParserType.Generic
+    supports_native_multimodal: bool = False
+
+
+def _infer_family(model_id: ModelId, model_card: ModelCard | None) -> str:
+    if model_card is not None and model_card.family:
+        return model_card.family
+    return model_id.normalize().split("-", 1)[0]
+
+
+def _is_gemma4_family(profile_family: str, normalized_model_id: str) -> bool:
+    return (
+        "gemma-4" in normalized_model_id
+        or "gemma4" in normalized_model_id
+        or profile_family in {"gemma4", "gemma-4"}
+    )
+
+
+def _is_deepseek_v32_family(profile_family: str, normalized_model_id: str) -> bool:
+    return (
+        "deepseek-v3.2" in normalized_model_id
+        or profile_family in {"deepseek-v3.2", "deepseek_v32"}
+    )
+
+
+def _is_gpt_oss_family(profile_family: str, normalized_model_id: str) -> bool:
+    return profile_family == "gpt-oss" or any(
+        marker in normalized_model_id for marker in ("gpt-oss", "gpt_oss")
+    )
+
+
+def resolve_model_capability_profile(
+    model_id: ModelId,
+    *,
+    model_card: ModelCard | None = None,
+    tokenizer: "TokenizerWrapper | None" = None,
+    task_params: TextGenerationTaskParams | None = None,
+) -> ResolvedCapabilityProfile:
+    """Resolve runtime capabilities for one request.
+
+    The resolver is intentionally conservative: if a card does not declare an
+    advanced capability, we fall back to generic runtime behavior and only
+    preserve the broad support we can infer from the existing card fields.
+    """
+
+    card = model_card or get_card(model_id)
+    normalized_model_id = model_id.normalize().lower()
+    profile_family = _infer_family(model_id, card)
+
+    supports_image_input = bool(
+        card is not None
+        and (
+            "vision" in card.capabilities
+            or card.vision is not None
+            or (
+                card.modalities is not None
+                and card.modalities.supports_native_multimodal is True
+            )
+        )
+    )
+    supports_thinking = bool(
+        card is not None
+        and ("thinking" in card.capabilities or card.reasoning is not None)
+    )
+    supports_tool_calling = bool(
+        (tokenizer is not None and getattr(tokenizer, "has_tool_calling", False))
+        or (
+            card is not None
+            and (
+                (card.tooling is not None and card.tooling.supports_tool_calling is True)
+                or (
+                    card.tooling is not None
+                    and card.tooling.tool_call_format is not None
+                    and card.tooling.tool_call_format != ToolCallFormat.Generic
+                )
+            )
+        )
+    )
+    thinking_format = (
+        ReasoningFormat.TokenDelimited
+        if tokenizer is not None and getattr(tokenizer, "has_thinking", False)
+        else ReasoningFormat.None_
+    )
+
+    profile = ResolvedCapabilityProfile(
+        family=profile_family,
+        supports_thinking=supports_thinking,
+        supports_image_input=supports_image_input,
+        supports_tool_calling=supports_tool_calling,
+        thinking_format=thinking_format,
+        supports_native_multimodal=supports_image_input,
+    )
+
+    # Family-specific defaults preserve current behavior until cards opt in to
+    # richer declarations. Explicit card fields override these defaults below.
+    if _is_gemma4_family(profile.family, normalized_model_id):
+        prompt_renderer = PromptRendererType.Tokenizer
+        if task_params is None or (
+            task_params.chat_template_messages is not None and not task_params.tools
+        ):
+            prompt_renderer = PromptRendererType.Gemma4
+
+        profile = profile.model_copy(
+            update={
+                "supports_thinking": True,
+                "supports_thinking_toggle": True,
+                "thinking_format": ReasoningFormat.ChannelDelimited,
+                "prompt_renderer": prompt_renderer,
+                "output_parser": OutputParserType.Gemma4,
+                "tool_call_format": ToolCallFormat.Gemma4,
+                "supports_native_multimodal": supports_image_input,
+            }
+        )
+    elif _is_deepseek_v32_family(profile.family, normalized_model_id):
+        profile = profile.model_copy(
+            update={
+                "supports_thinking": True,
+                "supports_thinking_toggle": True,
+                "prompt_renderer": PromptRendererType.Dsml,
+                "output_parser": OutputParserType.DeepseekV32,
+                "tool_call_format": ToolCallFormat.Dsml,
+            }
+        )
+    elif _is_gpt_oss_family(profile.family, normalized_model_id):
+        profile = profile.model_copy(
+            update={
+                "supports_tool_calling": True,
+                "output_parser": OutputParserType.GptOss,
+                "tool_call_format": ToolCallFormat.GptOss,
+            }
+        )
+
+    if card is not None and card.reasoning is not None:
+        updates: dict[str, object] = {}
+        if card.reasoning.supports_toggle is not None:
+            updates["supports_thinking_toggle"] = card.reasoning.supports_toggle
+        if card.reasoning.supports_budget is not None:
+            updates["supports_thinking_budget"] = card.reasoning.supports_budget
+        if card.reasoning.format is not None:
+            updates["thinking_format"] = card.reasoning.format
+        if card.reasoning.default_effort is not None:
+            updates["default_reasoning_effort"] = card.reasoning.default_effort
+        if card.reasoning.disabled_effort is not None:
+            updates["disabled_reasoning_effort"] = card.reasoning.disabled_effort
+        if updates:
+            profile = profile.model_copy(update=updates)
+
+    if card is not None and card.modalities is not None:
+        updates = {}
+        if card.modalities.supports_audio_input is not None:
+            updates["supports_audio_input"] = card.modalities.supports_audio_input
+        if card.modalities.supports_native_multimodal is not None:
+            updates["supports_native_multimodal"] = (
+                card.modalities.supports_native_multimodal
+            )
+        if updates:
+            profile = profile.model_copy(update=updates)
+
+    if card is not None and card.tooling is not None:
+        updates = {}
+        if card.tooling.supports_tool_calling is not None:
+            updates["supports_tool_calling"] = card.tooling.supports_tool_calling
+        if card.tooling.tool_call_format is not None:
+            updates["tool_call_format"] = card.tooling.tool_call_format
+        if updates:
+            profile = profile.model_copy(update=updates)
+
+    if card is not None and card.runtime is not None:
+        updates = {}
+        if card.runtime.prompt_renderer is not None:
+            updates["prompt_renderer"] = card.runtime.prompt_renderer
+        if card.runtime.output_parser is not None:
+            updates["output_parser"] = card.runtime.output_parser
+        if updates:
+            profile = profile.model_copy(update=updates)
+
+    # Preserve the existing fallback for tool-enabled Gemma 4 requests until we
+    # land the full prompt grammar. Cards can declare Gemma 4 behavior, but the
+    # runtime must still stay conservative here.
+    if (
+        task_params is not None
+        and task_params.tools
+        and profile.prompt_renderer == PromptRendererType.Gemma4
+    ):
+        profile = profile.model_copy(
+            update={"prompt_renderer": PromptRendererType.Tokenizer}
+        )
+
+    return profile

--- a/src/exo/shared/models/capabilities.py
+++ b/src/exo/shared/models/capabilities.py
@@ -150,6 +150,7 @@ def resolve_model_capability_profile(
             update={
                 "supports_thinking": True,
                 "supports_thinking_toggle": True,
+                "supports_tool_calling": True,
                 "thinking_format": ReasoningFormat.ChannelDelimited,
                 "prompt_renderer": prompt_renderer,
                 "output_parser": OutputParserType.Gemma4,
@@ -162,6 +163,7 @@ def resolve_model_capability_profile(
             update={
                 "supports_thinking": True,
                 "supports_thinking_toggle": True,
+                "supports_tool_calling": True,
                 "prompt_renderer": PromptRendererType.Dsml,
                 "output_parser": OutputParserType.DeepseekV32,
                 "tool_call_format": ToolCallFormat.Dsml,

--- a/src/exo/shared/models/capabilities.py
+++ b/src/exo/shared/models/capabilities.py
@@ -45,7 +45,9 @@ class ResolvedCapabilityProfile(FrozenModel):
 def _infer_family(model_id: ModelId, model_card: ModelCard | None) -> str:
     if model_card is not None and model_card.family:
         return model_card.family
-    return model_id.normalize().split("-", 1)[0]
+    short_model_id = model_id.short()
+    family = short_model_id.split("-", 1)[0]
+    return family or "generic"
 
 
 def _is_gemma4_family(profile_family: str, normalized_model_id: str) -> bool:
@@ -132,7 +134,7 @@ def resolve_model_capability_profile(
         supports_image_input=supports_image_input,
         supports_tool_calling=supports_tool_calling,
         thinking_format=thinking_format,
-        supports_native_multimodal=supports_image_input,
+        supports_native_multimodal=False,
     )
 
     # Family-specific defaults preserve current behavior until cards opt in to

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -28,6 +28,7 @@ from exo.shared.constants import (
 )
 from exo.shared.types.common import ModelId
 from exo.shared.types.memory import Memory
+from exo.shared.types.text_generation import ReasoningEffort
 from exo.utils.pydantic_ext import CamelCaseModel
 
 # kinda ugly...
@@ -134,6 +135,107 @@ class VisionCardConfig(CamelCaseModel):
     eoi_token_id: int | None = None
 
 
+class ReasoningFormat(str, Enum):
+    """Reasoning marker formats used by model families."""
+
+    None_ = "none"
+    TokenDelimited = "token_delimited"
+    ChannelDelimited = "channel_delimited"
+
+
+class PromptRendererType(str, Enum):
+    """Prompt renderer strategies supported by the runtime."""
+
+    Tokenizer = "tokenizer"
+    Gemma4 = "gemma4"
+    Dsml = "dsml"
+
+
+class OutputParserType(str, Enum):
+    """Output parser strategies supported by the runtime."""
+
+    Generic = "generic"
+    Gemma4 = "gemma4"
+    GptOss = "gpt_oss"
+    DeepseekV32 = "deepseek_v32"
+
+
+class ToolCallFormat(str, Enum):
+    """Tool-call output formats emitted by model families."""
+
+    Generic = "generic"
+    Gemma4 = "gemma4"
+    GptOss = "gpt_oss"
+    Dsml = "dsml"
+
+
+class ReasoningCardConfig(CamelCaseModel):
+    """Optional advanced reasoning capability declarations for a model card."""
+
+    supports_toggle: bool | None = None
+    supports_budget: bool | None = None
+    format: ReasoningFormat | None = None
+    default_effort: ReasoningEffort | None = None
+    disabled_effort: ReasoningEffort | None = None
+
+    @field_validator("format", mode="before")
+    @classmethod
+    def _validate_format(
+        cls, value: str | ReasoningFormat | None
+    ) -> ReasoningFormat | None:
+        if value is None or isinstance(value, ReasoningFormat):
+            return value
+        return ReasoningFormat(value)
+
+
+class ModalitiesCardConfig(CamelCaseModel):
+    """Optional advanced modality declarations for a model card."""
+
+    supports_audio_input: bool | None = None
+    supports_native_multimodal: bool | None = None
+
+
+class ToolingCardConfig(CamelCaseModel):
+    """Optional tool-calling behavior declarations for a model card."""
+
+    supports_tool_calling: bool | None = None
+    tool_call_format: ToolCallFormat | None = None
+
+    @field_validator("tool_call_format", mode="before")
+    @classmethod
+    def _validate_tool_call_format(
+        cls, value: str | ToolCallFormat | None
+    ) -> ToolCallFormat | None:
+        if value is None or isinstance(value, ToolCallFormat):
+            return value
+        return ToolCallFormat(value)
+
+
+class RuntimeCapabilityCardConfig(CamelCaseModel):
+    """Optional runtime behavior hints for a model card."""
+
+    prompt_renderer: PromptRendererType | None = None
+    output_parser: OutputParserType | None = None
+
+    @field_validator("prompt_renderer", mode="before")
+    @classmethod
+    def _validate_prompt_renderer(
+        cls, value: str | PromptRendererType | None
+    ) -> PromptRendererType | None:
+        if value is None or isinstance(value, PromptRendererType):
+            return value
+        return PromptRendererType(value)
+
+    @field_validator("output_parser", mode="before")
+    @classmethod
+    def _validate_output_parser(
+        cls, value: str | OutputParserType | None
+    ) -> OutputParserType | None:
+        if value is None or isinstance(value, OutputParserType):
+            return value
+        return OutputParserType(value)
+
+
 class ModelCard(CamelCaseModel):
     model_id: ModelId
     storage_size: Memory
@@ -152,6 +254,10 @@ class ModelCard(CamelCaseModel):
     trust_remote_code: bool = True
     is_custom: bool = False
     vision: VisionCardConfig | None = None
+    reasoning: ReasoningCardConfig | None = None
+    modalities: ModalitiesCardConfig | None = None
+    tooling: ToolingCardConfig | None = None
+    runtime: RuntimeCapabilityCardConfig | None = None
 
     @model_validator(mode="after")
     def _fill_vision_weights_repo(self) -> "ModelCard":

--- a/src/exo/shared/tests/test_model_capabilities.py
+++ b/src/exo/shared/tests/test_model_capabilities.py
@@ -126,6 +126,7 @@ def test_resolve_reasoning_params_treats_none_as_disabled_even_for_custom_profil
     )
 
     assert resolve_reasoning_params("none", None, profile) == ("minimal", False)
+    assert resolve_reasoning_params("none", True, profile) == ("minimal", False)
 
 
 def test_resolve_model_capability_profile_uses_safe_generic_fallback() -> None:

--- a/src/exo/shared/tests/test_model_capabilities.py
+++ b/src/exo/shared/tests/test_model_capabilities.py
@@ -118,6 +118,15 @@ def test_resolve_reasoning_params_uses_profile_defaults() -> None:
     assert resolve_reasoning_params(None, False, profile) == ("none", False)
 
 
+def test_resolve_reasoning_params_treats_none_as_disabled_even_for_custom_profiles() -> None:
+    profile = ResolvedCapabilityProfile(
+        default_reasoning_effort="high",
+        disabled_reasoning_effort="minimal",
+    )
+
+    assert resolve_reasoning_params("none", None, profile) == ("minimal", False)
+
+
 def test_resolve_model_capability_profile_uses_safe_generic_fallback() -> None:
     card = ModelCard(
         model_id=ModelId("example/plain-text-model"),
@@ -139,6 +148,15 @@ def test_resolve_model_capability_profile_uses_safe_generic_fallback() -> None:
     assert profile.supports_tool_calling is False
     assert profile.prompt_renderer == PromptRendererType.Tokenizer
     assert profile.output_parser == OutputParserType.Generic
+
+
+def test_resolve_model_capability_profile_infers_family_from_short_model_id() -> None:
+    profile = resolve_model_capability_profile(
+        ModelId("mlx-community/gemma-4-custom"),
+        model_card=None,
+    )
+
+    assert profile.family == "gemma"
 
 
 def test_resolve_model_capability_profile_honors_coarse_thinking_toggle_capability() -> None:
@@ -226,3 +244,21 @@ def test_resolve_model_capability_profile_uses_deepseek_v32_family_defaults() ->
     assert profile.prompt_renderer == PromptRendererType.Dsml
     assert profile.output_parser == OutputParserType.DeepseekV32
     assert profile.tool_call_format == ToolCallFormat.Dsml
+
+
+def test_resolve_model_capability_profile_keeps_native_multimodal_conservative_by_default() -> None:
+    card = ModelCard(
+        model_id=ModelId("mlx-community/vision-model"),
+        storage_size=Memory.from_mb(100),
+        n_layers=10,
+        hidden_size=1024,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family="vision",
+        capabilities=["text", "vision"],
+    )
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.supports_image_input is True
+    assert profile.supports_native_multimodal is False

--- a/src/exo/shared/tests/test_model_capabilities.py
+++ b/src/exo/shared/tests/test_model_capabilities.py
@@ -1,0 +1,208 @@
+from exo.shared.models.capabilities import (
+    ResolvedCapabilityProfile,
+    resolve_model_capability_profile,
+)
+from exo.shared.models.model_cards import (
+    ModalitiesCardConfig,
+    ModelCard,
+    ModelId,
+    ModelTask,
+    OutputParserType,
+    PromptRendererType,
+    ReasoningCardConfig,
+    ReasoningFormat,
+    RuntimeCapabilityCardConfig,
+    ToolCallFormat,
+    ToolingCardConfig,
+)
+from exo.shared.types.memory import Memory
+from exo.shared.types.text_generation import (
+    InputMessage,
+    TextGenerationTaskParams,
+    resolve_reasoning_params,
+)
+
+
+def _base_model_card(model_id: str) -> ModelCard:
+    return ModelCard(
+        model_id=ModelId(model_id),
+        storage_size=Memory.from_mb(100),
+        n_layers=10,
+        hidden_size=1024,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family="gemma",
+        capabilities=["text", "vision", "thinking"],
+    )
+
+
+def test_resolve_model_capability_profile_uses_extended_model_card_fields() -> None:
+    card = _base_model_card("example/gemma-test").model_copy(
+        update={
+            "reasoning": ReasoningCardConfig(
+                supports_toggle=True,
+                supports_budget=True,
+                format=ReasoningFormat.ChannelDelimited,
+                default_effort="high",
+                disabled_effort="none",
+            ),
+            "modalities": ModalitiesCardConfig(
+                supports_audio_input=True,
+                supports_native_multimodal=True,
+            ),
+            "tooling": ToolingCardConfig(
+                supports_tool_calling=True,
+                tool_call_format=ToolCallFormat.Gemma4,
+            ),
+            "runtime": RuntimeCapabilityCardConfig(
+                prompt_renderer=PromptRendererType.Gemma4,
+                output_parser=OutputParserType.Gemma4,
+            ),
+        }
+    )
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.supports_thinking_toggle is True
+    assert profile.supports_thinking_budget is True
+    assert profile.thinking_format == ReasoningFormat.ChannelDelimited
+    assert profile.default_reasoning_effort == "high"
+    assert profile.supports_audio_input is True
+    assert profile.tool_call_format == ToolCallFormat.Gemma4
+    assert profile.prompt_renderer == PromptRendererType.Gemma4
+    assert profile.output_parser == OutputParserType.Gemma4
+
+
+def test_resolve_model_capability_profile_keeps_gemma4_tool_fallback() -> None:
+    card = _base_model_card("mlx-community/gemma-4-26b-a4b-it-4bit").model_copy(
+        update={
+            "runtime": RuntimeCapabilityCardConfig(
+                prompt_renderer=PromptRendererType.Gemma4,
+                output_parser=OutputParserType.Gemma4,
+            )
+        }
+    )
+    task_params = TextGenerationTaskParams(
+        model=card.model_id,
+        input=[InputMessage(role="user", content="hello")],
+        chat_template_messages=[{"role": "user", "content": "hello"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup_weather",
+                    "description": "Lookup weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    profile = resolve_model_capability_profile(
+        card.model_id,
+        model_card=card,
+        task_params=task_params,
+    )
+
+    assert profile.prompt_renderer == PromptRendererType.Tokenizer
+    assert profile.output_parser == OutputParserType.Gemma4
+
+
+def test_resolve_reasoning_params_uses_profile_defaults() -> None:
+    profile = ResolvedCapabilityProfile(
+        default_reasoning_effort="high",
+        disabled_reasoning_effort="none",
+    )
+
+    assert resolve_reasoning_params(None, True, profile) == ("high", True)
+    assert resolve_reasoning_params(None, False, profile) == ("none", False)
+
+
+def test_resolve_model_capability_profile_uses_safe_generic_fallback() -> None:
+    card = ModelCard(
+        model_id=ModelId("example/plain-text-model"),
+        storage_size=Memory.from_mb(100),
+        n_layers=10,
+        hidden_size=1024,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family="example",
+        capabilities=["text"],
+    )
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.family == "example"
+    assert profile.supports_thinking is False
+    assert profile.supports_thinking_toggle is False
+    assert profile.supports_image_input is False
+    assert profile.supports_tool_calling is False
+    assert profile.prompt_renderer == PromptRendererType.Tokenizer
+    assert profile.output_parser == OutputParserType.Generic
+
+
+def test_resolve_model_capability_profile_uses_declared_tooling_without_model_id_match() -> None:
+    card = ModelCard(
+        model_id=ModelId("custom/open-model"),
+        storage_size=Memory.from_mb(100),
+        n_layers=10,
+        hidden_size=1024,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family="custom",
+        capabilities=["text"],
+        tooling=ToolingCardConfig(
+            supports_tool_calling=True,
+            tool_call_format=ToolCallFormat.GptOss,
+        ),
+        runtime=RuntimeCapabilityCardConfig(
+            output_parser=OutputParserType.GptOss,
+        ),
+    )
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.supports_tool_calling is True
+    assert profile.tool_call_format == ToolCallFormat.GptOss
+    assert profile.output_parser == OutputParserType.GptOss
+
+
+def test_resolve_model_capability_profile_uses_gpt_oss_family_defaults() -> None:
+    card = ModelCard(
+        model_id=ModelId("custom/oss-20b"),
+        storage_size=Memory.from_mb(100),
+        n_layers=10,
+        hidden_size=1024,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        family="gpt-oss",
+        capabilities=["text", "thinking"],
+    )
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.family == "gpt-oss"
+    assert profile.supports_tool_calling is True
+    assert profile.tool_call_format == ToolCallFormat.GptOss
+    assert profile.output_parser == OutputParserType.GptOss
+
+
+def test_resolve_model_capability_profile_uses_deepseek_v32_family_defaults() -> None:
+    card = ModelCard(
+        model_id=ModelId("custom/deepseek-compatible"),
+        storage_size=Memory.from_mb(100),
+        n_layers=10,
+        hidden_size=1024,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family="deepseek-v3.2",
+        capabilities=["text", "thinking"],
+    )
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.supports_thinking is True
+    assert profile.supports_thinking_toggle is True
+    assert profile.prompt_renderer == PromptRendererType.Dsml
+    assert profile.output_parser == OutputParserType.DeepseekV32
+    assert profile.tool_call_format == ToolCallFormat.Dsml

--- a/src/exo/shared/tests/test_model_capabilities.py
+++ b/src/exo/shared/tests/test_model_capabilities.py
@@ -104,6 +104,7 @@ def test_resolve_model_capability_profile_keeps_gemma4_tool_fallback() -> None:
         task_params=task_params,
     )
 
+    assert profile.supports_tool_calling is True
     assert profile.prompt_renderer == PromptRendererType.Tokenizer
     assert profile.output_parser == OutputParserType.Gemma4
 
@@ -241,6 +242,7 @@ def test_resolve_model_capability_profile_uses_deepseek_v32_family_defaults() ->
 
     assert profile.supports_thinking is True
     assert profile.supports_thinking_toggle is True
+    assert profile.supports_tool_calling is True
     assert profile.prompt_renderer == PromptRendererType.Dsml
     assert profile.output_parser == OutputParserType.DeepseekV32
     assert profile.tool_call_format == ToolCallFormat.Dsml

--- a/src/exo/shared/tests/test_model_capabilities.py
+++ b/src/exo/shared/tests/test_model_capabilities.py
@@ -141,6 +141,26 @@ def test_resolve_model_capability_profile_uses_safe_generic_fallback() -> None:
     assert profile.output_parser == OutputParserType.Generic
 
 
+def test_resolve_model_capability_profile_honors_coarse_thinking_toggle_capability() -> None:
+    card = ModelCard(
+        model_id=ModelId("mlx-community/Qwen3.5-122B-A10B-4bit"),
+        storage_size=Memory.from_mb(100),
+        n_layers=10,
+        hidden_size=1024,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family="qwen",
+        capabilities=["text", "thinking", "thinking_toggle"],
+    )
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.supports_thinking is True
+    assert profile.supports_thinking_toggle is True
+    assert profile.prompt_renderer == PromptRendererType.Tokenizer
+    assert profile.output_parser == OutputParserType.Generic
+
+
 def test_resolve_model_capability_profile_uses_declared_tooling_without_model_id_match() -> None:
     card = ModelCard(
         model_id=ModelId("custom/open-model"),

--- a/src/exo/shared/tests/test_resolve_reasoning_params.py
+++ b/src/exo/shared/tests/test_resolve_reasoning_params.py
@@ -7,10 +7,14 @@ def test_both_none_returns_none_none() -> None:
     assert resolve_reasoning_params(None, None) == (None, None)
 
 
-def test_both_set_passes_through_unchanged() -> None:
+def test_both_set_passes_through_unchanged_except_explicit_none() -> None:
     assert resolve_reasoning_params("high", True) == ("high", True)
-    assert resolve_reasoning_params("none", True) == ("none", True)
     assert resolve_reasoning_params("low", False) == ("low", False)
+
+
+def test_explicit_none_disables_thinking_even_with_explicit_flag() -> None:
+    assert resolve_reasoning_params("none", True) == ("none", False)
+    assert resolve_reasoning_params("none", False) == ("none", False)
 
 
 def test_enable_thinking_true_derives_medium() -> None:

--- a/src/exo/shared/types/text_generation.py
+++ b/src/exo/shared/types/text_generation.py
@@ -41,15 +41,13 @@ def resolve_reasoning_params(
         else "none"
     )
 
-    if reasoning_effort is None and enable_thinking is not None:
+    if reasoning_effort == "none":
+        resolved_effort = disabled_effort
+        resolved_thinking = False
+    elif reasoning_effort is None and enable_thinking is not None:
         resolved_effort = enabled_effort if enable_thinking else disabled_effort
-
-    if enable_thinking is None and reasoning_effort is not None:
-        if reasoning_effort == "none":
-            resolved_effort = disabled_effort
-            resolved_thinking = False
-        else:
-            resolved_thinking = reasoning_effort != disabled_effort
+    elif enable_thinking is None and reasoning_effort is not None:
+        resolved_thinking = reasoning_effort != disabled_effort
 
     return resolved_effort, resolved_thinking
 

--- a/src/exo/shared/types/text_generation.py
+++ b/src/exo/shared/types/text_generation.py
@@ -4,11 +4,14 @@ All external API formats (Chat Completions, Claude Messages, OpenAI Responses)
 are converted to TextGenerationTaskParams at the API boundary via adapters.
 """
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field
 
 from exo.shared.types.common import ModelId
+
+if TYPE_CHECKING:
+    from exo.shared.models.capabilities import ResolvedCapabilityProfile
 
 MessageRole = Literal["user", "assistant", "system", "developer"]
 ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
@@ -17,6 +20,7 @@ ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
 def resolve_reasoning_params(
     reasoning_effort: ReasoningEffort | None,
     enable_thinking: bool | None,
+    capability_profile: "ResolvedCapabilityProfile | None" = None,
 ) -> tuple[ReasoningEffort | None, bool | None]:
     """
     enable_thinking=True  -> reasoning_effort="medium"
@@ -26,12 +30,22 @@ def resolve_reasoning_params(
     """
     resolved_effort: ReasoningEffort | None = reasoning_effort
     resolved_thinking: bool | None = enable_thinking
+    enabled_effort = (
+        capability_profile.default_reasoning_effort
+        if capability_profile is not None
+        else "medium"
+    )
+    disabled_effort = (
+        capability_profile.disabled_reasoning_effort
+        if capability_profile is not None
+        else "none"
+    )
 
     if reasoning_effort is None and enable_thinking is not None:
-        resolved_effort = "medium" if enable_thinking else "none"
+        resolved_effort = enabled_effort if enable_thinking else disabled_effort
 
     if enable_thinking is None and reasoning_effort is not None:
-        resolved_thinking = reasoning_effort != "none"
+        resolved_thinking = reasoning_effort != disabled_effort
 
     return resolved_effort, resolved_thinking
 

--- a/src/exo/shared/types/text_generation.py
+++ b/src/exo/shared/types/text_generation.py
@@ -23,10 +23,10 @@ def resolve_reasoning_params(
     capability_profile: "ResolvedCapabilityProfile | None" = None,
 ) -> tuple[ReasoningEffort | None, bool | None]:
     """
-    enable_thinking=True  -> reasoning_effort="medium"
-    enable_thinking=False -> reasoning_effort="none"
-    reasoning_effort="none" -> enable_thinking=False
-    reasoning_effort=<anything else> -> enable_thinking=True
+    enable_thinking=True -> use the profile's default enabled effort
+    enable_thinking=False -> use the profile's disabled effort
+    reasoning_effort="none" -> normalize to the profile's disabled effort and disable thinking
+    reasoning_effort=<anything else> -> enable thinking unless it already matches the disabled effort
     """
     resolved_effort: ReasoningEffort | None = reasoning_effort
     resolved_thinking: bool | None = enable_thinking
@@ -45,7 +45,11 @@ def resolve_reasoning_params(
         resolved_effort = enabled_effort if enable_thinking else disabled_effort
 
     if enable_thinking is None and reasoning_effort is not None:
-        resolved_thinking = reasoning_effort != disabled_effort
+        if reasoning_effort == "none":
+            resolved_effort = disabled_effort
+            resolved_thinking = False
+        else:
+            resolved_thinking = reasoning_effort != disabled_effort
 
     return resolved_effort, resolved_thinking
 

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -2,7 +2,10 @@ import contextlib
 import functools
 import math
 import os
+import sys
+import threading
 import time
+import traceback
 from copy import deepcopy
 from importlib import metadata
 from typing import Callable, Generator, cast, get_args
@@ -73,6 +76,71 @@ from exo.worker.runner.bootstrap import logger
 generation_stream = mx.new_stream(mx.default_device())
 
 _MIN_PREFIX_HIT_RATIO_TO_UPDATE = 0.5
+
+
+def _mlx_hang_debug_enabled() -> bool:
+    """Return whether verbose warmup/prefill hang diagnostics are enabled."""
+    value = os.environ.get("EXO_MLX_HANG_DEBUG") or os.environ.get(
+        "SKULK_MLX_HANG_DEBUG"
+    )
+    if value is None:
+        return False
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _mlx_hang_debug_interval_seconds() -> float:
+    """Return the periodic interval for hang-debug watchdog logs."""
+    raw = os.environ.get("EXO_MLX_HANG_DEBUG_INTERVAL_SECONDS") or os.environ.get(
+        "SKULK_MLX_HANG_DEBUG_INTERVAL_SECONDS"
+    )
+    if raw is None:
+        return 30.0
+    with contextlib.suppress(ValueError):
+        return max(float(raw), 1.0)
+    return 30.0
+
+
+@contextlib.contextmanager
+def _hang_debug_watch(label: str) -> Generator[None]:
+    """Emit periodic stack-rich logs while the current thread is stuck in one phase."""
+    if not _mlx_hang_debug_enabled():
+        yield
+        return
+
+    interval_seconds = _mlx_hang_debug_interval_seconds()
+    started_at = time.monotonic()
+    monitored_thread_id = threading.get_ident()
+    finished = threading.Event()
+
+    logger.info(
+        f"[hang-debug] Entering {label} (watchdog interval={interval_seconds:.0f}s)"
+    )
+
+    def watchdog() -> None:
+        while not finished.wait(timeout=interval_seconds):
+            elapsed = time.monotonic() - started_at
+            frame = sys._current_frames().get(monitored_thread_id)
+            if frame is None:
+                stack_text = "<no Python frame available>"
+            else:
+                stack_text = "".join(traceback.format_stack(frame))
+            logger.warning(
+                f"[hang-debug] Still in {label} after {elapsed:.1f}s\n{stack_text}"
+            )
+
+    watchdog_thread = threading.Thread(
+        target=watchdog,
+        name=f"hang-debug:{label}",
+        daemon=True,
+    )
+    watchdog_thread.start()
+
+    try:
+        yield
+    finally:
+        finished.set()
+        elapsed = time.monotonic() - started_at
+        logger.info(f"[hang-debug] Leaving {label} after {elapsed:.1f}s")
 
 
 def _should_use_native_vision_reference_path() -> bool:
@@ -357,6 +425,9 @@ def prefill(
     if num_tokens == 0:
         return 0.0, 0, []
 
+    rank = group.rank() if group is not None else 0
+    group_size = group.size() if group is not None else 1
+
     logger.debug(f"Prefilling {num_tokens} tokens...")
     start_time = time.perf_counter()
     has_ssm = has_non_kv_caches(cache)
@@ -382,44 +453,61 @@ def prefill(
 
     set_pipeline_prefill(model, is_prefill=True)
 
-    mx_barrier(group)
-    logger.info("Starting prefill")
+    with _hang_debug_watch(f"prefill barrier rank={rank} group_size={group_size}"):
+        mx_barrier(group)
+    logger.info(
+        f"Starting prefill (rank={rank}, group_size={group_size}, prompt_tokens={num_tokens})"
+    )
 
     is_pipeline = _has_pipeline_communication_layer(model)
 
     prefill_step_size = 4096
+    logger.info(
+        "Prefill path selected: "
+        f"{'pipeline_parallel_prefill' if is_pipeline and num_tokens >= prefill_step_size else 'stream_generate'} "
+        f"(rank={rank}, prompt_tokens={num_tokens}, prefill_step_size={prefill_step_size})"
+    )
 
     try:
         if is_pipeline and num_tokens >= prefill_step_size:
             set_pipeline_queue_sends(model, queue_sends=True)
             assert group is not None, "Pipeline prefill requires a distributed group"
-            pipeline_parallel_prefill(
-                model=model,
-                prompt=prompt_tokens,
-                prompt_cache=cache,
-                prefill_step_size=prefill_step_size,
-                kv_group_size=KV_GROUP_SIZE,
-                kv_bits=KV_BITS,
-                prompt_progress_callback=progress_callback,
-                distributed_prompt_progress_callback=distributed_prompt_progress_callback,
-                group=group,
-            )
+            with _hang_debug_watch(
+                f"pipeline_parallel_prefill rank={rank} group_size={group_size}"
+            ):
+                pipeline_parallel_prefill(
+                    model=model,
+                    prompt=prompt_tokens,
+                    prompt_cache=cache,
+                    prefill_step_size=prefill_step_size,
+                    kv_group_size=KV_GROUP_SIZE,
+                    kv_bits=KV_BITS,
+                    prompt_progress_callback=progress_callback,
+                    distributed_prompt_progress_callback=distributed_prompt_progress_callback,
+                    group=group,
+                )
         else:
             # Use max_tokens=1 because max_tokens=0 does not work.
             # We just throw away the generated token - we only care about filling the cache
-            for _ in stream_generate(
-                model=model,
-                tokenizer=tokenizer,
-                prompt=prompt_tokens,
-                max_tokens=1,
-                sampler=sampler,
-                prompt_cache=cache,
-                prefill_step_size=prefill_step_size,
-                kv_group_size=KV_GROUP_SIZE,
-                kv_bits=KV_BITS,
-                prompt_progress_callback=combined_progress_callback,
+            with _hang_debug_watch(
+                f"stream_generate prefill rank={rank} group_size={group_size}"
             ):
-                break  # Stop after first iteration - cache is now filled
+                for _ in stream_generate(
+                    model=model,
+                    tokenizer=tokenizer,
+                    prompt=prompt_tokens,
+                    max_tokens=1,
+                    sampler=sampler,
+                    prompt_cache=cache,
+                    prefill_step_size=prefill_step_size,
+                    kv_group_size=KV_GROUP_SIZE,
+                    kv_bits=KV_BITS,
+                    prompt_progress_callback=combined_progress_callback,
+                ):
+                    logger.info(
+                        f"Prefill stream_generate yielded first token (rank={rank})"
+                    )
+                    break  # Stop after first iteration - cache is now filled
     except PrefillCancelled:
         set_pipeline_queue_sends(model, queue_sends=False)
         set_pipeline_prefill(model, is_prefill=False)
@@ -469,34 +557,44 @@ def warmup_inference(
         temperature=0.0,
     )
 
-    warmup_prompt = apply_chat_template(
-        tokenizer=tokenizer,
-        task_params=warmup_task_params,
+    with _hang_debug_watch(f"warmup apply_chat_template model={model_id}"):
+        warmup_prompt = apply_chat_template(
+            tokenizer=tokenizer,
+            task_params=warmup_task_params,
+        )
+    logger.info(
+        "Warmup prompt prepared "
+        f"(model={model_id}, prompt_chars={len(warmup_prompt)}, group_size={group.size() if group is not None else 1})"
     )
 
     tokens_generated = 0
 
-    mx_barrier(group)
+    with _hang_debug_watch(f"warmup pre-generation barrier model={model_id}"):
+        mx_barrier(group)
 
     logger.info("Generating warmup tokens")
 
     t = time.monotonic()
 
-    for _r in mlx_generate(
-        model=model,
-        tokenizer=tokenizer,
-        task=warmup_task_params,
-        prompt=warmup_prompt,
-        kv_prefix_cache=None,
-        group=group,
-    ):
-        tokens_generated += 1
+    with _hang_debug_watch(f"warmup mlx_generate model={model_id}"):
+        for _r in mlx_generate(
+            model=model,
+            tokenizer=tokenizer,
+            task=warmup_task_params,
+            prompt=warmup_prompt,
+            kv_prefix_cache=None,
+            group=group,
+        ):
+            tokens_generated += 1
 
     check_for_cancel_every = min(
         math.ceil(tokens_generated / max(time.monotonic() - t, 0.001)), 100
     )
 
-    mx_barrier(group)
+    with _hang_debug_watch(
+        f"warmup final barrier model={model_id} tokens_generated={tokens_generated}"
+    ):
+        mx_barrier(group)
 
     logger.info(f"warmed up by generating {tokens_generated} tokens")
     if group is not None:

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -28,6 +28,7 @@ from exo.api.types import (
     TopLogprobItem,
     Usage,
 )
+from exo.shared.models.model_cards import ModelCard
 from exo.shared.types.common import ModelId
 from exo.shared.types.memory import Memory
 from exo.shared.types.mlx import KVCacheType, Model
@@ -545,6 +546,7 @@ def warmup_inference(
     tokenizer: TokenizerWrapper,
     group: mx.distributed.Group | None,
     model_id: ModelId,
+    model_card: ModelCard | None = None,
 ) -> int:
     logger.info(f"warming up inference for instance: {model_id}")
 
@@ -561,6 +563,7 @@ def warmup_inference(
         warmup_prompt = apply_chat_template(
             tokenizer=tokenizer,
             task_params=warmup_task_params,
+            model_card=model_card,
         )
     logger.info(
         "Warmup prompt prepared "

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -80,8 +80,8 @@ _MIN_PREFIX_HIT_RATIO_TO_UPDATE = 0.5
 
 def _mlx_hang_debug_enabled() -> bool:
     """Return whether verbose warmup/prefill hang diagnostics are enabled."""
-    value = os.environ.get("EXO_MLX_HANG_DEBUG") or os.environ.get(
-        "SKULK_MLX_HANG_DEBUG"
+    value = os.environ.get("SKULK_MLX_HANG_DEBUG") or os.environ.get(
+        "EXO_MLX_HANG_DEBUG"
     )
     if value is None:
         return False
@@ -90,8 +90,8 @@ def _mlx_hang_debug_enabled() -> bool:
 
 def _mlx_hang_debug_interval_seconds() -> float:
     """Return the periodic interval for hang-debug watchdog logs."""
-    raw = os.environ.get("EXO_MLX_HANG_DEBUG_INTERVAL_SECONDS") or os.environ.get(
-        "SKULK_MLX_HANG_DEBUG_INTERVAL_SECONDS"
+    raw = os.environ.get("SKULK_MLX_HANG_DEBUG_INTERVAL_SECONDS") or os.environ.get(
+        "EXO_MLX_HANG_DEBUG_INTERVAL_SECONDS"
     )
     if raw is None:
         return 30.0

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -581,6 +581,7 @@ def get_tokenizer(model_path: Path, shard_metadata: ShardMetadata) -> TokenizerW
     return load_tokenizer_for_model_id(
         shard_metadata.model_card.model_id,
         model_path,
+        model_card=shard_metadata.model_card,
         trust_remote_code=shard_metadata.model_card.trust_remote_code,
     )
 
@@ -617,7 +618,11 @@ def get_eos_token_ids_for_model(model_id: ModelId) -> list[int] | None:
 
 
 def load_tokenizer_for_model_id(
-    model_id: ModelId, model_path: Path, *, trust_remote_code: bool = TRUST_REMOTE_CODE
+    model_id: ModelId,
+    model_path: Path,
+    *,
+    model_card: ModelCard | None = None,
+    trust_remote_code: bool = TRUST_REMOTE_CODE,
 ) -> TokenizerWrapper:
     """
     Load tokenizer for a model given its ID and local path.
@@ -634,7 +639,7 @@ def load_tokenizer_for_model_id(
     """
     model_id_lower = model_id.lower()
     eos_token_ids = get_eos_token_ids_for_model(model_id)
-    model_card = get_card(model_id)
+    model_card = model_card or get_card(model_id)
     capability_profile = resolve_model_capability_profile(
         model_id,
         model_card=model_card,

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -27,7 +27,14 @@ from mlx_lm.models.cache import KVCache
 from mlx_lm.models.deepseek_v3 import DeepseekV3Model
 from mlx_lm.tokenizer_utils import TokenizerWrapper
 
-from exo.shared.models.model_cards import ModelId
+from exo.shared.models.capabilities import resolve_model_capability_profile
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    PromptRendererType,
+    ToolCallFormat,
+    get_card,
+)
 from exo.worker.engines.mlx.constants import TRUST_REMOTE_CODE
 
 try:
@@ -70,22 +77,6 @@ from exo.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
 from exo.worker.runner.bootstrap import logger
 
 Group = mx.distributed.Group
-
-
-def _uses_gemma4_reference_prompt(task_params: TextGenerationTaskParams) -> bool:
-    """Return whether this request should use the dedicated Gemma 4 renderer."""
-    model_name = str(task_params.model).lower()
-    if "gemma-4" not in model_name and "gemma4" not in model_name:
-        return False
-
-    if task_params.tools:
-        # Tool-enabled Gemma 4 requests still use the tokenizer template until
-        # we port the full declaration/call grammar from the reference
-        # renderer. The current bug report is for plain multimodal prompting.
-        return False
-
-    return task_params.chat_template_messages is not None
-
 
 def _gemma4_output_length_for_pixel_values(
     pixel_values: mx.array,
@@ -643,6 +634,11 @@ def load_tokenizer_for_model_id(
     """
     model_id_lower = model_id.lower()
     eos_token_ids = get_eos_token_ids_for_model(model_id)
+    model_card = get_card(model_id)
+    capability_profile = resolve_model_capability_profile(
+        model_id,
+        model_card=model_card,
+    )
 
     # Kimi uses a custom TikTokenTokenizer that transformers 5.x can't load via AutoTokenizer
     if "kimi-k2" in model_id_lower:
@@ -710,7 +706,7 @@ def load_tokenizer_for_model_id(
         else:
             tokenizer.eos_token_ids = [gemma_eos_id, gemma_end_of_turn_id]
 
-    if "gemma-4" in model_id_lower:
+    if capability_profile.tool_call_format == ToolCallFormat.Gemma4:
         tokenizer.tool_call_start = "<|tool_call>"
         tokenizer.tool_call_end = "<tool_call|>"
         tokenizer.tool_parser = _parse_gemma4_tool_calls
@@ -790,13 +786,10 @@ def _patch_lossy_chat_template(template: str) -> str | None:
     return patched if n > 0 else None
 
 
-def _needs_dsml_encoding(task_params: TextGenerationTaskParams) -> bool:
-    return "deepseek-v3.2" in task_params.model.lower()
-
-
 def apply_chat_template(
     tokenizer: TokenizerWrapper,
     task_params: TextGenerationTaskParams,
+    model_card: ModelCard | None = None,
 ) -> str:
     """Convert TextGenerationTaskParams to a chat template prompt.
 
@@ -830,7 +823,14 @@ def apply_chat_template(
         partial_assistant_content = cast(str, formatted_messages[-1].get("content", ""))
         formatted_messages = formatted_messages[:-1]
 
-    if _needs_dsml_encoding(task_params):
+    capability_profile = resolve_model_capability_profile(
+        task_params.model,
+        model_card=model_card,
+        tokenizer=tokenizer,
+        task_params=task_params,
+    )
+
+    if capability_profile.prompt_renderer == PromptRendererType.Dsml:
         from exo.worker.engines.mlx.dsml_encoding import encode_messages
 
         prompt = encode_messages(
@@ -846,7 +846,7 @@ def apply_chat_template(
         logger.info(prompt)
         return prompt
 
-    if _uses_gemma4_reference_prompt(task_params):
+    if capability_profile.prompt_renderer == PromptRendererType.Gemma4:
         prompt = render_gemma4_prompt(
             formatted_messages,
             add_generation_prompt=True,

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -9,6 +9,7 @@ import mlx.core as mx
 from mlx_lm.tokenizer_utils import TokenizerWrapper
 
 from exo.shared.constants import EXO_MAX_CONCURRENT_REQUESTS
+from exo.shared.models.model_cards import ModelCard
 from exo.shared.types.chunks import ErrorChunk, PrefillProgressChunk
 from exo.shared.types.common import ModelId
 from exo.shared.types.events import ChunkGenerated, Event
@@ -117,6 +118,7 @@ class SequentialGenerator(InferenceGenerator):
     group: mx.distributed.Group | None
     kv_prefix_cache: KVPrefixCache | None
     tool_parser: ToolParser | None
+    model_card: ModelCard
     model_id: ModelId
     device_rank: int
     cancel_receiver: MpReceiver[TaskId]
@@ -235,15 +237,18 @@ class SequentialGenerator(InferenceGenerator):
         if task.task_params.bench:
             output_generator = queue.gen()
         else:
-            output_generator = apply_all_parsers(
-                queue.gen(),
-                apply_chat_template(self.tokenizer, task.task_params),
-                self.tool_parser,
-                self.tokenizer,
-                type(self.model),
-                self.model_id,
-                task.task_params.tools,
-            )
+                output_generator = apply_all_parsers(
+                    queue.gen(),
+                    apply_chat_template(
+                        self.tokenizer, task.task_params, model_card=self.model_card
+                    ),
+                    self.tool_parser,
+                    self.tokenizer,
+                    type(self.model),
+                    self.model_id,
+                    task.task_params.tools,
+                    self.model_card,
+                )
         self._active = (task, mlx_gen, queue, output_generator)
 
     def _send_error(self, task: TextGeneration, e: Exception) -> None:
@@ -261,7 +266,9 @@ class SequentialGenerator(InferenceGenerator):
 
     def _build_generator(self, task: TextGeneration) -> Generator[GenerationResponse]:
         _check_for_debug_prompts(task.task_params)
-        prompt = apply_chat_template(self.tokenizer, task.task_params)
+        prompt = apply_chat_template(
+            self.tokenizer, task.task_params, model_card=self.model_card
+        )
 
         def on_prefill_progress(processed: int, total: int) -> None:
             if self.device_rank == 0:
@@ -320,6 +327,7 @@ class BatchGenerator(InferenceGenerator):
     group: mx.distributed.Group | None
     kv_prefix_cache: KVPrefixCache | None
     tool_parser: ToolParser | None
+    model_card: ModelCard
     model_id: ModelId
     device_rank: int
     cancel_receiver: MpReceiver[TaskId]
@@ -415,12 +423,15 @@ class BatchGenerator(InferenceGenerator):
             else:
                 output_generator = apply_all_parsers(
                     queue.gen(),
-                    apply_chat_template(self.tokenizer, task.task_params),
+                    apply_chat_template(
+                        self.tokenizer, task.task_params, model_card=self.model_card
+                    ),
                     self.tool_parser,
                     self.tokenizer,
                     type(self.model),
                     self.model_id,
                     task.task_params.tools,
+                    self.model_card,
                 )
             self._active_tasks[uid] = (task, queue, output_generator)
 

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -118,7 +118,7 @@ class SequentialGenerator(InferenceGenerator):
     group: mx.distributed.Group | None
     kv_prefix_cache: KVPrefixCache | None
     tool_parser: ToolParser | None
-    model_card: ModelCard
+    model_card: ModelCard | None
     model_id: ModelId
     device_rank: int
     cancel_receiver: MpReceiver[TaskId]
@@ -150,6 +150,7 @@ class SequentialGenerator(InferenceGenerator):
             tokenizer=self.tokenizer,
             group=self.group,
             model_id=self.model_id,
+            model_card=self.model_card,
         )
 
     def submit(
@@ -237,18 +238,18 @@ class SequentialGenerator(InferenceGenerator):
         if task.task_params.bench:
             output_generator = queue.gen()
         else:
-                output_generator = apply_all_parsers(
-                    queue.gen(),
-                    apply_chat_template(
-                        self.tokenizer, task.task_params, model_card=self.model_card
-                    ),
-                    self.tool_parser,
-                    self.tokenizer,
-                    type(self.model),
-                    self.model_id,
-                    task.task_params.tools,
-                    self.model_card,
-                )
+            output_generator = apply_all_parsers(
+                queue.gen(),
+                apply_chat_template(
+                    self.tokenizer, task.task_params, model_card=self.model_card
+                ),
+                self.tool_parser,
+                self.tokenizer,
+                type(self.model),
+                self.model_id,
+                task.task_params.tools,
+                self.model_card,
+            )
         self._active = (task, mlx_gen, queue, output_generator)
 
     def _send_error(self, task: TextGeneration, e: Exception) -> None:
@@ -327,7 +328,7 @@ class BatchGenerator(InferenceGenerator):
     group: mx.distributed.Group | None
     kv_prefix_cache: KVPrefixCache | None
     tool_parser: ToolParser | None
-    model_card: ModelCard
+    model_card: ModelCard | None
     model_id: ModelId
     device_rank: int
     cancel_receiver: MpReceiver[TaskId]
@@ -365,6 +366,7 @@ class BatchGenerator(InferenceGenerator):
             tokenizer=self.tokenizer,
             group=self.group,
             model_id=self.model_id,
+            model_card=self.model_card,
         )
 
     def submit(
@@ -505,7 +507,9 @@ class BatchGenerator(InferenceGenerator):
 
     def _start_task(self, task: TextGeneration) -> int:
         _check_for_debug_prompts(task.task_params)
-        prompt = apply_chat_template(self.tokenizer, task.task_params)
+        prompt = apply_chat_template(
+            self.tokenizer, task.task_params, model_card=self.model_card
+        )
 
         def on_prefill_progress(processed: int, total: int) -> None:
             if self.device_rank == 0:

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -2,6 +2,8 @@ from collections.abc import Generator
 from functools import cache
 from typing import Any
 
+from mlx_lm.models.deepseek_v32 import Model as DeepseekV32Model
+from mlx_lm.models.gpt_oss import Model as GptOssModel
 from mlx_lm.tokenizer_utils import TokenizerWrapper
 from openai_harmony import (  # pyright: ignore[reportMissingTypeStubs]
     HarmonyEncodingName,
@@ -68,9 +70,13 @@ def apply_all_parsers(
             starts_in_thinking=detect_thinking_prompt_suffix(prompt, tokenizer),
         )
 
-    if capability_profile.output_parser == OutputParserType.GptOss:
+    if capability_profile.output_parser == OutputParserType.GptOss or issubclass(
+        model_type, GptOssModel
+    ):
         mlx_generator = parse_gpt_oss(mlx_generator)
-    elif capability_profile.output_parser == OutputParserType.DeepseekV32:
+    elif capability_profile.output_parser == OutputParserType.DeepseekV32 or issubclass(
+        model_type, DeepseekV32Model
+    ):
         mlx_generator = parse_deepseek_v32(mlx_generator)
     elif tool_parser:
         mlx_generator = parse_tool_calls(mlx_generator, tool_parser, tools)

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -2,8 +2,6 @@ from collections.abc import Generator
 from functools import cache
 from typing import Any
 
-from mlx_lm.models.deepseek_v32 import Model as DeepseekV32Model
-from mlx_lm.models.gpt_oss import Model as GptOssModel
 from mlx_lm.tokenizer_utils import TokenizerWrapper
 from openai_harmony import (  # pyright: ignore[reportMissingTypeStubs]
     HarmonyEncodingName,
@@ -14,6 +12,12 @@ from openai_harmony import (  # pyright: ignore[reportMissingTypeStubs]
 )
 
 from exo.api.types import ToolCallItem
+from exo.shared.models.capabilities import resolve_model_capability_profile
+from exo.shared.models.model_cards import (
+    ModelCard,
+    OutputParserType,
+    ReasoningFormat,
+)
 from exo.shared.types.common import ModelId
 from exo.shared.types.mlx import Model
 from exo.shared.types.worker.runner_response import GenerationResponse, ToolCallResponse
@@ -41,12 +45,22 @@ def apply_all_parsers(
     model_type: type[Model],
     model_id: ModelId,
     tools: list[dict[str, Any]] | None,
+    model_card: ModelCard | None = None,
 ) -> Generator[GenerationResponse | ToolCallResponse | None]:
     mlx_generator = receiver
+    capability_profile = resolve_model_capability_profile(
+        model_id,
+        model_card=model_card,
+        tokenizer=tokenizer,
+    )
 
-    if _uses_gemma4_thinking_channels(model_id):
+    if capability_profile.thinking_format == ReasoningFormat.ChannelDelimited:
         mlx_generator = parse_gemma4_thinking_channels(mlx_generator)
-    elif tokenizer.has_thinking:
+    elif (
+        capability_profile.thinking_format == ReasoningFormat.TokenDelimited
+        and tokenizer.think_start is not None
+        and tokenizer.think_end is not None
+    ):
         mlx_generator = parse_thinking_models(
             mlx_generator,
             tokenizer.think_start,
@@ -54,23 +68,14 @@ def apply_all_parsers(
             starts_in_thinking=detect_thinking_prompt_suffix(prompt, tokenizer),
         )
 
-    if issubclass(model_type, GptOssModel):
+    if capability_profile.output_parser == OutputParserType.GptOss:
         mlx_generator = parse_gpt_oss(mlx_generator)
-    elif (
-        issubclass(model_type, DeepseekV32Model)
-        and "deepseek" in model_id.normalize().lower()
-    ):
+    elif capability_profile.output_parser == OutputParserType.DeepseekV32:
         mlx_generator = parse_deepseek_v32(mlx_generator)
     elif tool_parser:
         mlx_generator = parse_tool_calls(mlx_generator, tool_parser, tools)
 
     return mlx_generator
-
-
-def _uses_gemma4_thinking_channels(model_id: ModelId) -> bool:
-    """Return whether the model emits Gemma 4 channel-delimited thinking."""
-    normalized_model_id = model_id.normalize().lower()
-    return "gemma-4" in normalized_model_id or "gemma4" in normalized_model_id
 
 
 def parse_gemma4_thinking_channels(

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -7,7 +7,7 @@ import mlx.core as mx
 from anyio import WouldBlock
 from mlx_lm.tokenizer_utils import TokenizerWrapper
 
-from exo.shared.models.model_cards import ModelTask
+from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.chunks import (
     ErrorChunk,
     TokenChunk,
@@ -105,6 +105,7 @@ class Runner:
 
         self.generator: Builder | InferenceGenerator = Builder(
             self.model_id,
+            self.shard_metadata.model_card,
             self.event_sender,
             self.cancel_receiver,
         )
@@ -404,6 +405,7 @@ class Runner:
 @dataclass
 class Builder:
     model_id: ModelId
+    model_card: ModelCard
     event_sender: MpSender[Event]
     cancel_receiver: MpReceiver[TaskId]
     inference_model: Model | None = None
@@ -463,6 +465,7 @@ class Builder:
                 group=self.group,
                 tool_parser=tool_parser,
                 kv_prefix_cache=kv_prefix_cache,
+                model_card=self.model_card,
                 model_id=self.model_id,
                 device_rank=device_rank,
                 cancel_receiver=self.cancel_receiver,
@@ -476,6 +479,7 @@ class Builder:
             group=self.group,
             tool_parser=tool_parser,
             kv_prefix_cache=kv_prefix_cache,
+            model_card=self.model_card,
             model_id=self.model_id,
             device_rank=device_rank,
             cancel_receiver=self.cancel_receiver,

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -105,9 +105,9 @@ class Runner:
 
         self.generator: Builder | InferenceGenerator = Builder(
             self.model_id,
-            self.shard_metadata.model_card,
             self.event_sender,
             self.cancel_receiver,
+            self.shard_metadata.model_card,
         )
 
         self.seen: set[TaskId] = set()
@@ -405,9 +405,9 @@ class Runner:
 @dataclass
 class Builder:
     model_id: ModelId
-    model_card: ModelCard
     event_sender: MpSender[Event]
     cancel_receiver: MpReceiver[TaskId]
+    model_card: ModelCard | None = None
     inference_model: Model | None = None
     tokenizer: TokenizerWrapper | None = None
     group: mx.distributed.Group | None = None

--- a/src/exo/worker/tests/unittests/test_mlx/test_tokenizer_capability_resolution.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_tokenizer_capability_resolution.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    ModelTask,
+    ToolCallFormat,
+    ToolingCardConfig,
+)
+from exo.shared.types.memory import Memory
+from exo.worker.engines.mlx.utils_mlx import (
+    _parse_gemma4_tool_calls,
+    get_tokenizer,
+    load_tokenizer_for_model_id,
+)
+
+
+class _FakeTokenizer:
+    def __init__(self) -> None:
+        self.eos_token_ids: list[int] | None = None
+        self.tool_call_start: str | None = None
+        self.tool_call_end: str | None = None
+        self.tool_parser = None
+
+
+def test_load_tokenizer_for_model_id_uses_explicit_model_card_when_cache_is_empty(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    card = ModelCard(
+        model_id=ModelId("custom/tool-model"),
+        storage_size=Memory.from_mb(100),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text"],
+        tooling=ToolingCardConfig(tool_call_format=ToolCallFormat.Gemma4),
+    )
+
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.utils_mlx.get_card",
+        lambda _model_id: None,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.utils_mlx.load_tokenizer",
+        lambda *_args, **_kwargs: _FakeTokenizer(),
+    )
+
+    tokenizer = load_tokenizer_for_model_id(
+        card.model_id,
+        tmp_path,
+        model_card=card,
+    )
+
+    assert tokenizer.tool_call_start == "<|tool_call>"
+    assert tokenizer.tool_call_end == "<tool_call|>"
+    assert tokenizer.tool_parser is _parse_gemma4_tool_calls
+
+
+def test_get_tokenizer_passes_shard_model_card_to_tokenizer_loader(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    card = ModelCard(
+        model_id=ModelId("custom/tool-model"),
+        storage_size=Memory.from_mb(100),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text"],
+        tooling=ToolingCardConfig(tool_call_format=ToolCallFormat.Gemma4),
+    )
+    shard_metadata = SimpleNamespace(model_card=card)
+
+    captured: dict[str, object] = {}
+
+    def _fake_loader(
+        model_id: ModelId,
+        model_path: Path,
+        *,
+        model_card: ModelCard | None = None,
+        trust_remote_code: bool = False,
+    ) -> _FakeTokenizer:
+        captured["model_id"] = model_id
+        captured["model_path"] = model_path
+        captured["model_card"] = model_card
+        captured["trust_remote_code"] = trust_remote_code
+        return _FakeTokenizer()
+
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.utils_mlx.load_tokenizer_for_model_id",
+        _fake_loader,
+    )
+
+    get_tokenizer(tmp_path, shard_metadata)
+
+    assert captured["model_id"] == card.model_id
+    assert captured["model_path"] == tmp_path
+    assert captured["model_card"] == card
+    assert captured["trust_remote_code"] == card.trust_remote_code

--- a/src/exo/worker/tests/unittests/test_runner/test_finish_reason_sse.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_finish_reason_sse.py
@@ -1,7 +1,9 @@
 from collections.abc import Generator
 from typing import Any
 
+from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.common import ModelId
+from exo.shared.types.memory import Memory
 from exo.shared.types.mlx import Model
 from exo.shared.types.worker.runner_response import (
     FinishReason,
@@ -376,6 +378,47 @@ class TestGemma4ThinkingChannels:
 
         assert thinking_text == "Reason silently."
         assert visible_text == "Final answer."
+
+    def test_apply_all_parsers_uses_deepseek_parser_from_family_without_model_class(
+        self,
+    ):
+        tokens = [
+            _make_response(TOOL_CALLS_START, 0),
+            _make_response("\n", 1),
+            _make_response(f'<{DSML_TOKEN}invoke name="get_weather">\n', 2),
+            _make_response(
+                f'<{DSML_TOKEN}parameter name="city" string="true">Tokyo</{DSML_TOKEN}parameter>\n',
+                3,
+            ),
+            _make_response(f"</{DSML_TOKEN}invoke>\n", 4),
+            _make_response(TOOL_CALLS_END, 5, finish_reason="stop"),
+        ]
+
+        results = _step_until_finish(
+            apply_all_parsers(
+                _queue_source(tokens),
+                prompt="",
+                tool_parser=None,
+                tokenizer=_NoThinkingTokenizer(),
+                model_type=Model,
+                model_id=ModelId("custom/deepseek-compatible"),
+                tools=None,
+                model_card=ModelCard(
+                    model_id=ModelId("custom/deepseek-compatible"),
+                    storage_size=Memory.from_bytes(1024),
+                    n_layers=1,
+                    hidden_size=1,
+                    supports_tensor=False,
+                    tasks=[ModelTask.TextGeneration],
+                    family="deepseek-v3.2",
+                    capabilities=["text", "thinking"],
+                ),
+            )
+        )
+
+        tool_results = [r for r in results if isinstance(r, ToolCallResponse)]
+        assert len(tool_results) == 1
+        assert tool_results[0].tool_calls[0].name == "get_weather"
 
 
 # ── parse_tool_calls (generic) ──────────────────────────────────

--- a/tests/test_gemma_vision.py
+++ b/tests/test_gemma_vision.py
@@ -5,14 +5,26 @@ model_type auto-detection priority, and VisionCardConfig BOI/EOI fields."""
 
 import base64
 import io
+from pathlib import Path
 from types import SimpleNamespace
 
 import mlx.core as mx
 import mlx.nn as nn
 from PIL import Image
 
-from exo.shared.models.model_cards import VisionCardConfig
+from exo.shared.constants import RESOURCES_DIR
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelTask,
+    OutputParserType,
+    PromptRendererType,
+    ReasoningFormat,
+    RuntimeCapabilityCardConfig,
+    ToolCallFormat,
+    VisionCardConfig,
+)
 from exo.shared.types.common import ModelId
+from exo.shared.types.memory import Memory
 from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
 from exo.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
 from exo.worker.engines.mlx.utils_mlx import apply_chat_template
@@ -115,6 +127,36 @@ class TestVisionCardConfigBoiEoi:
         assert config.boi_token_id == 255999
         assert config.eoi_token_id == 262144
 
+
+class TestGemma4ExtendedModelCard:
+    """Gemma 4 built-in cards should expose advanced runtime declarations."""
+
+    async def test_builtin_card_includes_reasoning_and_runtime_sections(self):
+        card = await ModelCard.load_from_path(
+            Path(RESOURCES_DIR)
+            / "inference_model_cards"
+            / "mlx-community--gemma-4-26b-a4b-it-4bit.toml"
+        )
+
+        assert card.reasoning is not None
+        assert card.reasoning.supports_toggle is True
+        assert card.reasoning.format == ReasoningFormat.ChannelDelimited
+        assert card.runtime is not None
+        assert card.runtime.prompt_renderer == PromptRendererType.Gemma4
+        assert card.runtime.output_parser == OutputParserType.Gemma4
+
+    async def test_gpt_oss_builtin_card_includes_tooling_and_runtime_sections(self):
+        card = await ModelCard.load_from_path(
+            Path(RESOURCES_DIR)
+            / "inference_model_cards"
+            / "mlx-community--gpt-oss-20b-MXFP4-Q8.toml"
+        )
+
+        assert card.tooling is not None
+        assert card.tooling.supports_tool_calling is True
+        assert card.tooling.tool_call_format == ToolCallFormat.GptOss
+        assert card.runtime is not None
+        assert card.runtime.output_parser == OutputParserType.GptOss
 
 class TestModelTypePriority:
     """Auto-detection should prefer top-level model_type over vision_config.model_type."""
@@ -223,6 +265,43 @@ class TestGemma4ReferencePromptRenderer:
         prompt = apply_chat_template(_Tokenizer(), task)  # type: ignore[arg-type]
 
         assert prompt.endswith("<|channel>thought\n<channel|>Draft answer:")
+
+    def test_apply_chat_template_uses_dsml_renderer_from_model_card(self):
+        class _Tokenizer:
+            def apply_chat_template(self, *args, **kwargs):
+                raise AssertionError(
+                    "Card-declared DSML rendering should not fall back to generic chat templating"
+                )
+
+        model_id = ModelId("custom/deepseek-compatible")
+        task = TextGenerationTaskParams(
+            model=model_id,
+            input=[InputMessage(role="user", content="hello there")],
+            chat_template_messages=[{"role": "user", "content": "hello there"}],
+            enable_thinking=False,
+        )
+        model_card = ModelCard(
+            model_id=model_id,
+            storage_size=Memory.from_bytes(1024),
+            n_layers=1,
+            hidden_size=1,
+            supports_tensor=False,
+            tasks=[ModelTask.TextGeneration],
+            family="custom",
+            capabilities=["text", "thinking"],
+            runtime=RuntimeCapabilityCardConfig(
+                prompt_renderer=PromptRendererType.Dsml,
+                output_parser=OutputParserType.DeepseekV32,
+            ),
+        )
+
+        prompt = apply_chat_template(  # type: ignore[arg-type]
+            _Tokenizer(),
+            task,
+            model_card=model_card,
+        )
+
+        assert "hello there" in prompt
 
     def test_build_vision_prompt_uses_reference_renderer_for_gemma4(self):
         from exo.worker.engines.mlx.vision import build_vision_prompt

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -325,7 +325,7 @@ Notes:
 
 - `enable_thinking` is a Skulk extension.
 - Reasoning support depends on model capabilities.
-- Use `/v1/models[].resolved_capabilities` to decide whether a model supports thinking and whether clients should render a thinking toggle.
+- Use `GET /v1/models` response `data[].resolved_capabilities` to decide whether a model supports thinking and whether clients should render a thinking toggle.
 
 ## Structured Output
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -326,6 +326,7 @@ Notes:
 - `enable_thinking` is a Skulk extension.
 - Reasoning support depends on model capabilities.
 - Use `GET /v1/models` response `data[].resolved_capabilities` to decide whether a model supports thinking and whether clients should render a thinking toggle.
+- Treat `resolved_capabilities` as the default tool-free request path; request-specific options such as tools can change prompt rendering and related resolved values for mixed-mode model families.
 
 ## Structured Output
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -325,7 +325,7 @@ Notes:
 
 - `enable_thinking` is a Skulk extension.
 - Reasoning support depends on model capabilities.
-- Models with `thinking` or `thinking_toggle` metadata are the likeliest candidates.
+- Use `/v1/models[].resolved_capabilities` to decide whether a model supports thinking and whether clients should render a thinking toggle.
 
 ## Structured Output
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -70,6 +70,12 @@ This is where Skulk selects inference behavior such as:
 - MLX execution path
 - KV cache backend choice
 
+The runtime behavior for a specific model family is increasingly driven by
+model-card-backed capability resolution rather than scattered family checks. See
+[Model Cards](model-cards), [Model Capabilities](model-capabilities), and
+[Gemma 4 behavior notes](model-behaviors/gemma4) for the current shape of that
+system.
+
 ### API
 
 The API server exposes:

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -192,6 +192,27 @@ The key pieces:
 
 This is opt-in. Without the logging config, skulk behaves identically to before.
 
+## Debugging MLX Hangs
+
+When a model appears to stall during warmup, prefill, or distributed generation,
+Skulk can emit phase-specific hang diagnostics from the runner process.
+
+Set these environment variables before starting `skulk`:
+
+- `SKULK_MLX_HANG_DEBUG=1`
+- `SKULK_MLX_HANG_DEBUG_INTERVAL_SECONDS=10`
+
+When enabled, the runner logs:
+
+- entry and exit for warmup and prefill phases
+- which prefill path was selected (`stream_generate` or `pipeline_parallel_prefill`)
+- whether prefill yielded its first token
+- periodic Python stack traces while the active phase remains stuck
+
+`SKULK_...` is the preferred prefix. `EXO_MLX_HANG_DEBUG` and
+`EXO_MLX_HANG_DEBUG_INTERVAL_SECONDS` remain accepted as compatibility
+fallbacks while older scripts are updated.
+
 ## When to Read More
 
 If you are:

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -22,6 +22,8 @@ If you are getting oriented, start with these pages:
 - [API guide](api-guide) for the happy path: place a model, then call the API
 - [Model store guide](model-store) for shared model storage and download workflows
 - [KV cache backends](kv-cache-backends) for backend and runtime tuning
+- [Model cards](model-cards) for the metadata and capability declarations Skulk uses to describe models
+- [Model capabilities](model-capabilities) for how declarative card fields become runtime behavior
 - [Architecture overview](architecture) for how the node, cluster, and event model fit together
 
 ## Common Jobs

--- a/website/docs/model-behaviors/deepseek-v32.md
+++ b/website/docs/model-behaviors/deepseek-v32.md
@@ -1,0 +1,52 @@
+---
+id: deepseek-v32
+title: DeepSeek V3.2 / DSML
+sidebar_position: 3
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+DeepSeek V3.2 is the Phase 1 reference point for DSML-based prompt and parsing
+behavior.
+
+## Why DeepSeek V3.2 Is Special
+
+DeepSeek V3.2 uses a DSML-oriented flow instead of the generic tokenizer chat
+template and generic output parsing path.
+
+That means the runtime needs to know:
+
+- when to use DSML prompt encoding
+- when to parse DSML-style reasoning and tool-call output
+- when a model should be treated as a DeepSeek V3.2 family member even if the
+  tokenizer metadata alone is not enough
+
+## Current Capability Handling
+
+Phase 1 supports DeepSeek V3.2 through resolved family defaults:
+
+- DSML prompt renderer
+- DeepSeek V3.2 output parser
+- DSML tool-call format
+- thinking-toggle aware family behavior
+
+## Built-In Card Status
+
+At the moment, Phase 1 documents DeepSeek V3.2 as a first-class resolved family,
+but built-in declarative card coverage may still lag behind Gemma 4 and GPT-OSS.
+
+That is acceptable for Phase 1 because:
+
+- the runtime behavior is now covered by the resolved capability layer
+- the docs make the gap explicit instead of leaving it hidden
+
+## Why This Matters
+
+DeepSeek V3.2 demonstrates that the capability system can represent a model
+family whose key differentiation is not vision, but a custom prompt/parser
+contract.
+
+## Related
+
+- [Model Cards](../model-cards)
+- [Model Capabilities](../model-capabilities)

--- a/website/docs/model-behaviors/gemma4.md
+++ b/website/docs/model-behaviors/gemma4.md
@@ -79,6 +79,27 @@ Some follow-up work is intentionally tracked separately, including:
 - audio input support for variants that expose it upstream
 - fuller Gemma 4 tool grammar support
 
+## Debugging Gemma 4 Stalls
+
+If Gemma 4 appears to hang during warmup or prefill, enable the MLX
+hang-debug instrumentation before starting Skulk:
+
+```bash
+export SKULK_MLX_HANG_DEBUG=1
+export SKULK_MLX_HANG_DEBUG_INTERVAL_SECONDS=10
+uv run skulk
+```
+
+This causes the runner to log:
+
+- warmup and prefill phase boundaries
+- the selected prefill path
+- whether the first prefill token was ever produced
+- repeated Python stack traces while the stuck phase is still active
+
+The older `EXO_MLX_HANG_DEBUG` names still work as compatibility fallbacks, but
+new scripts and docs should prefer the `SKULK_` prefix.
+
 ## Why This Matters
 
 Gemma 4 is the proof point for the model capability system.

--- a/website/docs/model-behaviors/gemma4.md
+++ b/website/docs/model-behaviors/gemma4.md
@@ -1,0 +1,95 @@
+---
+id: gemma4
+title: Gemma 4
+sidebar_position: 1
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+Gemma 4 is one of the first model families in Skulk that required explicit, model-specific runtime handling.
+
+That makes it a useful reference point for how the capability system is meant to work.
+
+## Why Gemma 4 Is Special
+
+Gemma 4 is not just “a text model with vision.”
+
+It brings together several distinct behaviors:
+
+- custom multimodal prompt structure
+- channel-delimited reasoning blocks
+- native multimodal execution paths
+- model-family-specific tool formatting considerations
+- variant-specific modality support, including audio on some smaller variants
+
+Generic least-common-denominator handling was enough to get partial behavior, but not enough to get reliable, correct behavior.
+
+## Prompt Handling
+
+Plain Gemma 4 requests use a dedicated renderer instead of the generic tokenizer chat template when Skulk needs exact control over the prompt shape.
+
+That is especially important for:
+
+- multimodal user messages
+- assistant generation prefix handling
+- reasoning channel initialization
+
+## Reasoning Format
+
+Gemma 4 reasoning uses a channel-delimited format rather than the simpler token-delimited approach used by some other models.
+
+In practice, that means Skulk needs to:
+
+- render the correct thought-channel structure
+- parse the channel markers correctly
+- route reasoning text away from visible assistant content
+
+This is exactly the kind of behavior the capability system is meant to describe explicitly.
+
+## Vision and Native Multimodality
+
+Gemma 4 can use a native multimodal execution path.
+
+That means model support is not just a matter of accepting image content parts. The runtime also needs to know:
+
+- whether native multimodal execution is expected
+- what processor/model type is used
+- how to interpret media token regions
+
+## Current Capability Declarations
+
+The built-in Gemma 4 cards now declare advanced capability sections so the runtime does not have to infer everything from scattered family checks.
+
+Today that includes declarations for:
+
+- reasoning toggle support
+- reasoning format
+- prompt renderer
+- output parser
+- native multimodal support
+- tool-call format family
+
+## Current Gaps
+
+Phase 1 does **not** mean Gemma 4 is fully feature-complete yet.
+
+Some follow-up work is intentionally tracked separately, including:
+
+- reasoning budget support
+- audio input support for variants that expose it upstream
+- fuller Gemma 4 tool grammar support
+
+## Why This Matters
+
+Gemma 4 is the proof point for the model capability system.
+
+If Skulk can express Gemma 4 behavior through model-card-backed capability declarations plus a resolved runtime profile, then future model-family support gets much cleaner:
+
+- less hidden coupling
+- fewer one-off patches
+- more accurate dashboard and API behavior
+
+## Related
+
+- [Model Cards](../model-cards)
+- [Model Capabilities](../model-capabilities)

--- a/website/docs/model-behaviors/gpt-oss.md
+++ b/website/docs/model-behaviors/gpt-oss.md
@@ -1,0 +1,52 @@
+---
+id: gpt-oss
+title: GPT-OSS
+sidebar_position: 2
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+GPT-OSS is one of the first non-Gemma families that Phase 1 treats as a
+first-class capability-system consumer.
+
+## Why GPT-OSS Is Special
+
+GPT-OSS needs more than coarse `thinking` metadata.
+
+The runtime needs to know:
+
+- that tool calling is expected
+- that GPT-OSS output uses a family-specific tool-call parsing flow
+- that the tokenizer and runtime should agree on the GPT-OSS tool format
+
+## Current Capability Declarations
+
+The built-in GPT-OSS cards now declare:
+
+- tool-calling support
+- GPT-OSS tool-call format
+- GPT-OSS output parser selection
+
+That moves GPT-OSS support out of “only infer it from the model id” territory
+and into the same declarative-plus-resolved model that Gemma 4 uses.
+
+## Current Gaps
+
+Phase 1 does not attempt to make every GPT-OSS behavior card-driven yet.
+
+It focuses on:
+
+- parser selection
+- tool-call format selection
+- API/dashboard capability surfacing
+
+## Why This Matters
+
+GPT-OSS is the proof that the capability system is not just a Gemma 4 special
+case. It shows that model-card-backed runtime behavior can cleanly cover a
+second specialized family with different parser and tool semantics.
+
+## Related
+
+- [Model Cards](../model-cards)
+- [Model Capabilities](../model-capabilities)

--- a/website/docs/model-capabilities.md
+++ b/website/docs/model-capabilities.md
@@ -1,0 +1,117 @@
+---
+id: model-capabilities
+title: Model Capabilities
+sidebar_position: 5
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+Skulk supports a wide range of models, but not every model behaves the same way.
+
+Some models need:
+
+- custom prompt rendering
+- non-generic reasoning delimiters
+- specialized tool-call formats
+- native multimodal execution
+- model-specific API controls
+
+The model capability system exists so Skulk can support those differences without turning the runtime into a pile of hidden one-off checks.
+
+## The Two Layers
+
+Skulk now treats capability handling as two related layers:
+
+### 1. Declarative model card
+
+The model card stores broad static metadata plus optional advanced capability sections.
+
+This is the durable, syncable, editable source of truth.
+
+### 2. Resolved runtime profile
+
+At runtime, Skulk resolves the card plus tokenizer/model-family facts into a normalized capability profile.
+
+That resolved profile answers questions like:
+
+- should this request use a custom prompt renderer?
+- what reasoning format should be expected?
+- which output parser should run?
+- what defaults should be used when thinking is toggled on or off?
+
+## Why Not Only One Layer?
+
+If Skulk used only model cards directly at runtime:
+
+- execution code would be full of `None` checks and partial fallbacks
+- every hot path would need to re-interpret optional metadata
+- backward compatibility would be harder to preserve cleanly
+
+If Skulk used only hard-coded runtime profiles:
+
+- custom cards would not be expressive enough
+- API and dashboard metadata would drift away from runtime behavior
+- model support would become scattered again
+
+The combined approach gives us:
+
+- one declarative source of truth
+- one normalized execution contract
+
+## Current Phase 1 Goal
+
+Phase 1 is about building the capability spine that UI and API work can depend on.
+
+That means:
+
+- cards can declare advanced capability sections
+- old cards still work
+- runtime behavior for key decisions is capability-driven
+- model metadata exposed by the API can begin surfacing refined behavior to clients
+
+Phase 1 specifically focuses on:
+
+- reasoning/thinking defaults
+- prompt renderer selection
+- output parser selection
+
+## Fallback Behavior
+
+If a model card does not define advanced sections, Skulk should still work.
+
+The runtime resolves that model to a conservative generic profile:
+
+- generic prompt rendering
+- generic parser behavior
+- no assumptions about special reasoning controls
+- no assumptions about special modalities or tool grammars
+
+This is critical for compatibility with existing built-in and custom cards.
+
+## Precedence Rules
+
+The resolved runtime profile follows a simple precedence model:
+
+1. explicit advanced fields from the model card win
+2. model-family defaults fill in known behavior for important families
+3. generic fallback preserves compatibility for everything else
+
+Phase 1 intentionally keeps those heuristics conservative. The goal is not to
+guess every possible advanced feature, but to preserve current behavior while
+letting extended cards make support more precise.
+
+## What This Enables
+
+Once the capability spine exists, Skulk can evolve cleanly toward:
+
+- model-aware thinking controls
+- reasoning budget support
+- audio modality support
+- richer tool grammars
+- safer dashboard controls based on real support instead of guesswork
+
+## Related
+
+- [Model Cards](model-cards)
+- [Architecture Overview](architecture)
+- [Gemma 4 behavior notes](model-behaviors/gemma4)

--- a/website/docs/model-cards.md
+++ b/website/docs/model-cards.md
@@ -1,0 +1,219 @@
+---
+id: model-cards
+title: Model Cards
+sidebar_position: 4
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+Model cards are Skulk's durable source of truth for model metadata.
+
+They are how Skulk knows things like:
+
+- what a model is called
+- what task types it supports
+- how large it is for placement and download planning
+- whether it supports tensor sharding
+- whether it has vision support
+- whether it declares advanced model-specific behavior
+
+## What Model Cards Do
+
+Model cards sit at the boundary between static metadata and runtime behavior.
+
+They drive:
+
+- placement and memory calculations
+- model browsing in the API and dashboard
+- custom model registration
+- modality hints such as vision
+- advanced capability declarations for model-specific runtime behavior
+
+## Where They Live
+
+Built-in cards are shipped in:
+
+- [`resources/inference_model_cards`](https://github.com/Foxlight-Foundation/Skulk/tree/main/resources/inference_model_cards)
+- [`resources/image_model_cards`](https://github.com/Foxlight-Foundation/Skulk/tree/main/resources/image_model_cards)
+- [`resources/embedding_model_cards`](https://github.com/Foxlight-Foundation/Skulk/tree/main/resources/embedding_model_cards)
+
+Custom cards are stored under the user data directory and synced through the cluster event flow.
+
+## Core Fields
+
+### Identity and size
+
+- `model_id`
+  - Hugging Face / MLX model identifier
+- `storage_size`
+  - total model size used for store/download/placement planning
+- `n_layers`
+  - number of transformer layers used for pipeline sharding
+- `hidden_size`
+  - hidden dimension used for placement and compatibility checks
+- `num_key_value_heads`
+  - optional KV head count for tensor compatibility decisions
+
+### Runtime and placement
+
+- `supports_tensor`
+  - whether tensor-style placement is allowed
+- `tasks`
+  - supported task families such as `TextGeneration`, `TextEmbedding`, or image tasks
+- `trust_remote_code`
+  - whether the loader may enable remote-code behavior for this model
+
+### Catalog metadata
+
+- `family`
+  - coarse family label such as `gemma`, `qwen`, `deepseek`
+- `quantization`
+  - human-facing quantization label
+- `base_model`
+  - display-friendly base model name
+- `context_length`
+  - advertised context length if known
+- `capabilities`
+  - coarse capability list such as `text`, `vision`, `thinking`, `embedding`
+
+These coarse capabilities remain useful for browsing, badges, and basic compatibility, but they are not expressive enough for model-specific runtime behavior on their own.
+
+## Vision Section
+
+`[vision]` is the existing structured section for multimodal text-generation models.
+
+Fields include:
+
+- `image_token_id`
+  - token used to represent image slots in prompt tokenization
+- `model_type`
+  - MLX-VLM model family identifier such as `gemma4`
+- `weights_repo`
+  - optional alternate weights repository for the vision tower
+- `image_token`
+  - optional literal image token string
+- `processor_repo`
+  - optional alternate processor repository
+- `boi_token_id`
+  - optional begin-of-image token id
+- `eoi_token_id`
+  - optional end-of-image token id
+
+## Extended Capability Sections
+
+Skulk now supports optional structured sections that declare refined model behavior.
+
+Existing cards do **not** need these sections. If they are absent, Skulk falls back to generic behavior.
+
+### `[reasoning]`
+
+Declares advanced reasoning behavior:
+
+- `supports_toggle`
+  - whether thinking/reasoning can be explicitly enabled or disabled
+- `supports_budget`
+  - whether the model supports a reasoning budget control
+- `format`
+  - reasoning marker format such as `channel_delimited` or `token_delimited`
+- `default_effort`
+  - reasoning effort used when thinking is enabled without an explicit effort
+- `disabled_effort`
+  - reasoning effort used when thinking is explicitly disabled
+
+### `[modalities]`
+
+Declares refined modality support:
+
+- `supports_audio_input`
+  - whether the model supports audio input
+- `supports_native_multimodal`
+  - whether the model uses a native multimodal path rather than generic text-only prompting
+
+### `[tooling]`
+
+Declares tool-calling behavior:
+
+- `supports_tool_calling`
+  - whether tool calling is supported
+- `tool_call_format`
+  - expected tool-call output format such as `generic`, `gemma4`, `gpt_oss`, or `dsml`
+
+### `[runtime]`
+
+Declares runtime integration preferences:
+
+- `prompt_renderer`
+  - prompt renderer to use, such as `tokenizer`, `gemma4`, or `dsml`
+- `output_parser`
+  - output parser to use, such as `generic`, `gemma4`, `gpt_oss`, or `deepseek_v32`
+
+## Declarative vs Resolved
+
+The model card is the **declarative** capability source.
+
+At runtime, Skulk resolves the card plus tokenizer/model-family facts into a normalized execution profile. That resolved profile is what prompt rendering, reasoning defaults, and output parsing consume.
+
+That gives Skulk three good properties:
+
+- old cards remain valid
+- advanced cards unlock refined behavior
+- runtime code can rely on normalized values instead of ad hoc optional checks
+
+## Resolution Precedence
+
+When Skulk resolves a runtime capability profile, it uses this order:
+
+1. explicit advanced model-card declarations
+2. conservative family/model heuristics
+3. generic fallback behavior
+
+That means a custom or built-in card can refine behavior without breaking old
+cards that only declare coarse metadata.
+
+## Extended Card Example
+
+This is a minimal example of a custom card that opts into refined runtime
+behavior:
+
+```toml
+model_id = "custom/gemma-compatible"
+n_layers = 10
+hidden_size = 1024
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "gemma"
+capabilities = ["text", "vision", "thinking"]
+
+[storage_size]
+in_bytes = 1073741824
+
+[reasoning]
+supports_toggle = true
+format = "channel_delimited"
+default_effort = "medium"
+disabled_effort = "none"
+
+[modalities]
+supports_native_multimodal = true
+
+[tooling]
+tool_call_format = "gemma4"
+
+[runtime]
+prompt_renderer = "gemma4"
+output_parser = "gemma4"
+```
+
+The card stays declarative. Skulk still resolves it into a normalized runtime
+profile before execution code consumes it.
+
+## When to Extend a Card
+
+Extend a card when:
+
+- the model needs special prompt rendering
+- the model uses a non-generic reasoning format
+- the model supports modalities or controls that generic metadata cannot express
+- the dashboard or API needs to expose richer behavior safely
+
+For concrete examples, see [Model Capabilities](model-capabilities) and the per-family notes in [Model Behaviors](model-behaviors/gemma4).

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -23,6 +23,17 @@ const sidebars: SidebarsConfig = {
         "api-guide",
         "model-store",
         "kv-cache-backends",
+        "model-cards",
+        "model-capabilities",
+        {
+          type: "category",
+          label: "Model Behaviors",
+          items: [
+            "model-behaviors/gemma4",
+            "model-behaviors/gpt-oss",
+            "model-behaviors/deepseek-v32",
+          ],
+        },
         "architecture",
       ],
     },


### PR DESCRIPTION
## Summary
- extend model cards with declarative reasoning, modality, tooling, and runtime sections
- add resolved runtime capability profiles and route prompt/parser/thinking behavior through them
- expose additive `/v1/models` capability metadata to the API and dashboard, with new Docusaurus docs for cards and per-model behavior

## Validation
- `uv run ruff check src/exo/shared/models/capabilities.py src/exo/worker/engines/mlx/utils_mlx.py src/exo/worker/runner/llm_inference/model_output_parsers.py src/exo/shared/tests/test_model_capabilities.py src/exo/api/tests/test_model_tags.py tests/test_gemma_vision.py src/exo/worker/tests/unittests/test_runner/test_finish_reason_sse.py`
- `uv run python -m pytest src/exo/shared/tests/test_model_capabilities.py src/exo/api/tests/test_model_tags.py tests/test_gemma_vision.py src/exo/worker/tests/unittests/test_runner/test_finish_reason_sse.py`
- `uv run python scripts/export_openapi.py`
- `cd dashboard-react && npm run build`
- `cd website && npm run gen-api-docs && npm run build`

## Notes
- `basedpyright` is not installed in this environment
- `nix fmt` is not installed in this environment
- refs #93