### PR TITLE
Revamp runtime tracing across the cluster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,19 @@ Centralized logging uses a three-layer stack:
 - **Vector**: A local log shipper on each node reads exo's stdout and forwards to VictoriaLogs. Config at `deployment/logging/vector.yaml`.
 - **VictoriaLogs + Grafana**: Central log storage and dashboards on the R720. Stack definition at `deployment/logging/docker-compose.yml`.
 
+### Tracing
+Runtime tracing is a cluster-scoped debugging feature controlled by command and
+event flow rather than a required env-var-only launch mode:
+- `SetTracingEnabled` toggles tracing for new requests across the live cluster session
+- `TracingStateChanged` updates `State.tracing_enabled` through the normal event-sourced apply path
+- workers collect task-scoped trace sessions and emit `TracesCollected`
+- the master waits for expected ranks, merges trace payloads, and emits `TracesMerged`
+- the API persists Chrome trace JSON locally and exposes both local `/v1/traces*`
+  and cluster-browsed `/v1/traces/cluster*` endpoints
+
+Cluster browsing is read-only in v1 and works by fan-out/proxy against reachable
+peer APIs rather than through a central authoritative trace store.
+
 ## Mandatory Workflow Rules
 
 These rules apply to every change. No exceptions.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ The model store is one of Skulk's biggest additions over upstream EXO.
 
 Without it, each node may download model data independently.
 With it, one node acts as the store host and the rest of the cluster stages from that machine over the LAN.
+Staged files are kept on worker nodes by default so repeated placements can
+reuse the local cache instead of re-copying large models every time.
 
 Use the model store when:
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Skulk exposes several API surfaces:
 The most important API doc lives here:
 
 - [docs/api.md](docs/api.md)
+- [website/docs/tracing.md](website/docs/tracing.md)
 
 That guide is written to be both newcomer-friendly and integration-friendly. It includes:
 
@@ -276,6 +277,34 @@ That guide is written to be both newcomer-friendly and integration-friendly. It 
 - copy-paste examples
 - common failure cases
 - store and config endpoints
+
+For live debugging, the tracing guide explains the runtime cluster toggle, the
+dashboard traces view, and the difference between local trace browsing and
+cluster trace browsing.
+
+## Tracing and Debugging
+
+Tracing is now a runtime feature, not an env-var-first workflow.
+
+Recommended path:
+
+1. Open the dashboard.
+2. Click the bug icon.
+3. Enable tracing from the traces page.
+4. Reproduce the workload.
+5. Inspect traces in local or cluster scope.
+
+The main control and browsing endpoints are:
+
+- `GET /v1/tracing`
+- `PUT /v1/tracing`
+- `GET /v1/traces`
+- `GET /v1/traces/cluster`
+
+For details, examples, and operational notes:
+
+- [website/docs/tracing.md](website/docs/tracing.md)
+- [docs/api.md](docs/api.md)
 
 ## Common Workflows
 
@@ -376,7 +405,7 @@ uv run exo --bootstrap-peers /ip4/192.168.1.20/tcp/5678/p2p/12D3KooW...
 | `EXO_ENABLE_IMAGE_MODELS` | Enable image model cards and image workflows | `false` |
 | `EXO_LIBP2P_NAMESPACE` | Custom namespace for cluster isolation | None |
 | `EXO_FAST_SYNCH` | Control MLX fast synch behavior | Auto |
-| `EXO_TRACING_ENABLED` | Enable distributed tracing | `false` |
+| `SKULK_TRACING_ENABLED` | Developer boot override for tracing. Prefer the dashboard traces toggle or `PUT /v1/tracing` for normal use. Legacy `EXO_TRACING_ENABLED` is still accepted. | `false` |
 | `EXO_KV_CACHE_BACKEND` | KV cache backend selection | `default` |
 | `EXO_KV_CACHE_BITS` | Bit width for `mlx_quantized` | None |
 | `EXO_TQ_K_BITS` | Key-cache bits for TurboQuant backends | `3` |

--- a/bench/REPRO_GEMMA4_HANG.md
+++ b/bench/REPRO_GEMMA4_HANG.md
@@ -1,0 +1,84 @@
+# Gemma-4 Hang Repro Harness
+
+Drives a running Skulk cluster with a deterministic sequence of multimodal
+chat turns and reports per-turn outcomes. Built to validate fixes for the
+gemma-4 / ring / multinode hang where the GPU command queue wedges and
+trips the macOS userspace watchdog into a kernel panic.
+
+## Quick start
+
+```bash
+# Cluster must already be running and reachable.
+uv run python bench/repro_gemma4_hang.py \
+    --api-url http://localhost:52415 \
+    --model mlx-community/gemma-4-26b-a4b-it-4bit \
+    --turns 200 \
+    --output-jsonl /tmp/repro.jsonl
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | All turns completed within thresholds. |
+| `1` | One or more `hang` outcomes (cluster stuck, supervisor did not recover). |
+| `2` | One or more `kernel_panic_inferred` outcomes (a node disappeared mid-run). |
+
+## What each turn record looks like
+
+```json
+{
+  "turn_idx": 17,
+  "session_idx": 6,
+  "session_label": "multimodal-history-text-followup",
+  "turn_within_session": 1,
+  "n_messages_in_history": 3,
+  "n_images_in_history": 2,
+  "status": "ok",
+  "reason": "",
+  "latency_seconds": 4.21,
+  "tokens_generated": 142,
+  "completion_id": "chatcmpl-..."
+}
+```
+
+`status` is one of:
+
+- `ok` — request succeeded, cluster looks healthy on the post-call timeline poll.
+- `recovered_hang` — `pipeline_eval_timeout` event present in the timeline. The eval-timeout patch fired and the supervisor restored the runner. Distinct from `ok` because we want to count and trend supervised recoveries separately.
+- `hang` — a runner has been parked in a non-long-running phase past the threshold and no recovery has been observed yet.
+- `api_error` — request itself failed (HTTP error, network blip, model not loaded, etc.).
+- `kernel_panic_inferred` — a node we were tracking at startup has vanished from the cluster timeline without a graceful unregister event. Strong signal for a hard reboot.
+
+## Tuning
+
+`--hang-after-seconds` defaults to **90s** — set deliberately above the 60s eval-timeout floor so that a recovery surfaces as `recovered_hang` rather than as a fresh `hang`. Tighten only if you have a clear reason; loosening makes the harness blind to slow hangs.
+
+`--seed` controls the session-rotation order. Use the same seed across runs when you're trying to compare two configs (e.g. FAST_SYNCH on vs off) — turn N hits the same session in both runs, so latency or status divergence at turn N is signal, not noise.
+
+`--expected-nodes` lets you pin the cluster shape explicitly. Default is to snapshot the live cluster at startup; pin only when you want the harness to fail loudly if a peer joins or leaves mid-run.
+
+## What the test corpus exercises
+
+Four session templates rotate through the run:
+
+1. **multimodal-history-text-followup** — two image turns then a text turn that references both. Mirrors the original incident's failure shape.
+2. **large-image-single-turn** — one 256x256 image, single turn. Stresses the multi-tile vision path.
+3. **text-only-multi-turn** — three text turns. Control: should never hang on gemma-4 if the bug really is multimodal-correlated.
+4. **three-image-sequence** — three back-to-back image turns. Sustained multimodal load.
+
+Images are generated procedurally inside the harness (or hardcoded as small base64 PNGs) so the corpus is bit-identical across machines and across runs.
+
+## Limitations
+
+- Hang detection samples after each turn returns. A hang detected *during* a long-running request is only flagged once the request finishes (or the API client times out). Adding a background poller is feasible but isn't needed for the "did 500 turns succeed?" question this harness was built to answer.
+- The harness uses non-streaming requests. Streaming has its own failure modes that aren't yet exercised.
+- The `_count_images` heuristic walks the OpenAI-style content array; non-OpenAI clients won't be counted correctly.
+
+## Running the unit tests
+
+```bash
+uv run pytest bench/tests/
+```
+
+The detection logic is a pure function over snapshot fixtures, so the tests cover all classification paths without a live cluster.

--- a/bench/repro_gemma4_hang.py
+++ b/bench/repro_gemma4_hang.py
@@ -1,0 +1,758 @@
+# type: ignore
+"""Deterministic repro harness for the gemma-4 multimodal hang.
+
+Drives the cluster's ``/v1/chat/completions`` endpoint with a fixed sequence
+of multimodal turns and detects hangs by polling
+``/v1/diagnostics/cluster/timeline``. Designed to validate fixes (does the
+cluster survive 500 turns?) and isolate triggers (which env, which model,
+which turn shape causes the wedge?). One command, runs unattended, writes
+JSONL with per-turn outcomes.
+
+Usage:
+    uv run python bench/repro_gemma4_hang.py \\
+        --api-url http://localhost:52415 \\
+        --model mlx-community/gemma-4-26b-a4b-it-4bit \\
+        --turns 200 \\
+        --seed 42
+
+Output: JSONL stream on stdout (or --output-jsonl), one record per turn.
+Exit 0 if all turns succeeded, 1 if any hangs were detected, 2 on
+unrecoverable error (cluster never came back, etc.).
+
+Why a pure-stdlib harness: failure modes include the entire cluster going
+unresponsive, so the harness must not depend on anything that might also
+be wedged when things are bad. ``http.client`` + stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import http.client
+import json
+import os
+import random
+import sys
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# Test assets
+# ---------------------------------------------------------------------------
+
+# Three base64-encoded PNG images of varying sizes. Hardcoded so the harness
+# runs offline with bit-identical inputs across machines. The actual content
+# does not matter for hang reproduction — what matters is the multimodal
+# code path being engaged with images that vary in tile count.
+
+# 1x1 transparent — the smallest possible PNG vision input.
+_TINY_PNG = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+# 32x32 solid color, generated with a simple raw-deflate stream.
+# Chosen size exceeds the smallest vision tile but stays well under the
+# multi-tile threshold; stresses the simple-image path.
+_SMALL_PNG = (
+    "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAALklEQVRYw+3R"
+    "MQEAAAjDMMC/56FBxw4JIN3aSaqqqqqqqqqqqqqqqv4r9qj0BcCVAAGz1hKZ"
+    "AAAAAElFTkSuQmCC"
+)
+
+# 256x256 — large enough to require multiple vision tiles in gemma-4's
+# preprocessor, mirroring the load shape that triggered the original hang.
+# Generated procedurally below to avoid bloating this file with kilobytes
+# of base64; cached after first generation.
+_LARGE_PNG_CACHE: list[str] = []
+
+
+def _build_large_png_b64() -> str:
+    """Build a 256x256 PNG procedurally with stdlib only.
+
+    Stable bit pattern across runs: every pixel is filled with a fixed RGB
+    based on (x + y) % 255, encoded as a single IDAT chunk. This is
+    intentionally not artistic — we just need a multi-tile image with
+    deterministic bytes.
+    """
+    if _LARGE_PNG_CACHE:
+        return _LARGE_PNG_CACHE[0]
+
+    import base64
+    import struct
+    import zlib
+
+    width = 256
+    height = 256
+    raw = bytearray()
+    for y in range(height):
+        raw.append(0)  # filter byte: None
+        for x in range(width):
+            v = (x + y) % 255
+            raw.extend([v, (v * 3) % 255, (v * 7) % 255])
+    compressed = zlib.compress(bytes(raw), level=6)
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        crc = zlib.crc32(tag + data) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", crc)
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", compressed)
+        + chunk(b"IEND", b"")
+    )
+    encoded = base64.b64encode(png).decode("ascii")
+    _LARGE_PNG_CACHE.append(encoded)
+    return encoded
+
+
+def _data_url(b64: str) -> str:
+    return f"data:image/png;base64,{b64}"
+
+
+# ---------------------------------------------------------------------------
+# Conversation generator
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Turn:
+    """One user message to send. Captures the prompt and any image attachments."""
+
+    text: str
+    image_b64s: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Session:
+    """A multi-turn chat session — accumulates message history client side.
+
+    Each session targets the failure pattern observed in the original
+    incident: image in history, then a new turn (text or text+image) that
+    references the prior context.
+    """
+
+    label: str
+    turns: tuple[Turn, ...]
+
+
+_SESSION_TEMPLATES: tuple[Session, ...] = (
+    # Session A: image-heavy, mirrors the original bug report. Two
+    # multimodal turns followed by a text turn referencing both images.
+    Session(
+        label="multimodal-history-text-followup",
+        turns=(
+            Turn("Describe what you see in this image briefly.", (_TINY_PNG,)),
+            Turn("Now describe this second image.", (_SMALL_PNG,)),
+            Turn("In one sentence, how do the two images differ?", ()),
+        ),
+    ),
+    # Session B: large image, single turn. Stresses the multi-tile vision
+    # path with a single-shot request.
+    Session(
+        label="large-image-single-turn",
+        turns=(
+            Turn("Describe the colors and patterns visible here.", ("LARGE",)),
+        ),
+    ),
+    # Session C: text-only multi-turn. Control — should never hang on
+    # gemma-4 if the bug is multimodal-correlated.
+    Session(
+        label="text-only-multi-turn",
+        turns=(
+            Turn("What is 27 times 14?", ()),
+            Turn("Now divide that by 6.", ()),
+            Turn("Express the result in words.", ()),
+        ),
+    ),
+    # Session D: image then image then image — sustained multimodal load.
+    Session(
+        label="three-image-sequence",
+        turns=(
+            Turn("What's in this picture?", (_TINY_PNG,)),
+            Turn("And this one?", (_SMALL_PNG,)),
+            Turn("How about this?", ("LARGE",)),
+        ),
+    ),
+)
+
+
+def _resolve_image(token: str) -> str:
+    """Resolve an image placeholder ('LARGE') to its base64 payload."""
+    if token == "LARGE":
+        return _build_large_png_b64()
+    return token
+
+
+def session_iterator(seed: int) -> Iterator[Session]:
+    """Yield sessions in a deterministic shuffled order.
+
+    Reseeded determinism means turn N of run M targets the same session as
+    turn N of run M+1, which is essential for distinguishing "regression at
+    turn 47" from "random session at turn 47 happened to be the bad one."
+    """
+    rng = random.Random(seed)
+    while True:
+        order = list(_SESSION_TEMPLATES)
+        rng.shuffle(order)
+        for session in order:
+            yield session
+
+
+def session_to_messages(session: Session) -> list[list[dict[str, Any]]]:
+    """Expand a Session into the progressive message-history list.
+
+    Returns one list per turn; each entry is the full history to send for
+    that turn. The harness sends each progressively larger history to
+    reproduce the original failure shape ("hang on turn 2 with image in
+    history").
+    """
+    progressions: list[list[dict[str, Any]]] = []
+    history: list[dict[str, Any]] = []
+    for turn in session.turns:
+        content: list[dict[str, Any]] = [{"type": "text", "text": turn.text}]
+        for image_b64 in turn.image_b64s:
+            resolved = _resolve_image(image_b64)
+            content.append(
+                {"type": "image_url", "image_url": {"url": _data_url(resolved)}}
+            )
+        history.append({"role": "user", "content": content})
+        progressions.append([dict(m) for m in history])
+        # Append a placeholder assistant turn so subsequent user turns have
+        # a real conversation history. Filled in after the response arrives.
+        history.append({"role": "assistant", "content": ""})
+    return progressions
+
+
+# ---------------------------------------------------------------------------
+# Hang detection — pure logic, importable by tests
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TimelineSnapshot:
+    """Subset of /v1/diagnostics/cluster/timeline used for hang detection.
+
+    Pulled out as its own type so unit tests can construct minimal fixtures
+    without depending on the live API shape.
+    """
+
+    runners: tuple["RunnerSnapshot", ...]
+    eval_timeout_events: tuple["TimeoutEvent", ...] = ()
+    unreachable_node_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RunnerSnapshot:
+    node_id: str
+    device_rank: int
+    phase: str
+    seconds_in_phase: float
+    last_progress_at: str | None
+
+
+@dataclass(frozen=True)
+class TimeoutEvent:
+    at: str
+    node_id: str
+    device_rank: int
+    detail: str | None
+
+
+@dataclass(frozen=True)
+class HangVerdict:
+    """Outcome of evaluating a timeline snapshot for hang signals."""
+
+    status: str  # "ok" | "hang" | "recovered_hang" | "kernel_panic_inferred"
+    reason: str
+    suspect_runner: RunnerSnapshot | None = None
+
+
+# Phases that are expected to take longer than the default hang threshold
+# during normal operation. Seeing a runner sit in one of these for >hang
+# threshold is not by itself a hang signal — it's a slow legit operation.
+_LONG_RUNNING_PHASES: frozenset[str] = frozenset(
+    {
+        "warmup",
+        "loading",
+        "downloading",
+        "created",
+        "shutdown_cleanup",
+    }
+)
+
+
+def evaluate_timeline_for_hang(
+    snapshot: TimelineSnapshot,
+    *,
+    hang_after_seconds: float,
+    expected_node_ids: frozenset[str] | None = None,
+) -> HangVerdict:
+    """Pure function: look at one snapshot and decide what it tells us.
+
+    Priority:
+
+    1. If the previously-reachable node set lost a member, infer kernel
+       panic on that node. The combination "node disappears mid-request +
+       Skulk's normal supervisor restart hasn't yet republished the runner"
+       is the cleanest in-band signal we have for a kernel-level reboot.
+    2. If any runner has emitted a ``pipeline_eval_timeout`` flight-recorder
+       event, classify as ``recovered_hang`` — the eval-timeout patch fired,
+       which is the supervised-recovery success case. Distinct from ``ok``
+       because we want to track recovery rate as a separate SLO line.
+    3. If any runner is sitting in a non-long-running phase past the
+       threshold, classify as a hang. Long-running phases (warmup, loading)
+       are exempt to avoid false positives during cold start.
+    4. Otherwise, ``ok``.
+
+    Note: ``last_progress_at`` is currently advisory; the threshold itself
+    on ``seconds_in_phase`` is the primary signal because the cluster
+    timeline endpoint already gives us bounded values from the supervisor.
+    """
+    if expected_node_ids is not None:
+        observed_ids = frozenset(r.node_id for r in snapshot.runners) | frozenset(
+            snapshot.unreachable_node_ids
+        )
+        missing = expected_node_ids - observed_ids
+        if missing:
+            return HangVerdict(
+                status="kernel_panic_inferred",
+                reason=(
+                    f"node(s) disappeared from cluster timeline: "
+                    f"{sorted(missing)}; if no graceful unregister event "
+                    "was observed this is a hard reboot signal."
+                ),
+            )
+
+    if snapshot.eval_timeout_events:
+        # Surface the most recent timeout event so the operator can see
+        # which site fired without re-querying the timeline.
+        latest = max(snapshot.eval_timeout_events, key=lambda e: e.at)
+        return HangVerdict(
+            status="recovered_hang",
+            reason=(
+                f"pipeline_eval_timeout fired at {latest.at} on "
+                f"node={latest.node_id} rank={latest.device_rank} "
+                f"site={latest.detail or '<unknown>'}"
+            ),
+        )
+
+    for runner in snapshot.runners:
+        if runner.phase in _LONG_RUNNING_PHASES:
+            continue
+        if runner.seconds_in_phase > hang_after_seconds:
+            return HangVerdict(
+                status="hang",
+                reason=(
+                    f"rank={runner.device_rank} stuck in "
+                    f"phase={runner.phase} for "
+                    f"{runner.seconds_in_phase:.1f}s "
+                    f"(threshold={hang_after_seconds:.0f}s)"
+                ),
+                suspect_runner=runner,
+            )
+
+    return HangVerdict(status="ok", reason="all runners within threshold")
+
+
+def parse_timeline_response(payload: dict[str, Any]) -> TimelineSnapshot:
+    """Convert a /v1/diagnostics/cluster/timeline response into the local shape.
+
+    Tolerates missing fields rather than crashing — the cluster may be
+    partially up, peers may be missing, etc. Errors here would mask real
+    hangs by making the harness itself fail.
+    """
+    runners: list[RunnerSnapshot] = []
+    for r in payload.get("runners", []) or []:
+        runners.append(
+            RunnerSnapshot(
+                node_id=str(r.get("nodeId", "")),
+                device_rank=int(r.get("deviceRank", -1)),
+                phase=str(r.get("phase", "")),
+                seconds_in_phase=float(r.get("secondsInPhase", 0.0)),
+                last_progress_at=r.get("lastProgressAt"),
+            )
+        )
+
+    timeouts: list[TimeoutEvent] = []
+    for entry in payload.get("timeline", []) or []:
+        if entry.get("event") == "pipeline_eval_timeout":
+            timeouts.append(
+                TimeoutEvent(
+                    at=str(entry.get("at", "")),
+                    node_id=str(entry.get("nodeId", "")),
+                    device_rank=int(entry.get("deviceRank", -1)),
+                    detail=entry.get("detail"),
+                )
+            )
+
+    unreachable = tuple(
+        str(u.get("nodeId", ""))
+        for u in payload.get("unreachableNodes", []) or []
+        if u.get("nodeId")
+    )
+
+    return TimelineSnapshot(
+        runners=tuple(runners),
+        eval_timeout_events=tuple(timeouts),
+        unreachable_node_ids=unreachable,
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTTP client (minimal, stdlib only)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApiClient:
+    base_url: str
+    timeout_seconds: float = 300.0
+
+    def _connect(self) -> http.client.HTTPConnection:
+        parsed = urlparse(self.base_url)
+        host = parsed.hostname or "localhost"
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        if parsed.scheme == "https":
+            return http.client.HTTPSConnection(host, port, timeout=self.timeout_seconds)
+        return http.client.HTTPConnection(host, port, timeout=self.timeout_seconds)
+
+    def get_json(self, path: str) -> Any:
+        conn = self._connect()
+        try:
+            conn.request("GET", path, headers={"Accept": "application/json"})
+            resp = conn.getresponse()
+            body = resp.read().decode("utf-8", errors="replace")
+            if resp.status >= 400:
+                raise RuntimeError(f"GET {path} -> {resp.status}: {body[:300]}")
+            return json.loads(body) if body else None
+        finally:
+            conn.close()
+
+    def post_chat_completion(
+        self, model: str, messages: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        conn = self._connect()
+        try:
+            payload = json.dumps(
+                {"model": model, "messages": messages, "stream": False}
+            ).encode("utf-8")
+            conn.request(
+                "POST",
+                "/v1/chat/completions",
+                body=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+            )
+            resp = conn.getresponse()
+            body = resp.read().decode("utf-8", errors="replace")
+            if resp.status >= 400:
+                raise RuntimeError(
+                    f"POST chat -> {resp.status}: {body[:300]}"
+                )
+            return json.loads(body)
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TurnRecord:
+    turn_idx: int
+    session_idx: int
+    session_label: str
+    turn_within_session: int
+    n_messages_in_history: int
+    n_images_in_history: int
+    status: str
+    reason: str
+    latency_seconds: float
+    tokens_generated: int | None = None
+    completion_id: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class RunSummary:
+    total_turns: int
+    ok_turns: int
+    hang_turns: int
+    recovered_hang_turns: int
+    api_error_turns: int
+    kernel_panic_turns: int
+    elapsed_seconds: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def count_images(history: list[dict[str, Any]]) -> int:
+    n = 0
+    for msg in history:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "image_url":
+                    n += 1
+    return n
+
+
+def run_repro(
+    *,
+    api: ApiClient,
+    model: str,
+    turns: int,
+    seed: int,
+    hang_after_seconds: float,
+    output_jsonl: str | None,
+    expected_node_ids: frozenset[str] | None,
+) -> RunSummary:
+    """Drive the cluster for ``turns`` turns and emit a JSONL record per turn.
+
+    The detection cadence is checked once per turn after the response (or
+    timeout) lands — running an in-flight poller is a future enhancement
+    that requires threading and isn't needed for the core "did this many
+    turns succeed?" question.
+    """
+    started = time.monotonic()
+    sessions = session_iterator(seed)
+    counts = {
+        "ok": 0,
+        "hang": 0,
+        "recovered_hang": 0,
+        "api_error": 0,
+        "kernel_panic_inferred": 0,
+    }
+
+    # Conditional file vs stdout — a `with` block doesn't compose cleanly here
+    # because we explicitly do not want to close stdout when no output path
+    # is set. The try/finally below handles the close path correctly.
+    out_fp = open(output_jsonl, "w") if output_jsonl else sys.stdout  # noqa: SIM115
+
+    try:
+        turn_idx = 0
+        session_idx = 0
+        for session in sessions:
+            if turn_idx >= turns:
+                break
+            session_idx += 1
+            histories = session_to_messages(session)
+            for within, history in enumerate(histories):
+                if turn_idx >= turns:
+                    break
+                turn_idx += 1
+
+                started_turn = time.monotonic()
+                status = "ok"
+                reason = ""
+                tokens_generated: int | None = None
+                completion_id: str | None = None
+
+                try:
+                    resp = api.post_chat_completion(model, history)
+                    choices = resp.get("choices") or []
+                    if choices:
+                        message = choices[0].get("message") or {}
+                        # Patch the placeholder assistant turn with the real
+                        # response so the next turn's history is realistic.
+                        if (
+                            within * 2 + 1 < len(history)
+                            and history[within * 2 + 1].get("role") == "assistant"
+                        ):
+                            history[within * 2 + 1]["content"] = (
+                                message.get("content") or ""
+                            )
+                    completion_id = resp.get("id")
+                    usage = resp.get("usage") or {}
+                    tokens_generated = usage.get("completion_tokens")
+                except Exception as exc:  # noqa: BLE001
+                    status = "api_error"
+                    reason = f"{type(exc).__name__}: {exc}"
+
+                # Independent of API outcome, sample the cluster timeline so
+                # we catch hangs that the supervisor recovered from before
+                # the request returned, and kernel panics where the request
+                # failed because the box rebooted under us.
+                if status == "ok":
+                    try:
+                        snap = parse_timeline_response(
+                            api.get_json("/v1/diagnostics/cluster/timeline")
+                        )
+                        verdict = evaluate_timeline_for_hang(
+                            snap,
+                            hang_after_seconds=hang_after_seconds,
+                            expected_node_ids=expected_node_ids,
+                        )
+                        if verdict.status != "ok":
+                            status = verdict.status
+                            reason = verdict.reason
+                    except Exception as exc:  # noqa: BLE001
+                        # Timeline endpoint itself unreachable is a
+                        # different failure: classify as kernel_panic
+                        # inferred only when we had previously been
+                        # successfully reaching it.
+                        status = "kernel_panic_inferred"
+                        reason = (
+                            f"timeline endpoint unreachable: "
+                            f"{type(exc).__name__}: {exc}"
+                        )
+
+                record = TurnRecord(
+                    turn_idx=turn_idx,
+                    session_idx=session_idx,
+                    session_label=session.label,
+                    turn_within_session=within,
+                    n_messages_in_history=len(history),
+                    n_images_in_history=count_images(history),
+                    status=status,
+                    reason=reason,
+                    latency_seconds=time.monotonic() - started_turn,
+                    tokens_generated=tokens_generated,
+                    completion_id=completion_id,
+                )
+                out_fp.write(json.dumps(record.as_dict()) + "\n")
+                out_fp.flush()
+                counts[status] = counts.get(status, 0) + 1
+
+                if status in {"hang", "kernel_panic_inferred"}:
+                    # Bail out fast on hard failures — no point burning
+                    # turns against a wedged cluster.
+                    break
+            else:
+                continue
+            break
+    finally:
+        if out_fp is not sys.stdout:
+            out_fp.close()
+
+    return RunSummary(
+        total_turns=turn_idx,
+        ok_turns=counts.get("ok", 0),
+        hang_turns=counts.get("hang", 0),
+        recovered_hang_turns=counts.get("recovered_hang", 0),
+        api_error_turns=counts.get("api_error", 0),
+        kernel_panic_turns=counts.get("kernel_panic_inferred", 0),
+        elapsed_seconds=time.monotonic() - started,
+    )
+
+
+def _parse_node_ids(raw: str | None) -> frozenset[str] | None:
+    if raw is None:
+        return None
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+def _discover_expected_node_ids(api: ApiClient) -> frozenset[str]:
+    """Snapshot the node set at startup so we can detect later disappearances."""
+    snap = parse_timeline_response(api.get_json("/v1/diagnostics/cluster/timeline"))
+    return frozenset(r.node_id for r in snap.runners)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--api-url",
+        default=os.environ.get("SKULK_API_URL", "http://localhost:52415"),
+        help="Base URL of the Skulk API (default %(default)s).",
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Model ID to drive (e.g. mlx-community/gemma-4-26b-a4b-it-4bit).",
+    )
+    parser.add_argument(
+        "--turns",
+        type=int,
+        default=200,
+        help="Number of turns to run (default %(default)d).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="RNG seed for session ordering (default %(default)d).",
+    )
+    parser.add_argument(
+        "--hang-after-seconds",
+        type=float,
+        default=90.0,
+        help=(
+            "Treat any non-long-running phase still active past this many "
+            "seconds as a hang signal (default %(default).0f). Set above the "
+            "60s eval timeout so a recovered hang is classified as "
+            "recovered_hang, not as a fresh hang."
+        ),
+    )
+    parser.add_argument(
+        "--output-jsonl",
+        default=None,
+        help=(
+            "Write JSONL records to this path instead of stdout. Summary "
+            "still prints to stderr regardless."
+        ),
+    )
+    parser.add_argument(
+        "--expected-nodes",
+        default=None,
+        help=(
+            "Comma-separated list of node IDs expected to be reachable. "
+            "Default: snapshot the current cluster at startup."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    api = ApiClient(base_url=args.api_url)
+
+    expected: frozenset[str] | None
+    explicit = _parse_node_ids(args.expected_nodes)
+    if explicit is not None:
+        expected = explicit
+    else:
+        try:
+            expected = _discover_expected_node_ids(api)
+            print(
+                f"[repro] discovered {len(expected)} node(s) at startup: "
+                f"{sorted(expected)}",
+                file=sys.stderr,
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"[repro] could not snapshot node set at startup ({exc!r}); "
+                "kernel-panic detection will be disabled.",
+                file=sys.stderr,
+            )
+            expected = None
+
+    summary = run_repro(
+        api=api,
+        model=args.model,
+        turns=args.turns,
+        seed=args.seed,
+        hang_after_seconds=args.hang_after_seconds,
+        output_jsonl=args.output_jsonl,
+        expected_node_ids=expected,
+    )
+
+    print(json.dumps({"summary": summary.as_dict()}, indent=2), file=sys.stderr)
+
+    if summary.kernel_panic_turns > 0:
+        return 2
+    if summary.hang_turns > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/tests/test_repro_gemma4_hang.py
+++ b/bench/tests/test_repro_gemma4_hang.py
@@ -1,0 +1,336 @@
+"""Tests for the gemma-4 hang repro harness.
+
+Hang detection is a pure function over snapshot data, so unit tests can
+exercise every classification path without an actual cluster. The kernel-
+panic, recovered-hang, and active-hang paths each have direct fixtures
+because each one represents a distinct on-call signal that we cannot
+afford to silently misclassify.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# bench/ is not on the standard import path; vend it in for tests.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from repro_gemma4_hang import (  # noqa: E402
+    RunnerSnapshot,
+    TimelineSnapshot,
+    TimeoutEvent,
+    count_images,
+    evaluate_timeline_for_hang,
+    parse_timeline_response,
+    session_iterator,
+    session_to_messages,
+)
+
+# ---------------------------------------------------------------------------
+# Hang detection
+# ---------------------------------------------------------------------------
+
+
+def _runner(
+    rank: int,
+    phase: str = "decode_stream",
+    seconds_in_phase: float = 0.5,
+    *,
+    node_id: str | None = None,
+    last_progress_at: str | None = "2026-04-25T12:00:00Z",
+) -> RunnerSnapshot:
+    return RunnerSnapshot(
+        node_id=node_id or f"node-{rank}",
+        device_rank=rank,
+        phase=phase,
+        seconds_in_phase=seconds_in_phase,
+        last_progress_at=last_progress_at,
+    )
+
+
+def test_healthy_cluster_returns_ok() -> None:
+    snap = TimelineSnapshot(runners=tuple(_runner(r) for r in range(3)))
+    verdict = evaluate_timeline_for_hang(snap, hang_after_seconds=90.0)
+    assert verdict.status == "ok"
+
+
+def test_long_running_phase_under_threshold_is_ok() -> None:
+    snap = TimelineSnapshot(runners=(_runner(0, "decode_stream", 12.0),))
+    verdict = evaluate_timeline_for_hang(snap, hang_after_seconds=90.0)
+    assert verdict.status == "ok"
+
+
+def test_runner_stuck_past_threshold_is_hang() -> None:
+    stuck = _runner(0, "decode_stream", 142.0)
+    snap = TimelineSnapshot(runners=(stuck, _runner(1), _runner(2)))
+    verdict = evaluate_timeline_for_hang(snap, hang_after_seconds=90.0)
+    assert verdict.status == "hang"
+    assert verdict.suspect_runner == stuck
+    assert "decode_stream" in verdict.reason
+    assert "142" in verdict.reason
+
+
+@pytest.mark.parametrize(
+    "exempt_phase",
+    ["warmup", "loading", "downloading", "created", "shutdown_cleanup"],
+)
+def test_long_running_phases_are_exempt_from_hang_detection(
+    exempt_phase: str,
+) -> None:
+    """Cold-start operations can legitimately exceed the hang threshold."""
+    snap = TimelineSnapshot(runners=(_runner(0, exempt_phase, 600.0),))
+    verdict = evaluate_timeline_for_hang(snap, hang_after_seconds=90.0)
+    assert verdict.status == "ok"
+
+
+def test_pipeline_eval_timeout_classifies_as_recovered_hang() -> None:
+    """Eval timeout firing means the supervised-recovery layer worked."""
+    snap = TimelineSnapshot(
+        runners=(_runner(0), _runner(1), _runner(2)),
+        eval_timeout_events=(
+            TimeoutEvent(
+                at="2026-04-25T12:00:01Z",
+                node_id="node-0",
+                device_rank=0,
+                detail="pipeline_last_eval_output",
+            ),
+        ),
+    )
+    verdict = evaluate_timeline_for_hang(snap, hang_after_seconds=90.0)
+    assert verdict.status == "recovered_hang"
+    assert "pipeline_last_eval_output" in verdict.reason
+
+
+def test_recovered_hang_takes_precedence_over_active_hang() -> None:
+    """If both signals are present we want the more informative one.
+
+    A timeout event names the exact eval site that wedged. An ongoing
+    secondsInPhase alarm just says "something is stuck right now." For
+    the upstream bug report the site is what matters; surface it first.
+    """
+    snap = TimelineSnapshot(
+        runners=(_runner(0, "decode_stream", 200.0),),
+        eval_timeout_events=(
+            TimeoutEvent(
+                at="2026-04-25T12:00:01Z",
+                node_id="node-0",
+                device_rank=0,
+                detail="pipeline_last_eval_output",
+            ),
+        ),
+    )
+    verdict = evaluate_timeline_for_hang(snap, hang_after_seconds=90.0)
+    assert verdict.status == "recovered_hang"
+
+
+def test_most_recent_timeout_event_is_surfaced() -> None:
+    snap = TimelineSnapshot(
+        runners=(_runner(0),),
+        eval_timeout_events=(
+            TimeoutEvent(
+                at="2026-04-25T12:00:01Z",
+                node_id="node-0",
+                device_rank=0,
+                detail="pipeline_first_eval_recv",
+            ),
+            TimeoutEvent(
+                at="2026-04-25T12:05:00Z",
+                node_id="node-1",
+                device_rank=1,
+                detail="mx_barrier",
+            ),
+        ),
+    )
+    verdict = evaluate_timeline_for_hang(snap, hang_after_seconds=90.0)
+    assert verdict.status == "recovered_hang"
+    assert "mx_barrier" in verdict.reason
+    assert "node-1" in verdict.reason
+
+
+def test_missing_node_classifies_as_kernel_panic_inferred() -> None:
+    """A node disappearing from the timeline (without unregister) means reboot."""
+    snap = TimelineSnapshot(
+        runners=(_runner(1), _runner(2)),  # rank 0 missing
+    )
+    verdict = evaluate_timeline_for_hang(
+        snap,
+        hang_after_seconds=90.0,
+        expected_node_ids=frozenset({"node-0", "node-1", "node-2"}),
+    )
+    assert verdict.status == "kernel_panic_inferred"
+    assert "node-0" in verdict.reason
+
+
+def test_unreachable_peer_does_not_trigger_kernel_panic_signal() -> None:
+    """An unreachable-but-known peer is a soft failure, not a panic.
+
+    The cluster timeline endpoint reports unreachable peers explicitly via
+    ``unreachableNodes``. That covers temporary network blips. Only a peer
+    that has *vanished entirely* (not in runners and not in unreachable)
+    should flag as a kernel-panic inference.
+    """
+    snap = TimelineSnapshot(
+        runners=(_runner(1), _runner(2)),
+        unreachable_node_ids=("node-0",),
+    )
+    verdict = evaluate_timeline_for_hang(
+        snap,
+        hang_after_seconds=90.0,
+        expected_node_ids=frozenset({"node-0", "node-1", "node-2"}),
+    )
+    assert verdict.status == "ok"
+
+
+def test_kernel_panic_takes_precedence_over_recovered_hang() -> None:
+    """If the box is gone we want to know that, even if a timeout had fired."""
+    snap = TimelineSnapshot(
+        runners=(_runner(1),),
+        eval_timeout_events=(
+            TimeoutEvent(
+                at="2026-04-25T12:00:01Z",
+                node_id="node-0",
+                device_rank=0,
+                detail="pipeline_last_eval_output",
+            ),
+        ),
+    )
+    verdict = evaluate_timeline_for_hang(
+        snap,
+        hang_after_seconds=90.0,
+        expected_node_ids=frozenset({"node-0", "node-1"}),
+    )
+    assert verdict.status == "kernel_panic_inferred"
+
+
+def test_no_expected_nodes_disables_kernel_panic_signal() -> None:
+    """If the harness couldn't snapshot the node set, don't false-positive."""
+    snap = TimelineSnapshot(runners=(_runner(0),))
+    verdict = evaluate_timeline_for_hang(
+        snap, hang_after_seconds=90.0, expected_node_ids=None
+    )
+    assert verdict.status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Timeline payload parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_timeline_handles_well_formed_payload() -> None:
+    payload = {
+        "runners": [
+            {
+                "nodeId": "node-A",
+                "deviceRank": 0,
+                "phase": "decode_stream",
+                "secondsInPhase": 1.5,
+                "lastProgressAt": "2026-04-25T12:00:00Z",
+            }
+        ],
+        "timeline": [
+            {
+                "at": "2026-04-25T12:00:01Z",
+                "nodeId": "node-A",
+                "deviceRank": 0,
+                "phase": "decode_stream",
+                "event": "pipeline_eval_timeout",
+                "detail": "pipeline_last_eval_output",
+            },
+            {
+                "at": "2026-04-25T12:00:00Z",
+                "nodeId": "node-A",
+                "deviceRank": 0,
+                "phase": "decode_stream",
+                "event": "enter",
+                "detail": "pipeline_last_eval_output",
+            },
+        ],
+        "unreachableNodes": [{"nodeId": "node-Z", "error": "connection refused"}],
+    }
+    snap = parse_timeline_response(payload)
+    assert len(snap.runners) == 1
+    assert snap.runners[0].node_id == "node-A"
+    assert len(snap.eval_timeout_events) == 1  # only the timeout one
+    assert snap.eval_timeout_events[0].detail == "pipeline_last_eval_output"
+    assert snap.unreachable_node_ids == ("node-Z",)
+
+
+def test_parse_timeline_tolerates_missing_top_level_fields() -> None:
+    snap = parse_timeline_response({})
+    assert snap.runners == ()
+    assert snap.eval_timeout_events == ()
+    assert snap.unreachable_node_ids == ()
+
+
+def test_parse_timeline_tolerates_null_arrays() -> None:
+    snap = parse_timeline_response(
+        {"runners": None, "timeline": None, "unreachableNodes": None}
+    )
+    assert snap.runners == ()
+
+
+# ---------------------------------------------------------------------------
+# Session generation
+# ---------------------------------------------------------------------------
+
+
+def test_session_iterator_is_deterministic_for_seed() -> None:
+    """Same seed → same first-N-session order, across runs and processes."""
+    seq_a = list(zip(range(20), session_iterator(123), strict=False))
+    seq_b = list(zip(range(20), session_iterator(123), strict=False))
+    assert [s.label for _, s in seq_a] == [s.label for _, s in seq_b]
+
+
+def test_session_iterator_eventually_yields_every_template() -> None:
+    """Every template should appear within the first cycle through the deck."""
+    seen: set[str] = set()
+    it = session_iterator(7)
+    for _ in range(8):
+        seen.add(next(it).label)
+    assert "multimodal-history-text-followup" in seen
+    assert "text-only-multi-turn" in seen
+    assert "three-image-sequence" in seen
+    assert "large-image-single-turn" in seen
+
+
+def test_session_to_messages_emits_progressive_history() -> None:
+    """Turn N's history must include all prior user+assistant pairs."""
+    it = session_iterator(0)
+    # Walk until we land on the multi-turn multimodal template.
+    while True:
+        sess = next(it)
+        if sess.label == "multimodal-history-text-followup":
+            break
+    progressions = session_to_messages(sess)
+    assert len(progressions) == 3
+    # Each progression is strictly larger than the prior one (history grows).
+    assert len(progressions[0]) < len(progressions[1]) < len(progressions[2])
+    # Final history mentions both images and ends with a user turn.
+    final = progressions[-1]
+    assert final[-1]["role"] == "user"
+    image_count = count_images(final)
+    assert image_count == 2  # two images, one in each user turn
+
+
+def testcount_images_recognizes_image_url_parts() -> None:
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "x"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,xxx"}},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,yyy"}},
+            ],
+        },
+        {"role": "assistant", "content": "ok"},
+    ]
+    assert count_images(history) == 2
+
+
+def testcount_images_handles_string_content() -> None:
+    history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+    ]
+    assert count_images(history) == 0

--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -48,7 +48,6 @@
         "redoc": "2.5.2",
         "storybook": "^10.3.3",
         "typedoc": "^0.28.14",
-        "typedoc-plugin-markdown": "^4.11.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1",
@@ -7435,19 +7434,6 @@
       },
       "peerDependencies": {
         "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
-      }
-    },
-    "node_modules/typedoc-plugin-markdown": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.11.0.tgz",
-      "integrity": "sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "typedoc": "0.28.x"
       }
     },
     "node_modules/typedoc/node_modules/balanced-match": {

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -9,6 +9,7 @@ import { TopologyGraph } from './components/topology/TopologyGraph';
 import { ConnectionBanner } from './components/status/ConnectionBanner';
 import { ToastContainer } from './components/status/ToastContainer';
 import { NetworkMesh } from './components/common/NetworkMesh';
+import { DiagnosticsDrawer } from './components/layout/DiagnosticsDrawer';
 import { SettingsPanel } from './components/layout/SettingsPanel';
 import { ModelStorePage } from './components/pages/DownloadsPage';
 import { ChatView } from './components/pages/ChatView';
@@ -119,6 +120,7 @@ export function App() {
     thunderboltBridgeCycles,
   } = useClusterState();
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [diagnosticsNodeId, setDiagnosticsNodeId] = useState<string | null>(null);
   const [storeDownloads, setStoreDownloads] = useState<StoreDownload[]>([]);
   const activeRoute = useUIStore((s) => s.activeRoute);
   const panelOpen = useUIStore((s) => s.panelOpen);
@@ -416,7 +418,10 @@ export function App() {
             ) : activeRoute === 'chat' ? (
               <ChatView readyInstances={instanceCards} />
             ) : topology ? (
-              <TopologyGraph data={topology} />
+              <TopologyGraph
+                data={topology}
+                onInspectNode={setDiagnosticsNodeId}
+              />
             ) : (
               <EmptyState>
                 {connected ? 'Loading cluster state…' : 'Connecting to backend…'}
@@ -432,6 +437,10 @@ export function App() {
           )}
         </ContentRow>
         <ToastContainer />
+        <DiagnosticsDrawer
+          nodeId={diagnosticsNodeId}
+          onClose={() => setDiagnosticsNodeId(null)}
+        />
         <SettingsPanel open={settingsOpen} onClose={() => setSettingsOpen(false)} />
       </Shell>
     </ThemeProvider>

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -126,6 +126,7 @@ export function App() {
   const themeName = useUIStore((s) => s.theme);
   const activeTheme = themeName === 'light' ? lightTheme : darkTheme;
   const selectedTraceTaskId = useUIStore((s) => s.selectedTraceTaskId);
+  const [traceScope, setTraceScope] = useState<'cluster' | 'local'>('cluster');
 
   // Reflect theme on the html root so non-styled-components surfaces (highlight.js,
   // scrollbars, etc.) can react via `html[data-theme='light'] …` selectors.
@@ -399,10 +400,13 @@ export function App() {
               selectedTraceTaskId ? (
                 <TraceDetailPage
                   taskId={selectedTraceTaskId}
+                  scope={traceScope}
                   onBack={() => setSelectedTraceTaskId(null)}
                 />
               ) : (
                 <TracesPage
+                  scope={traceScope}
+                  onScopeChange={setTraceScope}
                   onOpenTrace={(taskId) => {
                     setSelectedTraceTaskId(taskId);
                     setActiveRoute('traces');

--- a/dashboard-react/src/components/layout/DiagnosticsDrawer.tsx
+++ b/dashboard-react/src/components/layout/DiagnosticsDrawer.tsx
@@ -2,7 +2,14 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Button } from '../common/Button';
 import { formatBytes } from '../../utils/format';
-import type { NodeDiagnostics, DiagnosticsProcess } from '../../types/diagnostics';
+import type {
+  DiagnosticCaptureResponse,
+  DiagnosticsProcess,
+  MlxMemorySnapshot,
+  NodeDiagnostics,
+  RunnerFlightRecorderEntry,
+  RunnerSupervisorDiagnostics,
+} from '../../types/diagnostics';
 
 /** Props for the read-only node diagnostics drawer. */
 export interface DiagnosticsDrawerProps {
@@ -188,6 +195,42 @@ const TaskActionMeta = styled.div`
   color: ${({ theme }) => theme.colors.textSecondary};
 `;
 
+const TaskActionButtons = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+`;
+
+const CapturePanel = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.borderLight};
+  border-radius: ${({ theme }) => theme.radii.md};
+  padding: 10px;
+  margin: 10px 0;
+  background: ${({ theme }) => theme.colors.surface};
+`;
+
+const CaptureActions = styled.div`
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+`;
+
+const JsonPreview = styled.pre`
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 8px 0 0;
+  padding: 8px;
+  border-radius: ${({ theme }) => theme.radii.md};
+  background: ${({ theme }) => theme.colors.surfaceSunken};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+`;
+
 function memoryUsage(bytes?: number | null): string {
   if (bytes == null) return 'unknown';
   return formatBytes(bytes);
@@ -201,6 +244,39 @@ function shortId(id: string): string {
   return id.length > 12 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
 }
 
+function mlxMemorySummary(snapshot?: MlxMemorySnapshot | null): string {
+  if (!snapshot) return 'none reported';
+  return [
+    `active ${memoryUsage(snapshot.active?.inBytes)}`,
+    `cache ${memoryUsage(snapshot.cache?.inBytes)}`,
+    `peak ${memoryUsage(snapshot.peak?.inBytes)}`,
+    `wired ${memoryUsage(snapshot.wiredLimit?.inBytes)}`,
+  ].join(' · ');
+}
+
+function phaseTone(runner: RunnerSupervisorDiagnostics): 'good' | 'warn' | 'neutral' {
+  if (!runner.processAlive) return 'warn';
+  if (runner.secondsInPhase >= 120 && runner.inProgressTasks.length > 0) return 'warn';
+  if (runner.secondsInPhase >= 30 && runner.inProgressTasks.length > 0) return 'warn';
+  if (runner.statusKind === 'RunnerRunning' || runner.statusKind === 'RunnerReady') return 'good';
+  return 'neutral';
+}
+
+function recorderLine(entry: RunnerFlightRecorderEntry): string {
+  const attrs = Object.entries(entry.attrs ?? {})
+    .slice(0, 4)
+    .map(([key, value]) => `${key}=${Array.isArray(value) ? value.join('|') : value}`)
+    .join(' ');
+  return [
+    entry.at,
+    entry.phase,
+    entry.event,
+    entry.detail,
+    entry.taskId ? `task=${shortId(entry.taskId)}` : null,
+    attrs || null,
+  ].filter(Boolean).join(' · ');
+}
+
 export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
   const [diagnostics, setDiagnostics] = useState<NodeDiagnostics | null>(null);
   const [loading, setLoading] = useState(false);
@@ -209,6 +285,9 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
   const [cancelMessage, setCancelMessage] = useState<string | null>(null);
   const [cancelError, setCancelError] = useState<string | null>(null);
   const [cancelActionKey, setCancelActionKey] = useState<string | null>(null);
+  const [captureBundle, setCaptureBundle] = useState<DiagnosticCaptureResponse | null>(null);
+  const [captureError, setCaptureError] = useState<string | null>(null);
+  const [captureActionKey, setCaptureActionKey] = useState<string | null>(null);
 
   useEffect(() => {
     if (!nodeId) {
@@ -218,6 +297,9 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
       setCancelMessage(null);
       setCancelError(null);
       setCancelActionKey(null);
+      setCaptureBundle(null);
+      setCaptureError(null);
+      setCaptureActionKey(null);
       return;
     }
 
@@ -277,6 +359,55 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
     } finally {
       setCancelActionKey(null);
     }
+  }
+
+  async function requestCaptureBundle(runnerId: string, taskId?: string | null) {
+    const actionKey = `${runnerId}:${taskId ?? 'runner'}`;
+    setCaptureActionKey(actionKey);
+    setCaptureError(null);
+    setCaptureBundle(null);
+
+    try {
+      const response = await fetch(
+        `/v1/diagnostics/cluster/${encodeURIComponent(nodeId)}/capture`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            runnerId,
+            taskId: taskId ?? undefined,
+            includeProcessSamples: true,
+            sampleDurationSeconds: 3,
+          }),
+        },
+      );
+      const payload = await response.json().catch(() => null) as DiagnosticCaptureResponse | { detail?: string } | null;
+      if (!response.ok) {
+        throw new Error((payload as { detail?: string } | null)?.detail ?? `Capture request failed: ${response.status}`);
+      }
+      setCaptureBundle(payload as DiagnosticCaptureResponse);
+      setReloadToken((value) => value + 1);
+    } catch (err: unknown) {
+      setCaptureError(err instanceof Error ? err.message : 'Capture request failed');
+    } finally {
+      setCaptureActionKey(null);
+    }
+  }
+
+  async function copyCaptureBundle() {
+    if (!captureBundle) return;
+    await navigator.clipboard.writeText(JSON.stringify(captureBundle, null, 2));
+  }
+
+  function downloadCaptureBundle() {
+    if (!captureBundle) return;
+    const blob = new Blob([JSON.stringify(captureBundle, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `skulk-diagnostics-${captureBundle.nodeId}-${Date.now()}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
   }
 
   return (
@@ -361,6 +492,21 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
               </Warning>
               {cancelMessage && <Warning>{cancelMessage}</Warning>}
               {cancelError && <Warning>{cancelError}</Warning>}
+              {captureError && <Warning>{captureError}</Warning>}
+              {captureBundle && (
+                <CapturePanel>
+                  <Row><Key>Captured</Key><Value>{captureBundle.generatedAt}</Value></Row>
+                  <Row><Key>Runner</Key><Value>{captureBundle.runner ? shortId(captureBundle.runner.runnerId) : 'none'}</Value></Row>
+                  <Row><Key>MLX memory</Key><Value>{mlxMemorySummary(captureBundle.mlxMemory)}</Value></Row>
+                  <Row><Key>Samples</Key><Value>{captureBundle.processSamples.map((sample) => `${sample.name}:${sample.ok ? 'ok' : sample.error ?? 'failed'}`).join(', ') || 'none'}</Value></Row>
+                  {captureBundle.warnings.map((warning) => <Warning key={warning}>{warning}</Warning>)}
+                  <CaptureActions>
+                    <Button variant="outline" size="sm" onClick={() => void copyCaptureBundle()}>Copy JSON</Button>
+                    <Button variant="outline" size="sm" onClick={downloadCaptureBundle}>Download JSON</Button>
+                  </CaptureActions>
+                  <JsonPreview>{JSON.stringify(captureBundle, null, 2)}</JsonPreview>
+                </CapturePanel>
+              )}
               {diagnostics.supervisorRunners.length === 0 ? (
                 <Value>No local runner supervisors reported by this node.</Value>
               ) : diagnostics.supervisorRunners.map((runner) => (
@@ -376,6 +522,17 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
                   </Row>
                   <Row><Key>Shard</Key><Value>rank {runner.deviceRank}/{runner.worldSize} · layers {runner.startLayer}:{runner.endLayer}</Value></Row>
                   <Row><Key>Instance</Key><Value>{shortId(runner.instanceId)} · {runner.modelId}</Value></Row>
+                  <Row>
+                    <Key>Phase</Key>
+                    <Value $warn={phaseTone(runner) === 'warn'}>
+                      <Pill $tone={phaseTone(runner)}>{runner.phase}</Pill>{' '}
+                      {Math.round(runner.secondsInPhase)}s
+                      {runner.phaseDetail ? ` · ${runner.phaseDetail}` : ''}
+                    </Value>
+                  </Row>
+                  <Row><Key>Last progress</Key><Value>{runner.lastProgressAt ?? 'none'}</Value></Row>
+                  <Row><Key>Active task</Key><Value>{runner.activeTaskId ? shortId(runner.activeTaskId) : 'none'}</Value></Row>
+                  <Row><Key>MLX memory</Key><Value>{mlxMemorySummary(runner.lastMlxMemory)}</Value></Row>
                   <Row><Key>Last task sent</Key><Value>{runner.lastTaskSentAt ?? 'none'}</Value></Row>
                   <Row><Key>Last event</Key><Value>{runner.lastEventType ?? 'none'} {runner.lastEventReceivedAt ? `at ${runner.lastEventReceivedAt}` : ''}</Value></Row>
                   <Row>
@@ -398,18 +555,40 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
                               {task.taskKind}:{shortId(task.taskId)} · {task.taskStatus}
                               {task.commandId ? ` · cmd ${shortId(task.commandId)}` : ''}
                             </TaskActionMeta>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              loading={cancelActionKey === actionKey}
-                              onClick={() => { void requestRunnerCancel(runner.runnerId, task.taskId); }}
-                            >
-                              Cancel task
-                            </Button>
+                            <TaskActionButtons>
+                              <Button
+                                size="sm"
+                                variant="primary"
+                                loading={captureActionKey === actionKey}
+                                onClick={() => { void requestCaptureBundle(runner.runnerId, task.taskId); }}
+                              >
+                                Capture bundle
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                loading={cancelActionKey === actionKey}
+                                onClick={() => { void requestRunnerCancel(runner.runnerId, task.taskId); }}
+                              >
+                                Cancel task
+                              </Button>
+                            </TaskActionButtons>
                           </TaskActionItem>
                         );
                       })}
                     </TaskActionList>
+                  )}
+                  {runner.inProgressTasks.length === 0 && (
+                    <CaptureActions>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        loading={captureActionKey === `${runner.runnerId}:runner`}
+                        onClick={() => { void requestCaptureBundle(runner.runnerId); }}
+                      >
+                        Capture runner bundle
+                      </Button>
+                    </CaptureActions>
                   )}
                   <Row>
                     <Key>Cancelled</Key>
@@ -426,6 +605,18 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
                         </MilestoneItem>
                       ))}
                     </MilestoneList>
+                  )}
+                  {runner.flightRecorder.length > 0 && (
+                    <>
+                      <Row><Key>Flight recorder</Key><Value>{runner.flightRecorder.length} entries</Value></Row>
+                      <MilestoneList>
+                        {runner.flightRecorder.slice(-8).reverse().map((entry, index) => (
+                          <MilestoneItem key={`${entry.at}-${entry.event}-${index}`}>
+                            {recorderLine(entry)}
+                          </MilestoneItem>
+                        ))}
+                      </MilestoneList>
+                    </>
                   )}
                 </RunnerCard>
               ))}

--- a/dashboard-react/src/components/layout/DiagnosticsDrawer.tsx
+++ b/dashboard-react/src/components/layout/DiagnosticsDrawer.tsx
@@ -164,6 +164,30 @@ const MilestoneItem = styled.div`
   color: ${({ theme }) => theme.colors.textSecondary};
 `;
 
+const TaskActionList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const TaskActionItem = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid ${({ theme }) => theme.colors.borderLight};
+  border-radius: ${({ theme }) => theme.radii.md};
+  padding: 8px 10px;
+  background: ${({ theme }) => theme.colors.surface};
+`;
+
+const TaskActionMeta = styled.div`
+  min-width: 0;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
 function memoryUsage(bytes?: number | null): string {
   if (bytes == null) return 'unknown';
   return formatBytes(bytes);
@@ -181,12 +205,19 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
   const [diagnostics, setDiagnostics] = useState<NodeDiagnostics | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const [cancelMessage, setCancelMessage] = useState<string | null>(null);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+  const [cancelActionKey, setCancelActionKey] = useState<string | null>(null);
 
   useEffect(() => {
     if (!nodeId) {
       setDiagnostics(null);
       setError(null);
       setLoading(false);
+      setCancelMessage(null);
+      setCancelError(null);
+      setCancelActionKey(null);
       return;
     }
 
@@ -212,13 +243,41 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
       });
 
     return () => controller.abort();
-  }, [nodeId]);
+  }, [nodeId, reloadToken]);
 
   if (!nodeId) return null;
 
   const runtime = diagnostics?.runtime;
   const currentMemory = diagnostics?.resources.currentMemory;
   const system = diagnostics?.resources.system;
+
+  async function requestRunnerCancel(runnerId: string, taskId: string) {
+    const actionKey = `${runnerId}:${taskId}`;
+    setCancelActionKey(actionKey);
+    setCancelError(null);
+    setCancelMessage(null);
+
+    try {
+      const response = await fetch(
+        `/v1/diagnostics/cluster/${encodeURIComponent(nodeId)}/runners/${encodeURIComponent(runnerId)}/cancel`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ taskId }),
+        },
+      );
+      const payload = await response.json().catch(() => null) as { message?: string; detail?: string } | null;
+      if (!response.ok) {
+        throw new Error(payload?.detail ?? `Cancellation request failed: ${response.status}`);
+      }
+      setCancelMessage(payload?.message ?? 'Cancellation requested.');
+      setReloadToken((value) => value + 1);
+    } catch (err: unknown) {
+      setCancelError(err instanceof Error ? err.message : 'Cancellation request failed');
+    } finally {
+      setCancelActionKey(null);
+    }
+  }
 
   return (
     <Overlay onClick={onClose}>
@@ -297,6 +356,11 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
 
               <Section>
                 <SectionTitle>Live Runners</SectionTitle>
+              <Warning>
+                Cancel task sends a cooperative runner-local cancellation request. A runner wedged in native MLX work may ignore it and still require stronger intervention.
+              </Warning>
+              {cancelMessage && <Warning>{cancelMessage}</Warning>}
+              {cancelError && <Warning>{cancelError}</Warning>}
               {diagnostics.supervisorRunners.length === 0 ? (
                 <Value>No local runner supervisors reported by this node.</Value>
               ) : diagnostics.supervisorRunners.map((runner) => (
@@ -324,6 +388,29 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
                       {runner.inProgressTasks.map((task) => `${task.taskKind}:${shortId(task.taskId)} (${task.taskStatus})`).join(', ') || 'none'}
                     </Value>
                   </Row>
+                  {runner.inProgressTasks.length > 0 && (
+                    <TaskActionList>
+                      {runner.inProgressTasks.map((task) => {
+                        const actionKey = `${runner.runnerId}:${task.taskId}`;
+                        return (
+                          <TaskActionItem key={actionKey}>
+                            <TaskActionMeta title={`${task.taskKind}:${task.taskId}`}>
+                              {task.taskKind}:{shortId(task.taskId)} · {task.taskStatus}
+                              {task.commandId ? ` · cmd ${shortId(task.commandId)}` : ''}
+                            </TaskActionMeta>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              loading={cancelActionKey === actionKey}
+                              onClick={() => { void requestRunnerCancel(runner.runnerId, task.taskId); }}
+                            >
+                              Cancel task
+                            </Button>
+                          </TaskActionItem>
+                        );
+                      })}
+                    </TaskActionList>
+                  )}
                   <Row>
                     <Key>Cancelled</Key>
                     <Value>{runner.cancelledTaskIds.map((taskId) => shortId(taskId)).join(', ') || 'none'}</Value>

--- a/dashboard-react/src/components/layout/DiagnosticsDrawer.tsx
+++ b/dashboard-react/src/components/layout/DiagnosticsDrawer.tsx
@@ -136,6 +136,34 @@ const Monospace = styled.code`
   text-overflow: ellipsis;
 `;
 
+const RunnerCard = styled.div`
+  border-top: 1px solid ${({ theme }) => theme.colors.borderLight};
+  padding-top: 10px;
+  margin-top: 10px;
+
+  &:first-child {
+    border-top: none;
+    padding-top: 0;
+    margin-top: 0;
+  }
+`;
+
+const MilestoneList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const MilestoneItem = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.borderLight};
+  border-radius: ${({ theme }) => theme.radii.md};
+  padding: 8px 10px;
+  background: ${({ theme }) => theme.colors.surface};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
 function memoryUsage(bytes?: number | null): string {
   if (bytes == null) return 'unknown';
   return formatBytes(bytes);
@@ -267,18 +295,52 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
               ))}
             </Section>
 
-            <Section>
-              <SectionTitle>Live Runners</SectionTitle>
+              <Section>
+                <SectionTitle>Live Runners</SectionTitle>
               {diagnostics.supervisorRunners.length === 0 ? (
                 <Value>No local runner supervisors reported by this node.</Value>
               ) : diagnostics.supervisorRunners.map((runner) => (
-                <div key={runner.runnerId}>
+                <RunnerCard key={runner.runnerId}>
                   <Row><Key>Runner</Key><Value>{shortId(runner.runnerId)} · pid {runner.pid ?? 'unknown'}</Value></Row>
-                  <Row><Key>Status</Key><Value>{runner.statusKind} for {Math.round(runner.secondsInStatus)}s</Value></Row>
+                  <Row>
+                    <Key>Status</Key>
+                    <Value>
+                      {runner.statusKind} for {Math.round(runner.secondsInStatus)}s{' '}
+                      {runner.processAlive ? <Pill $tone="good">alive</Pill> : <Pill $tone="warn">exited</Pill>}
+                      {!runner.processAlive && runner.exitCode != null ? ` exit ${runner.exitCode}` : ''}
+                    </Value>
+                  </Row>
                   <Row><Key>Shard</Key><Value>rank {runner.deviceRank}/{runner.worldSize} · layers {runner.startLayer}:{runner.endLayer}</Value></Row>
+                  <Row><Key>Instance</Key><Value>{shortId(runner.instanceId)} · {runner.modelId}</Value></Row>
+                  <Row><Key>Last task sent</Key><Value>{runner.lastTaskSentAt ?? 'none'}</Value></Row>
                   <Row><Key>Last event</Key><Value>{runner.lastEventType ?? 'none'} {runner.lastEventReceivedAt ? `at ${runner.lastEventReceivedAt}` : ''}</Value></Row>
-                  <Row><Key>In progress</Key><Value>{runner.inProgressTasks.map((task) => `${task.taskKind}:${shortId(task.taskId)}`).join(', ') || 'none'}</Value></Row>
-                </div>
+                  <Row>
+                    <Key>Pending</Key>
+                    <Value>{runner.pendingTaskIds.map((taskId) => shortId(taskId)).join(', ') || 'none'}</Value>
+                  </Row>
+                  <Row>
+                    <Key>In progress</Key>
+                    <Value>
+                      {runner.inProgressTasks.map((task) => `${task.taskKind}:${shortId(task.taskId)} (${task.taskStatus})`).join(', ') || 'none'}
+                    </Value>
+                  </Row>
+                  <Row>
+                    <Key>Cancelled</Key>
+                    <Value>{runner.cancelledTaskIds.map((taskId) => shortId(taskId)).join(', ') || 'none'}</Value>
+                  </Row>
+                  <Row><Key>Completed</Key><Value>{runner.completedTaskCount}</Value></Row>
+                  <Row><Key>Milestones</Key><Value>{runner.milestones.length === 0 ? 'none' : `${runner.milestones.length} recorded`}</Value></Row>
+                  {runner.milestones.length > 0 && (
+                    <MilestoneList>
+                      {runner.milestones.slice().reverse().map((milestone, index) => (
+                        <MilestoneItem key={`${milestone.at}-${milestone.name}-${index}`}>
+                          {milestone.at} · {milestone.name}
+                          {milestone.detail ? ` · ${milestone.detail}` : ''}
+                        </MilestoneItem>
+                      ))}
+                    </MilestoneList>
+                  )}
+                </RunnerCard>
               ))}
             </Section>
 

--- a/dashboard-react/src/components/layout/DiagnosticsDrawer.tsx
+++ b/dashboard-react/src/components/layout/DiagnosticsDrawer.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { Button } from '../common/Button';
+import { formatBytes } from '../../utils/format';
+import type { NodeDiagnostics, DiagnosticsProcess } from '../../types/diagnostics';
+
+/** Props for the read-only node diagnostics drawer. */
+export interface DiagnosticsDrawerProps {
+  /** Node ID to inspect. Pass null to close the drawer. */
+  nodeId: string | null;
+  /** Called when the user closes the drawer. */
+  onClose: () => void;
+}
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  background: ${({ theme }) => theme.colors.overlay};
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const Drawer = styled.aside`
+  width: min(560px, 100vw);
+  height: 100%;
+  background: ${({ theme }) => theme.colors.surfaceElevated};
+  border-left: 1px solid ${({ theme }) => theme.colors.borderStrong};
+  box-shadow: -18px 0 48px ${({ theme }) => theme.colors.shadowStrong};
+  padding: 22px;
+  overflow: auto;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.xl};
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Subtitle = styled.div`
+  margin-top: 4px;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textMuted};
+  word-break: break-all;
+`;
+
+const Section = styled.section`
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.surfaceSunken};
+  border-radius: ${({ theme }) => theme.radii.lg};
+  padding: 14px;
+  margin-bottom: 12px;
+`;
+
+const SectionTitle = styled.h3`
+  margin: 0 0 10px;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  color: ${({ theme }) => theme.colors.gold};
+`;
+
+const Row = styled.div`
+  display: grid;
+  grid-template-columns: 150px minmax(0, 1fr);
+  gap: 10px;
+  padding: 3px 0;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+`;
+
+const Key = styled.div`
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const Value = styled.div<{ $warn?: boolean }>`
+  color: ${({ $warn, theme }) => $warn ? theme.colors.warningText : theme.colors.textSecondary};
+  word-break: break-word;
+`;
+
+const Warning = styled.div`
+  color: ${({ theme }) => theme.colors.warningText};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  line-height: 1.45;
+  margin-bottom: 6px;
+`;
+
+const Pill = styled.span<{ $tone?: 'good' | 'warn' | 'neutral' }>`
+  display: inline-flex;
+  align-items: center;
+  border-radius: ${({ theme }) => theme.radii.sm};
+  padding: 1px 6px;
+  border: 1px solid ${({ $tone, theme }) =>
+    $tone === 'good' ? theme.colors.healthy :
+    $tone === 'warn' ? theme.colors.warning :
+    theme.colors.borderStrong};
+  color: ${({ $tone, theme }) =>
+    $tone === 'good' ? theme.colors.healthy :
+    $tone === 'warn' ? theme.colors.warningText :
+    theme.colors.textSecondary};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-size: 11px;
+`;
+
+const ProcessLine = styled.div`
+  display: grid;
+  grid-template-columns: 62px 72px 74px minmax(0, 1fr);
+  gap: 8px;
+  align-items: baseline;
+  padding: 4px 0;
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  border-top: 1px solid ${({ theme }) => theme.colors.borderLight};
+
+  &:first-child {
+    border-top: none;
+  }
+`;
+
+const Monospace = styled.code`
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.textMuted};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+function memoryUsage(bytes?: number | null): string {
+  if (bytes == null) return 'unknown';
+  return formatBytes(bytes);
+}
+
+function processMemory(process: DiagnosticsProcess): string {
+  return process.rss ? memoryUsage(process.rss.inBytes) : 'unknown';
+}
+
+function shortId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id;
+}
+
+export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
+  const [diagnostics, setDiagnostics] = useState<NodeDiagnostics | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!nodeId) {
+      setDiagnostics(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    fetch(`/v1/diagnostics/cluster/${encodeURIComponent(nodeId)}`, {
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Diagnostics request failed: ${response.status}`);
+        }
+        return response.json() as Promise<NodeDiagnostics>;
+      })
+      .then((payload) => setDiagnostics(payload))
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Failed to load diagnostics');
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [nodeId]);
+
+  if (!nodeId) return null;
+
+  const runtime = diagnostics?.runtime;
+  const currentMemory = diagnostics?.resources.currentMemory;
+  const system = diagnostics?.resources.system;
+
+  return (
+    <Overlay onClick={onClose}>
+      <Drawer onClick={(event) => event.stopPropagation()}>
+        <Header>
+          <div>
+            <Title>Node Diagnostics</Title>
+            <Subtitle>{runtime?.friendlyName ?? runtime?.hostname ?? shortId(nodeId)} · {shortId(nodeId)}</Subtitle>
+          </div>
+          <Button variant="ghost" size="sm" onClick={onClose}>Close</Button>
+        </Header>
+
+        {loading && <Section><Value>Loading diagnostics…</Value></Section>}
+        {error && <Section><Warning>{error}</Warning></Section>}
+
+        {diagnostics && runtime && (
+          <>
+            {diagnostics.warnings.length > 0 && (
+              <Section>
+                <SectionTitle>Warnings</SectionTitle>
+                {diagnostics.warnings.map((warning) => (
+                  <Warning key={warning}>{warning}</Warning>
+                ))}
+              </Section>
+            )}
+
+            <Section>
+              <SectionTitle>Runtime</SectionTitle>
+              <Row><Key>Role</Key><Value>{runtime.isMaster ? <Pill $tone="good">master</Pill> : <Pill>worker/follower</Pill>}</Value></Row>
+              <Row><Key>Master</Key><Value>{runtime.masterNodeId ? shortId(runtime.masterNodeId) : 'unknown'}</Value></Row>
+              <Row><Key>Commit</Key><Value>{runtime.skulkCommit}</Value></Row>
+              <Row><Key>Version</Key><Value>{runtime.skulkVersion}</Value></Row>
+              <Row><Key>Namespace</Key><Value>{runtime.libp2pNamespace ?? 'default'}</Value></Row>
+              <Row><Key>CWD</Key><Value>{runtime.cwd}</Value></Row>
+              <Row><Key>Config</Key><Value $warn={!runtime.configFileExists}>{runtime.configPath} {runtime.configFileExists ? '' : '(missing)'}</Value></Row>
+              <Row><Key>Logging</Key><Value>{runtime.structuredLoggingConfigured ? 'centralized enabled' : 'not configured'}</Value></Row>
+            </Section>
+
+            <Section>
+              <SectionTitle>Resources</SectionTitle>
+              <Row><Key>RAM available</Key><Value>{memoryUsage(currentMemory?.ramAvailable?.inBytes)} / {memoryUsage(currentMemory?.ramTotal?.inBytes)}</Value></Row>
+              <Row><Key>Swap available</Key><Value>{memoryUsage(currentMemory?.swapAvailable?.inBytes)} / {memoryUsage(currentMemory?.swapTotal?.inBytes)}</Value></Row>
+              <Row><Key>GPU</Key><Value>{system?.gpuUsage != null ? `${Math.round(system.gpuUsage)}%` : 'unknown'}</Value></Row>
+              <Row><Key>Temp</Key><Value>{system?.temp != null ? `${Math.round(system.temp)}°C` : 'unknown'}</Value></Row>
+              <Row><Key>Power</Key><Value>{system?.sysPower != null ? `${Math.round(system.sysPower)}W` : 'unknown'}</Value></Row>
+            </Section>
+
+            <Section>
+              <SectionTitle>Placements</SectionTitle>
+              {diagnostics.placements.length === 0 ? (
+                <Value>No active placements.</Value>
+              ) : diagnostics.placements.map((placement) => (
+                <div key={placement.instanceId}>
+                  <Row><Key>Model</Key><Value>{placement.modelId}</Value></Row>
+                  <Row><Key>Instance</Key><Value>{shortId(placement.instanceId)}</Value></Row>
+                  <Row>
+                    <Key>Master placed</Key>
+                    <Value $warn={!placement.masterIsPlacementNode}>
+                      {placement.masterIsPlacementNode ? <Pill $tone="good">yes</Pill> : <Pill $tone="warn">no</Pill>}
+                    </Value>
+                  </Row>
+                  {placement.runners.map((runner) => (
+                    <Row key={runner.runnerId}>
+                      <Key>Rank {runner.deviceRank}</Key>
+                      <Value>
+                        {runner.friendlyName ?? shortId(runner.nodeId)} · {runner.statusKind ?? 'unknown'} · layers {runner.startLayer}:{runner.endLayer}
+                      </Value>
+                    </Row>
+                  ))}
+                  {placement.warnings.map((warning) => (
+                    <Warning key={warning}>{warning}</Warning>
+                  ))}
+                </div>
+              ))}
+            </Section>
+
+            <Section>
+              <SectionTitle>Live Runners</SectionTitle>
+              {diagnostics.supervisorRunners.length === 0 ? (
+                <Value>No local runner supervisors reported by this node.</Value>
+              ) : diagnostics.supervisorRunners.map((runner) => (
+                <div key={runner.runnerId}>
+                  <Row><Key>Runner</Key><Value>{shortId(runner.runnerId)} · pid {runner.pid ?? 'unknown'}</Value></Row>
+                  <Row><Key>Status</Key><Value>{runner.statusKind} for {Math.round(runner.secondsInStatus)}s</Value></Row>
+                  <Row><Key>Shard</Key><Value>rank {runner.deviceRank}/{runner.worldSize} · layers {runner.startLayer}:{runner.endLayer}</Value></Row>
+                  <Row><Key>Last event</Key><Value>{runner.lastEventType ?? 'none'} {runner.lastEventReceivedAt ? `at ${runner.lastEventReceivedAt}` : ''}</Value></Row>
+                  <Row><Key>In progress</Key><Value>{runner.inProgressTasks.map((task) => `${task.taskKind}:${shortId(task.taskId)}`).join(', ') || 'none'}</Value></Row>
+                </div>
+              ))}
+            </Section>
+
+            <Section>
+              <SectionTitle>Processes</SectionTitle>
+              {diagnostics.processes
+                .filter((process) => process.role !== 'other')
+                .map((process) => (
+                  <ProcessLine key={process.pid}>
+                    <span>{process.pid}</span>
+                    <span>{process.role}</span>
+                    <span>{processMemory(process)}</span>
+                    <Monospace title={process.command}>{process.command || process.status || 'unknown'}</Monospace>
+                  </ProcessLine>
+                ))}
+            </Section>
+          </>
+        )}
+      </Drawer>
+    </Overlay>
+  );
+}

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -1,6 +1,7 @@
 import styled, { css, useTheme } from 'styled-components';
-import { FiSettings, FiMenu, FiX, FiSidebar, FiDatabase, FiMessageSquare, FiSun, FiMoon, FiActivity } from 'react-icons/fi';
+import { FiSettings, FiMenu, FiX, FiSidebar, FiDatabase, FiMessageSquare, FiSun, FiMoon } from 'react-icons/fi';
 import { MdHub } from 'react-icons/md';
+import { VscBug } from 'react-icons/vsc';
 import { Button } from '../common/Button';
 import SkulkIcon from '../icons/SkulkIcon';
 import type { Theme } from '../../theme';
@@ -230,7 +231,7 @@ const SidebarIcon = () => <FiSidebar size={18} />;
 const ClusterIcon = () => <MdHub size={16} />;
 const StoreIcon = () => <FiDatabase size={16} />;
 const ChatIcon = () => <FiMessageSquare size={16} />;
-const TraceIcon = () => <FiActivity size={16} />;
+const TraceIcon = () => <VscBug size={16} />;
 const SettingsIcon = () => <FiSettings size={16} />;
 
 function ProgressCircle({ count, percentage }: { count: number; percentage: number }) {
@@ -336,10 +337,6 @@ export function HeaderNav({
           <ChatIcon /> Chat
         </NavLink>
 
-        <NavLink $active={activeRoute === 'traces'} onClick={() => navigate('traces')}>
-          <TraceIcon /> Traces
-        </NavLink>
-
         {instanceCount > 0 && (
           <InstanceToggle
             $healthy={instancesHealthy}
@@ -381,6 +378,17 @@ export function HeaderNav({
           title={themeName === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
         >
           {themeName === 'dark' ? <FiSun size={16} /> : <FiMoon size={16} />}
+        </Button>
+
+        <Button
+          variant={activeRoute === 'traces' ? 'outline' : 'ghost'}
+          size="lg"
+          icon
+          onClick={() => navigate('traces')}
+          aria-label="Traces"
+          title="Traces"
+        >
+          <TraceIcon />
         </Button>
 
         <Button variant="ghost" size="lg" icon onClick={() => onOpenSettings?.()} aria-label="Settings">

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -24,7 +24,7 @@ const defaultStoreConfig = (): StoreConfig => ({
   staging: {
     enabled: true,
     node_cache_path: '~/.exo/staging',
-    cleanup_on_deactivate: true,
+    cleanup_on_deactivate: false,
   },
 });
 
@@ -447,7 +447,7 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
                       Cleanup on deactivate
                       <InfoTooltip
                         filled
-                        content="When enabled, on deactivate staged models will be removed from cluster nodes to prevent storage bloat on cluster nodes."
+                        content="When enabled, staged models are removed when instances stop. Leave this off for faster re-placement from the local staging cache; use the model-store purge action when you need disk space back."
                       />
                     </FieldLabel>
                     <Toggle

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -247,13 +247,13 @@ function buildApiMessages(messages: ChatMessage[]): ApiMessagePayload[] {
   return messages.map((message) => {
     if (message.attachments?.some((attachment) => attachment.type.startsWith('image/') && attachment.preview)) {
       const parts: Array<{ type: string; text?: string; image_url?: { url: string } }> = [];
+      if (message.content) {
+        parts.push({ type: 'text', text: message.content });
+      }
       for (const attachment of message.attachments) {
         if (attachment.type.startsWith('image/') && attachment.preview) {
           parts.push({ type: 'image_url', image_url: { url: attachment.preview } });
         }
-      }
-      if (message.content) {
-        parts.push({ type: 'text', text: message.content });
       }
       return { role: message.role, content: parts };
     }

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -247,13 +247,13 @@ function buildApiMessages(messages: ChatMessage[]): ApiMessagePayload[] {
   return messages.map((message) => {
     if (message.attachments?.some((attachment) => attachment.type.startsWith('image/') && attachment.preview)) {
       const parts: Array<{ type: string; text?: string; image_url?: { url: string } }> = [];
-      if (message.content) {
-        parts.push({ type: 'text', text: message.content });
-      }
       for (const attachment of message.attachments) {
         if (attachment.type.startsWith('image/') && attachment.preview) {
           parts.push({ type: 'image_url', image_url: { url: attachment.preview } });
         }
+      }
+      if (message.content) {
+        parts.push({ type: 'text', text: message.content });
       }
       return { role: message.role, content: parts };
     }

--- a/dashboard-react/src/components/pages/TraceDetailPage.tsx
+++ b/dashboard-react/src/components/pages/TraceDetailPage.tsx
@@ -5,6 +5,7 @@ import type { TraceCategoryStats, TraceStatsResponse } from '../../types/traces'
 
 export interface TraceDetailPageProps {
   taskId: string;
+  scope: 'cluster' | 'local';
   onBack: () => void;
 }
 
@@ -13,6 +14,10 @@ interface PhaseData {
   subcategories: { name: string; stats: TraceCategoryStats }[];
   totalUs: number;
   stepCount: number;
+}
+
+function traceBasePath(scope: 'cluster' | 'local'): string {
+  return scope === 'cluster' ? '/v1/traces/cluster' : '/v1/traces';
 }
 
 function formatDuration(microseconds: number): string {
@@ -56,8 +61,8 @@ function parsePhases(byCategory: Record<string, TraceCategoryStats>): PhaseData[
     .sort((left, right) => right.totalUs - left.totalUs);
 }
 
-async function downloadTrace(taskId: string): Promise<void> {
-  const response = await fetch(`/v1/traces/${encodeURIComponent(taskId)}/raw`);
+async function downloadTrace(scope: 'cluster' | 'local', taskId: string): Promise<void> {
+  const response = await fetch(`${traceBasePath(scope)}/${encodeURIComponent(taskId)}/raw`);
   if (!response.ok) {
     throw new Error(`Failed to download trace (${response.status})`);
   }
@@ -70,8 +75,8 @@ async function downloadTrace(taskId: string): Promise<void> {
   URL.revokeObjectURL(url);
 }
 
-async function openInPerfetto(taskId: string): Promise<void> {
-  const response = await fetch(`/v1/traces/${encodeURIComponent(taskId)}/raw`);
+async function openInPerfetto(scope: 'cluster' | 'local', taskId: string): Promise<void> {
+  const response = await fetch(`${traceBasePath(scope)}/${encodeURIComponent(taskId)}/raw`);
   if (!response.ok) {
     throw new Error(`Failed to open trace (${response.status})`);
   }
@@ -107,7 +112,7 @@ async function openInPerfetto(taskId: string): Promise<void> {
   }, 10000);
 }
 
-export function TraceDetailPage({ taskId, onBack }: TraceDetailPageProps) {
+export function TraceDetailPage({ taskId, scope, onBack }: TraceDetailPageProps) {
   const [stats, setStats] = useState<TraceStatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -116,7 +121,7 @@ export function TraceDetailPage({ taskId, onBack }: TraceDetailPageProps) {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch(`/v1/traces/${encodeURIComponent(taskId)}/stats`);
+      const response = await fetch(`${traceBasePath(scope)}/${encodeURIComponent(taskId)}/stats`);
       if (!response.ok) {
         throw new Error(`Failed to load trace (${response.status})`);
       }
@@ -126,7 +131,7 @@ export function TraceDetailPage({ taskId, onBack }: TraceDetailPageProps) {
     } finally {
       setLoading(false);
     }
-  }, [taskId]);
+  }, [scope, taskId]);
 
   useEffect(() => {
     void refresh();
@@ -145,16 +150,17 @@ export function TraceDetailPage({ taskId, onBack }: TraceDetailPageProps) {
         <div>
           <Button variant="ghost" size="sm" onClick={onBack}>← All Traces</Button>
           <Title>Trace</Title>
-          <TaskId>{taskId}</TaskId>
+          <TaskIdLabel>{taskId}</TaskIdLabel>
+          <ScopeLabel>{scope === 'cluster' ? 'Cluster view' : 'Local view'}</ScopeLabel>
         </div>
         <HeaderActions>
           <Button variant="outline" size="sm" onClick={() => void refresh()} loading={loading}>
             Refresh
           </Button>
-          <Button variant="outline" size="sm" onClick={() => void downloadTrace(taskId)} disabled={loading || !!error}>
+          <Button variant="outline" size="sm" onClick={() => void downloadTrace(scope, taskId)} disabled={loading || !!error}>
             Download
           </Button>
-          <Button variant="primary" size="sm" onClick={() => void openInPerfetto(taskId)} disabled={loading || !!error}>
+          <Button variant="primary" size="sm" onClick={() => void openInPerfetto(scope, taskId)} disabled={loading || !!error}>
             Perfetto
           </Button>
         </HeaderActions>
@@ -170,12 +176,21 @@ export function TraceDetailPage({ taskId, onBack }: TraceDetailPageProps) {
             <SectionLabel>Summary</SectionLabel>
             <SummaryValue>{formatDuration(stats.totalWallTimeUs)}</SummaryValue>
             <SummaryHint>Total wall time</SummaryHint>
+            {stats.sourceNodes.length > 0 && (
+              <SourceNodes>
+                {stats.sourceNodes.map((sourceNode) => (
+                  <SourceNodeBadge key={sourceNode.nodeId}>
+                    {sourceNode.friendlyName || sourceNode.nodeId}
+                  </SourceNodeBadge>
+                ))}
+              </SourceNodes>
+            )}
           </SummaryCard>
 
           {phases.length > 0 && (
             <SectionCard>
               <SectionLabel>By Phase</SectionLabel>
-              <SectionHint>Average per node</SectionHint>
+              <SectionHint>Average per rank represented in the trace file.</SectionHint>
               <Stack>
                 {phases.map((phase) => {
                   const normalizedTotal = phase.totalUs / nodeCount;
@@ -274,12 +289,18 @@ const Title = styled.h1`
   color: ${({ theme }) => theme.colors.gold};
 `;
 
-const TaskId = styled.p`
+const TaskIdLabel = styled.p`
   margin: 6px 0 0;
   font-family: ${({ theme }) => theme.fonts.mono};
   font-size: ${({ theme }) => theme.fontSizes.sm};
   color: ${({ theme }) => theme.colors.textSecondary};
   word-break: break-all;
+`;
+
+const ScopeLabel = styled.p`
+  margin: 6px 0 0;
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
 `;
 
 const SummaryCard = styled.div`
@@ -301,6 +322,23 @@ const SummaryHint = styled.div`
   font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.xs};
   color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const SourceNodes = styled.div`
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+`;
+
+const SourceNodeBadge = styled.span`
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.surfaceElevated};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
 `;
 
 const SectionCard = styled.div`

--- a/dashboard-react/src/components/pages/TracesPage.tsx
+++ b/dashboard-react/src/components/pages/TracesPage.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { Button } from '../common/Button';
-import type { TraceListItem } from '../../types/traces';
+import type { TraceListItem, TraceListResponse, TracingStateResponse } from '../../types/traces';
 
 export interface TracesPageProps {
+  scope: 'cluster' | 'local';
+  onScopeChange: (scope: 'cluster' | 'local') => void;
   onOpenTrace: (taskId: string) => void;
 }
 
@@ -19,8 +21,12 @@ function formatDate(isoString: string): string {
   return new Date(isoString).toLocaleString();
 }
 
-async function downloadTrace(taskId: string): Promise<void> {
-  const response = await fetch(`/v1/traces/${encodeURIComponent(taskId)}/raw`);
+function traceBasePath(scope: 'cluster' | 'local'): string {
+  return scope === 'cluster' ? '/v1/traces/cluster' : '/v1/traces';
+}
+
+async function downloadTrace(scope: 'cluster' | 'local', taskId: string): Promise<void> {
+  const response = await fetch(`${traceBasePath(scope)}/${encodeURIComponent(taskId)}/raw`);
   if (!response.ok) {
     throw new Error(`Failed to download trace (${response.status})`);
   }
@@ -33,8 +39,8 @@ async function downloadTrace(taskId: string): Promise<void> {
   URL.revokeObjectURL(url);
 }
 
-async function openInPerfetto(taskId: string): Promise<void> {
-  const response = await fetch(`/v1/traces/${encodeURIComponent(taskId)}/raw`);
+async function openInPerfetto(scope: 'cluster' | 'local', taskId: string): Promise<void> {
+  const response = await fetch(`${traceBasePath(scope)}/${encodeURIComponent(taskId)}/raw`);
   if (!response.ok) {
     throw new Error(`Failed to open trace (${response.status})`);
   }
@@ -70,35 +76,114 @@ async function openInPerfetto(taskId: string): Promise<void> {
   }, 10000);
 }
 
-export function TracesPage({ onOpenTrace }: TracesPageProps) {
+export function TracesPage({ scope, onScopeChange, onOpenTrace }: TracesPageProps) {
   const [traces, setTraces] = useState<TraceListItem[]>([]);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [tracingEnabled, setTracingEnabled] = useState(false);
+  const [toggleLoading, setToggleLoading] = useState(false);
+  const [taskKindFilter, setTaskKindFilter] = useState<string>('all');
+  const [modelFilter, setModelFilter] = useState<string>('all');
+  const [sourceNodeFilter, setSourceNodeFilter] = useState<string>('all');
+  const [categoryOrTagFilter, setCategoryOrTagFilter] = useState('');
+  const [toolOnly, setToolOnly] = useState(false);
+
+  const refreshTracingState = useCallback(async () => {
+    const response = await fetch('/v1/tracing');
+    if (!response.ok) {
+      throw new Error(`Failed to load tracing state (${response.status})`);
+    }
+    const data = (await response.json()) as TracingStateResponse;
+    setTracingEnabled(data.enabled);
+  }, []);
 
   const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch('/v1/traces');
-      if (!response.ok) {
-        throw new Error(`Failed to load traces (${response.status})`);
+      const [traceResponse] = await Promise.all([
+        fetch(traceBasePath(scope)),
+        refreshTracingState(),
+      ]);
+      if (!traceResponse.ok) {
+        throw new Error(`Failed to load traces (${traceResponse.status})`);
       }
-      const data = (await response.json()) as { traces?: TraceListItem[] };
+      const data = (await traceResponse.json()) as TraceListResponse;
       setTraces(data.traces ?? []);
     } catch (caughtError) {
       setError(caughtError instanceof Error ? caughtError.message : 'Failed to load traces');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [refreshTracingState, scope]);
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
 
-  const allSelected = traces.length > 0 && selectedIds.size === traces.length;
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [scope]);
+
+  const toggleTracing = useCallback(async (enabled: boolean) => {
+    setToggleLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/v1/tracing', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to update tracing (${response.status})`);
+      }
+      const data = (await response.json()) as TracingStateResponse;
+      setTracingEnabled(data.enabled);
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : 'Failed to update tracing');
+    } finally {
+      setToggleLoading(false);
+    }
+  }, []);
+
+  const modelOptions = useMemo(
+    () => [...new Set(traces.map((trace) => trace.modelId).filter(Boolean))].sort(),
+    [traces],
+  );
+  const sourceNodeOptions = useMemo(
+    () =>
+      [...new Map(
+        traces
+          .flatMap((trace) => trace.sourceNodes)
+          .map((sourceNode) => [sourceNode.nodeId, sourceNode] as const),
+      ).values()].sort((left, right) => {
+        const leftLabel = left.friendlyName || left.nodeId;
+        const rightLabel = right.friendlyName || right.nodeId;
+        return leftLabel.localeCompare(rightLabel);
+      }),
+    [traces],
+  );
+
+  const filteredTraces = useMemo(() => {
+    const normalizedCategoryOrTag = categoryOrTagFilter.trim().toLowerCase();
+
+    return traces.filter((trace) => {
+      if (taskKindFilter !== 'all' && trace.taskKind !== taskKindFilter) return false;
+      if (modelFilter !== 'all' && trace.modelId !== modelFilter) return false;
+      if (sourceNodeFilter !== 'all' && !trace.sourceNodes.some((node) => node.nodeId === sourceNodeFilter)) {
+        return false;
+      }
+      if (toolOnly && !trace.hasToolActivity) return false;
+      if (!normalizedCategoryOrTag) return true;
+
+      const haystack = [...trace.categories, ...trace.tags].map((value) => value.toLowerCase());
+      return haystack.some((value) => value.includes(normalizedCategoryOrTag));
+    });
+  }, [categoryOrTagFilter, modelFilter, sourceNodeFilter, taskKindFilter, toolOnly, traces]);
+
+  const allSelected = scope === 'local' && filteredTraces.length > 0 && selectedIds.size === filteredTraces.length;
 
   const selectedCountLabel = useMemo(() => {
     const count = selectedIds.size;
@@ -106,6 +191,7 @@ export function TracesPage({ onOpenTrace }: TracesPageProps) {
   }, [selectedIds]);
 
   const toggleSelect = useCallback((taskId: string) => {
+    if (scope !== 'local') return;
     setSelectedIds((previous) => {
       const next = new Set(previous);
       if (next.has(taskId)) {
@@ -115,17 +201,17 @@ export function TracesPage({ onOpenTrace }: TracesPageProps) {
       }
       return next;
     });
-  }, []);
+  }, [scope]);
 
   const toggleSelectAll = useCallback(() => {
-    setSelectedIds(allSelected ? new Set() : new Set(traces.map((trace) => trace.taskId)));
-  }, [allSelected, traces]);
+    setSelectedIds(allSelected ? new Set() : new Set(filteredTraces.map((trace) => trace.taskId)));
+  }, [allSelected, filteredTraces]);
 
   const handleDelete = useCallback(async () => {
-    if (selectedIds.size === 0) return;
+    if (scope !== 'local' || selectedIds.size === 0) return;
     const count = selectedIds.size;
     const confirmed = window.confirm(
-      `Delete ${count} trace${count === 1 ? '' : 's'}? This cannot be undone.`,
+      `Delete ${count} trace${count === 1 ? '' : 's'}? This only removes local trace files on this node.`,
     );
     if (!confirmed) return;
 
@@ -147,17 +233,109 @@ export function TracesPage({ onOpenTrace }: TracesPageProps) {
     } finally {
       setDeleting(false);
     }
-  }, [refresh, selectedIds]);
+  }, [refresh, scope, selectedIds]);
 
   return (
     <Page>
       <Header>
         <div>
           <Title>Traces</Title>
-          <Subtitle>Distributed tracing artifacts for request and runtime analysis.</Subtitle>
+          <Subtitle>Cluster-aware runtime traces for image, text, and embedding requests.</Subtitle>
         </div>
         <HeaderActions>
-          {selectedIds.size > 0 && (
+          <Button variant="outline" size="sm" onClick={() => void refresh()} loading={loading}>
+            Refresh
+          </Button>
+        </HeaderActions>
+      </Header>
+
+      <ControlCard>
+        <ControlRow>
+          <div>
+            <ControlLabel>Cluster Tracing</ControlLabel>
+            <ControlValue $enabled={tracingEnabled}>{tracingEnabled ? 'Enabled' : 'Disabled'}</ControlValue>
+            <ControlHint>Applies to new requests on all nodes.</ControlHint>
+          </div>
+          <ControlActions>
+            <Button
+              variant={tracingEnabled ? 'primary' : 'outline'}
+              size="sm"
+              onClick={() => void toggleTracing(!tracingEnabled)}
+              loading={toggleLoading}
+            >
+              {tracingEnabled ? 'Turn Off' : 'Turn On'}
+            </Button>
+          </ControlActions>
+        </ControlRow>
+        <ScopeRow>
+          <ScopeLabel>Browse</ScopeLabel>
+          <ScopeButtons>
+            <Button variant={scope === 'cluster' ? 'primary' : 'outline'} size="sm" onClick={() => onScopeChange('cluster')}>
+              Cluster
+            </Button>
+            <Button variant={scope === 'local' ? 'primary' : 'outline'} size="sm" onClick={() => onScopeChange('local')}>
+              Local
+            </Button>
+          </ScopeButtons>
+          <ScopeHint>
+            {scope === 'cluster'
+              ? 'Read-only cluster view across reachable nodes.'
+              : 'Local trace files stored on this node. Deletion stays local-only.'}
+          </ScopeHint>
+        </ScopeRow>
+      </ControlCard>
+
+      <FiltersCard>
+        <FilterGrid>
+          <FilterField>
+            <FilterLabel>Task kind</FilterLabel>
+            <FilterSelect value={taskKindFilter} onChange={(event) => setTaskKindFilter(event.target.value)}>
+              <option value="all">All</option>
+              <option value="image">Image</option>
+              <option value="text">Text</option>
+              <option value="embedding">Embedding</option>
+            </FilterSelect>
+          </FilterField>
+
+          <FilterField>
+            <FilterLabel>Model</FilterLabel>
+            <FilterSelect value={modelFilter} onChange={(event) => setModelFilter(event.target.value)}>
+              <option value="all">All</option>
+              {modelOptions.map((modelId) => (
+                <option key={modelId} value={modelId}>
+                  {modelId}
+                </option>
+              ))}
+            </FilterSelect>
+          </FilterField>
+
+          <FilterField>
+            <FilterLabel>Source node</FilterLabel>
+            <FilterSelect value={sourceNodeFilter} onChange={(event) => setSourceNodeFilter(event.target.value)}>
+              <option value="all">All</option>
+              {sourceNodeOptions.map((sourceNode) => (
+                <option key={sourceNode.nodeId} value={sourceNode.nodeId}>
+                  {sourceNode.friendlyName || sourceNode.nodeId}
+                </option>
+              ))}
+            </FilterSelect>
+          </FilterField>
+
+          <FilterField>
+            <FilterLabel>Category / tag</FilterLabel>
+            <FilterInput
+              value={categoryOrTagFilter}
+              onChange={(event) => setCategoryOrTagFilter(event.target.value)}
+              placeholder="prefill, decode, tool_call…"
+            />
+          </FilterField>
+        </FilterGrid>
+
+        <FilterActions>
+          <Button variant={toolOnly ? 'primary' : 'outline'} size="sm" onClick={() => setToolOnly((current) => !current)}>
+            Tool activity only
+          </Button>
+          {scope === 'local' && selectedIds.size > 0 && (
             <>
               <SelectionLabel>{selectedCountLabel}</SelectionLabel>
               <Button variant="danger" size="sm" onClick={() => void handleDelete()} loading={deleting}>
@@ -165,33 +343,41 @@ export function TracesPage({ onOpenTrace }: TracesPageProps) {
               </Button>
             </>
           )}
-          <Button variant="outline" size="sm" onClick={() => void refresh()} loading={loading}>
-            Refresh
-          </Button>
-        </HeaderActions>
-      </Header>
+        </FilterActions>
+      </FiltersCard>
 
       {loading ? (
         <StateBox>Loading traces…</StateBox>
       ) : error ? (
         <ErrorBox>{error}</ErrorBox>
-      ) : traces.length === 0 ? (
+      ) : filteredTraces.length === 0 ? (
         <StateBox>
           <div>No traces found.</div>
-          <StateHint>Run Skulk with `SKULK_TRACING_ENABLED=1` to collect traces.</StateHint>
+          <StateHint>
+            {tracingEnabled
+              ? 'Tracing is enabled. Run a new request and it will appear here.'
+              : 'Tracing is off. Enable it above to start collecting traces for new requests on all nodes.'}
+          </StateHint>
         </StateBox>
       ) : (
         <>
-          <Toolbar>
-            <Button variant="ghost" size="sm" onClick={toggleSelectAll}>
-              {allSelected ? 'Deselect All' : 'Select All'}
-            </Button>
-          </Toolbar>
+          {scope === 'local' && (
+            <Toolbar>
+              <Button variant="ghost" size="sm" onClick={toggleSelectAll}>
+                {allSelected ? 'Deselect All' : 'Select All'}
+              </Button>
+            </Toolbar>
+          )}
           <TraceList>
-            {traces.map((trace) => {
+            {filteredTraces.map((trace) => {
               const selected = selectedIds.has(trace.taskId);
               return (
-                <TraceRow key={trace.taskId} $selected={selected} onClick={() => toggleSelect(trace.taskId)}>
+                <TraceRow
+                  key={trace.taskId}
+                  $interactive={scope === 'local'}
+                  $selected={selected}
+                  onClick={() => toggleSelect(trace.taskId)}
+                >
                   <TraceMain>
                     <TraceNameButton
                       onClick={(event) => {
@@ -204,15 +390,26 @@ export function TracesPage({ onOpenTrace }: TracesPageProps) {
                     <TraceMeta>
                       {formatDate(trace.createdAt)} · {formatBytes(trace.fileSize)}
                     </TraceMeta>
+                    <BadgeRow>
+                      {trace.taskKind && <MetaBadge>{trace.taskKind}</MetaBadge>}
+                      {trace.modelId && <MetaBadge>{trace.modelId}</MetaBadge>}
+                      {trace.hasToolActivity && <MetaBadge>tool_call</MetaBadge>}
+                      {trace.sourceNodes.map((sourceNode) => (
+                        <MetaBadge key={`${trace.taskId}-${sourceNode.nodeId}`}>
+                          {sourceNode.friendlyName || sourceNode.nodeId}
+                        </MetaBadge>
+                      ))}
+                    </BadgeRow>
+                    {trace.tags.length > 0 && <TagLine>{trace.tags.join(' · ')}</TagLine>}
                   </TraceMain>
                   <TraceActions onClick={(event) => event.stopPropagation()}>
                     <Button variant="outline" size="sm" onClick={() => onOpenTrace(trace.taskId)}>
                       View Stats
                     </Button>
-                    <Button variant="outline" size="sm" onClick={() => void downloadTrace(trace.taskId)}>
+                    <Button variant="outline" size="sm" onClick={() => void downloadTrace(scope, trace.taskId)}>
                       Download
                     </Button>
-                    <Button variant="primary" size="sm" onClick={() => void openInPerfetto(trace.taskId)}>
+                    <Button variant="primary" size="sm" onClick={() => void openInPerfetto(scope, trace.taskId)}>
                       Perfetto
                     </Button>
                   </TraceActions>
@@ -258,20 +455,156 @@ const Title = styled.h1`
 const Subtitle = styled.p`
   margin: 6px 0 0;
   font-family: ${({ theme }) => theme.fonts.body};
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const ControlCard = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  border-radius: ${({ theme }) => theme.radii.lg};
+  border: 1px solid ${({ theme }) => theme.colors.goldDim};
+  background: ${({ theme }) => theme.colors.surfaceAlt};
+`;
+
+const ControlRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+`;
+
+const ControlLabel = styled.div`
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const ControlValue = styled.div<{ $enabled: boolean }>`
+  margin-top: 6px;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+  font-weight: 600;
+  color: ${({ $enabled, theme }) => ($enabled ? theme.colors.gold : theme.colors.text)};
+`;
+
+const ControlHint = styled.p`
+  margin: 6px 0 0;
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const ControlActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const ScopeRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+`;
+
+const ScopeLabel = styled.span`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+`;
+
+const ScopeButtons = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const ScopeHint = styled.span`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+`;
+
+const FiltersCard = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border-radius: ${({ theme }) => theme.radii.lg};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.surface};
+`;
+
+const FilterGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+`;
+
+const FilterField = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const FilterLabel = styled.span`
   font-size: ${({ theme }) => theme.fontSizes.sm};
   color: ${({ theme }) => theme.colors.textMuted};
 `;
 
-const SelectionLabel = styled.span`
-  font-family: ${({ theme }) => theme.fonts.body};
-  font-size: ${({ theme }) => theme.fontSizes.sm};
+const FilterSelect = styled.select`
+  border-radius: ${({ theme }) => theme.radii.md};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.surfaceElevated};
+  color: ${({ theme }) => theme.colors.text};
+  padding: 10px 12px;
+`;
+
+const FilterInput = styled.input`
+  border-radius: ${({ theme }) => theme.radii.md};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.surfaceElevated};
+  color: ${({ theme }) => theme.colors.text};
+  padding: 10px 12px;
+`;
+
+const FilterActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const StateBox = styled.div`
+  padding: 24px;
+  border-radius: ${({ theme }) => theme.radii.lg};
+  border: 1px dashed ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.surfaceAlt};
   color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const StateHint = styled.div`
+  margin-top: 8px;
+`;
+
+const ErrorBox = styled(StateBox)`
+  border-style: solid;
+  border-color: ${({ theme }) => theme.colors.error};
+  color: ${({ theme }) => theme.colors.errorText};
 `;
 
 const Toolbar = styled.div`
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  gap: 8px;
+`;
+
+const SelectionLabel = styled.span`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
 `;
 
 const TraceList = styled.div`
@@ -280,7 +613,7 @@ const TraceList = styled.div`
   gap: 12px;
 `;
 
-const TraceRow = styled.div<{ $selected: boolean }>`
+const TraceRow = styled.div<{ $selected: boolean; $interactive: boolean }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -288,42 +621,51 @@ const TraceRow = styled.div<{ $selected: boolean }>`
   padding: 16px;
   border-radius: ${({ theme }) => theme.radii.lg};
   border: 1px solid ${({ $selected, theme }) => ($selected ? theme.colors.goldDim : theme.colors.border)};
-  background: ${({ $selected, theme }) => ($selected ? theme.colors.goldBg : theme.colors.surfaceSunken)};
-  cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease;
-
-  &:hover {
-    border-color: ${({ theme }) => theme.colors.goldDim};
-  }
+  background: ${({ $selected, theme }) => ($selected ? theme.colors.goldBg : theme.colors.surface)};
+  cursor: ${({ $interactive }) => ($interactive ? 'pointer' : 'default')};
+  flex-wrap: wrap;
 `;
 
 const TraceMain = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   min-width: 0;
-  flex: 1;
 `;
 
 const TraceNameButton = styled.button`
   all: unset;
   cursor: pointer;
-  display: block;
-  min-width: 0;
-  color: ${({ theme }) => theme.colors.text};
-  font-family: ${({ theme }) => theme.fonts.mono};
-  font-size: ${({ theme }) => theme.fontSizes.sm};
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-
-  &:hover {
-    color: ${({ theme }) => theme.colors.gold};
-  }
+  color: ${({ theme }) => theme.colors.gold};
+  font-weight: 600;
+  overflow-wrap: anywhere;
 `;
 
 const TraceMeta = styled.div`
-  margin-top: 6px;
-  color: ${({ theme }) => theme.colors.textMuted};
-  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+`;
+
+const BadgeRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+`;
+
+const MetaBadge = styled.span`
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  background: ${({ theme }) => theme.colors.surfaceElevated};
+  color: ${({ theme }) => theme.colors.textSecondary};
   font-size: ${({ theme }) => theme.fontSizes.xs};
+`;
+
+const TagLine = styled.div`
+  color: ${({ theme }) => theme.colors.textMuted};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  overflow-wrap: anywhere;
 `;
 
 const TraceActions = styled.div`
@@ -331,27 +673,4 @@ const TraceActions = styled.div`
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
-  justify-content: flex-end;
-`;
-
-const StateBox = styled.div`
-  padding: 32px 24px;
-  border-radius: ${({ theme }) => theme.radii.lg};
-  border: 1px solid ${({ theme }) => theme.colors.border};
-  background: ${({ theme }) => theme.colors.surfaceSunken};
-  color: ${({ theme }) => theme.colors.textSecondary};
-  font-family: ${({ theme }) => theme.fonts.body};
-  text-align: center;
-`;
-
-const StateHint = styled.div`
-  margin-top: 8px;
-  color: ${({ theme }) => theme.colors.textMuted};
-  font-size: ${({ theme }) => theme.fontSizes.xs};
-`;
-
-const ErrorBox = styled(StateBox)`
-  color: ${({ theme }) => theme.colors.errorText};
-  border-color: ${({ theme }) => theme.colors.errorBg};
-  background: ${({ theme }) => theme.colors.errorBg};
 `;

--- a/dashboard-react/src/components/pages/TracesPage.tsx
+++ b/dashboard-react/src/components/pages/TracesPage.tsx
@@ -183,12 +183,26 @@ export function TracesPage({ scope, onScopeChange, onOpenTrace }: TracesPageProp
     });
   }, [categoryOrTagFilter, modelFilter, sourceNodeFilter, taskKindFilter, toolOnly, traces]);
 
-  const allSelected = scope === 'local' && filteredTraces.length > 0 && selectedIds.size === filteredTraces.length;
+  // Visible-only view of the selection. Without this, ``selectedIds`` can hold
+  // task IDs that the active filters have hidden from view, and the Delete
+  // button would silently target invisible items the operator never reviewed.
+  // Pruning to ``filteredTraces`` keeps the UX honest: the count always
+  // matches what the user sees, and Delete only operates on visible rows.
+  const visibleSelectedIds = useMemo(() => {
+    if (selectedIds.size === 0) return new Set<string>();
+    const visible = new Set<string>();
+    for (const trace of filteredTraces) {
+      if (selectedIds.has(trace.taskId)) visible.add(trace.taskId);
+    }
+    return visible;
+  }, [filteredTraces, selectedIds]);
+
+  const allSelected = scope === 'local' && filteredTraces.length > 0 && visibleSelectedIds.size === filteredTraces.length;
 
   const selectedCountLabel = useMemo(() => {
-    const count = selectedIds.size;
+    const count = visibleSelectedIds.size;
     return count === 1 ? '1 trace selected' : `${count} traces selected`;
-  }, [selectedIds]);
+  }, [visibleSelectedIds]);
 
   const toggleSelect = useCallback((taskId: string) => {
     if (scope !== 'local') return;
@@ -208,8 +222,11 @@ export function TracesPage({ scope, onScopeChange, onOpenTrace }: TracesPageProp
   }, [allSelected, filteredTraces]);
 
   const handleDelete = useCallback(async () => {
-    if (scope !== 'local' || selectedIds.size === 0) return;
-    const count = selectedIds.size;
+    // Operate on the visible-only selection. ``selectedIds`` may still
+    // contain hidden IDs from earlier filter states; deleting those would
+    // remove items the operator never confirmed they wanted gone.
+    if (scope !== 'local' || visibleSelectedIds.size === 0) return;
+    const count = visibleSelectedIds.size;
     const confirmed = window.confirm(
       `Delete ${count} trace${count === 1 ? '' : 's'}? This only removes local trace files on this node.`,
     );
@@ -221,7 +238,7 @@ export function TracesPage({ scope, onScopeChange, onOpenTrace }: TracesPageProp
       const response = await fetch('/v1/traces/delete', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ taskIds: [...selectedIds] }),
+        body: JSON.stringify({ taskIds: [...visibleSelectedIds] }),
       });
       if (!response.ok) {
         throw new Error(`Failed to delete traces (${response.status})`);
@@ -233,7 +250,7 @@ export function TracesPage({ scope, onScopeChange, onOpenTrace }: TracesPageProp
     } finally {
       setDeleting(false);
     }
-  }, [refresh, scope, selectedIds]);
+  }, [refresh, scope, visibleSelectedIds]);
 
   return (
     <Page>
@@ -335,7 +352,7 @@ export function TracesPage({ scope, onScopeChange, onOpenTrace }: TracesPageProp
           <Button variant={toolOnly ? 'primary' : 'outline'} size="sm" onClick={() => setToolOnly((current) => !current)}>
             Tool activity only
           </Button>
-          {scope === 'local' && selectedIds.size > 0 && (
+          {scope === 'local' && visibleSelectedIds.size > 0 && (
             <>
               <SelectionLabel>{selectedCountLabel}</SelectionLabel>
               <Button variant="danger" size="sm" onClick={() => void handleDelete()} loading={deleting}>

--- a/dashboard-react/src/components/topology/ClusterNode.tsx
+++ b/dashboard-react/src/components/topology/ClusterNode.tsx
@@ -22,6 +22,8 @@ export interface ClusterNodeProps {
   allNodes?: Record<string, NodeInfo>;
   /** Called when the user confirms a node restart. */
   onRestart?: () => void;
+  /** Called when the user opens live diagnostics for this node. */
+  onInspect?: () => void;
 }
 
 function buildDebugContent(
@@ -127,6 +129,7 @@ export function ClusterNode({
   edges = [],
   allNodes = {},
   onRestart,
+  onInspect,
 }: ClusterNodeProps) {
   const theme = useTheme() as Theme;
   const model = detectDeviceModel(nodeInfo.system_info?.model_id);
@@ -182,6 +185,7 @@ export function ClusterNode({
         memoryY={iconTop + iconH + memoryOffset}
         debugContent={debugContent}
         onRestart={onRestart}
+        onInspect={onInspect}
       />
 
       {/* Device icon — centered at origin */}

--- a/dashboard-react/src/components/topology/NodeLabel.tsx
+++ b/dashboard-react/src/components/topology/NodeLabel.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useTheme } from 'styled-components';
+import { VscBug } from 'react-icons/vsc';
 import { formatBytes } from '../../utils/format';
 import { InfoTooltip } from '../common/InfoTooltip';
 import type { Theme } from '../../theme';
@@ -20,6 +21,8 @@ export interface NodeLabelProps {
   debugContent?: React.ReactNode;
   /** When set, shows a restart icon before the name. */
   onRestart?: () => void;
+  /** When set, shows a diagnostics inspect icon before the name. */
+  onInspect?: () => void;
   /** Optional status line that replaces the memory summary. */
   statusText?: string;
 }
@@ -34,6 +37,7 @@ export function NodeLabel({
   memoryY = 20,
   debugContent,
   onRestart,
+  onInspect,
   statusText,
 }: NodeLabelProps) {
   const theme = useTheme() as Theme;
@@ -71,7 +75,7 @@ export function NodeLabel({
       {/* Restart icon — positioned left of the name text */}
       {onRestart && (
         <foreignObject
-          x={cx - nameWidth / 2 - 24}
+          x={cx - nameWidth / 2 - (onInspect ? 48 : 24)}
           y={nameY - 10}
           width={20}
           height={20}
@@ -97,6 +101,34 @@ export function NodeLabel({
                 fill={confirming ? theme.colors.warning : theme.colors.textMuted}
               />
             </svg>
+          </InfoTooltip>
+        </foreignObject>
+      )}
+      {onInspect && (
+        <foreignObject
+          x={cx - nameWidth / 2 - 24}
+          y={nameY - 10}
+          width={20}
+          height={20}
+          style={{ overflow: 'visible' }}
+        >
+          <InfoTooltip placement="left" content="Inspect live node diagnostics">
+            <button
+              type="button"
+              aria-label="Inspect live node diagnostics"
+              onClick={onInspect}
+              style={{
+                all: 'unset',
+                cursor: 'pointer',
+                color: theme.colors.textMuted,
+                display: 'flex',
+                opacity: 0.65,
+              }}
+              onMouseEnter={(event) => { event.currentTarget.style.opacity = '1'; }}
+              onMouseLeave={(event) => { event.currentTarget.style.opacity = '0.65'; }}
+            >
+              <VscBug size={15} />
+            </button>
           </InfoTooltip>
         </foreignObject>
       )}

--- a/dashboard-react/src/components/topology/TopologyGraph.tsx
+++ b/dashboard-react/src/components/topology/TopologyGraph.tsx
@@ -6,6 +6,8 @@ import { ClusterNode } from './ClusterNode';
 
 export interface TopologyGraphProps {
   data: TopologyData;
+  /** Called when a node diagnostics inspection is requested. */
+  onInspectNode?: (nodeId: string) => void;
 }
 
 interface NodePosition {
@@ -95,7 +97,7 @@ const Container = styled.div`
 
 /* ---- component ---- */
 
-export function TopologyGraph({ data }: TopologyGraphProps) {
+export function TopologyGraph({ data, onInspectNode }: TopologyGraphProps) {
   const [svgRef, { width, height }] = useResizeObserver<SVGSVGElement>();
 
   const handleRestart = useCallback((nodeId: string) => {
@@ -236,6 +238,7 @@ export function TopologyGraph({ data }: TopologyGraphProps) {
               edges={data.edges}
               allNodes={data.nodes}
               onRestart={() => handleRestart(pos.id)}
+              onInspect={() => onInspectNode?.(pos.id)}
             />
           ))}
         </g>

--- a/dashboard-react/src/types/diagnostics.ts
+++ b/dashboard-react/src/types/diagnostics.ts
@@ -1,0 +1,137 @@
+/** Types for read-only Skulk node diagnostics API responses. */
+
+export interface MemoryValue {
+  /** Memory quantity in raw bytes. */
+  inBytes: number;
+}
+
+export interface DiagnosticsRuntime {
+  nodeId: string;
+  hostname: string;
+  friendlyName?: string | null;
+  isMaster: boolean;
+  masterNodeId?: string | null;
+  cwd: string;
+  configPath: string;
+  configFileExists: boolean;
+  skulkVersion: string;
+  skulkCommit: string;
+  libp2pNamespace?: string | null;
+  pythonUnbuffered: boolean;
+  tracingEnabled: boolean;
+  structuredLoggingConfigured: boolean;
+  loggingIngestUrl?: string | null;
+}
+
+export interface DiagnosticsProcess {
+  pid: number;
+  parentPid?: number | null;
+  role: 'skulk' | 'runner' | 'vector' | 'python' | 'other';
+  command: string;
+  status?: string | null;
+  cpuPercent?: number | null;
+  memoryPercent?: number | null;
+  rss?: MemoryValue | null;
+  elapsedSeconds?: number | null;
+  isChildOfSkulk: boolean;
+}
+
+export interface RunnerTaskDiagnostics {
+  taskId: string;
+  taskKind: string;
+  taskStatus: string;
+  instanceId: string;
+  commandId?: string | null;
+  runnerId?: string | null;
+  modelId?: string | null;
+}
+
+export interface RunnerLifecycleMilestone {
+  at: string;
+  name: string;
+  detail?: string | null;
+}
+
+export interface RunnerSupervisorDiagnostics {
+  runnerId: string;
+  instanceId: string;
+  nodeId: string;
+  modelId: string;
+  deviceRank: number;
+  worldSize: number;
+  startLayer: number;
+  endLayer: number;
+  nLayers: number;
+  pid?: number | null;
+  processAlive: boolean;
+  exitCode?: number | null;
+  statusKind: string;
+  statusSince: string;
+  secondsInStatus: number;
+  pendingTaskIds: string[];
+  inProgressTasks: RunnerTaskDiagnostics[];
+  completedTaskCount: number;
+  cancelledTaskIds: string[];
+  lastTaskSentAt?: string | null;
+  lastEventReceivedAt?: string | null;
+  lastEventType?: string | null;
+  milestones: RunnerLifecycleMilestone[];
+}
+
+export interface PlacementRunnerDiagnostics {
+  runnerId: string;
+  nodeId: string;
+  friendlyName?: string | null;
+  statusKind?: string | null;
+  deviceRank: number;
+  worldSize: number;
+  startLayer: number;
+  endLayer: number;
+  nLayers: number;
+  isLocal: boolean;
+  isMaster: boolean;
+  tasks: RunnerTaskDiagnostics[];
+}
+
+export interface InstancePlacementDiagnostics {
+  instanceId: string;
+  modelId: string;
+  masterNodeId?: string | null;
+  masterIsPlacementNode: boolean;
+  localNodeIsPlacementNode: boolean;
+  placementNodeIds: string[];
+  runners: PlacementRunnerDiagnostics[];
+  warnings: string[];
+}
+
+export interface NodeResourceDiagnostics {
+  gatheredMemory?: {
+    ramTotal: MemoryValue;
+    ramAvailable: MemoryValue;
+    swapTotal: MemoryValue;
+    swapAvailable: MemoryValue;
+  } | null;
+  currentMemory?: {
+    ramTotal: MemoryValue;
+    ramAvailable: MemoryValue;
+    swapTotal: MemoryValue;
+    swapAvailable: MemoryValue;
+  } | null;
+  system?: {
+    gpuUsage?: number;
+    temp?: number;
+    sysPower?: number;
+    pcpuUsage?: number;
+    ecpuUsage?: number;
+  } | null;
+}
+
+export interface NodeDiagnostics {
+  generatedAt: string;
+  runtime: DiagnosticsRuntime;
+  resources: NodeResourceDiagnostics;
+  processes: DiagnosticsProcess[];
+  supervisorRunners: RunnerSupervisorDiagnostics[];
+  placements: InstancePlacementDiagnostics[];
+  warnings: string[];
+}

--- a/dashboard-react/src/types/diagnostics.ts
+++ b/dashboard-react/src/types/diagnostics.ts
@@ -52,6 +52,72 @@ export interface RunnerLifecycleMilestone {
   detail?: string | null;
 }
 
+/** Runner phase names reported by the local flight recorder. */
+export type RunnerPhaseName =
+  | 'created'
+  | 'idle'
+  | 'connect_group'
+  | 'load_model'
+  | 'warmup'
+  | 'task_submission'
+  | 'task_agreement'
+  | 'prompt_build'
+  | 'vision_preprocess'
+  | 'kv_cache_lookup'
+  | 'prefill_barrier'
+  | 'prefill_pipeline'
+  | 'prefill_stream'
+  | 'decode_barrier'
+  | 'decode_wait_first_token'
+  | 'decode_stream'
+  | 'parser'
+  | 'cancel_requested'
+  | 'cancel_observed'
+  | 'completion'
+  | 'error'
+  | 'shutdown_cleanup';
+
+/** Best-effort memory counters reported by MLX/Metal inside a runner process. */
+export interface MlxMemorySnapshot {
+  generatedAt: string;
+  active?: MemoryValue | null;
+  cache?: MemoryValue | null;
+  peak?: MemoryValue | null;
+  wiredLimit?: MemoryValue | null;
+  source: string;
+}
+
+/** JSON-safe value type used for runner diagnostic attributes. */
+export type RunnerDiagnosticValue = string | number | boolean | string[];
+
+/** Stable runner identity attached to every flight-recorder entry. */
+export interface RunnerDiagnosticContext {
+  nodeId: string;
+  runnerId: string;
+  pid?: number | null;
+  instanceId: string;
+  modelId: string;
+  rank: number;
+  worldSize: number;
+  startLayer: number;
+  endLayer: number;
+  nLayers: number;
+}
+
+/** One bounded local-only flight-recorder event emitted by a runner process. */
+export interface RunnerFlightRecorderEntry {
+  at: string;
+  phase: RunnerPhaseName;
+  event: string;
+  detail?: string | null;
+  attrs: Record<string, RunnerDiagnosticValue>;
+  context: RunnerDiagnosticContext;
+  taskId?: string | null;
+  commandId?: string | null;
+  mlxMemory?: MlxMemorySnapshot | null;
+}
+
+/** Live supervisor diagnostics for one local runner process. */
 export interface RunnerSupervisorDiagnostics {
   runnerId: string;
   instanceId: string;
@@ -68,6 +134,15 @@ export interface RunnerSupervisorDiagnostics {
   statusKind: string;
   statusSince: string;
   secondsInStatus: number;
+  phase: RunnerPhaseName;
+  phaseStartedAt: string;
+  secondsInPhase: number;
+  lastProgressAt?: string | null;
+  activeTaskId?: string | null;
+  activeCommandId?: string | null;
+  phaseDetail?: string | null;
+  lastMlxMemory?: MlxMemorySnapshot | null;
+  flightRecorder: RunnerFlightRecorderEntry[];
   pendingTaskIds: string[];
   inProgressTasks: RunnerTaskDiagnostics[];
   completedTaskCount: number;
@@ -133,5 +208,29 @@ export interface NodeDiagnostics {
   processes: DiagnosticsProcess[];
   supervisorRunners: RunnerSupervisorDiagnostics[];
   placements: InstancePlacementDiagnostics[];
+  warnings: string[];
+}
+
+/** Heavyweight process sampling result inside an on-demand capture bundle. */
+export interface DiagnosticProcessSample {
+  name: string;
+  command: string[];
+  ok: boolean;
+  exitCode?: number | null;
+  durationSeconds: number;
+  stdout?: string | null;
+  stderr?: string | null;
+  error?: string | null;
+}
+
+/** On-demand local or proxied diagnostic capture bundle. */
+export interface DiagnosticCaptureResponse {
+  generatedAt: string;
+  nodeId: string;
+  nodeDiagnostics: NodeDiagnostics;
+  runner?: RunnerSupervisorDiagnostics | null;
+  flightRecorder: RunnerFlightRecorderEntry[];
+  mlxMemory?: MlxMemorySnapshot | null;
+  processSamples: DiagnosticProcessSample[];
   warnings: string[];
 }

--- a/dashboard-react/src/types/traces.ts
+++ b/dashboard-react/src/types/traces.ts
@@ -1,8 +1,40 @@
+export type TraceTaskKind = 'image' | 'text' | 'embedding';
+
+export interface TraceSourceNode {
+  nodeId: string;
+  friendlyName?: string | null;
+}
+
 /** Lightweight trace list item returned by the trace index API. */
 export interface TraceListItem {
   taskId: string;
   createdAt: string;
   fileSize: number;
+  modelId?: string | null;
+  taskKind?: TraceTaskKind | null;
+  categories: string[];
+  tags: string[];
+  hasToolActivity: boolean;
+  sourceNodes: TraceSourceNode[];
+}
+
+export interface TraceEventResponse {
+  name: string;
+  startUs: number;
+  durationUs: number;
+  rank: number;
+  category: string;
+  nodeId?: string | null;
+  modelId?: string | null;
+  taskKind?: TraceTaskKind | null;
+  tags: string[];
+  attrs: Record<string, string | number | boolean | string[]>;
+}
+
+export interface TraceResponse {
+  taskId: string;
+  traces: TraceEventResponse[];
+  sourceNodes: TraceSourceNode[];
 }
 
 /** Aggregated stats for one trace category. */
@@ -25,4 +57,13 @@ export interface TraceStatsResponse {
   totalWallTimeUs: number;
   byCategory: Record<string, TraceCategoryStats>;
   byRank: Record<string, TraceRankStats>;
+  sourceNodes: TraceSourceNode[];
+}
+
+export interface TraceListResponse {
+  traces: TraceListItem[];
+}
+
+export interface TracingStateResponse {
+  enabled: boolean;
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -138,11 +138,17 @@ If this fails with `404 No instance found for model ...`, the placement is not r
 - `GET /store/models/{model_id}/optimize/status`
 - `GET /filesystem/browse`
 - `GET /node/identity`
+- `GET /v1/tracing`
+- `PUT /v1/tracing`
 - `GET /v1/traces`
+- `GET /v1/traces/cluster`
 - `POST /v1/traces/delete`
 - `GET /v1/traces/{task_id}`
 - `GET /v1/traces/{task_id}/stats`
 - `GET /v1/traces/{task_id}/raw`
+- `GET /v1/traces/cluster/{task_id}`
+- `GET /v1/traces/cluster/{task_id}/stats`
+- `GET /v1/traces/cluster/{task_id}/raw`
 
 ## OpenAI Chat Completions
 
@@ -777,17 +783,97 @@ Returns stored events from the API-side event log.
 
 ### Traces
 
+- `GET /v1/tracing`
+- `PUT /v1/tracing`
 - `GET /v1/traces`
+- `GET /v1/traces/cluster`
 - `POST /v1/traces/delete`
 - `GET /v1/traces/{task_id}`
 - `GET /v1/traces/{task_id}/stats`
 - `GET /v1/traces/{task_id}/raw`
+- `GET /v1/traces/cluster/{task_id}`
+- `GET /v1/traces/cluster/{task_id}/stats`
+- `GET /v1/traces/cluster/{task_id}/raw`
 
 Use these endpoints when you are debugging generation behavior, cluster execution, or performance.
+
+Behavior notes:
+
+- `GET /v1/tracing` returns whether runtime tracing is currently enabled for new
+  requests across the live cluster session.
+- `PUT /v1/tracing` toggles tracing cluster-wide for new requests only. It does
+  not retroactively trace in-flight work.
+- `GET /v1/traces*` reads local trace artifacts stored on the current node.
+- `GET /v1/traces/cluster*` fans out to reachable peer APIs, deduplicates by
+  `task_id`, and proxies read-only trace access from any reachable node.
+- `POST /v1/traces/delete` remains local-only in v1 even when cluster browsing
+  is enabled.
+
+### Runtime tracing control
+
+**GET** `/v1/tracing`
+
+Returns the current cluster tracing state:
+
+```json
+{"enabled": false}
+```
+
+**PUT** `/v1/tracing`
+
+Enable or disable tracing for new requests across the current cluster session.
+
+Request body:
+
+```json
+{"enabled": true}
+```
+
+Response body:
+
+```json
+{"enabled": true}
+```
+
+Operational notes:
+
+- this is a runtime toggle, not a restart-required config edit
+- it applies to new requests only
+- it does not retroactively trace work already in flight
+- the dashboard traces page uses this same API
+
+### Local trace endpoints
+
+These endpoints operate on trace artifacts stored on the current node:
+
+- `GET /v1/traces` lists local trace artifacts with metadata such as task kind,
+  model, source nodes, and tool-activity tags
+- `GET /v1/traces/{task_id}` returns structured trace events for one task
+- `GET /v1/traces/{task_id}/stats` returns aggregated timing summaries
+- `GET /v1/traces/{task_id}/raw` downloads Chrome-trace-compatible JSON
+- `POST /v1/traces/delete` deletes one or more local trace artifacts
+
+### Cluster trace endpoints
+
+These endpoints let a dashboard or script on any reachable node browse traces
+across the cluster:
+
+- `GET /v1/traces/cluster`
+- `GET /v1/traces/cluster/{task_id}`
+- `GET /v1/traces/cluster/{task_id}/stats`
+- `GET /v1/traces/cluster/{task_id}/raw`
+
+Operational notes:
+
+- cluster browsing is read-only in v1
+- the API fans out to reachable peer APIs and deduplicates traces by `task_id`
+- if some peers are unreachable, cluster results may be partial
+- source node metadata in responses tells you which nodes contributed trace content
 
 ## Helpful Next Docs
 
 - [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md)
+- [Tracing system design](traces-system-design.md)
 - [Model store guide](model-store.md)
 - [Architecture overview](architecture.md)
 - [OpenAPI schema](reference/openapi.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,6 +182,22 @@ The key pieces:
 
 This is opt-in. Without the logging config, skulk behaves identically to before.
 
+## Where Tracing Fits
+
+This branch contains a substantial tracing revamp, but it also preserves a
+baseline design note for the earlier tracing system because those earlier
+durability and locality constraints explain why the new control plane exists.
+
+That preserved tracing design note covers:
+
+- how the earlier image-centric tracing path collected per-rank spans
+- how the master merged traces back into the event stream
+- why trace content could be cross-node even while browsing remained local-file based
+- what operational limitations existed before the runtime cluster toggle and cluster browsing work
+
+Read the preserved [Traces system design](traces-system-design.md) when you need
+that historical or migration context.
+
 ## When to Read More
 
 If you are:

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ If you are getting oriented, start with these pages:
 - [Model store guide](model-store.md) for shared model storage and download workflows
 - [KV cache backends](kv-cache-backends.md) for backend and runtime tuning
 - [Architecture overview](architecture.md) for how the node, cluster, and event model fit together
+- [Tracing system design](traces-system-design.md) for the preserved baseline tracing design that motivated the tracing revamp work
 
 ## Common Jobs
 
@@ -23,6 +24,7 @@ If you are getting oriented, start with these pages:
 - I want the raw machine-readable schema: [OpenAPI schema](reference/openapi.md)
 - I want frontend and TypeScript symbols: [TypeScript API](reference/typedoc/README.md)
 - I want implementation context before I integrate: [Architecture overview](architecture.md)
+- I want to understand tracing internals and the old durability model: [Tracing system design](traces-system-design.md)
 
 ## What Lives Here
 

--- a/docs/model-runtime-notes/gemma4.md
+++ b/docs/model-runtime-notes/gemma4.md
@@ -105,7 +105,8 @@ For a healthy clustered Gemma 4 run, expect to see:
 
 - `using SequentialGenerator (model_family=gemma4)`
 - `Using default KV cache`
-- `Prefill path selected: pipeline_parallel_prefill`
+- `Prefill path selected: stream_generate` for short one-chunk turns, or
+  `Prefill path selected: pipeline_parallel_prefill` for multi-chunk turns
 
 These are useful smell tests before trusting the output.
 
@@ -152,4 +153,3 @@ Still open:
   https://huggingface.co/google/gemma-4-26B-A4B-it
 - Existing user-facing behavior note:
   `website/docs/model-behaviors/gemma4.md`
-

--- a/docs/model-store.md
+++ b/docs/model-store.md
@@ -96,7 +96,7 @@ model_store:
   staging:
     enabled: true
     node_cache_path: ~/.skulk/staging
-    cleanup_on_deactivate: true
+    cleanup_on_deactivate: false
 
   node_overrides:
     mac-studio-1:
@@ -155,7 +155,11 @@ Where a node stages files before loading them.
 
 ### `model_store.staging.cleanup_on_deactivate`
 
-If `true`, staged files are cleaned up when instances are shut down.
+If `true`, staged files are cleaned up when instances are shut down. The
+recommended default is `false`, which keeps the local staging cache warm so
+large models do not need to be copied from the store again on every placement.
+Use `POST /store/purge-staging` when you intentionally want to reclaim disk
+space.
 
 ## Typical Flow
 
@@ -251,9 +255,19 @@ Remember that store registration only tracks artifacts and metadata. Actual
 image understanding still depends on launching the model and sending a
 multimodal request through the chat APIs.
 
+### Placements are slow even though the model is already in the store
+
+Check whether `cleanup_on_deactivate` is enabled. If it is `true`, each model
+deactivation removes the local staged copy, so the next placement must copy the
+model from the store host again before MLX can load it. Set it to `false` for
+normal clusters and purge staging caches explicitly when disk pressure requires
+it.
+
 ### Staged files are not being cleaned up
 
-Check `cleanup_on_deactivate` and any `node_overrides` that may disable cleanup for a specific machine.
+This is usually expected. Skulk keeps staged files by default so repeated
+placements are warm. If you need disk space back, either enable
+`cleanup_on_deactivate` for that node or use the model-store purge action.
 
 ## Good Defaults for Most Clusters
 

--- a/docs/traces-system-design.md
+++ b/docs/traces-system-design.md
@@ -1,0 +1,477 @@
+<!-- Copyright 2025 Foxlight Foundation -->
+
+# Skulk Traces System Design
+
+This document explains how the existing tracing system worked before the
+cluster-wide tracing revamp on `feature/tracing-revamp`.
+
+It is intentionally preserved as a baseline design reference. If behavior here
+conflicts with the new tracing control plane and API surface on this branch,
+trust the code on this branch first and use this document for historical and
+migration context.
+
+## Executive Summary
+
+Skulk tracing is a distributed execution trace path for image-generation
+workloads.
+
+The short answer to the most important question is:
+
+- trace content can be cross-rank and cross-node for a distributed image task
+- trace files are still stored as local JSON artifacts on each node's API cache
+- those local files are not authoritative cluster state
+- trace availability across nodes is best-effort via event broadcast and replay,
+  not guaranteed durable cluster-wide storage
+
+In practice:
+
+1. worker ranks record spans locally in memory during image pipeline execution
+2. each participating rank emits a `TracesCollected` event when the task ends
+3. the master waits for all expected ranks, merges their trace events, and
+   emits one `TracesMerged` event
+4. every API process that receives that merged event writes a local Chrome trace
+   JSON file under its own trace cache directory
+5. the dashboard on a given node reads only that node's local API trace cache
+
+So the system is not "current-node only" in content, and it is not a
+fully durable cluster-global trace store either. It is in between:
+distributed collection plus local artifact persistence.
+
+## Scope
+
+Today this tracing system is primarily wired into the distributed image pipeline.
+
+Relevant code paths:
+
+- `src/exo/shared/tracing.py`
+- `src/exo/worker/engines/image/pipeline/runner.py`
+- `src/exo/worker/runner/image_models/runner.py`
+- `src/exo/master/main.py`
+- `src/exo/api/main.py`
+- `dashboard-react/src/components/pages/TracesPage.tsx`
+- `dashboard-react/src/components/pages/TraceDetailPage.tsx`
+
+Important non-scope:
+
+- it is not currently a general-purpose trace system for all task families
+- it is not part of replicated `State`
+- it is not snapshot-backed cluster metadata
+- it is not a centralized long-term trace store
+
+## Enablement and Storage
+
+Tracing is controlled by:
+
+- `SKULK_TRACING_ENABLED`
+- legacy alias `EXO_TRACING_ENABLED`
+
+These resolve through `src/exo/shared/constants.py` and default to `false`.
+
+Local trace files are written to:
+
+- `SKULK_TRACING_CACHE_DIR = SKULK_CACHE_HOME / "traces"`
+- legacy alias `EXO_TRACING_CACHE_DIR`
+
+Each saved artifact is named:
+
+- `trace_{task_id}.json`
+
+The on-disk file format is Chrome trace JSON, which means it can be opened in
+Perfetto or other Chrome-trace-compatible tooling.
+
+## Main Components
+
+### 1. Worker trace recorder
+
+`src/exo/shared/tracing.py` provides the trace data model and in-process buffer:
+
+- `TraceEvent`
+- `trace(...)` context manager
+- `get_trace_buffer()`
+- `clear_trace_buffer()`
+- `export_trace(...)`
+- `load_trace_file(...)`
+- `compute_stats(...)`
+
+The recorder is process-local and in-memory. There is no shared buffer across
+nodes or across processes.
+
+### 2. Image pipeline instrumentation
+
+`src/exo/worker/engines/image/pipeline/runner.py` is where the actual trace
+spans are recorded today.
+
+It wraps major parts of the diffusion/pipeline execution in nested
+`trace(...)` scopes, including categories such as:
+
+- `sync`
+- `async`
+- nested compute and communication work within those phases
+
+Nested trace scopes inherit parent categories, so the saved categories become
+hierarchical values like:
+
+- `sync/compute`
+- `async/comm`
+
+The image pipeline explicitly clears the process trace buffer at the start of a
+diffusion run so traces do not leak across image requests.
+
+### 3. Image runner event emission
+
+`src/exo/worker/runner/image_models/runner.py` is responsible for turning the
+local buffer into cluster events.
+
+When tracing is enabled and the task completes or errors, the runner calls
+`_send_traces_if_enabled(...)`, which:
+
+1. reads the current in-memory buffer
+2. converts each `TraceEvent` into `TraceEventData`
+3. emits `TracesCollected(task_id, rank, traces)`
+4. clears the local buffer
+
+This currently happens on image generation and image edit task paths.
+
+### 4. Master merge coordinator
+
+`src/exo/master/main.py` handles distributed trace assembly.
+
+For `ImageGeneration` and `ImageEdits` commands, if tracing is enabled, the
+master records the set of expected device ranks for the selected instance in
+`self._expected_ranks[task_id]`.
+
+Later, in `_event_processor(...)`:
+
+- `TracesCollected` is intercepted and handled specially
+- it is not indexed directly into the main event log
+- instead, `_handle_traces_collected(...)` stores the per-rank payload in
+  `self._pending_traces[task_id][rank]`
+
+Once all expected ranks have reported, `_merge_and_save_traces(...)`:
+
+1. concatenates all collected trace arrays
+2. emits one `TracesMerged(task_id, traces)` event
+3. clears the pending merge buffers for that task
+
+### 5. API persistence and serving
+
+`src/exo/api/main.py` listens to indexed events from the event router.
+
+When it sees a `TracesMerged` event, it calls `_save_merged_trace(...)`, which:
+
+1. maps `TraceEventData` back into `TraceEvent`
+2. writes `trace_{task_id}.json` to the local trace cache directory
+
+The same API process exposes the trace endpoints:
+
+- `GET /v1/traces`
+- `GET /v1/traces/{task_id}`
+- `GET /v1/traces/{task_id}/stats`
+- `GET /v1/traces/{task_id}/raw`
+- `POST /v1/traces/delete`
+
+These endpoints only operate on files in the local node's trace cache
+directory.
+
+### 6. Dashboard UI
+
+The React dashboard reads traces entirely through the local API:
+
+- `dashboard-react/src/components/pages/TracesPage.tsx`
+- `dashboard-react/src/components/pages/TraceDetailPage.tsx`
+
+The UI supports:
+
+- listing local trace artifacts
+- deleting local trace artifacts
+- downloading raw Chrome trace JSON
+- opening a trace in Perfetto
+- viewing computed summary stats by category and by rank
+
+## End-to-End Flow
+
+```mermaid
+sequenceDiagram
+    participant ImageRank as Worker rank on node A/B/...
+    participant ImageRunner as Image runner
+    participant Master as Master
+    participant EventBus as Global indexed events
+    participant API as API on each node
+    participant UI as Dashboard on current node
+
+    ImageRank->>ImageRank: Record spans with trace(...)
+    ImageRunner->>ImageRunner: Read local trace buffer
+    ImageRunner->>Master: TracesCollected(task_id, rank, traces)
+    Master->>Master: Wait for all expected ranks
+    Master->>Master: Merge all rank trace arrays
+    Master->>EventBus: TracesMerged(task_id, traces)
+    EventBus->>API: Deliver indexed TracesMerged
+    API->>API: Save trace_{task_id}.json locally
+    UI->>API: GET /v1/traces or /v1/traces/{task_id}/stats
+    API->>UI: Return local trace file data or stats
+```
+
+## Cross-Node Semantics
+
+This is the part that tends to be confusing, so it is worth stating precisely.
+
+### What is cross-node
+
+For a distributed image task, the merged trace can include spans from ranks
+that ran on different nodes.
+
+Why:
+
+- the master determines the expected ranks from the selected instance's shard
+  assignments
+- each rank sends its own `TracesCollected`
+- the master merges all contributing rank traces into one `TracesMerged`
+
+That means the merged trace payload is cluster-aware and can represent work
+performed on multiple machines.
+
+### What is local-only
+
+The trace browser endpoints operate on local files:
+
+- the dashboard on node X calls the API on node X
+- that API lists files under node X's local trace cache directory
+- no `/v1/traces` call fans out across the cluster
+
+So the UI is local-file based, not a federated cluster query.
+
+### Why traces still often appear on multiple nodes
+
+`TracesMerged` is emitted into the regular indexed event stream, and each node's
+API subscribes to that event stream through the event router.
+
+As a result, every API process that is running and receives the merged event can
+save its own local copy of the same trace file.
+
+This creates a best-effort replication effect:
+
+- not cluster state replication
+- not durable object storage
+- not a single authoritative trace database
+- but often multiple local copies across nodes
+
+### Why this is not fully durable cluster-wide storage
+
+Trace artifacts are not part of `State`, and snapshots do not contain trace
+payloads.
+
+That matters because:
+
+- `TracesMerged` is a pass-through event in `apply(...)`
+- replay availability depends on the retained master event-log tail
+- if a node misses the merged event and it later falls out of replay retention,
+  that node cannot reconstruct the old trace from cluster state alone
+
+So cross-node trace visibility is:
+
+- stronger than current-node-only tracing
+- weaker than authoritative replicated storage
+
+## Event and Data Model
+
+### In-memory trace event
+
+`src/exo/shared/tracing.py`
+
+- `TraceEvent(name, start_us, duration_us, rank, category)`
+
+Fields:
+
+- `name`: operation name
+- `start_us`: wall-clock timestamp in microseconds
+- `duration_us`: span duration in microseconds
+- `rank`: device rank
+- `category`: hierarchical grouping label
+
+### Wire format events
+
+`src/exo/shared/types/events.py`
+
+- `TraceEventData`
+- `TracesCollected(task_id, rank, traces)`
+- `TracesMerged(task_id, traces)`
+
+`TracesCollected` is the worker-to-master aggregation signal.
+
+`TracesMerged` is the master-to-cluster publication event.
+
+### Persisted file format
+
+`export_trace(...)` writes Chrome trace JSON with:
+
+- `"ph": "X"` complete-event spans
+- `"pid": 0`
+- `"tid": rank`
+- metadata rows naming each rank thread as `"Rank {rank}"`
+
+This is why Perfetto can display each rank as a separate execution lane.
+
+### Stats format
+
+`compute_stats(...)` derives:
+
+- total wall time from the earliest start to the latest end
+- aggregate totals by category
+- aggregate totals by rank and category
+
+The API exposes that through `TraceStatsResponse`.
+
+## Detailed Lifecycle
+
+### 1. Task starts
+
+An image task is placed onto an instance. If tracing is enabled, the master
+records the ranks expected to participate.
+
+### 2. Worker executes pipeline
+
+The image pipeline clears any old local trace buffer and starts recording nested
+spans as the diffusion loop proceeds.
+
+### 3. Worker finishes or errors
+
+The image runner sends `TracesCollected` in a `finally` block, which means
+collection happens even on error paths as long as the runner reaches that block.
+
+### 4. Master waits for all ranks
+
+The master accumulates per-rank trace payloads until it has received all
+expected ranks for that task.
+
+### 5. Master publishes merged trace
+
+Once complete, the master emits one merged trace event into the indexed global
+event stream.
+
+### 6. APIs persist local artifacts
+
+Each API instance that receives the merged event writes a local trace JSON file.
+
+### 7. Dashboard inspects trace
+
+The current node's dashboard lists whatever trace files exist in its own API
+cache and can open them directly in Perfetto.
+
+## What Traces Cover Today
+
+The current code strongly indicates that this trace system is focused on the
+image pipeline, not on all inference paths.
+
+Evidence:
+
+- the actual `trace(...)` instrumentation lives in
+  `src/exo/worker/engines/image/pipeline/runner.py`
+- the worker trace-export hook is in
+  `src/exo/worker/runner/image_models/runner.py`
+- the master only precomputes expected tracing ranks for `ImageGeneration` and
+  `ImageEdits`
+
+What this means operationally:
+
+- distributed image requests can produce merged traces
+- text-generation requests do not currently use this same trace pipeline
+- the traces page is therefore more specialized than its name may suggest
+
+## Relationship to State and Replay
+
+Tracing uses the event system, but trace data is not part of the authoritative
+cluster state model.
+
+Specifically:
+
+- `TracesCollected` and `TracesMerged` are pass-through events in
+  `src/exo/shared/apply.py`
+- they advance `last_event_applied_idx`
+- they do not modify `State`
+
+Implications:
+
+- traces ride along the same ordered event transport as stateful events
+- traces can be rebroadcast and replayed while still retained in the master log
+- traces are not included in the state snapshot payload itself
+
+This is why replay can help a node recover recent traces, but snapshots alone
+cannot recreate them.
+
+## Operational Limitations
+
+### Local-file lifecycle
+
+Deleting a trace through `/v1/traces/delete` removes only the local file on the
+node whose API handled the request.
+
+### Best-effort replication
+
+Because trace files are written from merged events received by local APIs,
+cluster-wide availability depends on:
+
+- the API process being present and subscribed
+- the merged event still being replayable if the node was behind
+- the local trace file not having been deleted
+
+### Rank-based identity
+
+The persisted trace format groups by rank, not by node ID.
+
+That is fine for pipeline debugging, but it means the trace viewer does not
+directly label which node hosted each rank.
+
+### Task-family coverage
+
+The current implementation is not a universal tracing facility for all model
+families or all control-plane operations.
+
+### Test coverage gap
+
+There does not appear to be dedicated focused test coverage for:
+
+- master trace merge behavior
+- API trace-file persistence behavior
+- trace replay and cross-node availability semantics
+
+That makes this system more reliant on careful manual verification than ideal.
+
+## Practical Interpretation
+
+If you are asking "is traces cross-node or only the current node?", the most
+accurate answer is:
+
+- the trace data for distributed image workloads is cross-node in content
+- the browsing and storage model is local-file based per API node
+- merged traces are commonly replicated to multiple nodes through the event
+  stream, but that replication is best-effort rather than authoritative
+
+If you need guaranteed cluster-wide retention and queryability, the current
+trace system is not that. It is better thought of as:
+
+- distributed trace capture
+- master-side merge
+- local artifact fan-out
+
+## Suggested Verification Checklist
+
+To verify the current behavior on a live cluster:
+
+1. start multiple nodes with `SKULK_TRACING_ENABLED=1`
+2. run a distributed image generation workload that spans multiple ranks
+3. confirm the master receives `TracesCollected` from every expected rank
+4. confirm a `TracesMerged` event is emitted
+5. on more than one node, call `GET /v1/traces`
+6. confirm `GET /v1/traces/{task_id}/stats` shows multiple ranks
+7. open the raw file in Perfetto and verify multiple rank lanes are present
+
+To test the durability boundary:
+
+1. generate a traced image task
+2. stop one node's API or keep that node offline during the merge
+3. allow the master event log to compact past that trace event
+4. bring the node back and request replay
+5. confirm whether the node can or cannot reconstruct that older trace
+
+That second test demonstrates the difference between event-fan-out replication
+and authoritative state-backed storage.

--- a/exo.yaml.example
+++ b/exo.yaml.example
@@ -40,7 +40,9 @@ model_store:
     # Staging is where a node prepares model files before MLX loads them.
     enabled: true
     node_cache_path: ~/.exo/staging
-    cleanup_on_deactivate: true
+    # Keep staged model files by default so repeated placements can reuse the
+    # local cache. Use /store/purge-staging when disk needs to be reclaimed.
+    cleanup_on_deactivate: false
 
   node_overrides:
     # Store-host example: load directly from the store path instead of
@@ -54,7 +56,7 @@ model_store:
     # mac-mini-2:
     #   staging:
     #     node_cache_path: /Volumes/FastNVMe/exo-staging
-    #     cleanup_on_deactivate: true
+    #     cleanup_on_deactivate: false
 
 inference:
   # Valid values:

--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
@@ -25,6 +25,12 @@ tool_call_format = "gemma4"
 [runtime]
 prompt_renderer = "gemma4"
 output_parser = "gemma4"
+# MLX_METAL_FAST_SYNCH wedges the GPU command queue on this model under the
+# ring backend with multimodal load: the runner thread enters TH_UNINT in
+# the AGX driver at pipeline_last_eval_output, transitively starves
+# WindowServer, and trips the macOS userspace watchdog into a kernel panic.
+# Reproduced 2026-04 on M4 (Mac16,10) with multinode pipeline-parallel.
+metal_fast_synch = false
 
 [vision]
 image_token_id = 258880

--- a/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
@@ -24,6 +24,11 @@ tool_call_format = "gemma4"
 [runtime]
 prompt_renderer = "gemma4"
 output_parser = "gemma4"
+# Same FAST_SYNCH wedge as the 26b card — GPU command queue stalls in the
+# pipeline-parallel inference path, kernel watchdog panics the box. Disable
+# until the upstream MLX issue is fixed or a cheap inference-side fence
+# (mx.synchronize between eval and distributed.send) is validated.
+metal_fast_synch = false
 
 [vision]
 image_token_id = 258880

--- a/skulk.yaml.example
+++ b/skulk.yaml.example
@@ -40,7 +40,9 @@ model_store:
     # Staging is where a node prepares model files before MLX loads them.
     enabled: true
     node_cache_path: ~/.skulk/staging
-    cleanup_on_deactivate: true
+    # Keep staged model files by default so repeated placements can reuse the
+    # local cache. Use /store/purge-staging when disk needs to be reclaimed.
+    cleanup_on_deactivate: false
 
   node_overrides:
     # Store-host example: load directly from the store path instead of
@@ -54,7 +56,7 @@ model_store:
     # mac-mini-2:
     #   staging:
     #     node_cache_path: /Volumes/FastNVMe/exo-staging
-    #     cleanup_on_deactivate: true
+    #     cleanup_on_deactivate: false
 
 inference:
   # Valid values:

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -6,7 +6,7 @@ import os
 import random
 import socket
 import time
-from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable, Sequence
 from datetime import datetime, timezone
 from http import HTTPStatus
 from pathlib import Path
@@ -16,6 +16,7 @@ from uuid import uuid4
 import anyio
 import httpx
 import hypercorn.asyncio as hypercorn_asyncio
+import psutil
 import yaml
 from anyio import BrokenResourceError
 from fastapi import FastAPI, File, Form, HTTPException, Query, Request, UploadFile
@@ -26,6 +27,7 @@ from hypercorn.config import Config
 from hypercorn.typing import ASGIFramework
 from loguru import logger
 
+import exo.shared.types.tasks as task_types
 from exo.api.adapters.chat_completions import (
     chat_request_to_text_generation,
     collect_chat_response,
@@ -195,6 +197,19 @@ from exo.shared.types.commands import (
     TextGeneration,
 )
 from exo.shared.types.common import CommandId, Id, NodeId, SystemId
+from exo.shared.types.diagnostics import (
+    ClusterDiagnostics,
+    ClusterNodeDiagnostics,
+    DiagnosticsProcess,
+    InstancePlacementDiagnostics,
+    NodeDiagnostics,
+    NodeResourceDiagnostics,
+    NodeRuntimeDiagnostics,
+    PlacementRunnerDiagnostics,
+    ProcessRole,
+    RunnerSupervisorDiagnostics,
+    RunnerTaskDiagnostics,
+)
 from exo.shared.types.events import (
     ChunkGenerated,
     Event,
@@ -203,6 +218,7 @@ from exo.shared.types.events import (
     TracesMerged,
 )
 from exo.shared.types.memory import Memory
+from exo.shared.types.profiling import MemoryUsage
 from exo.shared.types.state import State
 from exo.shared.types.text_generation import TextGenerationTaskParams
 from exo.shared.types.worker.downloads import DownloadCompleted
@@ -280,6 +296,10 @@ API_TAGS_METADATA = [
     {
         "name": "State & Tracing",
         "description": "Cluster state, event log access, trace inspection/export, and onboarding helpers.",
+    },
+    {
+        "name": "Diagnostics",
+        "description": "Read-only local and cluster diagnostics for stuck runner, placement, resource, and process inspection.",
     },
     {
         "name": "Images",
@@ -416,12 +436,16 @@ class API:
         self.event_receiver = event_receiver
         self.election_receiver = election_receiver
         self.node_id: NodeId = node_id
+        self._master_node_id: NodeId = node_id
         self.last_completed_election: int = 0
         self.port = port
         self._exo_config = exo_config
         self._store_client = store_client
         self._config_path = resolve_config_path()
         self._model_optimizer: "ModelOptimizer | None" = None
+        self._runner_diagnostics_provider: Callable[
+            [], Sequence[RunnerSupervisorDiagnostics]
+        ] | None = None
         # Initialize optimizer if store path is available
         if exo_config and exo_config.model_store and exo_config.model_store.enabled:
             from exo.store.model_optimizer import ModelOptimizer
@@ -470,7 +494,20 @@ class API:
         self._image_store = ImageStore(EXO_IMAGE_CACHE_DIR)
         self._tg: TaskGroup = TaskGroup()
 
-    def reset(self, result_clock: int, event_receiver: Receiver[IndexedEvent]):
+    def set_runner_diagnostics_provider(
+        self,
+        provider: Callable[[], Sequence[RunnerSupervisorDiagnostics]] | None,
+    ) -> None:
+        """Attach a local worker diagnostics provider to this API instance."""
+
+        self._runner_diagnostics_provider = provider
+
+    def reset(
+        self,
+        result_clock: int,
+        event_receiver: Receiver[IndexedEvent],
+        master_node_id: NodeId,
+    ):
         logger.info("Resetting API State")
         if self._event_log is not None:
             self._event_log.close()
@@ -480,14 +517,16 @@ class API:
         self._text_generation_queues = {}
         self._image_generation_queues = {}
         self._embedding_queues = {}
-        self.unpause(result_clock)
+        self.unpause(result_clock, master_node_id=master_node_id)
         self.event_receiver.close()
         self.event_receiver = event_receiver
         self._tg.start_soon(self._apply_state)
 
-    def unpause(self, result_clock: int):
+    def unpause(self, result_clock: int, master_node_id: NodeId | None = None):
         logger.info("Unpausing API")
         self.last_completed_election = result_clock
+        if master_node_id is not None:
+            self._master_node_id = master_node_id
         self.paused = False
         self.paused_ev.set()
         self.paused_ev = anyio.Event()
@@ -838,6 +877,35 @@ class API:
             description="Download a raw Chrome trace artifact from local storage or a reachable peer node.",
             response_model=None,
         )(self.get_cluster_trace_raw)
+        self.app.get(
+            "/v1/diagnostics/node",
+            tags=["Diagnostics"],
+            summary="Get local node diagnostics",
+            description=(
+                "Return a read-only diagnostic bundle for this API node, including "
+                "runtime identity, placement analysis, live runner-supervisor "
+                "state, local resources, and relevant OS processes."
+            ),
+        )(self.get_node_diagnostics)
+        self.app.get(
+            "/v1/diagnostics/cluster",
+            tags=["Diagnostics"],
+            summary="Get cluster diagnostics",
+            description=(
+                "Fan out to reachable peer APIs and return read-only diagnostic "
+                "bundles for the local node and peers. Unreachable peers are "
+                "reported as partial failures instead of failing the whole request."
+            ),
+        )(self.get_cluster_diagnostics)
+        self.app.get(
+            "/v1/diagnostics/cluster/{node_id}",
+            tags=["Diagnostics"],
+            summary="Get one cluster node diagnostic bundle",
+            description=(
+                "Return diagnostics for the requested node from local state or by "
+                "proxying to a reachable peer API."
+            ),
+        )(self.get_cluster_node_diagnostics)
         self.app.get(
             "/v1/traces/{task_id}",
             tags=["State & Tracing"],
@@ -2787,7 +2855,9 @@ class API:
             }
         )
 
-    async def _reachable_peer_trace_urls(self) -> list[str]:
+    async def _reachable_peer_api_urls(self) -> dict[str, str]:
+        """Return reachable peer API base URLs keyed by node ID."""
+
         reachable_by_node: dict[str, str] = {}
         async for ip_address, node_id in check_reachable(
             self.state.topology,
@@ -2799,7 +2869,455 @@ class API:
                 continue
             host = f"[{ip_address}]" if ":" in ip_address else ip_address
             reachable_by_node[normalized_node_id] = f"http://{host}:52415"
-        return list(reachable_by_node.values())
+        return reachable_by_node
+
+    async def _reachable_peer_trace_urls(self) -> list[str]:
+        """Return reachable peer API base URLs for trace proxying."""
+
+        return list((await self._reachable_peer_api_urls()).values())
+
+    @staticmethod
+    def _status_kind(status: object | None) -> str | None:
+        """Return the concrete status model name for diagnostics."""
+
+        if status is None:
+            return None
+        return status.__class__.__name__
+
+    def _friendly_name_for_node(self, node_id: NodeId) -> str | None:
+        """Return a known friendly node name for diagnostics."""
+
+        identity = self.state.node_identities.get(node_id)
+        if identity is None:
+            return None
+        if identity.friendly_name and identity.friendly_name != "Unknown":
+            return identity.friendly_name
+        return None
+
+    @staticmethod
+    def _task_kind(task: task_types.Task) -> str:
+        """Return a stable task kind name from a tagged task model."""
+
+        return task.__class__.__name__
+
+    @staticmethod
+    def _task_command_id(task: task_types.Task) -> str | None:
+        """Return a user command ID for task types that carry one."""
+
+        if isinstance(
+            task,
+            (
+                task_types.TextGeneration,
+                task_types.ImageGeneration,
+                task_types.ImageEdits,
+                task_types.TextEmbedding,
+            ),
+        ):
+            return str(task.command_id)
+        return None
+
+    @staticmethod
+    def _task_model_id(task: task_types.Task, default_model_id: str | None) -> str | None:
+        """Return the model associated with a task when available."""
+
+        if isinstance(
+            task,
+            (
+                task_types.TextGeneration,
+                task_types.ImageGeneration,
+                task_types.ImageEdits,
+                task_types.TextEmbedding,
+            ),
+        ):
+            return str(task.task_params.model)
+        if isinstance(task, task_types.DownloadModel):
+            return str(task.shard_metadata.model_card.model_id)
+        if isinstance(task, task_types.CreateRunner):
+            return str(task.bound_instance.bound_shard.model_card.model_id)
+        return default_model_id
+
+    def _task_diagnostics(
+        self,
+        task: task_types.Task,
+        *,
+        runner_id: str | None,
+        default_model_id: str | None,
+    ) -> RunnerTaskDiagnostics:
+        """Build a compact event-sourced task diagnostics record."""
+
+        return RunnerTaskDiagnostics(
+            task_id=str(task.task_id),
+            task_kind=self._task_kind(task),
+            task_status=str(task.task_status.value),
+            instance_id=str(task.instance_id),
+            command_id=self._task_command_id(task),
+            runner_id=runner_id,
+            model_id=self._task_model_id(task, default_model_id),
+        )
+
+    def _placement_diagnostics(self) -> list[InstancePlacementDiagnostics]:
+        """Build placement diagnostics from event-sourced state."""
+
+        master_node_id = self._master_node_id
+        placements: list[InstancePlacementDiagnostics] = []
+
+        for instance_id, instance in self.state.instances.items():
+            shard_assignments = instance.shard_assignments
+            placement_node_ids = list(shard_assignments.node_to_runner.keys())
+            placement_node_id_strings = [str(node_id) for node_id in placement_node_ids]
+            master_is_placement_node = master_node_id in shard_assignments.node_to_runner
+            local_node_is_placement_node = self.node_id in shard_assignments.node_to_runner
+            warnings: list[str] = []
+
+            if not master_is_placement_node:
+                warnings.append(
+                    "Current master is not a placement node for this instance."
+                )
+
+            runners: list[PlacementRunnerDiagnostics] = []
+            for node_id, runner_id in shard_assignments.node_to_runner.items():
+                shard = shard_assignments.runner_to_shard[runner_id]
+                status = self.state.runners.get(runner_id)
+                task_records = [
+                    self._task_diagnostics(
+                        task,
+                        runner_id=str(runner_id),
+                        default_model_id=str(shard_assignments.model_id),
+                    )
+                    for task in self.state.tasks.values()
+                    if task.instance_id == instance_id
+                ]
+                if (
+                    status is not None
+                    and status.__class__.__name__ == "RunnerWarmingUp"
+                    and not master_is_placement_node
+                ):
+                    warnings.append(
+                        f"Runner {runner_id} is warming up while master is outside the placement."
+                    )
+                runners.append(
+                    PlacementRunnerDiagnostics(
+                        runner_id=str(runner_id),
+                        node_id=str(node_id),
+                        friendly_name=self._friendly_name_for_node(node_id),
+                        status_kind=self._status_kind(status),
+                        device_rank=shard.device_rank,
+                        world_size=shard.world_size,
+                        start_layer=shard.start_layer,
+                        end_layer=shard.end_layer,
+                        n_layers=shard.n_layers,
+                        is_local=node_id == self.node_id,
+                        is_master=node_id == master_node_id,
+                        tasks=task_records,
+                    )
+                )
+
+            placements.append(
+                InstancePlacementDiagnostics(
+                    instance_id=str(instance_id),
+                    model_id=str(shard_assignments.model_id),
+                    master_node_id=str(master_node_id),
+                    master_is_placement_node=master_is_placement_node,
+                    local_node_is_placement_node=local_node_is_placement_node,
+                    placement_node_ids=placement_node_id_strings,
+                    runners=sorted(runners, key=lambda runner: runner.device_rank),
+                    warnings=sorted(set(warnings)),
+                )
+            )
+
+        return placements
+
+    def _collect_runner_supervisor_diagnostics(
+        self,
+    ) -> list[RunnerSupervisorDiagnostics]:
+        """Collect live runner-supervisor diagnostics if the worker provided them."""
+
+        if self._runner_diagnostics_provider is None:
+            return []
+        try:
+            return list(self._runner_diagnostics_provider())
+        except Exception as exc:
+            logger.opt(exception=exc).warning(
+                "Failed to collect runner supervisor diagnostics"
+            )
+            return []
+
+    @staticmethod
+    def _process_role(
+        process: psutil.Process,
+        command: str,
+        *,
+        current_pid: int,
+        runner_pids: set[int],
+    ) -> ProcessRole:
+        """Infer a Skulk-specific role for a process."""
+
+        executable = ""
+        with contextlib.suppress(psutil.Error, OSError):
+            cmdline = process.cmdline()
+            if cmdline:
+                executable = Path(cmdline[0]).name.lower()
+
+        command_lower = command.lower()
+        if process.pid == current_pid:
+            return "skulk"
+        if process.pid in runner_pids:
+            return "runner"
+        if executable == "vector" or " vector --config " in f" {command_lower} ":
+            return "vector"
+        if "resource_tracker" in command_lower:
+            return "python"
+        if "skulk" in command_lower:
+            return "skulk"
+        if "spawn_main" in command_lower:
+            return "runner"
+        if "python" in executable:
+            return "python"
+        return "other"
+
+    @staticmethod
+    def _process_command(process: psutil.Process) -> str:
+        """Return a safe joined process command line."""
+
+        try:
+            command = process.cmdline()
+        except (psutil.Error, OSError):
+            return ""
+        return " ".join(command)
+
+    def _process_diagnostics(
+        self,
+        process: psutil.Process,
+        *,
+        child_pids: set[int],
+        runner_pids: set[int],
+    ) -> DiagnosticsProcess | None:
+        """Build diagnostics for one OS process, skipping vanished processes."""
+
+        try:
+            command = self._process_command(process)
+            rss = None
+            with contextlib.suppress(psutil.Error, OSError):
+                rss = Memory.from_bytes(process.memory_info().rss)
+            elapsed_seconds = None
+            with contextlib.suppress(psutil.Error, OSError):
+                elapsed_seconds = max(0.0, time.time() - process.create_time())
+            status = None
+            with contextlib.suppress(psutil.Error, OSError):
+                status = process.status()
+            cpu_percent = None
+            with contextlib.suppress(psutil.Error, OSError):
+                cpu_percent = process.cpu_percent(interval=None)
+            memory_percent = None
+            with contextlib.suppress(psutil.Error, OSError):
+                memory_percent = process.memory_percent()
+            parent_pid = None
+            with contextlib.suppress(psutil.Error, OSError):
+                parent_pid = process.ppid()
+
+            return DiagnosticsProcess(
+                pid=process.pid,
+                parent_pid=parent_pid,
+                role=self._process_role(
+                    process,
+                    command,
+                    current_pid=os.getpid(),
+                    runner_pids=runner_pids,
+                ),
+                command=command,
+                status=status,
+                cpu_percent=cpu_percent,
+                memory_percent=memory_percent,
+                rss=rss,
+                elapsed_seconds=elapsed_seconds,
+                is_child_of_skulk=process.pid in child_pids,
+            )
+        except psutil.NoSuchProcess:
+            return None
+
+    def _collect_process_diagnostics(
+        self,
+        supervisor_runners: Sequence[RunnerSupervisorDiagnostics],
+    ) -> list[DiagnosticsProcess]:
+        """Collect relevant Skulk, runner, and Vector process diagnostics."""
+
+        current = psutil.Process(os.getpid())
+        try:
+            children = current.children(recursive=True)
+        except (psutil.Error, OSError):
+            children = []
+
+        runner_pids = {
+            runner.pid
+            for runner in supervisor_runners
+            if runner.pid is not None
+        }
+        child_pids = {current.pid, *(child.pid for child in children)}
+        process_by_pid: dict[int, psutil.Process] = {
+            current.pid: current,
+            **{child.pid: child for child in children},
+        }
+
+        for process in psutil.process_iter():
+            if process.pid in process_by_pid:
+                continue
+            command = self._process_command(process)
+            if "vector" not in command.lower():
+                continue
+            process_by_pid[process.pid] = process
+
+        diagnostics: list[DiagnosticsProcess] = []
+        for process in sorted(process_by_pid.values(), key=lambda proc: proc.pid):
+            process_diagnostics = self._process_diagnostics(
+                process,
+                child_pids=child_pids,
+                runner_pids=runner_pids,
+            )
+            if process_diagnostics is not None:
+                diagnostics.append(process_diagnostics)
+        return diagnostics
+
+    def _runtime_diagnostics(self) -> NodeRuntimeDiagnostics:
+        """Build local runtime diagnostics from API process and state."""
+
+        identity = self.state.node_identities.get(self.node_id)
+        logging_config = self._exo_config.logging if self._exo_config is not None else None
+        master_node_id = self._master_node_id
+        return NodeRuntimeDiagnostics(
+            node_id=str(self.node_id),
+            hostname=socket.gethostname(),
+            friendly_name=self._friendly_name_for_node(self.node_id),
+            is_master=master_node_id == self.node_id,
+            master_node_id=str(master_node_id),
+            cwd=str(Path.cwd()),
+            config_path=str(self._config_path),
+            config_file_exists=self._config_path.exists(),
+            skulk_version=get_skulk_version(),
+            skulk_commit=identity.exo_commit if identity is not None else "Unknown",
+            libp2p_namespace=preferred_env_value(
+                "SKULK_LIBP2P_NAMESPACE",
+                "EXO_LIBP2P_NAMESPACE",
+            ),
+            python_unbuffered=os.environ.get("PYTHONUNBUFFERED") in {"1", "true", "True"},
+            tracing_enabled=self.state.tracing_enabled,
+            structured_logging_configured=bool(
+                logging_config is not None
+                and logging_config.enabled
+                and logging_config.ingest_url
+            ),
+            logging_ingest_url=logging_config.ingest_url
+            if logging_config is not None and logging_config.ingest_url
+            else None,
+        )
+
+    def _resource_diagnostics(self) -> NodeResourceDiagnostics:
+        """Build local resource diagnostics from gathered state and psutil."""
+
+        current_memory = None
+        with contextlib.suppress(Exception):
+            current_memory = MemoryUsage.from_psutil(override_memory=None)
+
+        return NodeResourceDiagnostics(
+            gathered_memory=self.state.node_memory.get(self.node_id),
+            current_memory=current_memory,
+            disk=self.state.node_disk.get(self.node_id),
+            system=self.state.node_system.get(self.node_id),
+            network=self.state.node_network.get(self.node_id),
+        )
+
+    async def get_node_diagnostics(self) -> NodeDiagnostics:
+        """Return local read-only diagnostics for this Skulk node."""
+
+        supervisor_runners = self._collect_runner_supervisor_diagnostics()
+        placements = self._placement_diagnostics()
+        warnings = sorted(
+            {
+                warning
+                for placement in placements
+                for warning in placement.warnings
+            }
+        )
+        return NodeDiagnostics(
+            generated_at=datetime.now(tz=timezone.utc).isoformat(),
+            runtime=self._runtime_diagnostics(),
+            identity=self.state.node_identities.get(self.node_id),
+            resources=self._resource_diagnostics(),
+            processes=self._collect_process_diagnostics(supervisor_runners),
+            supervisor_runners=supervisor_runners,
+            placements=placements,
+            warnings=warnings,
+        )
+
+    async def get_cluster_diagnostics(self) -> ClusterDiagnostics:
+        """Return read-only diagnostics for local and reachable peer nodes."""
+
+        local_diagnostics = await self.get_node_diagnostics()
+        nodes = [
+            ClusterNodeDiagnostics(
+                node_id=str(self.node_id),
+                url=None,
+                ok=True,
+                diagnostics=local_diagnostics,
+            )
+        ]
+
+        peer_urls = await self._reachable_peer_api_urls()
+        timeout = httpx.Timeout(timeout=10.0, connect=2.0)
+        async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
+            for node_id, base_url in peer_urls.items():
+                try:
+                    response = await client.get(f"{base_url}/v1/diagnostics/node")
+                    response.raise_for_status()
+                    diagnostics = NodeDiagnostics.model_validate(response.json())
+                    nodes.append(
+                        ClusterNodeDiagnostics(
+                            node_id=node_id,
+                            url=base_url,
+                            ok=True,
+                            diagnostics=diagnostics,
+                        )
+                    )
+                except (httpx.HTTPError, ValueError) as exc:
+                    nodes.append(
+                        ClusterNodeDiagnostics(
+                            node_id=node_id,
+                            url=base_url,
+                            ok=False,
+                            error=f"{exc.__class__.__name__}: {exc}",
+                        )
+                    )
+
+        return ClusterDiagnostics(
+            generated_at=datetime.now(tz=timezone.utc).isoformat(),
+            local_node_id=str(self.node_id),
+            master_node_id=str(self._master_node_id),
+            nodes=nodes,
+        )
+
+    async def get_cluster_node_diagnostics(self, node_id: str) -> NodeDiagnostics:
+        """Return diagnostics for one local or reachable peer node."""
+
+        if node_id == str(self.node_id):
+            return await self.get_node_diagnostics()
+
+        peer_urls = await self._reachable_peer_api_urls()
+        base_url = peer_urls.get(node_id)
+        if base_url is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Node diagnostics endpoint not reachable: {node_id}",
+            )
+
+        timeout = httpx.Timeout(timeout=10.0, connect=2.0)
+        async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
+            response = await client.get(f"{base_url}/v1/diagnostics/node")
+            if response.status_code == 404:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Node diagnostics not found: {node_id}",
+                )
+            response.raise_for_status()
+            return NodeDiagnostics.model_validate(response.json())
 
     async def get_tracing_state(self) -> TracingStateResponse:
         return TracingStateResponse(enabled=self.state.tracing_enabled)

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -202,6 +202,10 @@ from exo.shared.types.common import CommandId, Id, NodeId, SystemId
 from exo.shared.types.diagnostics import (
     ClusterDiagnostics,
     ClusterNodeDiagnostics,
+    ClusterTimeline,
+    ClusterTimelineEntry,
+    ClusterTimelineRunner,
+    ClusterTimelineUnreachable,
     DiagnosticCaptureRequest,
     DiagnosticCaptureResponse,
     DiagnosticProcessSample,
@@ -953,6 +957,20 @@ class API:
                 "reported as partial failures instead of failing the whole request."
             ),
         )(self.get_cluster_diagnostics)
+        self.app.get(
+            "/v1/diagnostics/cluster/timeline",
+            tags=["Diagnostics"],
+            summary="Get cross-rank runner timeline",
+            description=(
+                "Stitch every reachable node's runner-supervisor diagnostics into "
+                "one cross-rank chronological view. Returns a per-runner synopsis "
+                "(rank, current phase, seconds-in-phase, MLX memory) and every "
+                "flight-recorder entry across all ranks merged and sorted by "
+                "wall-clock timestamp. The intended use is debugging distributed "
+                "deadlocks where the rank-disagreement signature is invisible from "
+                "any single node's local diagnostics."
+            ),
+        )(self.get_cluster_timeline)
         self.app.get(
             "/v1/diagnostics/cluster/{node_id}",
             tags=["Diagnostics"],
@@ -3792,6 +3810,92 @@ class API:
             local_node_id=str(self.node_id),
             master_node_id=str(self._master_node_id),
             nodes=nodes,
+        )
+
+    async def get_cluster_timeline(self) -> ClusterTimeline:
+        """Return a cross-rank chronological view of runner activity.
+
+        Stitches every reachable node's ``RunnerSupervisorDiagnostics`` into
+        one structure: a per-runner synopsis sorted by ``(model_id, rank)``,
+        and every flight-recorder entry across all ranks merged and sorted by
+        ``at`` so distributed-deadlock signatures (e.g. "rank 0 entered
+        pipeline_last_eval_output 27 minutes ago while rank 1 is still in
+        pipeline_first_recv_like") are visible at a glance.
+
+        Reuses ``get_cluster_diagnostics`` for fan-out so peer discovery,
+        timeouts, and unreachable-peer handling stay in one place.
+        """
+        cluster = await self.get_cluster_diagnostics()
+
+        runners: list[ClusterTimelineRunner] = []
+        timeline_entries: list[ClusterTimelineEntry] = []
+        unreachable: list[ClusterTimelineUnreachable] = []
+
+        for node in cluster.nodes:
+            if not node.ok or node.diagnostics is None:
+                unreachable.append(
+                    ClusterTimelineUnreachable(
+                        node_id=node.node_id,
+                        url=node.url,
+                        error=node.error
+                        or "Node diagnostics returned no payload.",
+                    )
+                )
+                continue
+            for runner in node.diagnostics.supervisor_runners:
+                runners.append(
+                    ClusterTimelineRunner(
+                        node_id=runner.node_id,
+                        runner_id=runner.runner_id,
+                        instance_id=runner.instance_id,
+                        model_id=runner.model_id,
+                        device_rank=runner.device_rank,
+                        world_size=runner.world_size,
+                        pid=runner.pid,
+                        process_alive=runner.process_alive,
+                        status_kind=runner.status_kind,
+                        phase=runner.phase,
+                        phase_detail=runner.phase_detail,
+                        seconds_in_phase=runner.seconds_in_phase,
+                        last_progress_at=runner.last_progress_at,
+                        active_task_id=runner.active_task_id,
+                        active_command_id=runner.active_command_id,
+                        last_mlx_memory=runner.last_mlx_memory,
+                    )
+                )
+                for entry in runner.flight_recorder:
+                    # Lift node/rank identity onto each entry so the merged
+                    # timeline reads top-to-bottom as a distributed log.
+                    timeline_entries.append(
+                        ClusterTimelineEntry(
+                            at=entry.at,
+                            node_id=runner.node_id,
+                            runner_id=runner.runner_id,
+                            device_rank=runner.device_rank,
+                            world_size=runner.world_size,
+                            phase=entry.phase,
+                            event=entry.event,
+                            detail=entry.detail,
+                            attrs=dict(entry.attrs),
+                            task_id=entry.task_id,
+                            command_id=entry.command_id,
+                            mlx_memory=entry.mlx_memory,
+                        )
+                    )
+
+        # Stable sort by (model_id, rank) — multi-model deployments stay grouped.
+        runners.sort(key=lambda r: (r.model_id, r.device_rank, r.runner_id))
+        # Chronological merge across ranks. Ties broken by (node_id, rank) so the
+        # ordering is deterministic when two ranks emit at the same `at` string.
+        timeline_entries.sort(key=lambda e: (e.at, e.node_id, e.device_rank))
+
+        return ClusterTimeline(
+            generated_at=datetime.now(tz=timezone.utc).isoformat(),
+            local_node_id=cluster.local_node_id,
+            master_node_id=cluster.master_node_id,
+            runners=runners,
+            timeline=timeline_entries,
+            unreachable_nodes=unreachable,
         )
 
     async def get_cluster_node_diagnostics(self, node_id: str) -> NodeDiagnostics:

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Annotated, Literal, Protocol, cast
 from uuid import uuid4
 
 import anyio
+import httpx
 import hypercorn.asyncio as hypercorn_asyncio
 import yaml
 from anyio import BrokenResourceError
@@ -110,7 +111,11 @@ from exo.api.types import (
     TraceListResponse,
     TraceRankStats,
     TraceResponse,
+    TraceSourceNode,
     TraceStatsResponse,
+    TraceTaskKind,
+    TracingStateResponse,
+    UpdateTracingStateRequest,
     WebSearchToolRequest,
     WebSearchToolResponse,
     normalize_image_size,
@@ -182,6 +187,7 @@ from exo.shared.types.commands import (
     ImageGeneration,
     PlaceInstance,
     SendInputChunk,
+    SetTracingEnabled,
     StartDownload,
     TaskCancelled,
     TaskFinished,
@@ -208,6 +214,7 @@ from exo.tools.web_search import default_browser_tool_provider
 from exo.utils.banner import print_startup_banner
 from exo.utils.channels import Receiver, Sender, channel
 from exo.utils.disk_event_log import DiskEventLog
+from exo.utils.info_gatherer.net_profile import check_reachable
 from exo.utils.power_sampler import PowerSampler
 from exo.utils.task_group import TaskGroup
 from exo.worker.engines.mlx.constants import (
@@ -783,17 +790,54 @@ class API:
             description="Delete or cancel a download associated with a given node and model.",
         )(self.delete_download)
         self.app.get(
+            "/v1/tracing",
+            tags=["State & Tracing"],
+            summary="Get cluster tracing state",
+            description="Return whether runtime tracing is currently enabled for new requests across the cluster session.",
+        )(self.get_tracing_state)
+        self.app.put(
+            "/v1/tracing",
+            tags=["State & Tracing"],
+            summary="Set cluster tracing state",
+            description="Enable or disable runtime tracing for new requests across the cluster session.",
+        )(self.update_tracing_state)
+        self.app.get(
             "/v1/traces",
             tags=["State & Tracing"],
             summary="List saved traces",
             description="List saved trace files that can be inspected for debugging and performance analysis.",
         )(self.list_traces)
+        self.app.get(
+            "/v1/traces/cluster",
+            tags=["State & Tracing"],
+            summary="List cluster traces",
+            description="List deduplicated traces discoverable from this node across reachable peer APIs.",
+        )(self.list_cluster_traces)
         self.app.post(
             "/v1/traces/delete",
             tags=["State & Tracing"],
             summary="Delete saved traces",
             description="Delete one or more saved trace artifacts by task ID.",
         )(self.delete_traces)
+        self.app.get(
+            "/v1/traces/cluster/{task_id}",
+            tags=["State & Tracing"],
+            summary="Get one cluster trace",
+            description="Return a trace from local storage or proxy it from a reachable peer node.",
+        )(self.get_cluster_trace)
+        self.app.get(
+            "/v1/traces/cluster/{task_id}/stats",
+            tags=["State & Tracing"],
+            summary="Get one cluster trace summary",
+            description="Return aggregated timing statistics for a trace available locally or on a reachable peer node.",
+        )(self.get_cluster_trace_stats)
+        self.app.get(
+            "/v1/traces/cluster/{task_id}/raw",
+            tags=["State & Tracing"],
+            summary="Download raw cluster trace JSON",
+            description="Download a raw Chrome trace artifact from local storage or a reachable peer node.",
+            response_model=None,
+        )(self.get_cluster_trace_raw)
         self.app.get(
             "/v1/traces/{task_id}",
             tags=["State & Tracing"],
@@ -811,6 +855,7 @@ class API:
             tags=["State & Tracing"],
             summary="Download raw trace JSON",
             description="Download the raw Chrome trace JSON artifact for one task.",
+            response_model=None,
         )(self.get_trace_raw)
         self.app.get(
             "/onboarding",
@@ -2531,6 +2576,11 @@ class API:
                 duration_us=t.duration_us,
                 rank=t.rank,
                 category=t.category,
+                node_id=t.node_id,
+                model_id=t.model_id,
+                task_kind=t.task_kind,
+                tags=tuple(t.tags),
+                attrs=t.attrs,
             )
             for t in event.traces
         ]
@@ -2607,38 +2657,37 @@ class API:
             raise HTTPException(status_code=400, detail=f"Invalid task ID: {task_id}")
         return trace_path
 
-    async def list_traces(self) -> TraceListResponse:
-        traces: list[TraceListItem] = []
+    def _friendly_name_for_trace_node(self, node_id: str) -> str | None:
+        for known_node_id, identity in self.state.node_identities.items():
+            if str(known_node_id) != node_id:
+                continue
+            if identity.friendly_name and identity.friendly_name != "Unknown":
+                return identity.friendly_name
+            return None
+        return None
 
-        for trace_file in sorted(
-            EXO_TRACING_CACHE_DIR.glob("trace_*.json"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        ):
-            # Extract task_id from filename (trace_{task_id}.json)
-            task_id = trace_file.stem.removeprefix("trace_")
-            stat = trace_file.stat()
-            created_at = datetime.fromtimestamp(
-                stat.st_mtime, tz=timezone.utc
-            ).isoformat()
-            traces.append(
-                TraceListItem(
-                    task_id=task_id,
-                    created_at=created_at,
-                    file_size=stat.st_size,
-                )
-            )
+    def _trace_source_node(self, node_id: str) -> TraceSourceNode:
+        return TraceSourceNode(
+            node_id=node_id,
+            friendly_name=self._friendly_name_for_trace_node(node_id),
+        )
 
-        return TraceListResponse(traces=traces)
+    def _trace_source_nodes(self, trace_events: list[TraceEvent]) -> list[TraceSourceNode]:
+        node_ids = [event.node_id for event in trace_events if event.node_id]
+        if not node_ids:
+            node_ids = [str(self.node_id)]
 
-    async def get_trace(self, task_id: str) -> TraceResponse:
-        trace_path = self._get_trace_path(task_id)
+        unique_node_ids: list[str] = []
+        for node_id in node_ids:
+            assert node_id is not None
+            if node_id not in unique_node_ids:
+                unique_node_ids.append(node_id)
 
-        if not trace_path.exists():
-            raise HTTPException(status_code=404, detail=f"Trace not found: {task_id}")
+        return [self._trace_source_node(node_id) for node_id in unique_node_ids]
 
-        trace_events = load_trace_file(trace_path)
-
+    def _build_trace_response(
+        self, task_id: str, trace_events: list[TraceEvent]
+    ) -> TraceResponse:
         return TraceResponse(
             task_id=task_id,
             traces=[
@@ -2648,20 +2697,21 @@ class API:
                     duration_us=event.duration_us,
                     rank=event.rank,
                     category=event.category,
+                    node_id=event.node_id,
+                    model_id=event.model_id,
+                    task_kind=event.task_kind,
+                    tags=list(event.tags),
+                    attrs=event.attrs,
                 )
                 for event in trace_events
             ],
+            source_nodes=self._trace_source_nodes(trace_events),
         )
 
-    async def get_trace_stats(self, task_id: str) -> TraceStatsResponse:
-        trace_path = self._get_trace_path(task_id)
-
-        if not trace_path.exists():
-            raise HTTPException(status_code=404, detail=f"Trace not found: {task_id}")
-
-        trace_events = load_trace_file(trace_path)
+    def _build_trace_stats_response(
+        self, task_id: str, trace_events: list[TraceEvent]
+    ) -> TraceStatsResponse:
         stats = compute_stats(trace_events)
-
         return TraceStatsResponse(
             task_id=task_id,
             total_wall_time_us=stats.total_wall_time_us,
@@ -2690,7 +2740,160 @@ class API:
                 )
                 for rank, rank_stats in stats.by_rank.items()
             },
+            source_nodes=self._trace_source_nodes(trace_events),
         )
+
+    def _build_trace_list_item(self, task_id: str, trace_path: Path) -> TraceListItem:
+        stat = trace_path.stat()
+        created_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+        trace_events = load_trace_file(trace_path)
+
+        model_id = next((event.model_id for event in trace_events if event.model_id), None)
+        task_kind = cast(
+            TraceTaskKind | None,
+            next((event.task_kind for event in trace_events if event.task_kind), None),
+        )
+        categories = sorted({event.category for event in trace_events if event.category})
+        tags = sorted({tag for event in trace_events for tag in event.tags})
+        has_tool_activity = any("tool_call" in event.tags for event in trace_events)
+
+        return TraceListItem(
+            task_id=task_id,
+            created_at=created_at,
+            file_size=stat.st_size,
+            model_id=model_id,
+            task_kind=task_kind,
+            categories=categories,
+            tags=tags,
+            has_tool_activity=has_tool_activity,
+            source_nodes=self._trace_source_nodes(trace_events),
+        )
+
+    @staticmethod
+    def _merge_trace_list_item(existing: TraceListItem, incoming: TraceListItem) -> TraceListItem:
+        source_nodes_by_id = {
+            source.node_id: source for source in [*existing.source_nodes, *incoming.source_nodes]
+        }
+        return existing.model_copy(
+            update={
+                "created_at": max(existing.created_at, incoming.created_at),
+                "file_size": max(existing.file_size, incoming.file_size),
+                "model_id": existing.model_id or incoming.model_id,
+                "task_kind": existing.task_kind or incoming.task_kind,
+                "categories": sorted({*existing.categories, *incoming.categories}),
+                "tags": sorted({*existing.tags, *incoming.tags}),
+                "has_tool_activity": existing.has_tool_activity or incoming.has_tool_activity,
+                "source_nodes": list(source_nodes_by_id.values()),
+            }
+        )
+
+    async def _reachable_peer_trace_urls(self) -> list[str]:
+        reachable_by_node: dict[str, str] = {}
+        async for ip_address, node_id in check_reachable(
+            self.state.topology,
+            self.node_id,
+            self.state.node_network,
+        ):
+            normalized_node_id = str(node_id)
+            if normalized_node_id in reachable_by_node:
+                continue
+            host = f"[{ip_address}]" if ":" in ip_address else ip_address
+            reachable_by_node[normalized_node_id] = f"http://{host}:52415"
+        return list(reachable_by_node.values())
+
+    async def get_tracing_state(self) -> TracingStateResponse:
+        return TracingStateResponse(enabled=self.state.tracing_enabled)
+
+    async def update_tracing_state(
+        self, payload: UpdateTracingStateRequest
+    ) -> TracingStateResponse:
+        await self._send(SetTracingEnabled(enabled=payload.enabled))
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if self.state.tracing_enabled == payload.enabled:
+                break
+            await anyio.sleep(0.05)
+        return TracingStateResponse(enabled=self.state.tracing_enabled)
+
+    async def list_traces(self) -> TraceListResponse:
+        traces: list[TraceListItem] = []
+
+        for trace_file in sorted(
+            EXO_TRACING_CACHE_DIR.glob("trace_*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        ):
+            task_id = trace_file.stem.removeprefix("trace_")
+            try:
+                traces.append(self._build_trace_list_item(task_id, trace_file))
+            except OSError as exc:
+                logger.opt(exception=exc).warning(
+                    f"Failed to inspect trace file {trace_file}"
+                )
+
+        return TraceListResponse(traces=traces)
+
+    async def list_cluster_traces(self) -> TraceListResponse:
+        deduped: dict[str, TraceListItem] = {
+            trace.task_id: trace for trace in (await self.list_traces()).traces
+        }
+        peer_urls = await self._reachable_peer_trace_urls()
+        if not peer_urls:
+            return TraceListResponse(
+                traces=sorted(
+                    deduped.values(),
+                    key=lambda trace: trace.created_at,
+                    reverse=True,
+                )
+            )
+
+        timeout = httpx.Timeout(timeout=5.0, connect=2.0)
+        async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
+            for base_url in peer_urls:
+                try:
+                    response = await client.get(f"{base_url}/v1/traces")
+                    if response.status_code != 200:
+                        continue
+                    peer_traces = TraceListResponse.model_validate(response.json())
+                except (httpx.HTTPError, ValueError) as exc:
+                    logger.opt(exception=exc).debug(
+                        f"Skipping peer trace index from {base_url}"
+                    )
+                    continue
+
+                for trace in peer_traces.traces:
+                    if trace.task_id in deduped:
+                        deduped[trace.task_id] = self._merge_trace_list_item(
+                            deduped[trace.task_id], trace
+                        )
+                    else:
+                        deduped[trace.task_id] = trace
+
+        return TraceListResponse(
+            traces=sorted(
+                deduped.values(),
+                key=lambda trace: trace.created_at,
+                reverse=True,
+            )
+        )
+
+    async def get_trace(self, task_id: str) -> TraceResponse:
+        trace_path = self._get_trace_path(task_id)
+
+        if not trace_path.exists():
+            raise HTTPException(status_code=404, detail=f"Trace not found: {task_id}")
+
+        trace_events = load_trace_file(trace_path)
+        return self._build_trace_response(task_id, trace_events)
+
+    async def get_trace_stats(self, task_id: str) -> TraceStatsResponse:
+        trace_path = self._get_trace_path(task_id)
+
+        if not trace_path.exists():
+            raise HTTPException(status_code=404, detail=f"Trace not found: {task_id}")
+
+        trace_events = load_trace_file(trace_path)
+        return self._build_trace_stats_response(task_id, trace_events)
 
     async def get_trace_raw(self, task_id: str) -> FileResponse:
         trace_path = self._get_trace_path(task_id)
@@ -2703,6 +2906,100 @@ class API:
             media_type="application/json",
             filename=f"trace_{task_id}.json",
         )
+
+    async def get_cluster_trace(self, task_id: str) -> TraceResponse:
+        try:
+            return await self.get_trace(task_id)
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                raise
+
+        peer_urls = await self._reachable_peer_trace_urls()
+        timeout = httpx.Timeout(timeout=10.0, connect=2.0)
+        async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
+            for base_url in peer_urls:
+                try:
+                    response = await client.get(f"{base_url}/v1/traces/{task_id}")
+                except httpx.HTTPError as exc:
+                    logger.opt(exception=exc).debug(
+                        f"Failed to proxy trace {task_id} from {base_url}"
+                    )
+                    continue
+                if response.status_code == 404:
+                    continue
+                response.raise_for_status()
+                return TraceResponse.model_validate(response.json())
+
+        raise HTTPException(status_code=404, detail=f"Trace not found: {task_id}")
+
+    async def get_cluster_trace_stats(self, task_id: str) -> TraceStatsResponse:
+        try:
+            return await self.get_trace_stats(task_id)
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                raise
+
+        peer_urls = await self._reachable_peer_trace_urls()
+        timeout = httpx.Timeout(timeout=10.0, connect=2.0)
+        async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
+            for base_url in peer_urls:
+                try:
+                    response = await client.get(
+                        f"{base_url}/v1/traces/{task_id}/stats"
+                    )
+                except httpx.HTTPError as exc:
+                    logger.opt(exception=exc).debug(
+                        f"Failed to proxy trace stats {task_id} from {base_url}"
+                    )
+                    continue
+                if response.status_code == 404:
+                    continue
+                response.raise_for_status()
+                return TraceStatsResponse.model_validate(response.json())
+
+        raise HTTPException(status_code=404, detail=f"Trace not found: {task_id}")
+
+    async def get_cluster_trace_raw(self, task_id: str) -> FileResponse | StreamingResponse:
+        try:
+            return await self.get_trace_raw(task_id)
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                raise
+
+        peer_urls = await self._reachable_peer_trace_urls()
+        timeout = httpx.Timeout(timeout=30.0, connect=2.0)
+        async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
+            for base_url in peer_urls:
+                try:
+                    response = await client.get(
+                        f"{base_url}/v1/traces/{task_id}/raw"
+                    )
+                except httpx.HTTPError as exc:
+                    logger.opt(exception=exc).debug(
+                        f"Failed to proxy raw trace {task_id} from {base_url}"
+                    )
+                    continue
+                if response.status_code == 404:
+                    continue
+                response.raise_for_status()
+                content_type = cast(
+                    str,
+                    response.headers.get("content-type", "application/json"),
+                )
+                content_disposition = cast(
+                    str,
+                    response.headers.get(
+                        "content-disposition",
+                        f'attachment; filename="trace_{task_id}.json"',
+                    ),
+                )
+                return StreamingResponse(
+                    iter([response.content]),
+                    media_type=content_type,
+                    headers={"content-disposition": content_disposition},
+                )
+
+        raise HTTPException(status_code=404, detail=f"Trace not found: {task_id}")
 
     async def delete_traces(self, request: DeleteTracesRequest) -> DeleteTracesResponse:
         deleted: list[str] = []

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -3,7 +3,9 @@ import contextlib
 import hashlib
 import json
 import os
+import platform
 import random
+import shutil
 import socket
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable, Sequence
@@ -200,8 +202,12 @@ from exo.shared.types.common import CommandId, Id, NodeId, SystemId
 from exo.shared.types.diagnostics import (
     ClusterDiagnostics,
     ClusterNodeDiagnostics,
+    DiagnosticCaptureRequest,
+    DiagnosticCaptureResponse,
+    DiagnosticProcessSample,
     DiagnosticsProcess,
     InstancePlacementDiagnostics,
+    MlxMemorySnapshot,
     NodeDiagnostics,
     NodeResourceDiagnostics,
     NodeRuntimeDiagnostics,
@@ -926,6 +932,17 @@ class API:
                 "for diagnostics and may not stop a runner wedged in native code."
             ),
         )(self.cancel_local_runner_task)
+        self.app.post(
+            "/v1/diagnostics/node/capture",
+            tags=["Diagnostics"],
+            summary="Capture local node diagnostic bundle",
+            description=(
+                "Collect an on-demand diagnostic bundle for this node, optionally "
+                "focused on one live runner or task. The bundle includes current "
+                "node diagnostics, runner flight-recorder entries, the latest MLX "
+                "memory snapshot, and best-effort macOS process samples."
+            ),
+        )(self.capture_local_node_diagnostics)
         self.app.get(
             "/v1/diagnostics/cluster",
             tags=["Diagnostics"],
@@ -945,6 +962,15 @@ class API:
                 "proxying to a reachable peer API."
             ),
         )(self.get_cluster_node_diagnostics)
+        self.app.post(
+            "/v1/diagnostics/cluster/{node_id}/capture",
+            tags=["Diagnostics"],
+            summary="Capture one cluster node diagnostic bundle",
+            description=(
+                "Return an on-demand diagnostic capture bundle for the requested "
+                "node, proxying to a reachable peer API when the target is remote."
+            ),
+        )(self.capture_cluster_node_diagnostics)
         self.app.post(
             "/v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel",
             tags=["Diagnostics"],
@@ -3500,6 +3526,227 @@ class API:
                 detail=self._proxy_error_detail(response),
             )
         return RunnerTaskCancelResponse.model_validate(response.json())
+
+    @staticmethod
+    def _truncate_capture_output(value: bytes | str | None) -> str | None:
+        """Decode and cap heavyweight diagnostic command output."""
+
+        if value is None:
+            return None
+        text = value.decode(errors="replace") if isinstance(value, bytes) else value
+        max_chars = 64_000
+        if len(text) <= max_chars:
+            return text
+        return text[:max_chars] + "\n... <truncated>"
+
+    async def _run_process_sample_command(
+        self,
+        *,
+        name: str,
+        command: list[str],
+        timeout_seconds: float,
+    ) -> DiagnosticProcessSample:
+        """Run one local process-sampling command with a strict timeout."""
+
+        started = time.monotonic()
+        try:
+            completed = None
+            with anyio.move_on_after(timeout_seconds) as scope:
+                completed = await anyio.run_process(command, check=False)
+            duration = time.monotonic() - started
+            if scope.cancel_called or completed is None:
+                return DiagnosticProcessSample(
+                    name=name,
+                    command=command,
+                    ok=False,
+                    duration_seconds=duration,
+                    error=f"Timed out after {timeout_seconds:.1f}s",
+                )
+            return DiagnosticProcessSample(
+                name=name,
+                command=command,
+                ok=completed.returncode == 0,
+                exit_code=completed.returncode,
+                duration_seconds=duration,
+                stdout=self._truncate_capture_output(completed.stdout),
+                stderr=self._truncate_capture_output(completed.stderr),
+                error=None if completed.returncode == 0 else "Command exited non-zero",
+            )
+        except FileNotFoundError as exc:
+            missing_file = str(cast(object, exc.filename))
+            return DiagnosticProcessSample(
+                name=name,
+                command=command,
+                ok=False,
+                duration_seconds=time.monotonic() - started,
+                error=f"Command not found: {missing_file}",
+            )
+        except Exception as exc:
+            return DiagnosticProcessSample(
+                name=name,
+                command=command,
+                ok=False,
+                duration_seconds=time.monotonic() - started,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    async def _collect_process_samples(
+        self,
+        pid: int,
+        sample_duration_seconds: float,
+    ) -> list[DiagnosticProcessSample]:
+        """Collect best-effort heavyweight process samples for one PID."""
+
+        if platform.system() != "Darwin":
+            return [
+                DiagnosticProcessSample(
+                    name="process_samples",
+                    command=[],
+                    ok=False,
+                    duration_seconds=0.0,
+                    error="Process sampling is currently implemented for macOS only.",
+                )
+            ]
+
+        requested_duration = max(1, int(round(sample_duration_seconds)))
+        commands = [
+            (
+                "sample",
+                ["sample", str(pid), str(requested_duration)],
+                float(requested_duration + 5),
+            ),
+            ("vmmap", ["vmmap", "-summary", str(pid)], 8.0),
+            ("footprint", ["footprint", "-p", str(pid)], 8.0),
+        ]
+        samples: list[DiagnosticProcessSample] = []
+        for name, command, timeout in commands:
+            executable = command[0]
+            if shutil.which(executable) is None:
+                samples.append(
+                    DiagnosticProcessSample(
+                        name=name,
+                        command=command,
+                        ok=False,
+                        duration_seconds=0.0,
+                        error=f"{executable} not found on PATH",
+                    )
+                )
+                continue
+            samples.append(
+                await self._run_process_sample_command(
+                    name=name,
+                    command=command,
+                    timeout_seconds=timeout,
+                )
+            )
+        return samples
+
+    @staticmethod
+    def _match_capture_runner(
+        diagnostics: NodeDiagnostics,
+        request: DiagnosticCaptureRequest,
+    ) -> RunnerSupervisorDiagnostics | None:
+        """Find the requested runner or task inside one node diagnostics bundle."""
+
+        runner_id = str(request.runner_id) if request.runner_id is not None else None
+        task_id = str(request.task_id) if request.task_id is not None else None
+        if runner_id is None and task_id is None:
+            return None
+
+        for runner in diagnostics.supervisor_runners:
+            if runner_id is not None and runner.runner_id != runner_id:
+                continue
+            if task_id is not None:
+                task_ids = {task.task_id for task in runner.in_progress_tasks}
+                task_ids.update(runner.pending_task_ids)
+                task_ids.update(runner.cancelled_task_ids)
+                if task_id not in task_ids and runner.active_task_id != task_id:
+                    continue
+            return runner
+        return None
+
+    async def capture_local_node_diagnostics(
+        self,
+        request: DiagnosticCaptureRequest,
+    ) -> DiagnosticCaptureResponse:
+        """Collect an on-demand local diagnostics bundle for stuck-runner triage."""
+
+        diagnostics = await self.get_node_diagnostics()
+        runner = self._match_capture_runner(diagnostics, request)
+        if (request.runner_id is not None or request.task_id is not None) and runner is None:
+            raise HTTPException(
+                status_code=404,
+                detail="No local runner matched the requested runnerId/taskId.",
+            )
+
+        warnings: list[str] = []
+        process_samples: list[DiagnosticProcessSample] = []
+        mlx_memory: MlxMemorySnapshot | None = None
+        if runner is not None:
+            mlx_memory = runner.last_mlx_memory
+            if request.include_process_samples:
+                if runner.pid is None:
+                    warnings.append("Matched runner has no known subprocess PID.")
+                elif not runner.process_alive:
+                    warnings.append("Matched runner process is no longer alive.")
+                else:
+                    process_samples = await self._collect_process_samples(
+                        runner.pid,
+                        request.sample_duration_seconds,
+                    )
+            if mlx_memory is None:
+                warnings.append(
+                    "Matched runner has not reported an MLX memory snapshot yet."
+                )
+
+        return DiagnosticCaptureResponse(
+            generated_at=datetime.now(tz=timezone.utc).isoformat(),
+            node_id=self.node_id,
+            node_diagnostics=diagnostics,
+            runner=runner,
+            flight_recorder=list(runner.flight_recorder) if runner is not None else [],
+            mlx_memory=mlx_memory,
+            process_samples=process_samples,
+            warnings=warnings,
+        )
+
+    async def capture_cluster_node_diagnostics(
+        self,
+        node_id: str,
+        request: DiagnosticCaptureRequest,
+    ) -> DiagnosticCaptureResponse:
+        """Return an on-demand diagnostics capture for one local or peer node."""
+
+        if node_id == str(self.node_id):
+            return await self.capture_local_node_diagnostics(request)
+
+        peer_urls = await self._reachable_peer_api_urls()
+        base_url = peer_urls.get(node_id)
+        if base_url is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Node diagnostics endpoint not reachable: {node_id}",
+            )
+
+        timeout = httpx.Timeout(timeout=30.0, connect=2.0)
+        async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
+            try:
+                response = await client.post(
+                    f"{base_url}/v1/diagnostics/node/capture",
+                    json=request.model_dump(mode="json", by_alias=True),
+                )
+            except httpx.HTTPError as exc:
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Failed to proxy diagnostics capture to {node_id}: {exc}",
+                ) from exc
+
+        if response.status_code >= 400:
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=self._proxy_error_detail(response),
+            )
+        return DiagnosticCaptureResponse.model_validate(response.json())
 
     async def get_cluster_diagnostics(self) -> ClusterDiagnostics:
         """Return read-only diagnostics for local and reachable peer nodes."""

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -264,6 +264,15 @@ serve = cast(_HypercornServe, hypercorn_asyncio.serve)
 _API_EVENT_LOG_DIR = EXO_EVENT_LOG_DIR / "api"
 ONBOARDING_COMPLETE_FILE = EXO_CACHE_HOME / "onboarding_complete"
 
+
+def _text_image_hash_cache_enabled() -> bool:
+    value = preferred_env_value(
+        "SKULK_TEXT_IMAGE_HASH_CACHE",
+        "EXO_TEXT_IMAGE_HASH_CACHE",
+        "false",
+    )
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
 API_TAGS_METADATA = [
     {
         "name": "Compatibility APIs",
@@ -446,6 +455,7 @@ class API:
         self._runner_diagnostics_provider: Callable[
             [], Sequence[RunnerSupervisorDiagnostics]
         ] | None = None
+        self._sent_image_hashes: set[str] = set()
         # Initialize optimizer if store path is available
         if exo_config and exo_config.model_store and exo_config.model_store.enabled:
             from exo.store.model_optimizer import ModelOptimizer
@@ -1384,8 +1394,6 @@ class API:
             "TODO: we should send a notification to the user to download the model"
         )
 
-    _sent_image_hashes: set[str] = set()
-
     async def _send_text_generation_with_images(
         self, task_params: TextGenerationTaskParams
     ) -> TextGeneration:
@@ -1399,16 +1407,24 @@ class API:
 
         cached_hashes: dict[int, str] = {}
         new_images: list[tuple[int, str]] = []
-        for idx, (img, h) in enumerate(zip(images, hashes, strict=True)):
-            if h in self._sent_image_hashes:
-                cached_hashes[idx] = h
-            else:
-                self._sent_image_hashes.add(h)
-                new_images.append((idx, img))
+        cache_enabled = _text_image_hash_cache_enabled()
+        if cache_enabled:
+            for idx, (img, h) in enumerate(zip(images, hashes, strict=True)):
+                if h in self._sent_image_hashes:
+                    cached_hashes[idx] = h
+                else:
+                    self._sent_image_hashes.add(h)
+                    new_images.append((idx, img))
+        else:
+            # The worker cache is local, in-memory, and not placement-aware. Sending
+            # hash-only references by default can crash or wedge nodes after restarts
+            # or placement changes, so keep the optimization behind an explicit flag.
+            new_images = list(enumerate(images))
 
         _log_image_transport(
             f"TextGeneration image transport: total={len(images)} "
-            f"new={len(new_images)} cached={len(cached_hashes)}"
+            f"new={len(new_images)} cached={len(cached_hashes)} "
+            f"hash_cache_enabled={cache_enabled}"
         )
         for idx, img in new_images:
             _log_image_transport(

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -501,6 +501,7 @@ class API:
         self._embedding_queues: dict[
             CommandId, Sender[EmbeddingChunk | ErrorChunk]
         ] = {}
+        self._cancelled_command_ids: set[CommandId] = set()
         self._image_store = ImageStore(EXO_IMAGE_CACHE_DIR)
         self._tg: TaskGroup = TaskGroup()
 
@@ -527,6 +528,7 @@ class API:
         self._text_generation_queues = {}
         self._image_generation_queues = {}
         self._embedding_queues = {}
+        self._cancelled_command_ids = set()
         self.unpause(result_clock, master_node_id=master_node_id)
         self.event_receiver.close()
         self.event_receiver = event_receiver
@@ -1279,12 +1281,34 @@ class API:
             )
 
         await self._send(TaskCancelled(cancelled_command_id=command_id))
+        # Suppress the final TaskFinished emitted by local stream cleanup so the
+        # worker can observe the Cancelled task and deliver runner-local cancel
+        # before event-sourced task deletion happens.
+        self._cancelled_command_ids.add(command_id)
         sender.close()
 
         return CancelCommandResponse(
             message="Command cancelled.",
             command_id=command_id,
         )
+
+    async def _finalize_command_stream(
+        self,
+        command_id: CommandId,
+        queue_map: dict[CommandId, Sender[object]],
+    ) -> None:
+        """Clean up a local command stream and report natural completion.
+
+        Local cancellations intentionally suppress TaskFinished. Otherwise the
+        master can delete the task before workers synthesize CancelTask for the
+        runner that is still executing it.
+        """
+
+        should_send_finished = command_id not in self._cancelled_command_ids
+        self._cancelled_command_ids.discard(command_id)
+        if should_send_finished:
+            await self._send(TaskFinished(finished_command_id=command_id))
+        queue_map.pop(command_id, None)
 
     async def _token_chunk_stream(
         self, command_id: CommandId
@@ -1310,15 +1334,20 @@ class API:
 
         except anyio.get_cancelled_exc_class():
             command = TaskCancelled(cancelled_command_id=command_id)
+            self._cancelled_command_ids.add(command_id)
             with anyio.CancelScope(shield=True):
                 await self.command_sender.send(
                     ForwarderCommand(origin=self._system_id, command=command)
                 )
             raise
         finally:
-            await self._send(TaskFinished(finished_command_id=command_id))
-            if command_id in self._text_generation_queues:
-                del self._text_generation_queues[command_id]
+            await self._finalize_command_stream(
+                command_id,
+                cast(
+                    dict[CommandId, Sender[object]],
+                    self._text_generation_queues,
+                ),
+            )
 
     async def _collect_text_generation_with_stats(
         self, command_id: CommandId
@@ -1802,15 +1831,20 @@ class API:
 
         except anyio.get_cancelled_exc_class():
             command = TaskCancelled(cancelled_command_id=command_id)
+            self._cancelled_command_ids.add(command_id)
             with anyio.CancelScope(shield=True):
                 await self.command_sender.send(
                     ForwarderCommand(origin=self._system_id, command=command)
                 )
             raise
         finally:
-            await self._send(TaskFinished(finished_command_id=command_id))
-            if command_id in self._image_generation_queues:
-                del self._image_generation_queues[command_id]
+            await self._finalize_command_stream(
+                command_id,
+                cast(
+                    dict[CommandId, Sender[object]],
+                    self._image_generation_queues,
+                ),
+            )
 
     async def _collect_image_chunks(
         self,
@@ -1888,15 +1922,20 @@ class API:
             return (images, stats if capture_stats else None)
         except anyio.get_cancelled_exc_class():
             command = TaskCancelled(cancelled_command_id=command_id)
+            self._cancelled_command_ids.add(command_id)
             with anyio.CancelScope(shield=True):
                 await self.command_sender.send(
                     ForwarderCommand(origin=self._system_id, command=command)
                 )
             raise
         finally:
-            await self._send(TaskFinished(finished_command_id=command_id))
-            if command_id in self._image_generation_queues:
-                del self._image_generation_queues[command_id]
+            await self._finalize_command_stream(
+                command_id,
+                cast(
+                    dict[CommandId, Sender[object]],
+                    self._image_generation_queues,
+                ),
+            )
 
     async def _collect_image_generation(
         self,
@@ -3043,6 +3082,94 @@ class API:
 
         return placements
 
+    @staticmethod
+    def _short_diagnostics_id(value: str) -> str:
+        """Return a compact identifier for human-facing diagnostics warnings."""
+
+        return f"{value[:8]}…{value[-4:]}" if len(value) > 12 else value
+
+    def _augment_runner_divergence_warnings(
+        self,
+        placements: Sequence[InstancePlacementDiagnostics],
+        supervisor_runners: Sequence[RunnerSupervisorDiagnostics],
+    ) -> list[str]:
+        """Add warnings when live supervisor state diverges from cluster state."""
+
+        task_by_id = {str(task_id): task for task_id, task in self.state.tasks.items()}
+        placement_by_instance = {
+            placement.instance_id: placement for placement in placements
+        }
+        top_level_warnings: set[str] = set()
+        placement_warnings_by_instance: dict[str, set[str]] = {
+            placement.instance_id: set() for placement in placements
+        }
+
+        for runner in supervisor_runners:
+            placement = placement_by_instance.get(runner.instance_id)
+            placement_task_ids: set[str] = set()
+            instance_task_ids: set[str] = set()
+            if placement is not None:
+                instance_task_ids = {
+                    task.task_id for placement_runner in placement.runners for task in placement_runner.tasks
+                }
+                for placement_runner in placement.runners:
+                    if placement_runner.runner_id == runner.runner_id:
+                        placement_task_ids = {
+                            task.task_id for task in placement_runner.tasks
+                        }
+                        break
+
+            if runner.process_alive and runner.in_progress_tasks and not instance_task_ids:
+                message = (
+                    "Runner "
+                    f"{self._short_diagnostics_id(runner.runner_id)} is still alive with "
+                    f"{len(runner.in_progress_tasks)} in-progress task(s), but event-sourced "
+                    f"state shows no active tasks for instance "
+                    f"{self._short_diagnostics_id(runner.instance_id)}."
+                )
+                top_level_warnings.add(message)
+                placement_warnings_by_instance.setdefault(runner.instance_id, set()).add(
+                    message
+                )
+
+            for task in runner.in_progress_tasks:
+                matching_state_task = task_by_id.get(task.task_id)
+                if matching_state_task is None:
+                    message = (
+                        "Runner "
+                        f"{self._short_diagnostics_id(runner.runner_id)} still reports "
+                        f"{task.task_kind}:{self._short_diagnostics_id(task.task_id)} in progress, "
+                        "but cluster state no longer tracks that task."
+                    )
+                elif matching_state_task.task_status.value not in {"Pending", "Running"}:
+                    message = (
+                        "Runner "
+                        f"{self._short_diagnostics_id(runner.runner_id)} still reports "
+                        f"{task.task_kind}:{self._short_diagnostics_id(task.task_id)} in progress "
+                        f"while cluster state says {matching_state_task.task_status.value}."
+                    )
+                elif placement is not None and task.task_id not in placement_task_ids:
+                    message = (
+                        "Runner "
+                        f"{self._short_diagnostics_id(runner.runner_id)} still reports "
+                        f"{task.task_kind}:{self._short_diagnostics_id(task.task_id)} in progress, "
+                        "but placement diagnostics show no active task on this runner."
+                    )
+                else:
+                    continue
+
+                top_level_warnings.add(message)
+                placement_warnings_by_instance.setdefault(runner.instance_id, set()).add(
+                    message
+                )
+
+        for placement in placements:
+            extra_warnings = placement_warnings_by_instance.get(placement.instance_id, set())
+            if extra_warnings:
+                placement.warnings = sorted(set(placement.warnings) | extra_warnings)
+
+        return sorted(top_level_warnings)
+
     def _collect_runner_supervisor_diagnostics(
         self,
     ) -> list[RunnerSupervisorDiagnostics]:
@@ -3246,12 +3373,11 @@ class API:
 
         supervisor_runners = self._collect_runner_supervisor_diagnostics()
         placements = self._placement_diagnostics()
-        warnings = sorted(
-            {
-                warning
-                for placement in placements
-                for warning in placement.warnings
-            }
+        warnings = {
+            warning for placement in placements for warning in placement.warnings
+        }
+        warnings.update(
+            self._augment_runner_divergence_warnings(placements, supervisor_runners)
         )
         return NodeDiagnostics(
             generated_at=datetime.now(tz=timezone.utc).isoformat(),
@@ -3261,7 +3387,7 @@ class API:
             processes=self._collect_process_diagnostics(supervisor_runners),
             supervisor_runners=supervisor_runners,
             placements=placements,
-            warnings=warnings,
+            warnings=sorted(warnings),
         )
 
     async def get_cluster_diagnostics(self) -> ClusterDiagnostics:
@@ -3913,15 +4039,20 @@ class API:
 
         except anyio.get_cancelled_exc_class():
             cancel_command = TaskCancelled(cancelled_command_id=command_id)
+            self._cancelled_command_ids.add(command_id)
             with anyio.CancelScope(shield=True):
                 await self.command_sender.send(
                     ForwarderCommand(origin=self._system_id, command=cancel_command)
                 )
             raise
         finally:
-            await self._send(TaskFinished(finished_command_id=command_id))
-            if command_id in self._embedding_queues:
-                del self._embedding_queues[command_id]
+            await self._finalize_command_stream(
+                command_id,
+                cast(
+                    dict[CommandId, Sender[object]],
+                    self._embedding_queues,
+                ),
+            )
 
     async def restart_node(self, node_id: NodeId | None = None) -> JSONResponse:
         """Restart the exo process on this or a remote node.

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -208,6 +208,8 @@ from exo.shared.types.diagnostics import (
     PlacementRunnerDiagnostics,
     ProcessRole,
     RunnerSupervisorDiagnostics,
+    RunnerTaskCancelRequest,
+    RunnerTaskCancelResponse,
     RunnerTaskDiagnostics,
 )
 from exo.shared.types.events import (
@@ -223,6 +225,7 @@ from exo.shared.types.state import State
 from exo.shared.types.text_generation import TextGenerationTaskParams
 from exo.shared.types.worker.downloads import DownloadCompleted
 from exo.shared.types.worker.instances import Instance, InstanceId, InstanceMeta
+from exo.shared.types.worker.runners import RunnerId
 from exo.shared.types.worker.shards import Sharding
 from exo.shared.version import get_skulk_version, get_skulk_version_label
 from exo.store.config import resolve_config_path
@@ -455,6 +458,9 @@ class API:
         self._runner_diagnostics_provider: Callable[
             [], Sequence[RunnerSupervisorDiagnostics]
         ] | None = None
+        self._runner_cancel_provider: Callable[
+            [RunnerId, task_types.TaskId], Awaitable[RunnerTaskCancelResponse]
+        ] | None = None
         self._sent_image_hashes: set[str] = set()
         # Initialize optimizer if store path is available
         if exo_config and exo_config.model_store and exo_config.model_store.enabled:
@@ -512,6 +518,17 @@ class API:
         """Attach a local worker diagnostics provider to this API instance."""
 
         self._runner_diagnostics_provider = provider
+
+    def set_runner_cancel_provider(
+        self,
+        provider: Callable[
+            [RunnerId, task_types.TaskId], Awaitable[RunnerTaskCancelResponse]
+        ]
+        | None,
+    ) -> None:
+        """Attach a local worker control provider for direct runner cancellation."""
+
+        self._runner_cancel_provider = provider
 
     def reset(
         self,
@@ -899,6 +916,16 @@ class API:
                 "state, local resources, and relevant OS processes."
             ),
         )(self.get_node_diagnostics)
+        self.app.post(
+            "/v1/diagnostics/node/runners/{runner_id}/cancel",
+            tags=["Diagnostics"],
+            summary="Request direct local runner cancellation",
+            description=(
+                "Request cooperative cancellation for one live task on one local "
+                "runner supervisor. This is a best-effort control path intended "
+                "for diagnostics and may not stop a runner wedged in native code."
+            ),
+        )(self.cancel_local_runner_task)
         self.app.get(
             "/v1/diagnostics/cluster",
             tags=["Diagnostics"],
@@ -918,6 +945,16 @@ class API:
                 "proxying to a reachable peer API."
             ),
         )(self.get_cluster_node_diagnostics)
+        self.app.post(
+            "/v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel",
+            tags=["Diagnostics"],
+            summary="Request direct runner cancellation on one cluster node",
+            description=(
+                "Proxy a cooperative live-task cancellation request to the "
+                "requested node's local diagnostics control endpoint. This is "
+                "best-effort and may not stop a runner wedged in native code."
+            ),
+        )(self.cancel_cluster_runner_task)
         self.app.get(
             "/v1/traces/{task_id}",
             tags=["State & Tracing"],
@@ -3389,6 +3426,80 @@ class API:
             placements=placements,
             warnings=sorted(warnings),
         )
+
+    @staticmethod
+    def _proxy_error_detail(response: httpx.Response) -> str:
+        """Extract one user-facing error message from a proxied API response."""
+
+        with contextlib.suppress(ValueError):
+            payload = _coerce_json_object(cast(object, response.json()))
+            detail = payload.get("detail")
+            if isinstance(detail, str):
+                return detail
+            error = _coerce_json_object(payload.get("error"))
+            message = error.get("message")
+            if isinstance(message, str):
+                return message
+        return f"Peer request failed with status {response.status_code}"
+
+    async def cancel_local_runner_task(
+        self,
+        runner_id: RunnerId,
+        request: RunnerTaskCancelRequest,
+    ) -> RunnerTaskCancelResponse:
+        """Request cooperative cancellation for one live task on this node."""
+
+        if self._runner_cancel_provider is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Local worker runner controls are not available on this node.",
+            )
+
+        try:
+            return await self._runner_cancel_provider(runner_id, request.task_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    async def cancel_cluster_runner_task(
+        self,
+        node_id: str,
+        runner_id: RunnerId,
+        request: RunnerTaskCancelRequest,
+    ) -> RunnerTaskCancelResponse:
+        """Proxy one direct runner cancellation request to the requested node."""
+
+        if node_id == str(self.node_id):
+            return await self.cancel_local_runner_task(runner_id, request)
+
+        peer_urls = await self._reachable_peer_api_urls()
+        base_url = peer_urls.get(node_id)
+        if base_url is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Node diagnostics endpoint not reachable: {node_id}",
+            )
+
+        timeout = httpx.Timeout(timeout=10.0, connect=2.0)
+        async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
+            try:
+                response = await client.post(
+                    f"{base_url}/v1/diagnostics/node/runners/{runner_id}/cancel",
+                    json=request.model_dump(mode="json", by_alias=True),
+                )
+            except httpx.HTTPError as exc:
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Failed to proxy runner cancellation to {node_id}: {exc}",
+                ) from exc
+
+        if response.status_code >= 400:
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=self._proxy_error_detail(response),
+            )
+        return RunnerTaskCancelResponse.model_validate(response.json())
 
     async def get_cluster_diagnostics(self) -> ClusterDiagnostics:
         """Return read-only diagnostics for local and reachable peer nodes."""

--- a/src/exo/api/tests/test_cancel_command.py
+++ b/src/exo/api/tests/test_cancel_command.py
@@ -1,12 +1,14 @@
 # pyright: reportUnusedFunction=false, reportAny=false
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from exo.api.main import API
 from exo.shared.types.common import CommandId
+from exo.utils.channels import Sender
 
 
 def _make_api() -> Any:
@@ -18,6 +20,7 @@ def _make_api() -> Any:
     api._text_generation_queues = {}  # pyright: ignore[reportPrivateUsage]
     api._image_generation_queues = {}  # pyright: ignore[reportPrivateUsage]
     api._embedding_queues = {}  # pyright: ignore[reportPrivateUsage]
+    api._cancelled_command_ids = set()  # pyright: ignore[reportPrivateUsage]
     api._send = AsyncMock()  # pyright: ignore[reportPrivateUsage]
     api._setup_exception_handlers()  # pyright: ignore[reportPrivateUsage]
     app.post("/v1/cancel/{command_id}")(api.cancel_command)
@@ -54,6 +57,7 @@ def test_cancel_active_text_generation() -> None:
     assert data["command_id"] == str(cid)
     sender.close.assert_called_once()
     api._send.assert_called_once()
+    assert cid in api._cancelled_command_ids
     task_cancelled = api._send.call_args[0][0]
     assert task_cancelled.cancelled_command_id == cid
 
@@ -74,5 +78,44 @@ def test_cancel_active_image_generation() -> None:
     assert data["command_id"] == str(cid)
     sender.close.assert_called_once()
     api._send.assert_called_once()
+    assert cid in api._cancelled_command_ids
     task_cancelled = api._send.call_args[0][0]
     assert task_cancelled.cancelled_command_id == cid
+
+
+@pytest.mark.asyncio
+async def test_finalize_command_stream_suppresses_task_finished_for_cancelled_command() -> None:
+    """Local cancellation should skip TaskFinished so workers can observe Cancelled."""
+
+    api = _make_api()
+    cid = CommandId("cancelled-cmd")
+    sender = MagicMock()
+    queue: dict[CommandId, Sender[object]] = {
+        cid: cast(Sender[object], cast(object, sender))
+    }
+    api._cancelled_command_ids.add(cid)
+
+    await api._finalize_command_stream(cid, queue)
+
+    api._send.assert_not_called()
+    assert cid not in queue
+    assert cid not in api._cancelled_command_ids
+
+
+@pytest.mark.asyncio
+async def test_finalize_command_stream_reports_natural_completion() -> None:
+    """Natural completion should still emit TaskFinished."""
+
+    api = _make_api()
+    cid = CommandId("finished-cmd")
+    sender = MagicMock()
+    queue: dict[CommandId, Sender[object]] = {
+        cid: cast(Sender[object], cast(object, sender))
+    }
+
+    await api._finalize_command_stream(cid, queue)
+
+    api._send.assert_called_once()
+    task_finished = api._send.call_args[0][0]
+    assert task_finished.finished_command_id == cid
+    assert cid not in queue

--- a/src/exo/api/tests/test_diagnostics_api.py
+++ b/src/exo/api/tests/test_diagnostics_api.py
@@ -12,7 +12,12 @@ from exo.shared.election import ElectionMessage
 from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.commands import ForwarderCommand, ForwarderDownloadCommand
 from exo.shared.types.common import ModelId, NodeId
-from exo.shared.types.diagnostics import NodeDiagnostics
+from exo.shared.types.diagnostics import (
+    NodeDiagnostics,
+    RunnerLifecycleMilestone,
+    RunnerSupervisorDiagnostics,
+    RunnerTaskDiagnostics,
+)
 from exo.shared.types.events import IndexedEvent
 from exo.shared.types.memory import Memory
 from exo.shared.types.state import State
@@ -136,6 +141,90 @@ def test_node_diagnostics_marks_master_outside_placement() -> None:
     assert placement["localNodeIsPlacementNode"] is True
     warnings = _json_list(placement["warnings"])
     assert "Current master is not a placement node for this instance." in warnings
+
+
+def test_node_diagnostics_flags_orphaned_live_runner_tasks() -> None:
+    """Live supervisor tasks missing from state should surface divergence warnings."""
+
+    api = _build_api("local-node")
+    api._master_node_id = NodeId("master-node")  # pyright: ignore[reportPrivateUsage]
+    api.state = _running_state_without_master_placement()
+    warmup_task_id = next(iter(api.state.tasks.keys()))
+    api.set_runner_diagnostics_provider(
+        lambda: [
+            RunnerSupervisorDiagnostics(
+                runner_id="runner-1",
+                instance_id="instance-1",
+                node_id="local-node",
+                model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+                device_rank=0,
+                world_size=2,
+                start_layer=0,
+                end_layer=15,
+                n_layers=30,
+                pid=1234,
+                process_alive=True,
+                exit_code=None,
+                status_kind="RunnerRunning",
+                status_since="2026-04-23T00:00:00+00:00",
+                seconds_in_status=42.0,
+                pending_task_ids=[],
+                in_progress_tasks=[
+                    RunnerTaskDiagnostics(
+                        task_id="orphan-task",
+                        task_kind="TextGeneration",
+                        task_status="Pending",
+                        instance_id="instance-1",
+                        command_id="command-1",
+                        runner_id="runner-1",
+                        model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+                    ),
+                    RunnerTaskDiagnostics(
+                        task_id=str(warmup_task_id),
+                        task_kind="StartWarmup",
+                        task_status="Running",
+                        instance_id="instance-1",
+                        command_id=None,
+                        runner_id="runner-1",
+                        model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+                    ),
+                ],
+                completed_task_count=0,
+                cancelled_task_ids=[],
+                last_task_sent_at="2026-04-23T00:00:00+00:00",
+                last_event_received_at="2026-04-23T00:00:01+00:00",
+                last_event_type="TaskAcknowledged",
+                milestones=[
+                    RunnerLifecycleMilestone(
+                        at="2026-04-23T00:00:00+00:00",
+                        name="task_sent",
+                        detail="TextGeneration:orphan-task",
+                    )
+                ],
+            )
+        ]
+    )
+    client = TestClient(api.app)
+
+    response = client.get("/v1/diagnostics/node")
+
+    assert response.status_code == 200
+    body = _json_object(response)
+    warnings = _json_list(body["warnings"])
+    assert any(
+        "still reports TextGeneration:orphan-t…task in progress"
+        in cast(str, warning)
+        or "still reports TextGeneration:orphan-task in progress"
+        in cast(str, warning)
+        for warning in warnings
+    )
+    placements = _json_list(body["placements"])
+    placement = _json_mapping(placements[0])
+    placement_warnings = _json_list(placement["warnings"])
+    assert any(
+        "cluster state no longer tracks that task" in cast(str, warning)
+        for warning in placement_warnings
+    )
 
 
 def test_cluster_diagnostics_returns_local_and_peer_results(

--- a/src/exo/api/tests/test_diagnostics_api.py
+++ b/src/exo/api/tests/test_diagnostics_api.py
@@ -13,7 +13,12 @@ from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.commands import ForwarderCommand, ForwarderDownloadCommand
 from exo.shared.types.common import ModelId, NodeId
 from exo.shared.types.diagnostics import (
+    DiagnosticCaptureResponse,
+    DiagnosticProcessSample,
+    MlxMemorySnapshot,
     NodeDiagnostics,
+    RunnerDiagnosticContext,
+    RunnerFlightRecorderEntry,
     RunnerLifecycleMilestone,
     RunnerSupervisorDiagnostics,
     RunnerTaskCancelResponse,
@@ -169,6 +174,44 @@ def test_node_diagnostics_flags_orphaned_live_runner_tasks() -> None:
                 status_kind="RunnerRunning",
                 status_since="2026-04-23T00:00:00+00:00",
                 seconds_in_status=42.0,
+                phase="decode_wait_first_token",
+                phase_started_at="2026-04-23T00:00:02+00:00",
+                seconds_in_phase=40.0,
+                last_progress_at="2026-04-23T00:00:02+00:00",
+                active_task_id="orphan-task",
+                active_command_id="command-1",
+                phase_detail="stream_generate_first_token",
+                last_mlx_memory=MlxMemorySnapshot(
+                    generated_at="2026-04-23T00:00:02+00:00",
+                    active=Memory.from_mb(1024),
+                    cache=Memory.from_mb(128),
+                    peak=Memory.from_mb(2048),
+                    wired_limit=None,
+                    source="mlx.core",
+                ),
+                flight_recorder=[
+                    RunnerFlightRecorderEntry(
+                        at="2026-04-23T00:00:02+00:00",
+                        phase="decode_wait_first_token",
+                        event="enter",
+                        detail="stream_generate_first_token",
+                        attrs={"prompt_tokens": 123},
+                        context=RunnerDiagnosticContext(
+                            node_id="local-node",
+                            runner_id="runner-1",
+                            pid=1234,
+                            instance_id="instance-1",
+                            model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+                            rank=0,
+                            world_size=2,
+                            start_layer=0,
+                            end_layer=15,
+                            n_layers=30,
+                        ),
+                        task_id="orphan-task",
+                        command_id="command-1",
+                    )
+                ],
                 pending_task_ids=[],
                 in_progress_tasks=[
                     RunnerTaskDiagnostics(
@@ -226,6 +269,132 @@ def test_node_diagnostics_flags_orphaned_live_runner_tasks() -> None:
         "cluster state no longer tracks that task" in cast(str, warning)
         for warning in placement_warnings
     )
+
+
+def test_capture_local_node_diagnostics_returns_runner_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local capture should include flight recorder and partial process samples."""
+
+    api = _build_api("local-node")
+    runner = RunnerSupervisorDiagnostics(
+        runner_id="runner-1",
+        instance_id="instance-1",
+        node_id="local-node",
+        model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=30,
+        n_layers=30,
+        pid=1234,
+        process_alive=True,
+        exit_code=None,
+        status_kind="RunnerRunning",
+        status_since="2026-04-23T00:00:00+00:00",
+        seconds_in_status=12.0,
+        phase="decode_wait_first_token",
+        phase_started_at="2026-04-23T00:00:01+00:00",
+        seconds_in_phase=11.0,
+        last_progress_at="2026-04-23T00:00:01+00:00",
+        active_task_id="task-1",
+        active_command_id="command-1",
+        phase_detail="stream_generate_first_token",
+        last_mlx_memory=MlxMemorySnapshot(
+            generated_at="2026-04-23T00:00:01+00:00",
+            active=Memory.from_mb(512),
+            cache=Memory.from_mb(64),
+            peak=Memory.from_mb(1024),
+            wired_limit=None,
+            source="mlx.core",
+        ),
+        flight_recorder=[
+            RunnerFlightRecorderEntry(
+                at="2026-04-23T00:00:01+00:00",
+                phase="decode_wait_first_token",
+                event="enter",
+                detail="stream_generate_first_token",
+                attrs={"prompt_tokens": 42},
+                context=RunnerDiagnosticContext(
+                    node_id="local-node",
+                    runner_id="runner-1",
+                    pid=1234,
+                    instance_id="instance-1",
+                    model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+                    rank=0,
+                    world_size=1,
+                    start_layer=0,
+                    end_layer=30,
+                    n_layers=30,
+                ),
+                task_id="task-1",
+                command_id="command-1",
+            )
+        ],
+        pending_task_ids=[],
+        in_progress_tasks=[
+            RunnerTaskDiagnostics(
+                task_id="task-1",
+                task_kind="TextGeneration",
+                task_status="Running",
+                instance_id="instance-1",
+                command_id="command-1",
+                runner_id="runner-1",
+                model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+            )
+        ],
+        completed_task_count=0,
+        cancelled_task_ids=[],
+        last_task_sent_at="2026-04-23T00:00:00+00:00",
+        last_event_received_at="2026-04-23T00:00:01+00:00",
+        last_event_type="ChunkGenerated",
+        milestones=[],
+    )
+    api.set_runner_diagnostics_provider(lambda: [runner])
+
+    async def _sample_runner(_pid: int, _duration: float) -> list[DiagnosticProcessSample]:
+        return [
+            DiagnosticProcessSample(
+                name="sample",
+                command=["sample", "1234", "3"],
+                ok=False,
+                exit_code=1,
+                duration_seconds=0.1,
+                stderr="permission denied",
+                error="Command exited non-zero",
+            )
+        ]
+
+    monkeypatch.setattr(api, "_collect_process_samples", _sample_runner)
+    client = TestClient(api.app)
+
+    response = client.post(
+        "/v1/diagnostics/node/capture",
+        json={"runnerId": "runner-1", "taskId": "task-1"},
+    )
+
+    assert response.status_code == 200
+    body = _json_object(response)
+    assert _json_mapping(body["runner"])["phase"] == "decode_wait_first_token"
+    assert _json_mapping(body["mlxMemory"])["source"] == "mlx.core"
+    assert len(_json_list(body["flightRecorder"])) == 1
+    samples = _json_list(body["processSamples"])
+    assert _json_mapping(samples[0])["ok"] is False
+
+
+def test_capture_local_node_diagnostics_rejects_unknown_runner() -> None:
+    """Capture should return a clear 404 for unknown focused runner IDs."""
+
+    api = _build_api("local-node")
+    client = TestClient(api.app)
+
+    response = client.post(
+        "/v1/diagnostics/node/capture",
+        json={"runnerId": "runner-missing"},
+    )
+
+    assert response.status_code == 404
+    assert "No local runner matched" in response.text
 
 
 def test_cluster_diagnostics_returns_local_and_peer_results(
@@ -385,3 +554,74 @@ def test_cancel_cluster_runner_task_proxies_to_peer(
     body = _json_object(response)
     assert body["nodeId"] == "peer-node"
     assert body["status"] == "cancel_requested"
+
+
+def test_capture_cluster_node_diagnostics_proxies_to_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cluster capture should proxy the request body to a reachable peer."""
+
+    api = _build_api("local-node")
+    client = TestClient(api.app)
+
+    async def _reachable_peer_api_urls() -> dict[str, str]:
+        return {"peer-node": "http://peer-node:52415"}
+
+    capture = DiagnosticCaptureResponse(
+        generated_at="2026-04-23T00:00:00+00:00",
+        node_id=NodeId("peer-node"),
+        node_diagnostics=NodeDiagnostics(
+            generated_at="2026-04-23T00:00:00+00:00",
+            runtime=api._runtime_diagnostics().model_copy(  # pyright: ignore[reportPrivateUsage]
+                update={"node_id": "peer-node", "hostname": "peer-node.local"}
+            ),
+            resources=api._resource_diagnostics(),  # pyright: ignore[reportPrivateUsage]
+        ),
+        flight_recorder=[],
+        process_samples=[],
+        warnings=[],
+    )
+
+    class _FakeAsyncClient:
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            _exc_type: object,
+            _exc: object,
+            _tb: object,
+        ) -> None:
+            return None
+
+        async def post(self, url: str, json: object) -> httpx.Response:
+            assert url == "http://peer-node:52415/v1/diagnostics/node/capture"
+            assert json == {
+                "runnerId": "runner-1",
+                "taskId": "task-1",
+                "includeProcessSamples": True,
+                "sampleDurationSeconds": 3.0,
+            }
+            return httpx.Response(
+                200,
+                json=capture.model_dump(mode="json", by_alias=True),
+                request=httpx.Request("POST", url),
+            )
+
+    def _build_async_client(
+        *_args: object,
+        **_kwargs: object,
+    ) -> _FakeAsyncClient:
+        return _FakeAsyncClient()
+
+    monkeypatch.setattr(api, "_reachable_peer_api_urls", _reachable_peer_api_urls)
+    monkeypatch.setattr(api_main.httpx, "AsyncClient", _build_async_client)
+
+    response = client.post(
+        "/v1/diagnostics/cluster/peer-node/capture",
+        json={"runnerId": "runner-1", "taskId": "task-1"},
+    )
+
+    assert response.status_code == 200
+    body = _json_object(response)
+    assert body["nodeId"] == "peer-node"

--- a/src/exo/api/tests/test_diagnostics_api.py
+++ b/src/exo/api/tests/test_diagnostics_api.py
@@ -462,6 +462,237 @@ def test_cluster_diagnostics_returns_local_and_peer_results(
     assert all(node["ok"] is True for node in nodes)
 
 
+def _build_supervisor_runner(
+    *,
+    node_id: str,
+    rank: int,
+    runner_id: str,
+    flight_at: list[str],
+) -> RunnerSupervisorDiagnostics:
+    """Build a minimal supervisor diagnostics record for cluster-timeline tests."""
+
+    context = RunnerDiagnosticContext(
+        node_id=node_id,
+        runner_id=runner_id,
+        pid=1234 + rank,
+        instance_id="instance-1",
+        model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+        rank=rank,
+        world_size=2,
+        start_layer=0,
+        end_layer=15,
+        n_layers=30,
+    )
+    return RunnerSupervisorDiagnostics(
+        runner_id=runner_id,
+        instance_id="instance-1",
+        node_id=node_id,
+        model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+        device_rank=rank,
+        world_size=2,
+        start_layer=0,
+        end_layer=15,
+        n_layers=30,
+        pid=1234 + rank,
+        process_alive=True,
+        exit_code=None,
+        status_kind="RunnerRunning",
+        status_since="2026-04-23T00:00:00+00:00",
+        seconds_in_status=12.0,
+        phase="decode_stream",
+        phase_started_at="2026-04-23T00:00:01+00:00",
+        seconds_in_phase=11.0,
+        last_progress_at=flight_at[-1] if flight_at else None,
+        active_task_id="task-1",
+        active_command_id="command-1",
+        phase_detail="pipeline_last_eval_output",
+        last_mlx_memory=None,
+        flight_recorder=[
+            RunnerFlightRecorderEntry(
+                at=ts,
+                phase="decode_stream",
+                event="enter",
+                detail="pipeline_last_eval_output",
+                attrs={"rank": rank},
+                context=context,
+                task_id="task-1",
+                command_id="command-1",
+            )
+            for ts in flight_at
+        ],
+        pending_task_ids=[],
+        in_progress_tasks=[],
+        completed_task_count=0,
+        cancelled_task_ids=[],
+        last_task_sent_at=None,
+        last_event_received_at=None,
+        last_event_type=None,
+        milestones=[],
+    )
+
+
+def test_cluster_timeline_merges_flight_recorders_by_wall_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cluster timeline should merge per-rank flight recorders chronologically.
+
+    The intended consumer is a human staring at a distributed deadlock: they
+    need to see "rank 0 entered phase X at T while rank 1 was still in phase Y"
+    by reading top to bottom. Verify that ranks are stitched into one list
+    sorted by `at`, with `node_id` / `device_rank` lifted onto each entry.
+    """
+
+    api = _build_api("local-node")
+    client = TestClient(api.app)
+
+    # Local rank 0: two flight-recorder entries, the later one being the
+    # eval site that hangs in production.
+    local_runner = _build_supervisor_runner(
+        node_id="local-node",
+        rank=0,
+        runner_id="runner-0",
+        flight_at=[
+            "2026-04-24T22:03:50.000000+00:00",
+            "2026-04-24T22:03:51.508000+00:00",
+        ],
+    )
+    api.set_runner_diagnostics_provider(lambda: [local_runner])
+
+    # Peer rank 1: two entries that interleave with the local timeline so
+    # chronological merge is observable in the response order.
+    peer_runner = _build_supervisor_runner(
+        node_id="peer-node",
+        rank=1,
+        runner_id="runner-1",
+        flight_at=[
+            "2026-04-24T22:03:50.500000+00:00",
+            "2026-04-24T22:03:52.000000+00:00",
+        ],
+    )
+
+    runtime = api._runtime_diagnostics()  # pyright: ignore[reportPrivateUsage]
+    peer_diagnostics = NodeDiagnostics(
+        generated_at="2026-04-24T22:03:53+00:00",
+        runtime=runtime.model_copy(
+            update={"node_id": "peer-node", "hostname": "peer-node.local"}
+        ),
+        resources=api._resource_diagnostics(),  # pyright: ignore[reportPrivateUsage]
+        supervisor_runners=[peer_runner],
+    )
+
+    async def _reachable_peer_api_urls() -> dict[str, str]:
+        return {"peer-node": "http://peer-node:52415"}
+
+    class _FakeAsyncClient:
+        def __init__(self, responses: dict[str, httpx.Response]) -> None:
+            self._responses = responses
+
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            _exc_type: object,
+            _exc: object,
+            _tb: object,
+        ) -> None:
+            return None
+
+        async def get(self, url: str) -> httpx.Response:
+            return self._responses[url]
+
+    def _build_async_client(*_args: object, **_kwargs: object) -> _FakeAsyncClient:
+        return _FakeAsyncClient(
+            responses={
+                "http://peer-node:52415/v1/diagnostics/node": httpx.Response(
+                    200,
+                    json=peer_diagnostics.model_dump(mode="json", by_alias=True),
+                    request=httpx.Request(
+                        "GET",
+                        "http://peer-node:52415/v1/diagnostics/node",
+                    ),
+                )
+            }
+        )
+
+    monkeypatch.setattr(api, "_reachable_peer_api_urls", _reachable_peer_api_urls)
+    monkeypatch.setattr(api_main.httpx, "AsyncClient", _build_async_client)
+
+    response = client.get("/v1/diagnostics/cluster/timeline")
+
+    assert response.status_code == 200
+    body = _json_object(response)
+
+    runners = [_json_mapping(r) for r in _json_list(body["runners"])]
+    assert [r["deviceRank"] for r in runners] == [0, 1]
+    assert [r["nodeId"] for r in runners] == ["local-node", "peer-node"]
+
+    timeline = [_json_mapping(e) for e in _json_list(body["timeline"])]
+    assert [e["at"] for e in timeline] == [
+        "2026-04-24T22:03:50.000000+00:00",
+        "2026-04-24T22:03:50.500000+00:00",
+        "2026-04-24T22:03:51.508000+00:00",
+        "2026-04-24T22:03:52.000000+00:00",
+    ]
+    assert [e["deviceRank"] for e in timeline] == [0, 1, 0, 1]
+    assert [e["nodeId"] for e in timeline] == [
+        "local-node",
+        "peer-node",
+        "local-node",
+        "peer-node",
+    ]
+    # Every entry must carry world_size + runner identity for downstream tools.
+    assert all(e["worldSize"] == 2 for e in timeline)
+    assert {e["runnerId"] for e in timeline} == {"runner-0", "runner-1"}
+
+
+def test_cluster_timeline_records_unreachable_peers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unreachable peers should appear in unreachableNodes, not break the response."""
+
+    api = _build_api("local-node")
+    client = TestClient(api.app)
+
+    api.set_runner_diagnostics_provider(list)
+
+    async def _reachable_peer_api_urls() -> dict[str, str]:
+        return {"peer-node": "http://peer-node:52415"}
+
+    class _FakeAsyncClient:
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            _exc_type: object,
+            _exc: object,
+            _tb: object,
+        ) -> None:
+            return None
+
+        async def get(self, _url: str) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+    def _build_async_client(*_args: object, **_kwargs: object) -> _FakeAsyncClient:
+        return _FakeAsyncClient()
+
+    monkeypatch.setattr(api, "_reachable_peer_api_urls", _reachable_peer_api_urls)
+    monkeypatch.setattr(api_main.httpx, "AsyncClient", _build_async_client)
+
+    response = client.get("/v1/diagnostics/cluster/timeline")
+
+    assert response.status_code == 200
+    body = _json_object(response)
+    unreachable = [_json_mapping(u) for u in _json_list(body["unreachableNodes"])]
+    assert len(unreachable) == 1
+    assert unreachable[0]["nodeId"] == "peer-node"
+    assert "connection refused" in str(unreachable[0]["error"])
+    # Local node has no runners — timeline is empty but well-formed.
+    assert _json_list(body["timeline"]) == []
+    assert _json_list(body["runners"]) == []
+
+
 def test_cancel_local_runner_task_calls_worker_provider() -> None:
     """Local runner control should call the attached worker provider."""
 

--- a/src/exo/api/tests/test_diagnostics_api.py
+++ b/src/exo/api/tests/test_diagnostics_api.py
@@ -16,12 +16,13 @@ from exo.shared.types.diagnostics import (
     NodeDiagnostics,
     RunnerLifecycleMilestone,
     RunnerSupervisorDiagnostics,
+    RunnerTaskCancelResponse,
     RunnerTaskDiagnostics,
 )
 from exo.shared.types.events import IndexedEvent
 from exo.shared.types.memory import Memory
 from exo.shared.types.state import State
-from exo.shared.types.tasks import StartWarmup, TaskStatus
+from exo.shared.types.tasks import StartWarmup, TaskId, TaskStatus
 from exo.shared.types.worker.instances import InstanceId, MlxRingInstance
 from exo.shared.types.worker.runners import RunnerId, RunnerWarmingUp, ShardAssignments
 from exo.shared.types.worker.shards import PipelineShardMetadata
@@ -290,3 +291,97 @@ def test_cluster_diagnostics_returns_local_and_peer_results(
     ]
     assert {node["nodeId"] for node in nodes} == {"local-node", "peer-node"}
     assert all(node["ok"] is True for node in nodes)
+
+
+def test_cancel_local_runner_task_calls_worker_provider() -> None:
+    """Local runner control should call the attached worker provider."""
+
+    api = _build_api("local-node")
+    captured: list[tuple[str, str]] = []
+    expected_task_id = TaskId("task-1")
+
+    async def _cancel_provider(runner_id: object, task_id: object) -> RunnerTaskCancelResponse:
+        captured.append((str(runner_id), str(task_id)))
+        return RunnerTaskCancelResponse(
+            node_id=NodeId("local-node"),
+            runner_id=RunnerId(str(runner_id)),
+            task_id=expected_task_id,
+            status="cancel_requested",
+            message="cancelled",
+        )
+
+    api.set_runner_cancel_provider(_cancel_provider)
+    client = TestClient(api.app)
+
+    response = client.post(
+        "/v1/diagnostics/node/runners/runner-1/cancel",
+        json={"taskId": "task-1"},
+    )
+
+    assert response.status_code == 200
+    assert captured == [("runner-1", "task-1")]
+    body = _json_object(response)
+    assert body["status"] == "cancel_requested"
+    assert body["runnerId"] == "runner-1"
+    assert body["taskId"] == "task-1"
+
+
+def test_cancel_cluster_runner_task_proxies_to_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cluster runner control should proxy to a reachable peer node."""
+
+    api = _build_api("local-node")
+    client = TestClient(api.app)
+
+    async def _reachable_peer_api_urls() -> dict[str, str]:
+        return {"peer-node": "http://peer-node:52415"}
+
+    class _FakeAsyncClient:
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            _exc_type: object,
+            _exc: object,
+            _tb: object,
+        ) -> None:
+            return None
+
+        async def post(self, url: str, json: object) -> httpx.Response:
+            assert (
+                url
+                == "http://peer-node:52415/v1/diagnostics/node/runners/runner-1/cancel"
+            )
+            assert json == {"taskId": "task-1"}
+            return httpx.Response(
+                200,
+                json=RunnerTaskCancelResponse(
+                    node_id=NodeId("peer-node"),
+                    runner_id=RunnerId("runner-1"),
+                    task_id=TaskId("task-1"),
+                    status="cancel_requested",
+                    message="proxied",
+                ).model_dump(mode="json", by_alias=True),
+                request=httpx.Request("POST", url),
+            )
+
+    def _build_async_client(
+        *_args: object,
+        **_kwargs: object,
+    ) -> _FakeAsyncClient:
+        return _FakeAsyncClient()
+
+    monkeypatch.setattr(api, "_reachable_peer_api_urls", _reachable_peer_api_urls)
+    monkeypatch.setattr(api_main.httpx, "AsyncClient", _build_async_client)
+
+    response = client.post(
+        "/v1/diagnostics/cluster/peer-node/runners/runner-1/cancel",
+        json={"taskId": "task-1"},
+    )
+
+    assert response.status_code == 200
+    body = _json_object(response)
+    assert body["nodeId"] == "peer-node"
+    assert body["status"] == "cancel_requested"

--- a/src/exo/api/tests/test_diagnostics_api.py
+++ b/src/exo/api/tests/test_diagnostics_api.py
@@ -1,0 +1,203 @@
+"""Tests for read-only node and cluster diagnostics endpoints."""
+
+from typing import cast
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+import exo.api.main as api_main
+from exo.api.main import API
+from exo.shared.election import ElectionMessage
+from exo.shared.models.model_cards import ModelCard, ModelTask
+from exo.shared.types.commands import ForwarderCommand, ForwarderDownloadCommand
+from exo.shared.types.common import ModelId, NodeId
+from exo.shared.types.diagnostics import NodeDiagnostics
+from exo.shared.types.events import IndexedEvent
+from exo.shared.types.memory import Memory
+from exo.shared.types.state import State
+from exo.shared.types.tasks import StartWarmup, TaskStatus
+from exo.shared.types.worker.instances import InstanceId, MlxRingInstance
+from exo.shared.types.worker.runners import RunnerId, RunnerWarmingUp, ShardAssignments
+from exo.shared.types.worker.shards import PipelineShardMetadata
+from exo.utils.channels import channel
+
+
+def _json_object(response: httpx.Response) -> dict[str, object]:
+    """Return a JSON response payload as a typed object mapping."""
+
+    return cast(dict[str, object], cast(object, response.json()))
+
+
+def _json_list(value: object) -> list[object]:
+    """Narrow a nested JSON array from a response payload."""
+
+    return cast(list[object], value)
+
+
+def _json_mapping(value: object) -> dict[str, object]:
+    """Narrow one nested JSON object from a response payload."""
+
+    return cast(dict[str, object], value)
+
+
+def _build_api(node_id: str = "local-node") -> API:
+    """Create a minimal API instance for diagnostics endpoint testing."""
+
+    command_sender, _ = channel[ForwarderCommand]()
+    download_sender, _ = channel[ForwarderDownloadCommand]()
+    _, event_receiver = channel[IndexedEvent]()
+    _, election_receiver = channel[ElectionMessage]()
+    return API(
+        NodeId(node_id),
+        port=52415,
+        event_receiver=event_receiver,
+        command_sender=command_sender,
+        download_command_sender=download_sender,
+        election_receiver=election_receiver,
+        enable_event_log=False,
+        mount_dashboard=False,
+    )
+
+
+def _running_state_without_master_placement() -> State:
+    """Build state where the master is outside a warming placement."""
+
+    model_card = ModelCard(
+        model_id=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        storage_size=Memory.from_mb(100),
+        n_layers=30,
+        hidden_size=2816,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+    )
+    instance_id = InstanceId("instance-1")
+    runner_1 = RunnerId("runner-1")
+    runner_2 = RunnerId("runner-2")
+    shard_1 = PipelineShardMetadata(
+        model_card=model_card,
+        device_rank=0,
+        world_size=2,
+        start_layer=0,
+        end_layer=15,
+        n_layers=30,
+    )
+    shard_2 = PipelineShardMetadata(
+        model_card=model_card,
+        device_rank=1,
+        world_size=2,
+        start_layer=15,
+        end_layer=30,
+        n_layers=30,
+    )
+    warmup_task = StartWarmup(
+        instance_id=instance_id,
+        task_status=TaskStatus.Running,
+    )
+    return State(
+        instances={
+            instance_id: MlxRingInstance(
+                instance_id=instance_id,
+                shard_assignments=ShardAssignments(
+                    model_id=model_card.model_id,
+                    runner_to_shard={runner_1: shard_1, runner_2: shard_2},
+                    node_to_runner={
+                        NodeId("local-node"): runner_1,
+                        NodeId("peer-node"): runner_2,
+                    },
+                ),
+                hosts_by_node={},
+                ephemeral_port=58484,
+            )
+        },
+        runners={runner_1: RunnerWarmingUp(), runner_2: RunnerWarmingUp()},
+        tasks={warmup_task.task_id: warmup_task},
+    )
+
+
+def test_node_diagnostics_marks_master_outside_placement() -> None:
+    """Local diagnostics should expose master-vs-placement mismatch warnings."""
+
+    api = _build_api("local-node")
+    api._master_node_id = NodeId("master-node")  # pyright: ignore[reportPrivateUsage]
+    api.state = _running_state_without_master_placement()
+    client = TestClient(api.app)
+
+    response = client.get("/v1/diagnostics/node")
+
+    assert response.status_code == 200
+    body = _json_object(response)
+    runtime = _json_mapping(body["runtime"])
+    assert runtime["masterNodeId"] == "master-node"
+    assert runtime["isMaster"] is False
+    placements = _json_list(body["placements"])
+    placement = _json_mapping(placements[0])
+    assert placement["masterIsPlacementNode"] is False
+    assert placement["localNodeIsPlacementNode"] is True
+    warnings = _json_list(placement["warnings"])
+    assert "Current master is not a placement node for this instance." in warnings
+
+
+def test_cluster_diagnostics_returns_local_and_peer_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cluster diagnostics should fan out and tolerate reachable peers."""
+
+    api = _build_api("local-node")
+    client = TestClient(api.app)
+
+    async def _reachable_peer_api_urls() -> dict[str, str]:
+        return {"peer-node": "http://peer-node:52415"}
+
+    class _FakeAsyncClient:
+        def __init__(self, responses: dict[str, httpx.Response]) -> None:
+            self._responses = responses
+
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            _exc_type: object,
+            _exc: object,
+            _tb: object,
+        ) -> None:
+            return None
+
+        async def get(self, url: str) -> httpx.Response:
+            return self._responses[url]
+
+    runtime = api._runtime_diagnostics()  # pyright: ignore[reportPrivateUsage]
+    peer_diagnostics = NodeDiagnostics(
+        generated_at="2026-04-23T00:00:00+00:00",
+        runtime=runtime.model_copy(
+            update={"node_id": "peer-node", "hostname": "peer-node.local"}
+        ),
+        resources=api._resource_diagnostics(),  # pyright: ignore[reportPrivateUsage]
+    )
+
+    def _build_async_client(*_args: object, **_kwargs: object) -> _FakeAsyncClient:
+        return _FakeAsyncClient(
+            responses={
+                "http://peer-node:52415/v1/diagnostics/node": httpx.Response(
+                    200,
+                    json=peer_diagnostics.model_dump(mode="json", by_alias=True),
+                    request=httpx.Request(
+                        "GET",
+                        "http://peer-node:52415/v1/diagnostics/node",
+                    ),
+                )
+            }
+        )
+
+    monkeypatch.setattr(api, "_reachable_peer_api_urls", _reachable_peer_api_urls)
+    monkeypatch.setattr(api_main.httpx, "AsyncClient", _build_async_client)
+
+    response = client.get("/v1/diagnostics/cluster")
+
+    assert response.status_code == 200
+    nodes = [
+        _json_mapping(node) for node in _json_list(_json_object(response)["nodes"])
+    ]
+    assert {node["nodeId"] for node in nodes} == {"local-node", "peer-node"}
+    assert all(node["ok"] is True for node in nodes)

--- a/src/exo/api/tests/test_text_image_transport.py
+++ b/src/exo/api/tests/test_text_image_transport.py
@@ -1,0 +1,95 @@
+import hashlib
+
+import pytest
+
+from exo.api.main import API
+from exo.shared.election import ElectionMessage
+from exo.shared.models.model_cards import ModelId
+from exo.shared.types.commands import (
+    ForwarderCommand,
+    ForwarderDownloadCommand,
+    SendInputChunk,
+    TextGeneration,
+)
+from exo.shared.types.common import NodeId
+from exo.shared.types.events import IndexedEvent
+from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+from exo.utils.channels import Receiver, channel
+
+
+def _build_api() -> tuple[API, Receiver[ForwarderCommand]]:
+    command_sender, command_receiver = channel[ForwarderCommand]()
+    download_sender, _ = channel[ForwarderDownloadCommand]()
+    _, event_receiver = channel[IndexedEvent]()
+    _, election_receiver = channel[ElectionMessage]()
+    api = API(
+        NodeId("api-node"),
+        port=52415,
+        event_receiver=event_receiver,
+        command_sender=command_sender,
+        download_command_sender=download_sender,
+        election_receiver=election_receiver,
+        enable_event_log=False,
+        mount_dashboard=False,
+    )
+    return api, command_receiver
+
+
+def _task_params(image: str) -> TextGenerationTaskParams:
+    return TextGenerationTaskParams(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        input=[InputMessage(role="user", content="describe this image")],
+        images=[image],
+    )
+
+
+@pytest.mark.asyncio
+async def test_text_image_transport_resends_images_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SKULK_TEXT_IMAGE_HASH_CACHE", raising=False)
+    monkeypatch.delenv("EXO_TEXT_IMAGE_HASH_CACHE", raising=False)
+    api, receiver = _build_api()
+    image = "aGVsbG8="
+
+    await api._send_text_generation_with_images(_task_params(image))  # pyright: ignore[reportPrivateUsage]
+    await api._send_text_generation_with_images(_task_params(image))  # pyright: ignore[reportPrivateUsage]
+
+    messages = await receiver.receive_at_least(4)
+    commands = [message.command for message in messages]
+    assert isinstance(commands[0], SendInputChunk)
+    assert isinstance(commands[1], TextGeneration)
+    assert isinstance(commands[2], SendInputChunk)
+    assert isinstance(commands[3], TextGeneration)
+
+    first_chunk = commands[0].chunk
+    second_chunk = commands[2].chunk
+    first_generation = commands[1].task_params
+    second_generation = commands[3].task_params
+    assert first_chunk.data == image
+    assert second_chunk.data == image
+    assert first_generation.image_hashes == {}
+    assert second_generation.image_hashes == {}
+    assert first_generation.total_input_chunks == 1
+    assert second_generation.total_input_chunks == 1
+
+
+@pytest.mark.asyncio
+async def test_text_image_hash_cache_requires_explicit_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SKULK_TEXT_IMAGE_HASH_CACHE", "1")
+    api, receiver = _build_api()
+    image = "aGVsbG8="
+    image_hash = hashlib.sha256(image.encode("ascii")).hexdigest()
+
+    await api._send_text_generation_with_images(_task_params(image))  # pyright: ignore[reportPrivateUsage]
+    await api._send_text_generation_with_images(_task_params(image))  # pyright: ignore[reportPrivateUsage]
+
+    messages = await receiver.receive_at_least(3)
+    commands = [message.command for message in messages]
+    assert isinstance(commands[0], SendInputChunk)
+    assert isinstance(commands[1], TextGeneration)
+    assert isinstance(commands[2], TextGeneration)
+    assert commands[2].task_params.image_hashes == {0: image_hash}
+    assert commands[2].task_params.total_input_chunks == 0

--- a/src/exo/api/tests/test_tracing_api.py
+++ b/src/exo/api/tests/test_tracing_api.py
@@ -1,0 +1,278 @@
+"""Tests for tracing control and trace-browsing API endpoints."""
+
+from pathlib import Path
+from typing import Literal, cast
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from httpx import Response
+
+import exo.api.main as api_main
+from exo.api.main import API
+from exo.shared.election import ElectionMessage
+from exo.shared.tracing import TraceEvent, export_trace
+from exo.shared.types.commands import (
+    ForwarderCommand,
+    ForwarderDownloadCommand,
+    SetTracingEnabled,
+)
+from exo.shared.types.common import NodeId
+from exo.shared.types.events import IndexedEvent
+from exo.shared.types.profiling import NodeIdentity
+from exo.utils.channels import channel
+
+
+def _json_object(response: Response) -> dict[str, object]:
+    """Return a JSON response payload as a typed object mapping."""
+
+    return cast(dict[str, object], cast(object, response.json()))
+
+
+def _json_list(value: object) -> list[object]:
+    """Narrow a nested JSON array from a response payload."""
+
+    return cast(list[object], value)
+
+
+def _json_mapping(value: object) -> dict[str, object]:
+    """Narrow one nested JSON object from a response payload."""
+
+    return cast(dict[str, object], value)
+
+
+def _build_api(node_id: str = "test-node") -> API:
+    """Create a minimal API instance for tracing endpoint testing."""
+
+    command_sender, _ = channel[ForwarderCommand]()
+    download_sender, _ = channel[ForwarderDownloadCommand]()
+    _, event_receiver = channel[IndexedEvent]()
+    _, election_receiver = channel[ElectionMessage]()
+    return API(
+        NodeId(node_id),
+        port=52415,
+        event_receiver=event_receiver,
+        command_sender=command_sender,
+        download_command_sender=download_sender,
+        election_receiver=election_receiver,
+        enable_event_log=False,
+        mount_dashboard=False,
+    )
+
+
+def _write_trace(
+    trace_dir: Path,
+    task_id: str,
+    *,
+    node_id: str,
+    model_id: str,
+    task_kind: Literal["image", "text", "embedding"],
+    category: str,
+    tags: tuple[str, ...] = (),
+) -> None:
+    """Write one trace artifact to the given directory."""
+
+    export_trace(
+        [
+            TraceEvent(
+                name="decode_step",
+                start_us=100,
+                duration_us=50,
+                rank=0,
+                category=category,
+                node_id=node_id,
+                model_id=model_id,
+                task_kind=task_kind,
+                tags=tags,
+                attrs={"shared_span": False},
+            )
+        ],
+        trace_dir / f"trace_{task_id}.json",
+    )
+
+
+def test_get_tracing_state_returns_cluster_state() -> None:
+    """GET /v1/tracing should expose the current cluster tracing toggle."""
+
+    api = _build_api()
+    api.state = api.state.model_copy(update={"tracing_enabled": True})
+    client = TestClient(api.app)
+
+    response = client.get("/v1/tracing")
+
+    assert response.status_code == 200
+    assert response.json() == {"enabled": True}
+
+
+def test_update_tracing_state_sends_cluster_toggle_command() -> None:
+    """PUT /v1/tracing should send SetTracingEnabled and reflect the new state."""
+
+    api = _build_api()
+    client = TestClient(api.app)
+
+    async def _send_and_apply(command: object) -> None:
+        assert isinstance(command, SetTracingEnabled)
+        api.state = api.state.model_copy(update={"tracing_enabled": command.enabled})
+
+    with patch.object(
+        api,
+        "_send",
+        new=AsyncMock(side_effect=_send_and_apply),
+    ) as mock_send:
+        response = client.put("/v1/tracing", json={"enabled": True})
+
+    assert response.status_code == 200
+    assert response.json() == {"enabled": True}
+    assert mock_send.await_args is not None
+    sent_command = cast(object, mock_send.await_args.args[0])
+    assert isinstance(sent_command, SetTracingEnabled)
+    assert sent_command.enabled is True
+
+
+def test_list_traces_returns_metadata_rich_items(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /v1/traces should expose model, task kind, tags, and source nodes."""
+
+    monkeypatch.setattr(api_main, "EXO_TRACING_CACHE_DIR", tmp_path)
+    _write_trace(
+        tmp_path,
+        "task-123",
+        node_id="peer-node",
+        model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+        task_kind="text",
+        category="decode",
+        tags=("tool_call",),
+    )
+
+    api = _build_api("local-node")
+    api.state = api.state.model_copy(
+        update={
+            "node_identities": {
+                NodeId("peer-node"): NodeIdentity(friendly_name="Kite 2")
+            }
+        }
+    )
+    client = TestClient(api.app)
+
+    response = client.get("/v1/traces")
+
+    assert response.status_code == 200
+    trace = _json_mapping(_json_list(_json_object(response)["traces"])[0])
+    assert trace["taskId"] == "task-123"
+    assert trace["modelId"] == "mlx-community/gemma-4-26b-a4b-it-4bit"
+    assert trace["taskKind"] == "text"
+    assert trace["categories"] == ["decode"]
+    assert trace["tags"] == ["tool_call"]
+    assert trace["hasToolActivity"] is True
+    source_node = _json_mapping(_json_list(trace["sourceNodes"])[0])
+    assert source_node["nodeId"] == "peer-node"
+    assert source_node["friendlyName"] == "Kite 2"
+
+
+def test_list_cluster_traces_dedupes_local_and_peer_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /v1/traces/cluster should dedupe matching task IDs across peers."""
+
+    monkeypatch.setattr(api_main, "EXO_TRACING_CACHE_DIR", tmp_path)
+    _write_trace(
+        tmp_path,
+        "task-123",
+        node_id="local-node",
+        model_id="mlx-community/local-model",
+        task_kind="text",
+        category="decode",
+    )
+
+    api = _build_api("local-node")
+    client = TestClient(api.app)
+
+    async def _reachable_peer_trace_urls() -> list[str]:
+        return ["http://peer-node:52415"]
+
+    class _FakeAsyncClient:
+        def __init__(self, responses: dict[str, httpx.Response]) -> None:
+            self._responses = responses
+
+        async def __aenter__(self) -> "_FakeAsyncClient":
+            return self
+
+        async def __aexit__(
+            self,
+            _exc_type: object,
+            _exc: object,
+            _tb: object,
+        ) -> None:
+            return None
+
+        async def get(self, url: str) -> httpx.Response:
+            return self._responses[url]
+
+    peer_payload = {
+        "traces": [
+            {
+                "taskId": "task-123",
+                "createdAt": "2026-04-22T12:00:00+00:00",
+                "fileSize": 999,
+                "modelId": "mlx-community/peer-model",
+                "taskKind": "text",
+                "categories": ["decode", "prefill"],
+                "tags": ["tool_call"],
+                "hasToolActivity": True,
+                "sourceNodes": [
+                    {"nodeId": "peer-node", "friendlyName": "Kite 3"}
+                ],
+            },
+            {
+                "taskId": "task-999",
+                "createdAt": "2026-04-22T12:01:00+00:00",
+                "fileSize": 111,
+                "modelId": "mlx-community/embedding-model",
+                "taskKind": "embedding",
+                "categories": ["embedding"],
+                "tags": [],
+                "hasToolActivity": False,
+                "sourceNodes": [
+                    {"nodeId": "peer-node", "friendlyName": "Kite 3"}
+                ],
+            },
+        ]
+    }
+
+    def _build_async_client(*_args: object, **_kwargs: object) -> _FakeAsyncClient:
+        return _FakeAsyncClient(
+            responses={
+                "http://peer-node:52415/v1/traces": httpx.Response(
+                    200,
+                    json=peer_payload,
+                )
+            }
+        )
+
+    monkeypatch.setattr(api, "_reachable_peer_trace_urls", _reachable_peer_trace_urls)
+    monkeypatch.setattr(api_main.httpx, "AsyncClient", _build_async_client)
+
+    response = client.get("/v1/traces/cluster")
+
+    assert response.status_code == 200
+    trace_items = [
+        _json_mapping(trace_item)
+        for trace_item in _json_list(_json_object(response)["traces"])
+    ]
+    traces: dict[str, dict[str, object]] = {
+        cast(str, trace["taskId"]): trace for trace in trace_items
+    }
+    assert set(traces) == {"task-123", "task-999"}
+    merged = traces["task-123"]
+    assert merged["hasToolActivity"] is True
+    assert merged["modelId"] == "mlx-community/local-model"
+    assert merged["taskKind"] == "text"
+    assert merged["categories"] == ["decode", "prefill"]
+    assert merged["tags"] == ["tool_call"]
+    source_nodes = _json_list(merged["sourceNodes"])
+    source_node_ids = {
+        cast(str, _json_mapping(source_node)["nodeId"]) for source_node in source_nodes
+    }
+    assert source_node_ids == {"local-node", "peer-node"}

--- a/src/exo/api/types/__init__.py
+++ b/src/exo/api/types/__init__.py
@@ -69,7 +69,11 @@ from .api import TraceListItem as TraceListItem
 from .api import TraceListResponse as TraceListResponse
 from .api import TraceRankStats as TraceRankStats
 from .api import TraceResponse as TraceResponse
+from .api import TraceSourceNode as TraceSourceNode
 from .api import TraceStatsResponse as TraceStatsResponse
+from .api import TraceTaskKind as TraceTaskKind
+from .api import TracingStateResponse as TracingStateResponse
+from .api import UpdateTracingStateRequest as UpdateTracingStateRequest
 from .api import Usage as Usage
 from .api import WebSearchResult as WebSearchResult
 from .api import WebSearchToolRequest as WebSearchToolRequest

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -888,17 +888,33 @@ class PurgeStagingResponse(CamelCaseModel):
     message: str
 
 
+TraceTaskKind = Literal["image", "text", "embedding"]
+
+
+class TraceSourceNode(CamelCaseModel):
+    node_id: str
+    friendly_name: str | None = None
+
+
 class TraceEventResponse(CamelCaseModel):
     name: str
     start_us: int
     duration_us: int
     rank: int
     category: str
+    node_id: str | None = None
+    model_id: str | None = None
+    task_kind: TraceTaskKind | None = None
+    tags: list[str] = Field(default_factory=list)
+    attrs: dict[str, str | int | float | bool | list[str]] = Field(
+        default_factory=dict
+    )
 
 
 class TraceResponse(CamelCaseModel):
     task_id: str
     traces: list[TraceEventResponse]
+    source_nodes: list[TraceSourceNode] = Field(default_factory=list)
 
 
 class TraceCategoryStats(CamelCaseModel):
@@ -918,16 +934,31 @@ class TraceStatsResponse(CamelCaseModel):
     total_wall_time_us: int
     by_category: dict[str, TraceCategoryStats]
     by_rank: dict[int, TraceRankStats]
+    source_nodes: list[TraceSourceNode] = Field(default_factory=list)
 
 
 class TraceListItem(CamelCaseModel):
     task_id: str
     created_at: str
     file_size: int
+    model_id: str | None = None
+    task_kind: TraceTaskKind | None = None
+    categories: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    has_tool_activity: bool = False
+    source_nodes: list[TraceSourceNode] = Field(default_factory=list)
 
 
 class TraceListResponse(CamelCaseModel):
     traces: list[TraceListItem]
+
+
+class TracingStateResponse(CamelCaseModel):
+    enabled: bool
+
+
+class UpdateTracingStateRequest(CamelCaseModel):
+    enabled: bool
 
 
 class DeleteTracesRequest(CamelCaseModel):

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -284,6 +284,7 @@ class Node:
             )
             if api is not None:
                 api.set_runner_diagnostics_provider(worker.collect_runner_diagnostics)
+                api.set_runner_cancel_provider(worker.cancel_runner_task)
         else:
             worker = None
 
@@ -629,6 +630,9 @@ class Node:
                         if self.api is not None:
                             self.api.set_runner_diagnostics_provider(
                                 self.worker.collect_runner_diagnostics
+                            )
+                            self.api.set_runner_cancel_provider(
+                                self.worker.cancel_runner_task
                             )
                     if self.api:
                         self.api.reset(

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -282,6 +282,8 @@ class Node:
                 store_client=worker_store_client,
                 staging_config=worker_staging_cfg,
             )
+            if api is not None:
+                api.set_runner_diagnostics_provider(worker.collect_runner_diagnostics)
         else:
             worker = None
 
@@ -624,15 +626,26 @@ class Node:
                             staging_config=elect_staging2,
                         )
                         self._tg.start_soon(self.worker.run)
+                        if self.api is not None:
+                            self.api.set_runner_diagnostics_provider(
+                                self.worker.collect_runner_diagnostics
+                            )
                     if self.api:
-                        self.api.reset(result.won_clock, self.event_router.receiver())
+                        self.api.reset(
+                            result.won_clock,
+                            self.event_router.receiver(),
+                            result.session_id.master_node_id,
+                        )
                     if start_replacement_event_router:
                         self._tg.start_soon(self.event_router.run)
                     # Broadcast config to cluster so worker nodes get the right store address
                     await self._broadcast_config_if_store_host()
                 else:
                     if self.api:
-                        self.api.unpause(result.won_clock)
+                        self.api.unpause(
+                            result.won_clock,
+                            master_node_id=result.session_id.master_node_id,
+                        )
 
 
 def main():

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -526,6 +526,11 @@ class Master:
                         await self._handle_traces_collected(event)
                         continue
 
+                    if isinstance(event, TaskDeleted):
+                        for command_id, task_id in list(self.command_task_mapping.items()):
+                            if task_id == event.task_id:
+                                self.command_task_mapping.pop(command_id, None)
+
                     logger.debug(f"Master indexing event: {str(event)[:100]}")
                     indexed = IndexedEvent(event=event, idx=len(self._event_log))
                     self.state = apply(self.state, indexed)

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -27,6 +27,7 @@ from exo.shared.types.commands import (
     PlaceInstance,
     RequestEventLog,
     SendInputChunk,
+    SetTracingEnabled,
     TaskCancelled,
     TaskFinished,
     TestCommand,
@@ -51,6 +52,7 @@ from exo.shared.types.events import (
     TraceEventData,
     TracesCollected,
     TracesMerged,
+    TracingStateChanged,
 )
 from exo.shared.types.state import State
 from exo.shared.types.state_sync import StateSnapshot, StateSyncMessage
@@ -101,7 +103,7 @@ class Master:
     ):
         self.node_id = node_id
         self.session_id = session_id
-        self.state = State()
+        self.state = State(tracing_enabled=EXO_TRACING_ENABLED)
         self._tg: TaskGroup = TaskGroup()
         self.command_task_mapping: dict[CommandId, TaskId] = {}
         self.command_receiver = command_receiver
@@ -121,6 +123,26 @@ class Master:
         self._last_snapshot_idx = -1
         self._pending_traces: dict[TaskId, dict[int, list[TraceEventData]]] = {}
         self._expected_ranks: dict[TaskId, set[int]] = {}
+
+    def _configure_expected_trace_ranks(
+        self, task_id: TaskId, instance_id: InstanceId, *, trace_enabled: bool
+    ) -> None:
+        """Track which device ranks must report traces for a newly traced task."""
+
+        if not trace_enabled:
+            return
+
+        selected_instance = self.state.instances.get(instance_id)
+        if selected_instance is None:
+            logger.warning(
+                f"Unable to configure trace ranks for task {task_id}; instance {instance_id} not found"
+            )
+            return
+
+        self._expected_ranks[task_id] = {
+            shard.device_rank
+            for shard in selected_instance.shard_assignments.runner_to_shard.values()
+        }
 
     async def run(self):
         logger.info("Starting Master")
@@ -183,20 +205,28 @@ class Master:
                             )
 
                             task_id = TaskId()
+                            selected_instance_id = available_instance_ids[0]
+                            trace_enabled = self.state.tracing_enabled
                             generated_events.append(
                                 TaskCreated(
                                     task_id=task_id,
                                     task=TextGenerationTask(
                                         task_id=task_id,
                                         command_id=command.command_id,
-                                        instance_id=available_instance_ids[0],
+                                        instance_id=selected_instance_id,
                                         task_status=TaskStatus.Pending,
                                         task_params=command.task_params,
+                                        trace_enabled=trace_enabled,
                                     ),
                                 )
                             )
 
                             self.command_task_mapping[command.command_id] = task_id
+                            self._configure_expected_trace_ranks(
+                                task_id,
+                                selected_instance_id,
+                                trace_enabled=trace_enabled,
+                            )
                         case ImageGeneration():
                             for instance in self.state.instances.values():
                                 if (
@@ -226,6 +256,7 @@ class Master:
 
                             task_id = TaskId()
                             selected_instance_id = available_instance_ids[0]
+                            trace_enabled = self.state.tracing_enabled
                             generated_events.append(
                                 TaskCreated(
                                     task_id=task_id,
@@ -235,22 +266,17 @@ class Master:
                                         instance_id=selected_instance_id,
                                         task_status=TaskStatus.Pending,
                                         task_params=command.task_params,
+                                        trace_enabled=trace_enabled,
                                     ),
                                 )
                             )
 
                             self.command_task_mapping[command.command_id] = task_id
-
-                            if EXO_TRACING_ENABLED:
-                                selected_instance = self.state.instances.get(
-                                    selected_instance_id
-                                )
-                                if selected_instance:
-                                    ranks = set(
-                                        shard.device_rank
-                                        for shard in selected_instance.shard_assignments.runner_to_shard.values()
-                                    )
-                                    self._expected_ranks[task_id] = ranks
+                            self._configure_expected_trace_ranks(
+                                task_id,
+                                selected_instance_id,
+                                trace_enabled=trace_enabled,
+                            )
                         case ImageEdits():
                             for instance in self.state.instances.values():
                                 if (
@@ -280,6 +306,7 @@ class Master:
 
                             task_id = TaskId()
                             selected_instance_id = available_instance_ids[0]
+                            trace_enabled = self.state.tracing_enabled
                             generated_events.append(
                                 TaskCreated(
                                     task_id=task_id,
@@ -289,22 +316,17 @@ class Master:
                                         instance_id=selected_instance_id,
                                         task_status=TaskStatus.Pending,
                                         task_params=command.task_params,
+                                        trace_enabled=trace_enabled,
                                     ),
                                 )
                             )
 
                             self.command_task_mapping[command.command_id] = task_id
-
-                            if EXO_TRACING_ENABLED:
-                                selected_instance = self.state.instances.get(
-                                    selected_instance_id
-                                )
-                                if selected_instance:
-                                    ranks = set(
-                                        shard.device_rank
-                                        for shard in selected_instance.shard_assignments.runner_to_shard.values()
-                                    )
-                                    self._expected_ranks[task_id] = ranks
+                            self._configure_expected_trace_ranks(
+                                task_id,
+                                selected_instance_id,
+                                trace_enabled=trace_enabled,
+                            )
                         case TextEmbedding():
                             for instance in self.state.instances.values():
                                 if (
@@ -333,20 +355,32 @@ class Master:
                             )
 
                             task_id = TaskId()
+                            selected_instance_id = available_instance_ids[0]
+                            trace_enabled = self.state.tracing_enabled
                             generated_events.append(
                                 TaskCreated(
                                     task_id=task_id,
                                     task=TextEmbeddingTask(
                                         task_id=task_id,
                                         command_id=command.command_id,
-                                        instance_id=available_instance_ids[0],
+                                        instance_id=selected_instance_id,
                                         task_status=TaskStatus.Pending,
                                         task_params=command.task_params,
+                                        trace_enabled=trace_enabled,
                                     ),
                                 )
                             )
 
                             self.command_task_mapping[command.command_id] = task_id
+                            self._configure_expected_trace_ranks(
+                                task_id,
+                                selected_instance_id,
+                                trace_enabled=trace_enabled,
+                            )
+                        case SetTracingEnabled():
+                            generated_events.append(
+                                TracingStateChanged(enabled=command.enabled)
+                            )
                         case DeleteInstance():
                             placement = delete_instance(command, self.state.instances)
                             transition_events = get_transition_events(

--- a/src/exo/master/tests/test_master.py
+++ b/src/exo/master/tests/test_master.py
@@ -25,13 +25,14 @@ from exo.shared.types.events import (
     LocalForwarderEvent,
     NodeGatheredInfo,
     TaskCreated,
+    TaskDeleted,
 )
 from exo.shared.types.memory import Memory
 from exo.shared.types.profiling import (
     MemoryUsage,
 )
 from exo.shared.types.state_sync import StateSyncMessage
-from exo.shared.types.tasks import TaskStatus
+from exo.shared.types.tasks import TaskId, TaskStatus
 from exo.shared.types.tasks import TextGeneration as TextGenerationTask
 from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
 from exo.shared.types.worker.instances import (
@@ -387,3 +388,51 @@ async def test_persist_snapshot_keeps_bounded_replay_tail() -> None:
     await master._persist_snapshot(force=True)  # pyright: ignore[reportPrivateUsage]
 
     assert compact_calls == [max(26 - REPLAY_TAIL_RETENTION_EVENTS, 0)]
+
+
+@pytest.mark.asyncio
+async def test_task_deleted_event_clears_command_mapping() -> None:
+    keypair = get_node_id_keypair()
+    node_id = NodeId(keypair.to_node_id())
+    session_id = SessionId(master_node_id=node_id, election_clock=0)
+
+    global_sender, _global_receiver = channel[GlobalForwarderEvent]()
+    _command_sender, command_receiver = channel[ForwarderCommand]()
+    local_event_sender, local_event_receiver = channel[LocalForwarderEvent]()
+    _request_sender, state_sync_receiver = channel[StateSyncMessage]()
+    state_sync_sender, _response_receiver = channel[StateSyncMessage]()
+    download_sender, _download_receiver = channel[ForwarderDownloadCommand]()
+    event_sender, _event_receiver = channel[Event]()
+
+    master = Master(
+        node_id,
+        session_id,
+        event_sender=event_sender,
+        global_event_sender=global_sender,
+        local_event_receiver=local_event_receiver,
+        command_receiver=command_receiver,
+        state_sync_receiver=state_sync_receiver,
+        state_sync_sender=state_sync_sender,
+        download_command_sender=download_sender,
+    )
+
+    command_id = CommandId("cmd-a")
+    task_id = TaskId("task-a")
+    master.command_task_mapping[command_id] = task_id
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(master._event_processor)  # pyright: ignore[reportPrivateUsage]
+        await local_event_sender.send(
+            LocalForwarderEvent(
+                origin=SystemId("Worker"),
+                origin_idx=0,
+                session=session_id,
+                event=TaskDeleted(task_id=task_id),
+            )
+        )
+        with anyio.fail_after(2):
+            while command_id in master.command_task_mapping:
+                await anyio.sleep(0.01)
+        tg.cancel_scope.cancel()
+
+    assert command_id not in master.command_task_mapping

--- a/src/exo/master/tests/test_tracing_control.py
+++ b/src/exo/master/tests/test_tracing_control.py
@@ -1,0 +1,149 @@
+"""Tests for master-side tracing control and task inheritance."""
+
+import anyio
+import pytest
+
+from exo.master.main import Master
+from exo.routing.router import get_node_id_keypair
+from exo.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from exo.shared.types.commands import (
+    ForwarderCommand,
+    ForwarderDownloadCommand,
+    SetTracingEnabled,
+    TextGeneration,
+)
+from exo.shared.types.common import CommandId, Host, NodeId, SessionId, SystemId
+from exo.shared.types.events import (
+    Event,
+    GlobalForwarderEvent,
+    LocalForwarderEvent,
+    TaskCreated,
+    TracingStateChanged,
+)
+from exo.shared.types.memory import Memory
+from exo.shared.types.state_sync import StateSyncMessage
+from exo.shared.types.tasks import TextGeneration as TextGenerationTask
+from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+from exo.shared.types.worker.instances import InstanceId, MlxRingInstance
+from exo.shared.types.worker.runners import RunnerId, ShardAssignments
+from exo.shared.types.worker.shards import PipelineShardMetadata
+from exo.utils.channels import Receiver, Sender, channel
+
+
+def _build_master() -> tuple[Master, NodeId, Sender[ForwarderCommand], Receiver[Event]]:
+    """Create a master with in-memory channels for command-processor tests."""
+
+    keypair = get_node_id_keypair()
+    node_id = NodeId(keypair.to_node_id())
+    session_id = SessionId(master_node_id=node_id, election_clock=0)
+
+    global_event_sender, _ = channel[GlobalForwarderEvent]()
+    command_sender, command_receiver = channel[ForwarderCommand]()
+    _, local_event_receiver = channel[LocalForwarderEvent]()
+    state_sync_sender, state_sync_receiver = channel[StateSyncMessage]()
+    download_command_sender, _ = channel[ForwarderDownloadCommand]()
+    event_sender, event_receiver = channel[Event]()
+
+    master = Master(
+        node_id,
+        session_id,
+        event_sender=event_sender,
+        global_event_sender=global_event_sender,
+        local_event_receiver=local_event_receiver,
+        command_receiver=command_receiver,
+        state_sync_receiver=state_sync_receiver,
+        state_sync_sender=state_sync_sender,
+        download_command_sender=download_command_sender,
+    )
+    return master, node_id, command_sender, event_receiver
+
+
+def _single_node_instance(node_id: NodeId) -> MlxRingInstance:
+    instance_id = InstanceId("instance-1")
+    runner_id = RunnerId("runner-1")
+    model_card = ModelCard(
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        storage_size=Memory.from_mb(1024),
+        n_layers=16,
+        hidden_size=2048,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+    )
+    shard_metadata = PipelineShardMetadata(
+        model_card=model_card,
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=16,
+        n_layers=16,
+    )
+    shard_assignments = ShardAssignments(
+        model_id=model_card.model_id,
+        runner_to_shard={runner_id: shard_metadata},
+        node_to_runner={node_id: runner_id},
+    )
+    return MlxRingInstance(
+        instance_id=instance_id,
+        shard_assignments=shard_assignments,
+        hosts_by_node={node_id: [Host(ip="0.0.0.0", port=58484)]},
+        ephemeral_port=58484,
+    )
+
+
+@pytest.mark.asyncio
+async def test_master_emits_tracing_state_changed_for_toggle_command() -> None:
+    """The master should translate SetTracingEnabled into TracingStateChanged."""
+
+    master, _node_id, command_sender, event_receiver = _build_master()
+    event: Event | None = None
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(master._command_processor)  # pyright: ignore[reportPrivateUsage]
+        await command_sender.send(
+            ForwarderCommand(
+                origin=SystemId("API"),
+                command=SetTracingEnabled(enabled=True),
+            )
+        )
+        event = await event_receiver.receive()
+        task_group.cancel_scope.cancel()
+
+    assert isinstance(event, TracingStateChanged)
+    assert event.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_master_new_text_tasks_inherit_cluster_tracing_state() -> None:
+    """New text tasks should inherit the cluster tracing toggle."""
+
+    master, node_id, command_sender, event_receiver = _build_master()
+    instance = _single_node_instance(node_id)
+    event: Event | None = None
+    master.state = master.state.model_copy(
+        update={
+            "tracing_enabled": True,
+            "instances": {instance.instance_id: instance},
+        }
+    )
+
+    command = TextGeneration(
+        command_id=CommandId("cmd-1"),
+        task_params=TextGenerationTaskParams(
+            model=instance.shard_assignments.model_id,
+            input=[InputMessage(role="user", content="hello")],
+        ),
+    )
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(master._command_processor)  # pyright: ignore[reportPrivateUsage]
+        await command_sender.send(
+            ForwarderCommand(origin=SystemId("API"), command=command)
+        )
+        event = await event_receiver.receive()
+        task_group.cancel_scope.cancel()
+
+    assert isinstance(event, TaskCreated)
+    assert isinstance(event.task, TextGenerationTask)
+    assert event.task.trace_enabled is True
+    assert master.command_task_mapping[command.command_id] == event.task_id
+    assert master._expected_ranks[event.task_id] == {0}  # pyright: ignore[reportPrivateUsage]

--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -29,6 +29,7 @@ from exo.shared.types.events import (
     TopologyEdgeDeleted,
     TracesCollected,
     TracesMerged,
+    TracingStateChanged,
 )
 from exo.shared.types.profiling import (
     NodeIdentity,
@@ -96,6 +97,8 @@ def event_apply(event: Event, state: State) -> State:
             return apply_topology_edge_created(event, state)
         case TopologyEdgeDeleted():
             return apply_topology_edge_deleted(event, state)
+        case TracingStateChanged():
+            return state.model_copy(update={"tracing_enabled": event.enabled})
         case StateSnapshotHydrated():
             return event.state
 

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -234,6 +234,18 @@ class RuntimeCapabilityCardConfig(CamelCaseModel):
 
     prompt_renderer: PromptRendererType | None = None
     output_parser: OutputParserType | None = None
+    metal_fast_synch: bool | None = None
+    """Per-model override for the MLX ``MLX_METAL_FAST_SYNCH`` flag.
+
+    ``None`` means "no opinion" — fall through to the cluster default
+    selected by the runner. Set explicitly to ``False`` for models that
+    deadlock under FAST_SYNCH on the ring backend (e.g. gemma-4 with
+    multimodal load: the Metal command queue wedges in
+    ``pipeline_last_eval_output``, transitively starves WindowServer,
+    and trips the macOS kernel watchdog into a panic). Set explicitly
+    to ``True`` for models that have been measured to benefit and are
+    known to be safe under the deployment's collective backend.
+    """
 
     @field_validator("prompt_renderer", mode="before")
     @classmethod

--- a/src/exo/shared/tests/test_apply/test_apply_tracing_state.py
+++ b/src/exo/shared/tests/test_apply/test_apply_tracing_state.py
@@ -1,0 +1,25 @@
+"""Tests for applying tracing state events."""
+
+from exo.shared.apply import apply
+from exo.shared.types.events import IndexedEvent, TracingStateChanged
+from exo.shared.types.state import State
+
+
+def test_apply_tracing_state_changed_updates_cluster_state() -> None:
+    """TracingStateChanged should update the immutable cluster state toggle."""
+
+    enabled_state = apply(
+        State(),
+        IndexedEvent(idx=0, event=TracingStateChanged(enabled=True)),
+    )
+
+    assert enabled_state.tracing_enabled is True
+    assert enabled_state.last_event_applied_idx == 0
+
+    disabled_state = apply(
+        enabled_state,
+        IndexedEvent(idx=1, event=TracingStateChanged(enabled=False)),
+    )
+
+    assert disabled_state.tracing_enabled is False
+    assert disabled_state.last_event_applied_idx == 1

--- a/src/exo/shared/tests/test_node_election_reset.py
+++ b/src/exo/shared/tests/test_node_election_reset.py
@@ -80,6 +80,9 @@ class _FakeApi:
     def set_runner_diagnostics_provider(self, _provider: object) -> None:
         self._events.append("api.runner_diagnostics_provider")
 
+    def set_runner_cancel_provider(self, _provider: object) -> None:
+        self._events.append("api.runner_cancel_provider")
+
 
 @pytest.mark.asyncio
 async def test_election_restarts_event_router_after_receivers_are_rewired(
@@ -111,6 +114,9 @@ async def test_election_restarts_event_router_after_receivers_are_rewired(
 
         def collect_runner_diagnostics(self) -> list[object]:
             return []
+
+        async def cancel_runner_task(self, *_args: Any, **_kwargs: Any) -> object:
+            return object()
 
     monkeypatch.setattr("exo.main.EventRouter", NewEventRouter)
     monkeypatch.setattr("exo.main.Worker", NewWorker)
@@ -196,6 +202,9 @@ async def test_new_master_does_not_wait_on_unavailable_state_sync_config(
 
         def collect_runner_diagnostics(self) -> list[object]:
             return []
+
+        async def cancel_runner_task(self, *_args: Any, **_kwargs: Any) -> object:
+            return object()
 
     monkeypatch.setattr("exo.main.EventRouter", NewEventRouter)
     monkeypatch.setattr("exo.main.Master", NewMaster)

--- a/src/exo/shared/tests/test_node_election_reset.py
+++ b/src/exo/shared/tests/test_node_election_reset.py
@@ -62,11 +62,23 @@ class _FakeApi:
     def __init__(self, events: list[str]) -> None:
         self._events = events
 
-    def reset(self, _result_clock: int, _event_receiver: object) -> None:
+    def reset(
+        self,
+        _result_clock: int,
+        _event_receiver: object,
+        _master_node_id: NodeId,
+    ) -> None:
         self._events.append("api.reset")
 
-    def unpause(self, _result_clock: int) -> None:
+    def unpause(
+        self,
+        _result_clock: int,
+        master_node_id: NodeId | None = None,
+    ) -> None:
         self._events.append("api.unpause")
+
+    def set_runner_diagnostics_provider(self, _provider: object) -> None:
+        self._events.append("api.runner_diagnostics_provider")
 
 
 @pytest.mark.asyncio
@@ -96,6 +108,9 @@ async def test_election_restarts_event_router_after_receivers_are_rewired(
 
         async def run(self) -> None:
             return
+
+        def collect_runner_diagnostics(self) -> list[object]:
+            return []
 
     monkeypatch.setattr("exo.main.EventRouter", NewEventRouter)
     monkeypatch.setattr("exo.main.Worker", NewWorker)
@@ -178,6 +193,9 @@ async def test_new_master_does_not_wait_on_unavailable_state_sync_config(
 
         async def run(self) -> None:
             return
+
+        def collect_runner_diagnostics(self) -> list[object]:
+            return []
 
     monkeypatch.setattr("exo.main.EventRouter", NewEventRouter)
     monkeypatch.setattr("exo.main.Master", NewMaster)

--- a/src/exo/shared/tests/test_tracing.py
+++ b/src/exo/shared/tests/test_tracing.py
@@ -1,0 +1,141 @@
+"""Tests for task-scoped tracing helpers."""
+
+from pathlib import Path
+
+from exo.shared.tracing import (
+    begin_trace_session,
+    bind_trace_session,
+    clear_trace_session,
+    export_trace,
+    load_trace_file,
+    pop_trace_session,
+    record_shared_span,
+    record_trace_marker,
+    trace,
+)
+
+
+def test_task_scoped_sessions_do_not_mix_events() -> None:
+    """Concurrent trace sessions should keep their buffered spans isolated."""
+
+    task_a = "task-a"
+    task_b = "task-b"
+    begin_trace_session(
+        task_a,
+        rank=0,
+        node_id="kite-dev",
+        model_id="mlx-community/model-a",
+        task_kind="text",
+        tags=["chat"],
+    )
+    begin_trace_session(
+        task_b,
+        rank=1,
+        node_id="kite-2",
+        model_id="mlx-community/model-b",
+        task_kind="embedding",
+    )
+
+    try:
+        with bind_trace_session(task_a):
+            record_trace_marker("queued", rank=0)
+            with trace("prefill", rank=0, category="compute"):
+                pass
+
+        with bind_trace_session(task_b):
+            record_trace_marker("tokenize", rank=1)
+
+        task_a_events = pop_trace_session(task_a)
+        task_b_events = pop_trace_session(task_b)
+    finally:
+        clear_trace_session(task_a)
+        clear_trace_session(task_b)
+
+    assert [event.name for event in task_a_events] == ["queued", "prefill"]
+    assert [event.name for event in task_b_events] == ["tokenize"]
+    assert all(event.node_id == "kite-dev" for event in task_a_events)
+    assert all(event.model_id == "mlx-community/model-a" for event in task_a_events)
+    assert all(event.task_kind == "text" for event in task_a_events)
+    assert all("chat" in event.tags for event in task_a_events)
+    assert task_b_events[0].node_id == "kite-2"
+    assert task_b_events[0].task_kind == "embedding"
+
+
+def test_shared_spans_are_copied_into_each_participant_trace() -> None:
+    """Shared batch work should appear in each participating task trace."""
+
+    task_ids = ["task-one", "task-two"]
+    for task_id in task_ids:
+        begin_trace_session(
+            task_id,
+            rank=0,
+            node_id="kite-dev",
+            model_id="mlx-community/gemma",
+            task_kind="text",
+        )
+
+    try:
+        record_shared_span(
+            task_ids,
+            name="decode_step",
+            start_us=123,
+            duration_us=456,
+            rank=2,
+            category="decode",
+            tags=["tool_call"],
+            attrs={
+                "shared_span": True,
+                "batch_size": 2,
+                "participant_task_ids": task_ids,
+            },
+        )
+        task_one_events = pop_trace_session(task_ids[0])
+        task_two_events = pop_trace_session(task_ids[1])
+    finally:
+        for task_id in task_ids:
+            clear_trace_session(task_id)
+
+    for event in [*task_one_events, *task_two_events]:
+        assert event.name == "decode_step"
+        assert event.duration_us == 456
+        assert event.rank == 2
+        assert event.category == "decode"
+        assert "tool_call" in event.tags
+        assert event.attrs["shared_span"] is True
+        assert event.attrs["batch_size"] == 2
+        assert event.attrs["participant_task_ids"] == task_ids
+
+
+def test_export_trace_round_trips_metadata(tmp_path: Path) -> None:
+    """Chrome trace export should preserve task metadata in the args payload."""
+
+    task_id = "task-roundtrip"
+    begin_trace_session(
+        task_id,
+        rank=4,
+        node_id="kite3.local",
+        model_id="mlx-community/gemma-4-26b-a4b-it-4bit",
+        task_kind="image",
+        tags=["tool_call"],
+        attrs={"batch_size": 1},
+    )
+
+    try:
+        with bind_trace_session(task_id):
+            record_trace_marker("finish", rank=4, attrs={"success": True})
+        output_path = tmp_path / "trace_roundtrip.json"
+        export_trace(pop_trace_session(task_id), output_path)
+    finally:
+        clear_trace_session(task_id)
+
+    loaded = load_trace_file(output_path)
+
+    assert len(loaded) == 1
+    event = loaded[0]
+    assert event.name == "finish"
+    assert event.node_id == "kite3.local"
+    assert event.model_id == "mlx-community/gemma-4-26b-a4b-it-4bit"
+    assert event.task_kind == "image"
+    assert "tool_call" in event.tags
+    assert event.attrs["batch_size"] == 1
+    assert event.attrs["success"] is True

--- a/src/exo/shared/tracing.py
+++ b/src/exo/shared/tracing.py
@@ -3,18 +3,23 @@ from __future__ import annotations
 import json
 import time
 from collections import defaultdict
-from collections.abc import Generator
+from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import cast, final
+from typing import Literal, cast, final
 
-from exo.shared.constants import EXO_TRACING_ENABLED
 from exo.worker.runner.bootstrap import logger
 
 # Context variable to track the current trace category for hierarchical nesting
 _current_category: ContextVar[str | None] = ContextVar("current_category", default=None)
+_current_trace_task_id: ContextVar[str | None] = ContextVar(
+    "current_trace_task_id", default=None
+)
+
+TraceTaskKind = Literal["image", "text", "embedding"]
+TraceAttrValue = str | int | float | bool | list[str]
 
 
 @final
@@ -25,6 +30,11 @@ class TraceEvent:
     duration_us: int
     rank: int
     category: str
+    node_id: str | None = None
+    model_id: str | None = None
+    task_kind: TraceTaskKind | None = None
+    tags: tuple[str, ...] = ()
+    attrs: dict[str, TraceAttrValue] = field(default_factory=dict)
 
 
 @final
@@ -58,20 +68,135 @@ class TraceStats:
     by_rank: dict[int, dict[str, CategoryStats]] = field(default_factory=dict)
 
 
-# Global trace buffer - each rank accumulates traces here
-_trace_buffer: list[TraceEvent] = []
+@final
+@dataclass
+class TraceSession:
+    task_id: str
+    rank: int
+    node_id: str
+    model_id: str
+    task_kind: TraceTaskKind
+    tags: tuple[str, ...] = ()
+    attrs: dict[str, TraceAttrValue] = field(default_factory=dict)
+    events: list[TraceEvent] = field(default_factory=list)
+
+
+_trace_sessions: dict[str, TraceSession] = {}
+
+
+def now_us() -> int:
+    """Return the current wall-clock time in microseconds."""
+
+    return int(time.time() * 1_000_000)
+
+
+def _merge_tags(
+    session_tags: Sequence[str], event_tags: Sequence[str] | None
+) -> tuple[str, ...]:
+    merged: list[str] = []
+    for tag in (*session_tags, *(event_tags or ())):
+        if tag not in merged:
+            merged.append(tag)
+    return tuple(merged)
+
+
+def _merge_attrs(
+    session_attrs: Mapping[str, TraceAttrValue],
+    event_attrs: Mapping[str, TraceAttrValue] | None,
+) -> dict[str, TraceAttrValue]:
+    merged = dict(session_attrs)
+    if event_attrs is not None:
+        merged.update(event_attrs)
+    return merged
+
+
+def begin_trace_session(
+    task_id: object,
+    *,
+    rank: int,
+    node_id: str,
+    model_id: str,
+    task_kind: TraceTaskKind,
+    tags: Sequence[str] | None = None,
+    attrs: Mapping[str, TraceAttrValue] | None = None,
+) -> None:
+    """Create or replace a task-scoped trace session.
+
+    Runtime tracing is task-scoped so concurrent requests can emit spans without
+    contaminating one another, even when they share a batch engine.
+    """
+
+    normalized_task_id = str(task_id)
+    _trace_sessions[normalized_task_id] = TraceSession(
+        task_id=normalized_task_id,
+        rank=rank,
+        node_id=node_id,
+        model_id=model_id,
+        task_kind=task_kind,
+        tags=tuple(tags or ()),
+        attrs=dict(attrs or {}),
+    )
+
+
+def has_trace_session(task_id: object) -> bool:
+    """Return whether *task_id* currently has an active trace session."""
+
+    return str(task_id) in _trace_sessions
+
+
+def tracing_active(task_id: object | None = None) -> bool:
+    """Return whether tracing is currently enabled for a task context."""
+
+    if task_id is not None:
+        return has_trace_session(task_id)
+    current_task_id = _current_trace_task_id.get()
+    return current_task_id is not None and current_task_id in _trace_sessions
+
+
+@contextmanager
+def bind_trace_session(task_id: object) -> Generator[None, None, None]:
+    """Bind a trace session to the current execution context."""
+
+    normalized_task_id = str(task_id)
+    if normalized_task_id not in _trace_sessions:
+        yield
+        return
+
+    task_token = _current_trace_task_id.set(normalized_task_id)
+    category_token = _current_category.set(None)
+    try:
+        yield
+    finally:
+        _current_category.reset(category_token)
+        _current_trace_task_id.reset(task_token)
 
 
 def _record_span(
-    name: str, start_us: int, duration_us: int, rank: int, category: str
+    task_id: str,
+    name: str,
+    start_us: int,
+    duration_us: int,
+    rank: int,
+    category: str,
+    tags: Sequence[str] | None = None,
+    attrs: Mapping[str, TraceAttrValue] | None = None,
 ) -> None:
-    _trace_buffer.append(
+    session = _trace_sessions.get(task_id)
+    if session is None:
+        return
+
+    session.events.append(
         TraceEvent(
             name=name,
             start_us=start_us,
             duration_us=duration_us,
             rank=rank,
             category=category,
+            node_id=session.node_id,
+            model_id=session.model_id,
+            task_kind=session.task_kind,
+            tags=_merge_tags(session.tags, tags),
+            attrs=_merge_attrs(session.attrs, attrs),
         )
     )
 
@@ -81,6 +206,10 @@ def trace(
     name: str,
     rank: int,
     category: str = "compute",
+    *,
+    task_id: object | None = None,
+    tags: Sequence[str] | None = None,
+    attrs: Mapping[str, TraceAttrValue] | None = None,
 ) -> Generator[None, None, None]:
     """Context manager to trace any operation.
 
@@ -98,7 +227,10 @@ def trace(
                 # Recorded with category "sync/compute"
                 hidden_states = some_computation(...)
     """
-    if not EXO_TRACING_ENABLED:
+    normalized_task_id = (
+        str(task_id) if task_id is not None else _current_trace_task_id.get()
+    )
+    if normalized_task_id is None or normalized_task_id not in _trace_sessions:
         yield
         return
 
@@ -110,21 +242,104 @@ def trace(
     token = _current_category.set(full_category)
 
     try:
-        start_us = int(time.time() * 1_000_000)
+        start_us = now_us()
         start_perf = time.perf_counter()
         yield
         duration_us = int((time.perf_counter() - start_perf) * 1_000_000)
-        _record_span(name, start_us, duration_us, rank, full_category)
+        _record_span(
+            normalized_task_id,
+            name,
+            start_us,
+            duration_us,
+            rank,
+            full_category,
+            tags=tags,
+            attrs=attrs,
+        )
     finally:
         _current_category.reset(token)
 
 
-def get_trace_buffer() -> list[TraceEvent]:
-    return list(_trace_buffer)
+def record_trace_marker(
+    name: str,
+    rank: int,
+    category: str = "lifecycle",
+    *,
+    task_id: object | None = None,
+    tags: Sequence[str] | None = None,
+    attrs: Mapping[str, TraceAttrValue] | None = None,
+) -> None:
+    """Record a zero-duration marker in the current or explicit trace session."""
+
+    normalized_task_id = (
+        str(task_id) if task_id is not None else _current_trace_task_id.get()
+    )
+    if normalized_task_id is None or normalized_task_id not in _trace_sessions:
+        return
+
+    parent = _current_category.get()
+    full_category = f"{parent}/{category}" if parent else category
+    _record_span(
+        normalized_task_id,
+        name,
+        now_us(),
+        0,
+        rank,
+        full_category,
+        tags=tags,
+        attrs=attrs,
+    )
 
 
-def clear_trace_buffer() -> None:
-    _trace_buffer.clear()
+def record_shared_span(
+    task_ids: Sequence[object],
+    *,
+    name: str,
+    start_us: int,
+    duration_us: int,
+    rank: int,
+    category: str,
+    tags: Sequence[str] | None = None,
+    attrs: Mapping[str, TraceAttrValue] | None = None,
+) -> None:
+    """Duplicate a shared span into multiple task traces.
+
+    Batch text generation can advance several requests in one decode step. We
+    duplicate that shared work into each participating task trace and mark it
+    explicitly so the dashboard can filter or explain it later.
+    """
+
+    for task_id in task_ids:
+        _record_span(
+            str(task_id),
+            name,
+            start_us,
+            duration_us,
+            rank,
+            category,
+            tags=tags,
+            attrs=attrs,
+        )
+
+
+def collect_trace_session(task_id: object) -> list[TraceEvent]:
+    """Return the current buffered events for *task_id* without clearing them."""
+
+    session = _trace_sessions.get(str(task_id))
+    return list(session.events) if session is not None else []
+
+
+def pop_trace_session(task_id: object) -> list[TraceEvent]:
+    """Return and clear the buffered events for *task_id*."""
+
+    session = _trace_sessions.pop(str(task_id), None)
+    return list(session.events) if session is not None else []
+
+
+def clear_trace_session(task_id: object) -> None:
+    """Discard any buffered trace state for *task_id*."""
+
+    _trace_sessions.pop(str(task_id), None)
 
 
 def export_trace(traces: list[TraceEvent], output_path: Path) -> None:
@@ -140,7 +355,14 @@ def export_trace(traces: list[TraceEvent], output_path: Path) -> None:
             "dur": event.duration_us,
             "pid": 0,
             "tid": event.rank,
-            "args": {"rank": event.rank},
+            "args": {
+                "rank": event.rank,
+                "node_id": event.node_id,
+                "model_id": event.model_id,
+                "task_kind": event.task_kind,
+                "tags": list(event.tags),
+                "attrs": event.attrs,
+            },
         }
         trace_events.append(chrome_event)
 
@@ -189,11 +411,34 @@ def load_trace_file(path: Path) -> list[TraceEvent]:
         # Get rank from tid or args
         rank = int(tid_value) if isinstance(tid_value, (int, float, str)) else 0
         args = event.get("args")
+        node_id: str | None = None
+        model_id: str | None = None
+        task_kind: TraceTaskKind | None = None
+        tags: tuple[str, ...] = ()
+        attrs: dict[str, TraceAttrValue] = {}
         if isinstance(args, dict):
             args_dict = cast(dict[str, object], args)
             rank_from_args = args_dict.get("rank")
             if isinstance(rank_from_args, (int, float, str)):
                 rank = int(rank_from_args)
+            node_id_value = args_dict.get("node_id")
+            if isinstance(node_id_value, str) and node_id_value:
+                node_id = node_id_value
+            model_id_value = args_dict.get("model_id")
+            if isinstance(model_id_value, str) and model_id_value:
+                model_id = model_id_value
+            task_kind_value = args_dict.get("task_kind")
+            if task_kind_value in ("image", "text", "embedding"):
+                task_kind = task_kind_value
+            tags_value = args_dict.get("tags")
+            if isinstance(tags_value, list):
+                tag_items = cast(list[object], tags_value)
+                tags = tuple(
+                    tag if isinstance(tag, str) else str(tag) for tag in tag_items
+                )
+            attrs_value = args_dict.get("attrs")
+            if isinstance(attrs_value, dict):
+                attrs = cast(dict[str, TraceAttrValue], attrs_value)
 
         traces.append(
             TraceEvent(
@@ -202,6 +447,11 @@ def load_trace_file(path: Path) -> list[TraceEvent]:
                 duration_us=duration_us,
                 rank=rank,
                 category=category,
+                node_id=node_id,
+                model_id=model_id,
+                task_kind=task_kind,
+                tags=tags,
+                attrs=attrs,
             )
         )
 

--- a/src/exo/shared/types/commands.py
+++ b/src/exo/shared/types/commands.py
@@ -38,6 +38,12 @@ class TextEmbedding(BaseCommand):
     task_params: TextEmbeddingTaskParams
 
 
+class SetTracingEnabled(BaseCommand):
+    """Command to toggle runtime tracing for new requests cluster-wide."""
+
+    enabled: bool
+
+
 class PlaceInstance(BaseCommand):
     model_card: ModelCard
     sharding: Sharding
@@ -126,6 +132,7 @@ Command = (
     | ImageGeneration
     | ImageEdits
     | TextEmbedding
+    | SetTracingEnabled
     | PlaceInstance
     | CreateInstance
     | DeleteInstance

--- a/src/exo/shared/types/diagnostics.py
+++ b/src/exo/shared/types/diagnostics.py
@@ -1,0 +1,328 @@
+"""Read-only diagnostic response models for live Skulk node inspection."""
+
+from typing import Literal
+
+from pydantic import Field
+
+from exo.shared.types.memory import Memory
+from exo.shared.types.profiling import (
+    DiskUsage,
+    MemoryUsage,
+    NodeIdentity,
+    NodeNetworkInfo,
+    SystemPerformanceProfile,
+)
+from exo.utils.pydantic_ext import CamelCaseModel
+
+ProcessRole = Literal["skulk", "runner", "vector", "python", "other"]
+
+
+class DiagnosticsProcess(CamelCaseModel):
+    """One local operating-system process relevant to Skulk diagnostics."""
+
+    pid: int = Field(description="Operating-system process ID.")
+    parent_pid: int | None = Field(
+        default=None,
+        description="Operating-system parent process ID, when visible.",
+    )
+    role: ProcessRole = Field(
+        description="Best-effort Skulk role inferred from process lineage and command line.",
+    )
+    command: str = Field(description="Joined process command line.")
+    status: str | None = Field(
+        default=None,
+        description="Operating-system process status such as running or sleeping.",
+    )
+    cpu_percent: float | None = Field(
+        default=None,
+        description="Recent CPU percentage reported by psutil.",
+    )
+    memory_percent: float | None = Field(
+        default=None,
+        description="Percent of physical memory used by this process.",
+    )
+    rss: Memory | None = Field(
+        default=None,
+        description="Resident set size for this process, when available.",
+    )
+    elapsed_seconds: float | None = Field(
+        default=None,
+        description="Seconds since process creation, when available.",
+    )
+    is_child_of_skulk: bool = Field(
+        default=False,
+        description="Whether this process is in the current Skulk API process tree.",
+    )
+
+
+class RunnerTaskDiagnostics(CamelCaseModel):
+    """Compact task information for a task known to a runner or cluster state."""
+
+    task_id: str = Field(description="Skulk task ID.")
+    task_kind: str = Field(description="Concrete task model name.")
+    task_status: str = Field(description="Current event-sourced task status.")
+    instance_id: str = Field(description="Instance associated with the task.")
+    command_id: str | None = Field(
+        default=None,
+        description="External command ID for user-facing inference tasks.",
+    )
+    runner_id: str | None = Field(
+        default=None,
+        description="Runner assigned to the task, if known.",
+    )
+    model_id: str | None = Field(
+        default=None,
+        description="Model associated with the task, if known.",
+    )
+
+
+class RunnerLifecycleMilestone(CamelCaseModel):
+    """Bounded live milestone emitted by the runner supervisor."""
+
+    at: str = Field(description="UTC timestamp when the milestone was recorded.")
+    name: str = Field(description="Short milestone name.")
+    detail: str | None = Field(
+        default=None,
+        description="Optional compact detail for the milestone.",
+    )
+
+
+class RunnerSupervisorDiagnostics(CamelCaseModel):
+    """Live runner-supervisor state that is not event-sourced."""
+
+    runner_id: str = Field(description="Runner ID.")
+    instance_id: str = Field(description="Instance ID.")
+    node_id: str = Field(description="Node ID that owns this runner.")
+    model_id: str = Field(description="Model assigned to this runner.")
+    device_rank: int = Field(description="Distributed device rank.")
+    world_size: int = Field(description="Distributed world size.")
+    start_layer: int = Field(description="Inclusive first model layer on this shard.")
+    end_layer: int = Field(description="Exclusive final model layer on this shard.")
+    n_layers: int = Field(description="Total number of model layers.")
+    pid: int | None = Field(
+        default=None,
+        description="Runner subprocess PID, when started.",
+    )
+    process_alive: bool = Field(description="Whether the runner subprocess is alive.")
+    exit_code: int | None = Field(
+        default=None,
+        description="Runner subprocess exit code, when exited.",
+    )
+    status_kind: str = Field(description="Current runner status variant.")
+    status_since: str = Field(description="UTC timestamp for the current status.")
+    seconds_in_status: float = Field(
+        description="Wall-clock seconds spent in the current runner status."
+    )
+    pending_task_ids: list[str] = Field(
+        default_factory=list,
+        description="Tasks sent to the supervisor but not acknowledged by the runner.",
+    )
+    in_progress_tasks: list[RunnerTaskDiagnostics] = Field(
+        default_factory=list,
+        description="Tasks currently known as in progress by the supervisor.",
+    )
+    completed_task_count: int = Field(
+        description="Number of tasks completed by this supervisor."
+    )
+    cancelled_task_ids: list[str] = Field(
+        default_factory=list,
+        description="Task IDs cancelled through this supervisor.",
+    )
+    last_task_sent_at: str | None = Field(
+        default=None,
+        description="UTC timestamp for the last task submitted to the runner.",
+    )
+    last_event_received_at: str | None = Field(
+        default=None,
+        description="UTC timestamp for the last event received from the runner.",
+    )
+    last_event_type: str | None = Field(
+        default=None,
+        description="Class name of the last event received from the runner.",
+    )
+    milestones: list[RunnerLifecycleMilestone] = Field(
+        default_factory=list,
+        description="Recent lifecycle milestones retained by the supervisor.",
+    )
+
+
+class PlacementRunnerDiagnostics(CamelCaseModel):
+    """Event-sourced placement details for one runner assignment."""
+
+    runner_id: str = Field(description="Runner ID.")
+    node_id: str = Field(description="Node ID assigned to this runner.")
+    friendly_name: str | None = Field(
+        default=None,
+        description="Friendly node name, when known.",
+    )
+    status_kind: str | None = Field(
+        default=None,
+        description="Current event-sourced runner status variant.",
+    )
+    device_rank: int = Field(description="Distributed device rank.")
+    world_size: int = Field(description="Distributed world size.")
+    start_layer: int = Field(description="Inclusive first model layer on this shard.")
+    end_layer: int = Field(description="Exclusive final model layer on this shard.")
+    n_layers: int = Field(description="Total number of model layers.")
+    is_local: bool = Field(description="Whether this assignment is on the API node.")
+    is_master: bool = Field(description="Whether this assignment is on the master node.")
+    tasks: list[RunnerTaskDiagnostics] = Field(
+        default_factory=list,
+        description="Event-sourced tasks associated with this runner assignment.",
+    )
+
+
+class InstancePlacementDiagnostics(CamelCaseModel):
+    """Cluster placement analysis for one model instance."""
+
+    instance_id: str = Field(description="Instance ID.")
+    model_id: str = Field(description="Placed model ID.")
+    master_node_id: str | None = Field(
+        default=None,
+        description="Current master node ID, when known.",
+    )
+    master_is_placement_node: bool = Field(
+        description="Whether the current master is part of this model placement."
+    )
+    local_node_is_placement_node: bool = Field(
+        description="Whether the API node is part of this model placement."
+    )
+    placement_node_ids: list[str] = Field(
+        default_factory=list,
+        description="Node IDs participating in the placement.",
+    )
+    runners: list[PlacementRunnerDiagnostics] = Field(
+        default_factory=list,
+        description="Per-runner placement details.",
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Heuristic warnings that may help explain a stuck placement.",
+    )
+
+
+class NodeRuntimeDiagnostics(CamelCaseModel):
+    """Static and slow-changing runtime information for one Skulk node."""
+
+    node_id: str = Field(description="Local node ID.")
+    hostname: str = Field(description="Local hostname.")
+    friendly_name: str | None = Field(
+        default=None,
+        description="Friendly node name from gathered identity data.",
+    )
+    is_master: bool = Field(description="Whether this node is the current master.")
+    master_node_id: str | None = Field(
+        default=None,
+        description="Current master node ID, when known.",
+    )
+    cwd: str = Field(description="Current working directory of the API process.")
+    config_path: str = Field(description="Config path resolved by this API process.")
+    config_file_exists: bool = Field(
+        description="Whether the resolved config path exists from this process cwd."
+    )
+    skulk_version: str = Field(description="Installed Skulk package version.")
+    skulk_commit: str = Field(description="Git commit reported by node identity.")
+    libp2p_namespace: str | None = Field(
+        default=None,
+        description="Configured libp2p namespace environment value, if set.",
+    )
+    python_unbuffered: bool = Field(
+        description="Whether PYTHONUNBUFFERED is enabled for this process."
+    )
+    tracing_enabled: bool = Field(
+        description="Current cluster runtime tracing state as seen by this API node."
+    )
+    structured_logging_configured: bool = Field(
+        description="Whether config enables centralized structured logging."
+    )
+    logging_ingest_url: str | None = Field(
+        default=None,
+        description="Configured centralized logging ingest URL, when present.",
+    )
+
+
+class NodeResourceDiagnostics(CamelCaseModel):
+    """Resource readings for one node from gathered state and local psutil."""
+
+    gathered_memory: MemoryUsage | None = Field(
+        default=None,
+        description="Last event-sourced memory reading for this node.",
+    )
+    current_memory: MemoryUsage | None = Field(
+        default=None,
+        description="Live memory reading from the API process.",
+    )
+    disk: DiskUsage | None = Field(
+        default=None,
+        description="Last event-sourced disk reading for this node.",
+    )
+    system: SystemPerformanceProfile | None = Field(
+        default=None,
+        description="Last event-sourced system performance reading.",
+    )
+    network: NodeNetworkInfo | None = Field(
+        default=None,
+        description="Last event-sourced network interface reading.",
+    )
+
+
+class NodeDiagnostics(CamelCaseModel):
+    """Read-only diagnostic bundle for one Skulk node."""
+
+    generated_at: str = Field(description="UTC timestamp when this bundle was built.")
+    runtime: NodeRuntimeDiagnostics = Field(description="Runtime identity and config.")
+    identity: NodeIdentity | None = Field(
+        default=None,
+        description="Last gathered node identity data.",
+    )
+    resources: NodeResourceDiagnostics = Field(description="Resource readings.")
+    processes: list[DiagnosticsProcess] = Field(
+        default_factory=list,
+        description="Relevant local OS processes.",
+    )
+    supervisor_runners: list[RunnerSupervisorDiagnostics] = Field(
+        default_factory=list,
+        description="Live local runner-supervisor diagnostics.",
+    )
+    placements: list[InstancePlacementDiagnostics] = Field(
+        default_factory=list,
+        description="Event-sourced placement analysis for current instances.",
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Top-level diagnostic warnings for this node.",
+    )
+
+
+class ClusterNodeDiagnostics(CamelCaseModel):
+    """One node result inside a cluster diagnostics response."""
+
+    node_id: str = Field(description="Node ID for this cluster diagnostics result.")
+    url: str | None = Field(
+        default=None,
+        description="Peer API URL used to collect diagnostics, if remote.",
+    )
+    ok: bool = Field(description="Whether diagnostics were collected successfully.")
+    diagnostics: NodeDiagnostics | None = Field(
+        default=None,
+        description="Collected node diagnostics when ok is true.",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Collection error when ok is false.",
+    )
+
+
+class ClusterDiagnostics(CamelCaseModel):
+    """Read-only diagnostic bundle collected from reachable cluster nodes."""
+
+    generated_at: str = Field(description="UTC timestamp when collection finished.")
+    local_node_id: str = Field(description="Node ID of the API serving this response.")
+    master_node_id: str | None = Field(
+        default=None,
+        description="Current master node ID, when known.",
+    )
+    nodes: list[ClusterNodeDiagnostics] = Field(
+        default_factory=list,
+        description="Local and reachable peer diagnostic results.",
+    )

--- a/src/exo/shared/types/diagnostics.py
+++ b/src/exo/shared/types/diagnostics.py
@@ -599,3 +599,126 @@ class ClusterDiagnostics(CamelCaseModel):
         default_factory=list,
         description="Local and reachable peer diagnostic results.",
     )
+
+
+class ClusterTimelineRunner(CamelCaseModel):
+    """Compact current-state synopsis for one runner in the cluster timeline view.
+
+    Designed for at-a-glance debugging of distributed deadlocks: each runner's
+    rank, current phase, and time-stuck-in-phase make a rank-disagreement
+    pattern visible without having to cross-reference per-node payloads.
+    """
+
+    node_id: str = Field(description="Node owning this runner.")
+    runner_id: str = Field(description="Runner ID.")
+    instance_id: str = Field(description="Instance ID.")
+    model_id: str = Field(description="Model assigned to this runner.")
+    device_rank: int = Field(description="Distributed device rank.")
+    world_size: int = Field(description="Distributed world size.")
+    pid: int | None = Field(
+        default=None, description="Runner subprocess PID, when started."
+    )
+    process_alive: bool = Field(description="Whether the runner subprocess is alive.")
+    status_kind: str = Field(description="Current runner status variant.")
+    phase: RunnerPhaseName = Field(description="Last runner phase reported.")
+    phase_detail: str | None = Field(
+        default=None, description="Compact human-readable detail for the current phase."
+    )
+    seconds_in_phase: float = Field(
+        description="Wall-clock seconds spent in the current phase."
+    )
+    last_progress_at: str | None = Field(
+        default=None,
+        description="UTC timestamp for the last flight-recorder update.",
+    )
+    active_task_id: str | None = Field(
+        default=None,
+        description="Task ID associated with the current phase, when known.",
+    )
+    active_command_id: str | None = Field(
+        default=None,
+        description="Command ID associated with the current phase, when known.",
+    )
+    last_mlx_memory: MlxMemorySnapshot | None = Field(
+        default=None,
+        description="Most recent MLX memory snapshot reported by the runner.",
+    )
+
+
+class ClusterTimelineEntry(CamelCaseModel):
+    """One flight-recorder entry annotated with cluster identity for merge.
+
+    Identical in spirit to ``RunnerFlightRecorderEntry`` but with redundant
+    ``node_id`` / ``device_rank`` / ``world_size`` lifted onto the entry so
+    a chronologically merged list across all ranks reads top-to-bottom as a
+    single distributed timeline.
+    """
+
+    at: str = Field(description="UTC timestamp when the runner emitted the update.")
+    node_id: str = Field(description="Node owning the runner that emitted this entry.")
+    runner_id: str = Field(description="Runner ID that emitted this entry.")
+    device_rank: int = Field(description="Distributed device rank for this entry.")
+    world_size: int = Field(description="Distributed world size for this entry.")
+    phase: RunnerPhaseName = Field(description="Runner phase at this entry.")
+    event: str = Field(description="Short event name within the phase.")
+    detail: str | None = Field(
+        default=None,
+        description="Compact human-readable detail for diagnostics.",
+    )
+    attrs: dict[str, RunnerDiagnosticValue] = Field(
+        default_factory=dict,
+        description="Structured low-cardinality diagnostic attributes.",
+    )
+    task_id: str | None = Field(
+        default=None,
+        description="Task ID associated with the entry, when known.",
+    )
+    command_id: str | None = Field(
+        default=None,
+        description="Command ID associated with the entry, when known.",
+    )
+    mlx_memory: MlxMemorySnapshot | None = Field(
+        default=None,
+        description="MLX memory snapshot captured with this entry, when present.",
+    )
+
+
+class ClusterTimelineUnreachable(CamelCaseModel):
+    """One peer that could not be reached when building the cluster timeline."""
+
+    node_id: str = Field(description="Node ID for the unreachable peer.")
+    url: str | None = Field(
+        default=None, description="Peer API URL that was attempted, if known."
+    )
+    error: str = Field(description="Reason the peer was unreachable.")
+
+
+class ClusterTimeline(CamelCaseModel):
+    """Cross-rank chronological view of runner activity across the cluster.
+
+    Produced by stitching the per-node ``RunnerSupervisorDiagnostics`` from
+    every reachable node into one unified shape. The ``runners`` list gives
+    a per-rank "where is each rank right now" snapshot; the ``timeline``
+    list gives every flight-recorder entry across all ranks, merged and
+    sorted by ``at`` so a distributed deadlock's rank-disagreement signature
+    is visible at a glance.
+    """
+
+    generated_at: str = Field(description="UTC timestamp when the timeline was built.")
+    local_node_id: str = Field(description="Node ID of the API serving this response.")
+    master_node_id: str | None = Field(
+        default=None,
+        description="Current master node ID, when known.",
+    )
+    runners: list[ClusterTimelineRunner] = Field(
+        default_factory=list,
+        description="Current synopsis for each runner, sorted by (model_id, rank).",
+    )
+    timeline: list[ClusterTimelineEntry] = Field(
+        default_factory=list,
+        description="Flight-recorder entries from all runners, merged and sorted by `at` ascending.",
+    )
+    unreachable_nodes: list[ClusterTimelineUnreachable] = Field(
+        default_factory=list,
+        description="Peer nodes that could not be reached for this timeline.",
+    )

--- a/src/exo/shared/types/diagnostics.py
+++ b/src/exo/shared/types/diagnostics.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 from pydantic import Field
 
+from exo.shared.types.common import NodeId
 from exo.shared.types.memory import Memory
 from exo.shared.types.profiling import (
     DiskUsage,
@@ -12,9 +13,16 @@ from exo.shared.types.profiling import (
     NodeNetworkInfo,
     SystemPerformanceProfile,
 )
+from exo.shared.types.tasks import TaskId
+from exo.shared.types.worker.runners import RunnerId
 from exo.utils.pydantic_ext import CamelCaseModel
 
 ProcessRole = Literal["skulk", "runner", "vector", "python", "other"]
+RunnerTaskCancelStatus = Literal[
+    "cancel_requested",
+    "already_cancelled",
+    "already_completed",
+]
 
 
 class DiagnosticsProcess(CamelCaseModel):
@@ -143,6 +151,28 @@ class RunnerSupervisorDiagnostics(CamelCaseModel):
     milestones: list[RunnerLifecycleMilestone] = Field(
         default_factory=list,
         description="Recent lifecycle milestones retained by the supervisor.",
+    )
+
+
+class RunnerTaskCancelRequest(CamelCaseModel):
+    """Payload for a direct live-runner task cancellation request."""
+
+    task_id: TaskId = Field(description="Live task ID to request cancellation for.")
+
+
+class RunnerTaskCancelResponse(CamelCaseModel):
+    """Result of a direct live-runner task cancellation request."""
+
+    node_id: NodeId = Field(description="Node that accepted the cancellation request.")
+    runner_id: RunnerId = Field(
+        description="Runner supervisor that handled the request."
+    )
+    task_id: TaskId = Field(description="Task ID the request targeted.")
+    status: RunnerTaskCancelStatus = Field(
+        description="Cancellation outcome as observed by the local runner supervisor."
+    )
+    message: str = Field(
+        description="Human-readable description of what the node did."
     )
 
 

--- a/src/exo/shared/types/diagnostics.py
+++ b/src/exo/shared/types/diagnostics.py
@@ -18,11 +18,143 @@ from exo.shared.types.worker.runners import RunnerId
 from exo.utils.pydantic_ext import CamelCaseModel
 
 ProcessRole = Literal["skulk", "runner", "vector", "python", "other"]
+RunnerPhaseName = Literal[
+    "created",
+    "idle",
+    "connect_group",
+    "load_model",
+    "warmup",
+    "task_submission",
+    "task_agreement",
+    "prompt_build",
+    "vision_preprocess",
+    "kv_cache_lookup",
+    "prefill_barrier",
+    "prefill_pipeline",
+    "prefill_stream",
+    "decode_barrier",
+    "decode_wait_first_token",
+    "decode_stream",
+    "parser",
+    "cancel_requested",
+    "cancel_observed",
+    "completion",
+    "error",
+    "shutdown_cleanup",
+]
 RunnerTaskCancelStatus = Literal[
     "cancel_requested",
     "already_cancelled",
     "already_completed",
 ]
+
+
+class MlxMemorySnapshot(CamelCaseModel):
+    """Best-effort snapshot of memory reported by MLX/Metal."""
+
+    generated_at: str = Field(description="UTC timestamp when the snapshot was taken.")
+    active: Memory | None = Field(
+        default=None,
+        description="Currently active MLX memory, when the runtime exposes it.",
+    )
+    cache: Memory | None = Field(
+        default=None,
+        description="MLX cache memory, when the runtime exposes it.",
+    )
+    peak: Memory | None = Field(
+        default=None,
+        description="Peak MLX memory since the last reset, when available.",
+    )
+    wired_limit: Memory | None = Field(
+        default=None,
+        description=(
+            "Configured MLX wired memory limit when known. Current MLX releases "
+            "do not expose a getter on all platforms, so this may be null."
+        ),
+    )
+    source: str = Field(
+        description="Runtime module that supplied the measurement, such as mlx.core."
+    )
+
+
+RunnerDiagnosticValue = str | int | float | bool | list[str]
+
+
+class RunnerDiagnosticContext(CamelCaseModel):
+    """Stable runner identity included with each flight-recorder update."""
+
+    node_id: str = Field(description="Node ID that owns this runner.")
+    runner_id: str = Field(description="Runner ID.")
+    pid: int | None = Field(default=None, description="Runner subprocess PID.")
+    instance_id: str = Field(description="Instance ID.")
+    model_id: str = Field(description="Model assigned to this runner.")
+    rank: int = Field(description="Distributed rank for this runner.")
+    world_size: int = Field(description="Distributed world size.")
+    start_layer: int = Field(description="Inclusive first layer on this shard.")
+    end_layer: int = Field(description="Exclusive final layer on this shard.")
+    n_layers: int = Field(description="Total model layers.")
+
+
+class RunnerDiagnosticUpdate(CamelCaseModel):
+    """One non-blocking runner-to-supervisor diagnostic update."""
+
+    at: str = Field(description="UTC timestamp when the runner emitted the update.")
+    phase: RunnerPhaseName = Field(description="Current runner phase.")
+    event: str = Field(description="Short event name within the phase.")
+    detail: str | None = Field(
+        default=None,
+        description="Compact human-readable detail for diagnostics.",
+    )
+    attrs: dict[str, RunnerDiagnosticValue] = Field(
+        default_factory=dict,
+        description="Structured low-cardinality diagnostic attributes.",
+    )
+    context: RunnerDiagnosticContext = Field(
+        description="Stable runner identity fields for this update."
+    )
+    task_id: str | None = Field(
+        default=None,
+        description="Active task ID associated with the update, when known.",
+    )
+    command_id: str | None = Field(
+        default=None,
+        description="External command ID associated with the update, when known.",
+    )
+    mlx_memory: MlxMemorySnapshot | None = Field(
+        default=None,
+        description="MLX memory snapshot captured with this update, when requested.",
+    )
+
+
+class RunnerFlightRecorderEntry(CamelCaseModel):
+    """One retained runner flight-recorder entry."""
+
+    at: str = Field(description="UTC timestamp when the runner emitted the update.")
+    phase: RunnerPhaseName = Field(description="Runner phase at this entry.")
+    event: str = Field(description="Short event name within the phase.")
+    detail: str | None = Field(
+        default=None,
+        description="Compact human-readable detail for diagnostics.",
+    )
+    attrs: dict[str, RunnerDiagnosticValue] = Field(
+        default_factory=dict,
+        description="Structured low-cardinality diagnostic attributes.",
+    )
+    context: RunnerDiagnosticContext = Field(
+        description="Stable runner identity fields for this entry."
+    )
+    task_id: str | None = Field(
+        default=None,
+        description="Task ID associated with the entry, when known.",
+    )
+    command_id: str | None = Field(
+        default=None,
+        description="Command ID associated with the entry, when known.",
+    )
+    mlx_memory: MlxMemorySnapshot | None = Field(
+        default=None,
+        description="MLX memory snapshot captured with this entry, when present.",
+    )
 
 
 class DiagnosticsProcess(CamelCaseModel):
@@ -121,6 +253,37 @@ class RunnerSupervisorDiagnostics(CamelCaseModel):
     seconds_in_status: float = Field(
         description="Wall-clock seconds spent in the current runner status."
     )
+    phase: RunnerPhaseName = Field(description="Last runner phase reported.")
+    phase_started_at: str = Field(
+        description="UTC timestamp when the current phase started."
+    )
+    seconds_in_phase: float = Field(
+        description="Wall-clock seconds spent in the current phase."
+    )
+    last_progress_at: str | None = Field(
+        default=None,
+        description="UTC timestamp for the last flight-recorder update.",
+    )
+    active_task_id: str | None = Field(
+        default=None,
+        description="Task ID associated with the current phase, when known.",
+    )
+    active_command_id: str | None = Field(
+        default=None,
+        description="Command ID associated with the current phase, when known.",
+    )
+    phase_detail: str | None = Field(
+        default=None,
+        description="Compact human-readable detail for the current phase.",
+    )
+    last_mlx_memory: MlxMemorySnapshot | None = Field(
+        default=None,
+        description="Most recent MLX memory snapshot reported by the runner.",
+    )
+    flight_recorder: list[RunnerFlightRecorderEntry] = Field(
+        default_factory=list,
+        description="Last 128 local-only runner diagnostic events.",
+    )
     pending_task_ids: list[str] = Field(
         default_factory=list,
         description="Tasks sent to the supervisor but not acknowledged by the runner.",
@@ -173,6 +336,86 @@ class RunnerTaskCancelResponse(CamelCaseModel):
     )
     message: str = Field(
         description="Human-readable description of what the node did."
+    )
+
+
+class DiagnosticProcessSample(CamelCaseModel):
+    """One macOS process-sampling command result in a diagnostic capture bundle."""
+
+    name: str = Field(description="Sampling command name.")
+    command: list[str] = Field(description="Command argv that was attempted.")
+    ok: bool = Field(description="Whether the sampling command completed cleanly.")
+    exit_code: int | None = Field(
+        default=None,
+        description="Process exit code, when a command was launched.",
+    )
+    duration_seconds: float = Field(
+        description="Wall-clock duration spent waiting for the command."
+    )
+    stdout: str | None = Field(
+        default=None,
+        description="Truncated standard output from the sampling command.",
+    )
+    stderr: str | None = Field(
+        default=None,
+        description="Truncated standard error from the sampling command.",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Structured failure reason when the command could not run.",
+    )
+
+
+class DiagnosticCaptureRequest(CamelCaseModel):
+    """Request payload for on-demand local or proxied node diagnostics capture."""
+
+    runner_id: RunnerId | None = Field(
+        default=None,
+        description="Optional runner ID to focus the capture bundle.",
+    )
+    task_id: TaskId | None = Field(
+        default=None,
+        description="Optional task ID to find the relevant runner for capture.",
+    )
+    include_process_samples: bool = Field(
+        default=True,
+        description="Whether to run heavyweight local process sampling commands.",
+    )
+    sample_duration_seconds: float = Field(
+        default=3.0,
+        ge=1.0,
+        le=10.0,
+        description="Requested duration for macOS sample collection.",
+    )
+
+
+class DiagnosticCaptureResponse(CamelCaseModel):
+    """On-demand diagnostics capture bundle for a local or proxied node."""
+
+    generated_at: str = Field(description="UTC timestamp when capture completed.")
+    node_id: NodeId = Field(description="Node that produced the capture bundle.")
+    node_diagnostics: "NodeDiagnostics" = Field(
+        description="Full live node diagnostics at capture time."
+    )
+    runner: RunnerSupervisorDiagnostics | None = Field(
+        default=None,
+        description="Matched runner diagnostics, when a runner or task filter matched.",
+    )
+    flight_recorder: list[RunnerFlightRecorderEntry] = Field(
+        default_factory=list,
+        description="Flight-recorder entries retained for the matched runner.",
+    )
+    mlx_memory: MlxMemorySnapshot | None = Field(
+        default=None,
+        description="Most recent MLX memory snapshot reported by the matched runner.",
+    )
+    process_samples: list[DiagnosticProcessSample] = Field(
+        default_factory=list,
+        description="Heavyweight process sampling results, when requested.",
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Capture warnings and partial-failure notes.",
     )
 
 

--- a/src/exo/shared/types/events.py
+++ b/src/exo/shared/types/events.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import final
+from typing import Literal, final
 
 from pydantic import Field
 
@@ -129,6 +129,13 @@ class TraceEventData(FrozenModel):
     duration_us: int
     rank: int
     category: str
+    node_id: str | None = None
+    model_id: str | None = None
+    task_kind: Literal["image", "text", "embedding"] | None = None
+    tags: list[str] = Field(default_factory=list)
+    attrs: dict[str, str | int | float | bool | list[str]] = Field(
+        default_factory=dict
+    )
 
 
 @final
@@ -142,6 +149,13 @@ class TracesCollected(BaseEvent):
 class TracesMerged(BaseEvent):
     task_id: TaskId
     traces: list[TraceEventData]
+
+
+@final
+class TracingStateChanged(BaseEvent):
+    """Cluster-wide runtime tracing state change."""
+
+    enabled: bool
 
 
 Event = (
@@ -163,6 +177,7 @@ Event = (
     | TopologyEdgeDeleted
     | TracesCollected
     | TracesMerged
+    | TracingStateChanged
     | CustomModelCardAdded
     | CustomModelCardDeleted
     | StateSnapshotHydrated

--- a/src/exo/shared/types/state.py
+++ b/src/exo/shared/types/state.py
@@ -46,6 +46,7 @@ class State(CamelCaseModel):
     tasks: Mapping[TaskId, Task] = {}
     last_seen: Mapping[NodeId, datetime] = {}
     topology: Topology = Field(default_factory=Topology)
+    tracing_enabled: bool = False
     last_event_applied_idx: int = Field(default=-1, ge=-1)
 
     # Granular node state mappings (update independently at different frequencies)

--- a/src/exo/shared/types/tasks.py
+++ b/src/exo/shared/types/tasks.py
@@ -60,6 +60,7 @@ class StartWarmup(BaseTask):  # emitted by Worker
 class TextGeneration(BaseTask):  # emitted by Master
     command_id: CommandId
     task_params: TextGenerationTaskParams
+    trace_enabled: bool = False
 
     error_type: str | None = Field(default=None)
     error_message: str | None = Field(default=None)
@@ -73,6 +74,7 @@ class CancelTask(BaseTask):
 class ImageGeneration(BaseTask):  # emitted by Master
     command_id: CommandId
     task_params: ImageGenerationTaskParams
+    trace_enabled: bool = False
 
     error_type: str | None = Field(default=None)
     error_message: str | None = Field(default=None)
@@ -81,6 +83,7 @@ class ImageGeneration(BaseTask):  # emitted by Master
 class ImageEdits(BaseTask):  # emitted by Master
     command_id: CommandId
     task_params: ImageEditsTaskParams
+    trace_enabled: bool = False
 
     error_type: str | None = Field(default=None)
     error_message: str | None = Field(default=None)
@@ -89,6 +92,7 @@ class ImageEdits(BaseTask):  # emitted by Master
 class TextEmbedding(BaseTask):  # emitted by Master
     command_id: CommandId
     task_params: TextEmbeddingTaskParams
+    trace_enabled: bool = False
 
     error_type: str | None = Field(default=None)
     error_message: str | None = Field(default=None)

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -56,7 +56,7 @@ Example ``exo.yaml``::
       staging:
         enabled: true
         node_cache_path: ~/.exo/staging
-        cleanup_on_deactivate: true
+        cleanup_on_deactivate: false
 
       node_overrides:
         mac-studio-1:
@@ -144,14 +144,15 @@ class StagingNodeConfig(FrozenModel):
             subdirectory named ``<org>--<model>`` (e.g.
             ``mlx-community--Qwen3-30B-A3B-4bit``).
         cleanup_on_deactivate: When ``True``, staged files are deleted when
-            the model instance is shut down, freeing local disk space.
-            Set to ``False`` on the store host so the canonical copy is
-            never removed.
+            the model instance is shut down, freeing local disk space at the
+            cost of making later placements cold again. The default keeps the
+            staged files so large models can be reused from local storage;
+            use the explicit staging-cache purge endpoint for cleanup.
     """
 
     enabled: bool = True
     node_cache_path: str = "~/.exo/staging"
-    cleanup_on_deactivate: bool = True
+    cleanup_on_deactivate: bool = False
 
 
 @final

--- a/src/exo/store/tests/test_config.py
+++ b/src/exo/store/tests/test_config.py
@@ -37,6 +37,14 @@ def test_node_matches_store_host_keeps_node_id_matching_exact() -> None:
     )
 
 
+def test_staging_cleanup_defaults_to_warm_cache() -> None:
+    config = StagingNodeConfig()
+
+    assert config.enabled
+    assert config.node_cache_path == "~/.exo/staging"
+    assert not config.cleanup_on_deactivate
+
+
 def test_resolve_node_staging_matches_local_hostname_alias(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("exo.store.config.socket.gethostname", lambda: "kite3")
     config = ModelStoreConfig(

--- a/src/exo/utils/disk_event_log.py
+++ b/src/exo/utils/disk_event_log.py
@@ -159,7 +159,16 @@ class DiskEventLog:
         # length fall behind the in-memory state index and break future event
         # application on the master.
         self._offset_cache.clear()
-        retained_events = list(self.read_range(keep_from_idx, absolute_end))
+        try:
+            retained_events = list(self.read_range(keep_from_idx, absolute_end))
+        except Exception as exc:
+            self._offset_cache.clear()
+            logger.opt(exception=exc).error(
+                "Refusing to compact event log because the retained tail could "
+                f"not be read (keep_from_idx={keep_from_idx}, "
+                f"absolute_end={absolute_end}); active log left intact"
+            )
+            return
         if len(retained_events) != expected_retained_count:
             logger.error(
                 "Refusing to compact event log because the retained tail was read "
@@ -199,8 +208,16 @@ class DiskEventLog:
         self._file.flush()
         with open(self._active_path, "rb") as f:
             self._seek_to(f, start)
-            for _ in range(end - start):
-                event = _read_record(f)
+            for idx in range(start, end):
+                try:
+                    event = _read_record(f)
+                except Exception as exc:
+                    self._offset_cache.clear()
+                    logger.opt(exception=exc).error(
+                        "Stopping event log read because a record could not be "
+                        f"decoded (idx={idx}, start={start}, end={end})"
+                    )
+                    break
                 if event is None:
                     break
                 yield event

--- a/src/exo/utils/restart.py
+++ b/src/exo/utils/restart.py
@@ -1,19 +1,49 @@
 """Utility for restarting the current exo process in-place.
 
 Uses os.execv to replace the current process image with a fresh one.
-Because exec replaces the image within the same PID, bound sockets are
-closed (assuming non-inheritable, which is Python's default) and Metal/GPU
-allocations are released by the OS. The new process then binds fresh.
+Because exec replaces the image within the same PID, Metal/GPU allocations are
+released by the OS. Open file descriptors that libraries mark inheritable are
+reset to close-on-exec immediately before replacement so the new process can
+bind fresh sockets.
 """
 
 import os
 import sys
 import threading
+from collections.abc import Iterable
 
 from loguru import logger
 
 _restart_scheduled = False
 _restart_lock = threading.Lock()
+
+
+def _iter_open_file_descriptors() -> Iterable[int]:
+    """Yield currently open file descriptors when the platform exposes them."""
+    for path in ("/dev/fd", "/proc/self/fd"):
+        try:
+            names = os.listdir(path)
+        except OSError:
+            continue
+        for name in names:
+            try:
+                fd = int(name)
+            except ValueError:
+                continue
+            yield fd
+        return
+
+
+def _mark_open_file_descriptors_close_on_exec() -> None:
+    """Prevent inherited listener sockets from surviving the process exec."""
+    for fd in _iter_open_file_descriptors():
+        if fd <= 2:
+            continue
+        try:
+            os.set_inheritable(fd, False)
+        except OSError:
+            # The fd may have closed after the directory snapshot.
+            continue
 
 
 def schedule_restart(delay: float = 1.0) -> bool:
@@ -37,6 +67,7 @@ def schedule_restart(delay: float = 1.0) -> bool:
             # Use `python -m exo` so restart works even when invoked via the
             # `exo` console script (where sys.argv[0] is just "exo", not a
             # valid Python file path). Preserve all original arguments.
+            _mark_open_file_descriptors_close_on_exec()
             os.execv(sys.executable, [sys.executable, "-m", "exo", *sys.argv[1:]])
         except Exception as exc:
             # If we can't exec the replacement, keep the current process alive

--- a/src/exo/utils/tests/test_event_log.py
+++ b/src/exo/utils/tests/test_event_log.py
@@ -216,3 +216,61 @@ def test_compact_aborts_when_retained_tail_is_incomplete(
     ]
 
     log.close()
+
+
+def _record_offset(path: Path, idx: int) -> int:
+    offset = 0
+    with open(path, "rb") as f:
+        for _ in range(idx):
+            f.seek(offset)
+            header = f.read(4)
+            assert len(header) == 4
+            length = int.from_bytes(header, byteorder="big")
+            offset += 4 + length
+    return offset
+
+
+def test_read_range_stops_on_corrupt_record(log_dir: Path):
+    log = DiskEventLog(log_dir)
+    events = [TestEvent() for _ in range(6)]
+    for event in events:
+        log.append(event)
+
+    assert len(list(log.read_all())) == len(events)
+    active_path = log_dir / "events.bin"
+    corrupt_offset = _record_offset(active_path, 3)
+    with open(active_path, "r+b") as f:
+        f.seek(corrupt_offset + 4)
+        f.write(b"e")
+
+    result = list(log.read_range(1, 5))
+
+    assert [event.event_id for event in result] == [
+        events[1].event_id,
+        events[2].event_id,
+    ]
+
+    log.close()
+
+
+def test_compact_keeps_active_log_when_retained_tail_is_corrupt(log_dir: Path):
+    log = DiskEventLog(log_dir)
+    events = [TestEvent() for _ in range(6)]
+    for event in events:
+        log.append(event)
+
+    assert len(list(log.read_all())) == len(events)
+    active_path = log_dir / "events.bin"
+    corrupt_offset = _record_offset(active_path, 4)
+    with open(active_path, "r+b") as f:
+        f.seek(corrupt_offset + 4)
+        f.write(b"e")
+    corrupt_bytes = active_path.read_bytes()
+
+    log.compact(4)
+
+    assert log.start_idx == 0
+    assert len(log) == 6
+    assert active_path.read_bytes() == corrupt_bytes
+
+    log.close()

--- a/src/exo/utils/tests/test_restart.py
+++ b/src/exo/utils/tests/test_restart.py
@@ -17,6 +17,7 @@ def test_schedule_restart_calls_execv() -> None:
     _reset_restart_state()
 
     with (
+        patch.object(restart, "_mark_open_file_descriptors_close_on_exec") as mock_close,
         patch.object(restart.os, "execv") as mock_execv,
         patch.object(restart.threading, "Thread") as mock_thread_cls,
     ):
@@ -32,6 +33,7 @@ def test_schedule_restart_calls_execv() -> None:
         with patch("time.sleep"):
             target_fn()
 
+        mock_close.assert_called_once()
         mock_execv.assert_called_once()
 
 
@@ -97,3 +99,29 @@ def test_schedule_restart_recovers_on_execv_failure() -> None:
 
         # Guard should be reset so we can schedule again
         assert not restart._restart_scheduled
+
+
+def test_mark_open_file_descriptors_close_on_exec_skips_standard_fds() -> None:
+    """Restart preparation should leave stdio alone and clear inheritable fds."""
+    calls: list[tuple[int, bool]] = []
+
+    def _set_inheritable(fd: int, inheritable: bool) -> None:
+        calls.append((fd, inheritable))
+        if fd == 7:
+            raise OSError("fd closed")
+
+    with (
+        patch.object(
+            restart,
+            "_iter_open_file_descriptors",
+            return_value=iter([0, 1, 2, 3, 7]),
+        ),
+        patch.object(
+            restart.os,
+            "set_inheritable",
+            side_effect=_set_inheritable,
+        ),
+    ):
+        restart._mark_open_file_descriptors_close_on_exec()
+
+    assert calls == [(3, False), (7, False)]

--- a/src/exo/worker/engines/image/pipeline/runner.py
+++ b/src/exo/worker/engines/image/pipeline/runner.py
@@ -8,11 +8,7 @@ from mflux.models.common.config.config import Config
 from mflux.utils.exceptions import StopImageGenerationException
 from tqdm import tqdm
 
-from exo.shared.constants import EXO_TRACING_ENABLED
-from exo.shared.tracing import (
-    clear_trace_buffer,
-    trace,
-)
+from exo.shared.tracing import trace, tracing_active
 from exo.shared.types.worker.shards import CfgShardMetadata, PipelineShardMetadata
 from exo.worker.engines.image.config import ImageModelConfig
 from exo.worker.engines.image.models.base import (
@@ -512,7 +508,6 @@ class DiffusionRunner:
             capture_steps = set()
 
         self._reset_all_caches()
-        clear_trace_buffer()
 
         time_steps = tqdm(range(runtime_config.num_inference_steps))
 
@@ -807,7 +802,7 @@ class DiffusionRunner:
                         rotary_embeddings=image_rotary_embeddings,
                     )
 
-                if EXO_TRACING_ENABLED:
+                if tracing_active():
                     mx.eval(encoder_hidden_states, hidden_states)
 
         if self.owns_concat_stage:
@@ -876,7 +871,7 @@ class DiffusionRunner:
                         rotary_embeddings=image_rotary_embeddings,
                     )
 
-                if EXO_TRACING_ENABLED:
+                if tracing_active():
                     mx.eval(hidden_states)
 
             if not self.is_last_stage:
@@ -1159,7 +1154,7 @@ class DiffusionRunner:
                         rotary_embeddings=image_rotary_embeddings,
                     )
 
-                if EXO_TRACING_ENABLED:
+                if tracing_active():
                     mx.eval(encoder_hidden_states, patch)
 
         if self.owns_concat_stage:
@@ -1235,7 +1230,7 @@ class DiffusionRunner:
                         rotary_embeddings=image_rotary_embeddings,
                     )
 
-                if EXO_TRACING_ENABLED:
+                if tracing_active():
                     mx.eval(patch)
 
             if not self.is_last_stage:

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -5,7 +5,7 @@ import threading
 import time
 import traceback
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Mapping
 from functools import partial
 from inspect import signature
 from types import FrameType
@@ -65,7 +65,7 @@ from mlx_lm.models.step3p5 import Step3p5Model as Step35InnerModel
 from exo.shared.constants import preferred_env_value
 from exo.shared.types.worker.shards import PipelineShardMetadata
 from exo.worker.runner.bootstrap import logger
-from exo.worker.runner.diagnostics import runner_phase
+from exo.worker.runner.diagnostics import record_runner_phase, runner_phase
 
 if TYPE_CHECKING:
     from mlx_lm.models.cache import Cache
@@ -233,6 +233,49 @@ def eval_with_timeout(
         completed.set()
 
 
+def pipeline_eval_timeout_seconds() -> float:
+    """Per-eval hard timeout for the pipeline-parallel forward pass.
+
+    Healthy ring-collective evals on a warm cluster are sub-millisecond; the
+    pre-decode barrier is the slowest legit collective at ~1s. 60s gives ~60×
+    headroom over the slowest legitimate value while still bounding the
+    "node bricked" failure mode caused by ring channel state desync.
+    """
+    raw = preferred_env_value(
+        "SKULK_PIPELINE_EVAL_TIMEOUT_SECONDS",
+        "EXO_PIPELINE_EVAL_TIMEOUT_SECONDS",
+    )
+    if raw is None:
+        return 60.0
+    with contextlib.suppress(ValueError):
+        return max(float(raw), 1.0)
+    return 60.0
+
+
+def pipeline_timeout_callback(
+    site: str, attrs: Mapping[str, object], is_prefill: bool
+) -> TimeoutCallback:
+    """Return an on_timeout callback that emits a flight-recorder breadcrumb.
+
+    Recorded under the same phase name as the surrounding `runner_phase`
+    block so post-mortem diagnostics tie the timeout event back to the
+    enter/exit pair already in the recorder.
+    """
+    phase = "prefill_pipeline" if is_prefill else "decode_stream"
+
+    def _on_timeout() -> None:
+        with contextlib.suppress(Exception):
+            record_runner_phase(
+                phase,
+                event="pipeline_eval_timeout",
+                detail=site,
+                attrs=dict(attrs),
+                include_memory=True,
+            )
+
+    return _on_timeout
+
+
 class _LayerCallable(Protocol):
     """Structural type that any compatible layer must satisfy.
 
@@ -282,18 +325,28 @@ class PipelineFirstLayer(CustomMlxLayer):
         if self.r != 0:
             # We want to avoid GPU timeout errors by evalling the distributed operation
             # so that it stays on CPU, which does not have a timeout.
+            _attrs_input: dict[str, object] = {
+                "rank": self.r,
+                "src": self.r - 1,
+            }
             with runner_phase(
                 "prefill_pipeline" if self.is_prefill else "decode_stream",
                 detail="pipeline_first_eval_input",
-                attrs={"rank": self.r, "src": self.r - 1},
+                attrs=_attrs_input,
             ), _hang_debug_watch(
                 f"pipeline_first eval_input rank={self.r} src={self.r - 1}"
             ):
-                mx.eval(x)
+                eval_with_timeout(
+                    x,
+                    timeout_seconds=pipeline_eval_timeout_seconds(),
+                    on_timeout=pipeline_timeout_callback(
+                        "pipeline_first_eval_input", _attrs_input, self.is_prefill
+                    ),
+                )
             with runner_phase(
                 "prefill_pipeline" if self.is_prefill else "decode_stream",
                 detail="pipeline_first_recv_like",
-                attrs={"rank": self.r, "src": self.r - 1},
+                attrs=_attrs_input,
             ), _hang_debug_watch(
                 f"pipeline_first recv_like rank={self.r} src={self.r - 1}"
             ):
@@ -301,11 +354,17 @@ class PipelineFirstLayer(CustomMlxLayer):
             with runner_phase(
                 "prefill_pipeline" if self.is_prefill else "decode_stream",
                 detail="pipeline_first_eval_recv",
-                attrs={"rank": self.r, "src": self.r - 1},
+                attrs=_attrs_input,
             ), _hang_debug_watch(
                 f"pipeline_first eval_recv rank={self.r} src={self.r - 1}"
             ):
-                mx.eval(x)
+                eval_with_timeout(
+                    x,
+                    timeout_seconds=pipeline_eval_timeout_seconds(),
+                    on_timeout=pipeline_timeout_callback(
+                        "pipeline_first_eval_recv", _attrs_input, self.is_prefill
+                    ),
+                )
         with runner_phase(
             "prefill_pipeline" if self.is_prefill else "decode_stream",
             detail="pipeline_first_original_layer",
@@ -346,35 +405,44 @@ class PipelineLastLayer(CustomMlxLayer):
 
         # Eval layer output to materialize it before send — this splits the graph
         # so the send is isolated and the receiving rank's recv can complete.
+        _attrs_eval: dict[str, object] = {
+            "rank": self.r,
+            "world_size": self.s,
+            "prefill": self.is_prefill,
+        }
         with runner_phase(
             "prefill_pipeline" if self.is_prefill else "decode_stream",
             detail="pipeline_last_eval_output",
-            attrs={"rank": self.r, "world_size": self.s, "prefill": self.is_prefill},
+            attrs=_attrs_eval,
         ), _hang_debug_watch(
             f"pipeline_last eval_output rank={self.r} world={self.s} prefill={self.is_prefill}"
         ):
-            mx.eval(output)
+            eval_with_timeout(
+                output,
+                timeout_seconds=pipeline_eval_timeout_seconds(),
+                on_timeout=pipeline_timeout_callback(
+                    "pipeline_last_eval_output", _attrs_eval, self.is_prefill
+                ),
+            )
 
         if self.r != self.s - 1:
+            _dst = (self.r + 1) % self.s
+            _attrs_send: dict[str, object] = {
+                "rank": self.r,
+                "dst": _dst,
+                "prefill": self.is_prefill,
+            }
             if self.queue_sends:
-                _pending_prefill_sends.append(
-                    (output, (self.r + 1) % self.s, self.group)
-                )
+                _pending_prefill_sends.append((output, _dst, self.group))
             else:
                 with runner_phase(
                     "prefill_pipeline" if self.is_prefill else "decode_stream",
                     detail="pipeline_last_send",
-                    attrs={
-                        "rank": self.r,
-                        "dst": (self.r + 1) % self.s,
-                        "prefill": self.is_prefill,
-                    },
+                    attrs=_attrs_send,
                 ), _hang_debug_watch(
-                    f"pipeline_last send rank={self.r} dst={(self.r + 1) % self.s} prefill={self.is_prefill}"
+                    f"pipeline_last send rank={self.r} dst={_dst} prefill={self.is_prefill}"
                 ):
-                    output = mx.distributed.send(
-                        output, (self.r + 1) % self.s, group=self.group
-                    )
+                    output = mx.distributed.send(output, _dst, group=self.group)
             if cache is not None:
                 # CacheList (used by MLA models like DeepSeekV32, GLM MoE DSA)
                 # doesn't have .keys directly; access via first sub-cache.
@@ -382,16 +450,34 @@ class PipelineLastLayer(CustomMlxLayer):
                 if hasattr(_cache, "keys"):  # pyright: ignore[reportAny]
                     _cache.keys = mx.depends(_cache.keys, output)  # type: ignore
             with _hang_debug_watch(
-                f"pipeline_last eval_send rank={self.r} dst={(self.r + 1) % self.s} prefill={self.is_prefill}"
+                f"pipeline_last eval_send rank={self.r} dst={_dst} prefill={self.is_prefill}"
             ):
-                mx.eval(output)
+                eval_with_timeout(
+                    output,
+                    timeout_seconds=pipeline_eval_timeout_seconds(),
+                    on_timeout=pipeline_timeout_callback(
+                        "pipeline_last_eval_send", _attrs_send, self.is_prefill
+                    ),
+                )
             if cache is not None and hasattr(_cache, "keys"):  # type: ignore
                 with _hang_debug_watch(
-                    f"pipeline_last eval_cache_dep rank={self.r} dst={(self.r + 1) % self.s} prefill={self.is_prefill}"
+                    f"pipeline_last eval_cache_dep rank={self.r} dst={_dst} prefill={self.is_prefill}"
                 ):
-                    mx.eval(_cache.keys)  # type: ignore
+                    eval_with_timeout(
+                        _cache.keys,  # type: ignore
+                        timeout_seconds=pipeline_eval_timeout_seconds(),
+                        on_timeout=pipeline_timeout_callback(
+                            "pipeline_last_eval_cache_dep",
+                            _attrs_send,
+                            self.is_prefill,
+                        ),
+                    )
 
         if not self.is_prefill:
+            _attrs_gather: dict[str, object] = {
+                "rank": self.r,
+                "world_size": self.s,
+            }
             with _hang_debug_watch(
                 f"pipeline_last all_gather rank={self.r} world={self.s}"
             ):
@@ -401,7 +487,15 @@ class PipelineLastLayer(CustomMlxLayer):
             with _hang_debug_watch(
                 f"pipeline_last eval_all_gather rank={self.r} world={self.s}"
             ):
-                mx.eval(output)
+                eval_with_timeout(
+                    output,
+                    timeout_seconds=pipeline_eval_timeout_seconds(),
+                    on_timeout=pipeline_timeout_callback(
+                        "pipeline_last_eval_all_gather",
+                        _attrs_gather,
+                        self.is_prefill,
+                    ),
+                )
 
         return output
 

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -65,6 +65,7 @@ from mlx_lm.models.step3p5 import Step3p5Model as Step35InnerModel
 from exo.shared.constants import preferred_env_value
 from exo.shared.types.worker.shards import PipelineShardMetadata
 from exo.worker.runner.bootstrap import logger
+from exo.worker.runner.diagnostics import runner_phase
 
 if TYPE_CHECKING:
     from mlx_lm.models.cache import Cache
@@ -180,9 +181,17 @@ def _hang_debug_watch(label: str) -> Generator[None]:
 
 def flush_prefill_sends() -> None:
     for output, dst, group in _pending_prefill_sends:
-        with _hang_debug_watch(f"flush_prefill_sends send dst={dst}"):
+        with runner_phase(
+            "prefill_pipeline",
+            detail="flush_prefill_send",
+            attrs={"dst": dst, "shape": str(tuple(output.shape))},
+        ), _hang_debug_watch(f"flush_prefill_sends send dst={dst}"):
             sent = mx.distributed.send(output, dst, group=group)
-        with _hang_debug_watch(f"flush_prefill_sends async_eval dst={dst}"):
+        with runner_phase(
+            "prefill_pipeline",
+            detail="flush_prefill_async_eval",
+            attrs={"dst": dst},
+        ), _hang_debug_watch(f"flush_prefill_sends async_eval dst={dst}"):
             mx.async_eval(sent)
     _pending_prefill_sends.clear()
 
@@ -273,19 +282,35 @@ class PipelineFirstLayer(CustomMlxLayer):
         if self.r != 0:
             # We want to avoid GPU timeout errors by evalling the distributed operation
             # so that it stays on CPU, which does not have a timeout.
-            with _hang_debug_watch(
+            with runner_phase(
+                "prefill_pipeline" if self.is_prefill else "decode_stream",
+                detail="pipeline_first_eval_input",
+                attrs={"rank": self.r, "src": self.r - 1},
+            ), _hang_debug_watch(
                 f"pipeline_first eval_input rank={self.r} src={self.r - 1}"
             ):
                 mx.eval(x)
-            with _hang_debug_watch(
+            with runner_phase(
+                "prefill_pipeline" if self.is_prefill else "decode_stream",
+                detail="pipeline_first_recv_like",
+                attrs={"rank": self.r, "src": self.r - 1},
+            ), _hang_debug_watch(
                 f"pipeline_first recv_like rank={self.r} src={self.r - 1}"
             ):
                 x = mx.distributed.recv_like(x, (self.r - 1), group=self.group)
-            with _hang_debug_watch(
+            with runner_phase(
+                "prefill_pipeline" if self.is_prefill else "decode_stream",
+                detail="pipeline_first_eval_recv",
+                attrs={"rank": self.r, "src": self.r - 1},
+            ), _hang_debug_watch(
                 f"pipeline_first eval_recv rank={self.r} src={self.r - 1}"
             ):
                 mx.eval(x)
-        with _hang_debug_watch(f"pipeline_first original_layer rank={self.r}"):
+        with runner_phase(
+            "prefill_pipeline" if self.is_prefill else "decode_stream",
+            detail="pipeline_first_original_layer",
+            attrs={"rank": self.r},
+        ), _hang_debug_watch(f"pipeline_first original_layer rank={self.r}"):
             return self.original_layer(x, *args, **kwargs)
 
 
@@ -310,14 +335,22 @@ class PipelineLastLayer(CustomMlxLayer):
             x, *args, **kwargs
         ).arguments.get("cache", None)
 
-        with _hang_debug_watch(
+        with runner_phase(
+            "prefill_pipeline" if self.is_prefill else "decode_stream",
+            detail="pipeline_last_original_layer",
+            attrs={"rank": self.r, "world_size": self.s, "prefill": self.is_prefill},
+        ), _hang_debug_watch(
             f"pipeline_last original_layer rank={self.r} world={self.s} prefill={self.is_prefill}"
         ):
             output: mx.array = self.original_layer(x, *args, **kwargs)
 
         # Eval layer output to materialize it before send — this splits the graph
         # so the send is isolated and the receiving rank's recv can complete.
-        with _hang_debug_watch(
+        with runner_phase(
+            "prefill_pipeline" if self.is_prefill else "decode_stream",
+            detail="pipeline_last_eval_output",
+            attrs={"rank": self.r, "world_size": self.s, "prefill": self.is_prefill},
+        ), _hang_debug_watch(
             f"pipeline_last eval_output rank={self.r} world={self.s} prefill={self.is_prefill}"
         ):
             mx.eval(output)
@@ -328,7 +361,15 @@ class PipelineLastLayer(CustomMlxLayer):
                     (output, (self.r + 1) % self.s, self.group)
                 )
             else:
-                with _hang_debug_watch(
+                with runner_phase(
+                    "prefill_pipeline" if self.is_prefill else "decode_stream",
+                    detail="pipeline_last_send",
+                    attrs={
+                        "rank": self.r,
+                        "dst": (self.r + 1) % self.s,
+                        "prefill": self.is_prefill,
+                    },
+                ), _hang_debug_watch(
                     f"pipeline_last send rank={self.r} dst={(self.r + 1) % self.s} prefill={self.is_prefill}"
                 ):
                     output = mx.distributed.send(

--- a/src/exo/worker/engines/mlx/constants.py
+++ b/src/exo/worker/engines/mlx/constants.py
@@ -13,7 +13,7 @@ ATTENTION_KV_BITS: int | None = 4
 # be an output cap, not a proxy for model context length: very large defaults can
 # push distributed decode into long-running native MLX/Metal waits before the
 # user has asked for that much output.
-DEFAULT_MAX_OUTPUT_TOKENS: int = 2048
+DEFAULT_MAX_OUTPUT_TOKENS: int = 4096
 _max_tokens_value = preferred_env_value(
     "SKULK_MAX_OUTPUT_TOKENS",
     "EXO_MAX_TOKENS",

--- a/src/exo/worker/engines/mlx/constants.py
+++ b/src/exo/worker/engines/mlx/constants.py
@@ -9,7 +9,19 @@ from exo.shared.constants import preferred_env_value
 KV_GROUP_SIZE: int | None = 32
 KV_BITS: int | None = None
 ATTENTION_KV_BITS: int | None = 4
-MAX_TOKENS: int = 32168
+# Default generated-token budget when an API client omits max_tokens. This must
+# be an output cap, not a proxy for model context length: very large defaults can
+# push distributed decode into long-running native MLX/Metal waits before the
+# user has asked for that much output.
+DEFAULT_MAX_OUTPUT_TOKENS: int = 2048
+_max_tokens_value = preferred_env_value(
+    "SKULK_MAX_OUTPUT_TOKENS",
+    "EXO_MAX_TOKENS",
+    str(DEFAULT_MAX_OUTPUT_TOKENS),
+)
+MAX_TOKENS: int = int(_max_tokens_value) if _max_tokens_value else DEFAULT_MAX_OUTPUT_TOKENS
+if MAX_TOKENS < 1:
+    raise ValueError("SKULK_MAX_OUTPUT_TOKENS must be greater than 0")
 MAX_KV_SIZE: int | None = 3200
 KEEP_KV_SIZE: int | None = 1600
 QUANTIZE_MODEL_MODE: str | None = "affine"

--- a/src/exo/worker/engines/mlx/gemma4_prompt.py
+++ b/src/exo/worker/engines/mlx/gemma4_prompt.py
@@ -49,7 +49,9 @@ def _render_gemma4_content(content: object, role: str) -> str:
             text = str(part.get("text", ""))
             parts.append(strip_gemma4_thinking(text) if role == "model" else text.strip())
         elif item_type == "image":
-            parts.append("\n\n<|image|>\n\n")
+            label = str(part.get("label", "")).strip()
+            label_prefix = f"\n\n{label}:\n" if label else "\n\n"
+            parts.append(f"{label_prefix}<|image|>\n\n")
         elif item_type == "audio":
             parts.append("<|audio|>")
         elif item_type == "video":

--- a/src/exo/worker/engines/mlx/gemma4_prompt.py
+++ b/src/exo/worker/engines/mlx/gemma4_prompt.py
@@ -50,8 +50,11 @@ def _render_gemma4_content(content: object, role: str) -> str:
             parts.append(strip_gemma4_thinking(text) if role == "model" else text.strip())
         elif item_type == "image":
             label = str(part.get("label", "")).strip()
-            label_prefix = f"\n\n{label}:\n" if label else "\n\n"
-            parts.append(f"{label_prefix}<|image|>\n\n")
+            if label:
+                if parts and not parts[-1].endswith((" ", "\n", "\t")):
+                    parts.append("\n")
+                parts.append(f"{label}:\n")
+            parts.append("<|image|>")
         elif item_type == "audio":
             parts.append("<|audio|>")
         elif item_type == "video":
@@ -83,7 +86,7 @@ def render_gemma4_prompt(
     if has_system_message or enable_thinking:
         prompt_parts.append("<|turn>system\n")
         if enable_thinking:
-            prompt_parts.append("<|think|>")
+            prompt_parts.append("<|think|>\n")
         if has_system_message:
             prompt_parts.append(_render_gemma4_content(messages[0].get("content", ""), "system"))
             loop_messages = messages[1:]

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -146,6 +146,7 @@ class ExoBatchGenerator:
                         vision_processor=self.vision_processor,
                         tokenizer=self.tokenizer,
                         model=self.model,
+                        task_id=task_id,
                     )
             except Exception:
                 logger.opt(exception=True).warning(

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -22,8 +22,10 @@ from exo.api.types import (
     TopLogprobItem,
     Usage,
 )
+from exo.shared.tracing import trace
 from exo.shared.types.memory import Memory
 from exo.shared.types.mlx import KVCacheType, Model
+from exo.shared.types.tasks import TaskId
 from exo.shared.types.text_generation import TextGenerationTaskParams
 from exo.shared.types.worker.runner_response import GenerationResponse
 from exo.worker.engines.mlx.cache import (
@@ -114,11 +116,13 @@ class ExoBatchGenerator:
 
     def submit(
         self,
+        task_id: TaskId,
         task_params: TextGenerationTaskParams,
         prompt: str,
         on_prefill_progress: Callable[[int, int], None] | None = None,
         distributed_prompt_progress_callback: Callable[[], None] | None = None,
         on_generation_token: Callable[[], None] | None = None,
+        trace_rank: int = 0,
     ) -> int:
         all_prompt_tokens = encode_prompt(self.tokenizer, prompt)
         all_prompt_tokens = fix_unmatched_think_end_tokens(
@@ -130,13 +134,19 @@ class ExoBatchGenerator:
 
         if self.vision_processor is not None:
             try:
-                vision = prepare_vision(
-                    images=task_params.images,
-                    chat_template_messages=task_params.chat_template_messages,
-                    vision_processor=self.vision_processor,
-                    tokenizer=self.tokenizer,
-                    model=self.model,
-                )
+                with trace(
+                    "native_vision_preprocess",
+                    trace_rank,
+                    "vision",
+                    task_id=task_id,
+                ):
+                    vision = prepare_vision(
+                        images=task_params.images,
+                        chat_template_messages=task_params.chat_template_messages,
+                        vision_processor=self.vision_processor,
+                        tokenizer=self.tokenizer,
+                        model=self.model,
+                    )
             except Exception:
                 logger.opt(exception=True).warning(
                     "Vision processing failed, falling back to text-only"
@@ -211,7 +221,12 @@ class ExoBatchGenerator:
         else:
             vision_ctx = contextlib.nullcontext()
         try:
-            with vision_ctx:
+            with vision_ctx, trace(
+                "prefill",
+                trace_rank,
+                "prefill",
+                task_id=task_id,
+            ):
                 _prefill_tps, _prefill_tokens, cache_snapshots = prefill(
                     self.model,
                     self.tokenizer,

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -368,20 +368,18 @@ def _should_force_native_vision_full_prefill_for_request(
 ) -> bool:
     """Return whether a distributed native-vision request should skip prefix cache.
 
-    Distributed Gemma 4 follow-up turns with cached image prefixes can wedge
-    during decode after the pipeline-aware path trims native pixel values to the
-    uncached suffix. The upstream MLX-VLM reference path also crashes for this
-    shape because its prompt cache contains uninitialized entries, so the stable
-    fallback is to keep Skulk's distributed path but re-prefill the full prompt
-    with every image tensor.
+    Multi-image Gemma 4 follow-up turns with cached image prefixes can pair the
+    next uncached image span with stale pixel values. Keep those conservative.
+    Single-image fully cached follow-ups should reuse the prefix cache instead:
+    forcing a full native-vision re-prefill has reproduced first-decode stalls
+    even for modest prompts.
     """
-    has_cached_multimodal_prefix = prefix_hit_length > 0 and media_region_count > 1
-    has_fully_cached_native_images = prefix_hit_length > 0 and native_pixel_values is None
+    has_cached_multi_image_prefix = prefix_hit_length > 0 and media_region_count > 1
     return (
         is_native_vision
         and group is not None
         and group.size() > 1
-        and (has_cached_multimodal_prefix or has_fully_cached_native_images)
+        and has_cached_multi_image_prefix
     )
 
 

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -78,6 +78,7 @@ from exo.worker.engines.mlx.vision import (
     prepare_vision,
 )
 from exo.worker.runner.bootstrap import logger
+from exo.worker.runner.diagnostics import record_runner_phase, runner_phase
 
 generation_stream = mx.new_stream(mx.default_device())
 
@@ -272,6 +273,40 @@ def _native_pixel_values_debug_state(
     if isinstance(pixel_values, list):
         return f"list[{len(pixel_values)}]"
     return f"array{tuple(pixel_values.shape)}"
+
+
+def _native_pixel_values_attrs(
+    pixel_values: mx.array | list[mx.array] | None,
+) -> dict[str, object]:
+    """Return bounded JSON-safe diagnostic attrs for native pixel tensors."""
+
+    if pixel_values is None:
+        return {"pixel_values": "none", "pixel_value_count": 0}
+    if isinstance(pixel_values, list):
+        return {
+            "pixel_values": "list",
+            "pixel_value_count": len(pixel_values),
+            "pixel_value_shapes": [str(tuple(value.shape)) for value in pixel_values],
+        }
+    return {
+        "pixel_values": "array",
+        "pixel_value_count": int(pixel_values.shape[0]) if pixel_values.ndim else 1,
+        "pixel_value_shapes": [str(tuple(pixel_values.shape))],
+    }
+
+
+def _media_region_attrs(media_regions: list[MediaRegion]) -> dict[str, object]:
+    """Return compact diagnostic attrs for prompt media regions."""
+
+    return {
+        "media_region_count": len(media_regions),
+        "media_region_lengths": [
+            str(region.end_pos - region.start_pos) for region in media_regions
+        ],
+        "media_region_hashes": [
+            region.content_hash[:12] for region in media_regions
+        ],
+    }
 
 
 def _decode_debug_context(
@@ -528,6 +563,19 @@ def pipeline_parallel_prefill(
     logger.info(
         f"[R{rank}] Pipeline prefill: {n_real} real + {n_leading} leading + {n_trailing} trailing = {n_total} iterations"
     )
+    record_runner_phase(
+        "prefill_pipeline",
+        event="pipeline_prefill_start",
+        attrs={
+            "rank": rank,
+            "world_size": world_size,
+            "real_chunks": n_real,
+            "leading_dummies": n_leading,
+            "trailing_dummies": n_trailing,
+            "prompt_tokens": total,
+        },
+        include_memory=True,
+    )
     clear_prefill_sends()
 
     # Initial callback matching generate_step
@@ -541,6 +589,18 @@ def pipeline_parallel_prefill(
 
             for i in range(n_real):
                 chunk_size = real_chunk_sizes[i]
+                if i == 0 or i == n_real - 1 or i % 4 == 0:
+                    record_runner_phase(
+                        "prefill_pipeline",
+                        event="pipeline_prefill_chunk",
+                        attrs={
+                            "rank": rank,
+                            "chunk_index": i,
+                            "chunk_size": chunk_size,
+                            "processed": processed,
+                            "total": total,
+                        },
+                    )
                 model(
                     prompt[processed : processed + chunk_size][None],
                     cache=_prompt_cache,
@@ -579,6 +639,17 @@ def pipeline_parallel_prefill(
     logger.info(
         f"[R{rank}] Prefill: {n_real} real + {n_leading}+{n_trailing} dummy iterations, "
         f"Processed {processed} tokens in {(time.perf_counter() - t_start) * 1000:.1f}ms"
+    )
+    record_runner_phase(
+        "prefill_pipeline",
+        event="pipeline_prefill_complete",
+        attrs={
+            "rank": rank,
+            "processed": processed,
+            "total": total,
+            "elapsed_ms": (time.perf_counter() - t_start) * 1000,
+        },
+        include_memory=True,
     )
 
 
@@ -659,7 +730,12 @@ def prefill(
     # that are never consumed during prefill and later deadlock the ranks.
     set_pipeline_prefill(model, is_prefill=is_pipeline)
 
-    with _hang_debug_watch(f"prefill barrier rank={rank} group_size={group_size}"):
+    with runner_phase(
+        "prefill_barrier",
+        detail="prefill_mx_barrier",
+        attrs={"rank": rank, "group_size": group_size, "prompt_tokens": num_tokens},
+        include_memory=True,
+    ), _hang_debug_watch(f"prefill barrier rank={rank} group_size={group_size}"):
         mx_barrier(group)
     logger.info(
         f"Starting prefill (rank={rank}, group_size={group_size}, prompt_tokens={num_tokens})"
@@ -672,7 +748,17 @@ def prefill(
             pipeline_distributed_callback = (
                 distributed_prompt_progress_callback if pipeline_chunks >= 2 else None
             )
-            with _hang_debug_watch(
+            with runner_phase(
+                "prefill_pipeline",
+                detail="pipeline_parallel_prefill",
+                attrs={
+                    "rank": rank,
+                    "group_size": group_size,
+                    "pipeline_chunks": pipeline_chunks,
+                    "prompt_tokens": num_tokens,
+                },
+                include_memory=True,
+            ), _hang_debug_watch(
                 f"pipeline_parallel_prefill rank={rank} group_size={group_size}"
             ):
                 pipeline_parallel_prefill(
@@ -693,7 +779,16 @@ def prefill(
             # flight and wedging the next collective.
             # Use max_tokens=1 because max_tokens=0 does not work.
             # We just throw away the generated token - we only care about filling the cache
-            with _hang_debug_watch(
+            with runner_phase(
+                "prefill_stream",
+                detail="stream_generate_prefill",
+                attrs={
+                    "rank": rank,
+                    "group_size": group_size,
+                    "prompt_tokens": num_tokens,
+                },
+                include_memory=True,
+            ), _hang_debug_watch(
                 f"stream_generate prefill rank={rank} group_size={group_size}"
             ):
                 for _ in stream_generate(
@@ -757,6 +852,15 @@ def warmup_inference(
     reserved for single-node investigation.
     """
     logger.info(f"warming up inference for instance: {model_id}")
+    record_runner_phase(
+        "warmup",
+        event="warmup_start",
+        attrs={
+            "model_id": str(model_id),
+            "group_size": group.size() if group is not None else 1,
+        },
+        include_memory=True,
+    )
 
     if _is_distributed_warmup(group) and (
         _warmup_repeat_count() != 1 or _warmup_instructions(None) is not None
@@ -808,14 +912,24 @@ def warmup_inference(
 
     tokens_generated = 0
 
-    with _hang_debug_watch(f"warmup pre-generation barrier model={model_id}"):
+    with runner_phase(
+        "prefill_barrier",
+        detail="warmup_pre_generation_barrier",
+        attrs={"model_id": str(model_id)},
+        include_memory=True,
+    ), _hang_debug_watch(f"warmup pre-generation barrier model={model_id}"):
         mx_barrier(group)
 
     logger.info("Generating warmup tokens")
 
     t = time.monotonic()
 
-    with _hang_debug_watch(f"warmup mlx_generate model={model_id}"):
+    with runner_phase(
+        "warmup",
+        detail="warmup_mlx_generate",
+        attrs={"model_id": str(model_id)},
+        include_memory=True,
+    ), _hang_debug_watch(f"warmup mlx_generate model={model_id}"):
         for _r in mlx_generate(
             model=model,
             tokenizer=tokenizer,
@@ -839,7 +953,12 @@ def warmup_inference(
             min(math.ceil(tokens_generated / max(time.monotonic() - t, 0.001)), 100),
         )
 
-    with _hang_debug_watch(
+    with runner_phase(
+        "decode_barrier",
+        detail="warmup_final_barrier",
+        attrs={"model_id": str(model_id), "tokens_generated": tokens_generated},
+        include_memory=True,
+    ), _hang_debug_watch(
         f"warmup final barrier model={model_id} tokens_generated={tokens_generated}"
     ):
         mx_barrier(group)
@@ -1000,24 +1119,51 @@ def _mlx_generate_native_vision(
 
     logger.info(f"Native decode context: {decode_context}")
     logger.info("Starting native mlx-vlm multimodal decode")
-    with _hang_debug_watch(f"native decode barrier ({decode_context})"):
+    with runner_phase(
+        "decode_barrier",
+        detail="native_decode_barrier",
+        attrs={
+            "prompt_tokens": prompt_token_count,
+            "media_regions": len(vision.media_regions),
+            **_native_pixel_values_attrs(vision.pixel_values),
+        },
+        task_id=trace_task_id,
+        include_memory=True,
+    ), _hang_debug_watch(f"native decode barrier ({decode_context})"):
         mx_barrier(group)
 
-    token_generator = vlm_generate_step(
-        input_ids=all_prompt_tokens[None],
-        model=model,
-        pixel_values=vision.pixel_values,
-        mask=None,
-        max_tokens=max_tokens,
-        sampler=sampler,
-        logits_processors=logits_processors,
-        prefill_step_size=4096,
-        kv_group_size=KV_GROUP_SIZE or 32,
-        kv_bits=KV_BITS,
-    )
+    with runner_phase(
+        "prefill_pipeline",
+        detail="native_vlm_generate_step",
+        attrs={
+            "prompt_tokens": prompt_token_count,
+            "max_tokens": max_tokens,
+            **_native_pixel_values_attrs(vision.pixel_values),
+        },
+        task_id=trace_task_id,
+        include_memory=True,
+    ):
+        token_generator = vlm_generate_step(
+            input_ids=all_prompt_tokens[None],
+            model=model,
+            pixel_values=vision.pixel_values,
+            mask=None,
+            max_tokens=max_tokens,
+            sampler=sampler,
+            logits_processors=logits_processors,
+            prefill_step_size=4096,
+            kv_group_size=KV_GROUP_SIZE or 32,
+            kv_bits=KV_BITS,
+        )
 
     first_token_wait_started = time.perf_counter()
-    with _hang_debug_watch(f"native decode first token ({decode_context})"):
+    with runner_phase(
+        "decode_wait_first_token",
+        detail="native_decode_first_token",
+        attrs={"prompt_tokens": prompt_token_count, "max_tokens": max_tokens},
+        task_id=trace_task_id,
+        include_memory=True,
+    ), _hang_debug_watch(f"native decode first token ({decode_context})"):
         try:
             first_token, first_logprobs = next(token_generator)
         except StopIteration:
@@ -1029,6 +1175,13 @@ def _mlx_generate_native_vision(
     logger.info(
         "Native decode produced the first response after "
         f"{time.perf_counter() - first_token_wait_started:.2f}s ({decode_context})"
+    )
+    record_runner_phase(
+        "decode_stream",
+        event="native_first_token",
+        task_id=trace_task_id,
+        attrs={"wait_seconds": time.perf_counter() - first_token_wait_started},
+        include_memory=True,
     )
 
     for token, logprobs in itertools.chain(
@@ -1142,7 +1295,12 @@ def _mlx_generate_native_vision(
         usage=final_usage,
     )
 
-    with _hang_debug_watch(f"native decode final barrier ({decode_context})"):
+    with runner_phase(
+        "decode_barrier",
+        detail="native_decode_final_barrier",
+        task_id=trace_task_id,
+        include_memory=True,
+    ), _hang_debug_watch(f"native decode final barrier ({decode_context})"):
         mx_barrier(group)
 
 
@@ -1162,19 +1320,51 @@ def mlx_generate(
 ) -> Generator[GenerationResponse]:
     # Ensure that generation stats only contains peak memory for this generation
     mx.reset_peak_memory()
+    record_runner_phase(
+        "prompt_build",
+        event="mlx_generate_start",
+        attrs={
+            "model": str(task.model),
+            "input_images": len(task.images),
+            "max_output_tokens": task.max_output_tokens or MAX_TOKENS,
+        },
+        task_id=trace_task_id,
+        include_memory=True,
+    )
     # TODO: Randomise task seed and set in taskparams, instead of hard coding as 42.
     seed = task.seed or 42
     mx.random.seed(seed)
 
     # Encode prompt once at the top and fix unmatched think tags
-    all_prompt_tokens = encode_prompt(tokenizer, prompt)
-    all_prompt_tokens = fix_unmatched_think_end_tokens(all_prompt_tokens, tokenizer)
+    with runner_phase(
+        "prompt_build",
+        detail="prompt_tokenization",
+        attrs={"prompt_chars": len(prompt), "seed": seed},
+        task_id=trace_task_id,
+    ):
+        all_prompt_tokens = encode_prompt(tokenizer, prompt)
+        all_prompt_tokens = fix_unmatched_think_end_tokens(all_prompt_tokens, tokenizer)
+    record_runner_phase(
+        "prompt_build",
+        event="prompt_tokenized",
+        attrs={"prompt_tokens": len(all_prompt_tokens)},
+        task_id=trace_task_id,
+    )
     min_prefix_hit_length = max(1000, system_prompt_token_count(task, tokenizer))
 
     vision: VisionResult | None = None
     if vision_processor is not None:
         try:
-            with trace(
+            with runner_phase(
+                "vision_preprocess",
+                detail="prepare_vision",
+                attrs={
+                    "image_count": len(task.images),
+                    "chat_template_messages": len(task.chat_template_messages or []),
+                },
+                task_id=trace_task_id,
+                include_memory=True,
+            ), trace(
                 "native_vision_preprocess",
                 trace_rank,
                 "vision",
@@ -1191,9 +1381,27 @@ def mlx_generate(
             logger.opt(exception=True).warning(
                 "Vision processing failed, falling back to text-only"
             )
+            record_runner_phase(
+                "vision_preprocess",
+                event="prepare_vision_failed",
+                detail="falling back to text-only",
+                task_id=trace_task_id,
+                include_memory=True,
+            )
     if vision is not None:
         all_prompt_tokens = vision.prompt_tokens
     media_regions: list[MediaRegion] = vision.media_regions if vision else []
+    record_runner_phase(
+        "vision_preprocess",
+        event="vision_ready" if vision is not None else "vision_not_used",
+        attrs={
+            "prompt_tokens": len(all_prompt_tokens),
+            **_media_region_attrs(media_regions),
+            **_native_pixel_values_attrs(vision.pixel_values if vision else None),
+        },
+        task_id=trace_task_id,
+        include_memory=True,
+    )
 
     # Do not use the prefix cache if we are trying to do benchmarks.
     is_bench = task.bench
@@ -1203,13 +1411,24 @@ def mlx_generate(
     # Use prefix cache if available, otherwise create fresh cache
     prefix_hit_length = 0
     matched_index: int | None = None
-    if kv_prefix_cache is None:
-        caches = make_kv_cache(model=model)
-        prompt_tokens = all_prompt_tokens
-    else:
-        caches, prompt_tokens, matched_index = kv_prefix_cache.get_kv_cache(
-            model, all_prompt_tokens, media_regions=media_regions
-        )
+    with runner_phase(
+        "kv_cache_lookup",
+        detail="prefix_cache_lookup",
+        attrs={
+            "cache_enabled": kv_prefix_cache is not None,
+            "prompt_tokens": len(all_prompt_tokens),
+            **_media_region_attrs(media_regions),
+        },
+        task_id=trace_task_id,
+        include_memory=True,
+    ):
+        if kv_prefix_cache is None:
+            caches = make_kv_cache(model=model)
+            prompt_tokens = all_prompt_tokens
+        else:
+            caches, prompt_tokens, matched_index = kv_prefix_cache.get_kv_cache(
+                model, all_prompt_tokens, media_regions=media_regions
+            )
         prefix_hit_length = len(all_prompt_tokens) - len(prompt_tokens)
         if prefix_hit_length > 0:
             logger.info(
@@ -1220,6 +1439,17 @@ def mlx_generate(
                 f"KV cache miss: 0/{len(all_prompt_tokens)} tokens cached "
                 f"(media_regions={len(media_regions)})"
             )
+    record_runner_phase(
+        "kv_cache_lookup",
+        event="kv_cache_result",
+        attrs={
+            "prefix_hit_length": prefix_hit_length,
+            "uncached_prompt_tokens": len(prompt_tokens),
+            "total_prompt_tokens": len(all_prompt_tokens),
+            "matched_index": matched_index if matched_index is not None else -1,
+        },
+        task_id=trace_task_id,
+    )
 
     logits_processors: list[Callable[[mx.array, mx.array], mx.array]] = (
         make_logits_processors(
@@ -1254,6 +1484,16 @@ def mlx_generate(
                     "Disabling KV prefix cache for native vision generation to follow "
                     "the mlx-vlm reference execution path"
                 )
+            record_runner_phase(
+                "vision_preprocess",
+                event="native_reference_path_selected",
+                attrs={
+                    **_media_region_attrs(media_regions),
+                    **_native_pixel_values_attrs(vision.pixel_values),
+                },
+                task_id=trace_task_id,
+                include_memory=True,
+            )
             yield from _mlx_generate_native_vision(
                 model=model,
                 tokenizer=tokenizer,
@@ -1265,12 +1505,22 @@ def mlx_generate(
                 on_prefill_progress=on_prefill_progress,
                 on_generation_token=on_generation_token,
                 group=group,
+                trace_task_id=trace_task_id,
             )
             return
 
         logger.info(
             "Using pipeline-aware native vision generation path on fixed "
             "mlx/mlx-vlm stack"
+        )
+        record_runner_phase(
+            "vision_preprocess",
+            event="pipeline_native_vision_path_selected",
+            attrs={
+                **_media_region_attrs(media_regions),
+                **_native_pixel_values_attrs(vision.pixel_values),
+            },
+            task_id=trace_task_id,
         )
 
     is_native_vision = vision is not None and vision.pixel_values is not None
@@ -1308,6 +1558,18 @@ def mlx_generate(
             "request with cached image regions to avoid known Gemma 4 decode "
             f"wedge/reference-cache crashes ({decode_context})"
         )
+        record_runner_phase(
+            "kv_cache_lookup",
+            event="forced_full_prefill_fallback",
+            detail="distributed native-vision follow-up",
+            attrs={
+                "prefix_hit_length": prefix_hit_length,
+                **_media_region_attrs(media_regions),
+                **_native_pixel_values_attrs(native_pixel_values),
+            },
+            task_id=trace_task_id,
+            include_memory=True,
+        )
         assert vision is not None
         caches = make_kv_cache(model=model)
         prompt_tokens = all_prompt_tokens
@@ -1327,13 +1589,20 @@ def mlx_generate(
         )
 
     if native_pixel_values is not None:
-        if hasattr(model, "set_pixel_values"):
-            cast(
-                Callable[[mx.array | list[mx.array] | None], None],
-                object.__getattribute__(model, "set_pixel_values"),
-            )(native_pixel_values)
-        else:
-            object.__setattr__(model, "_pixel_values", native_pixel_values)
+        with runner_phase(
+            "vision_preprocess",
+            detail="set_pixel_values",
+            attrs=_native_pixel_values_attrs(native_pixel_values),
+            task_id=trace_task_id,
+            include_memory=True,
+        ):
+            if hasattr(model, "set_pixel_values"):
+                cast(
+                    Callable[[mx.array | list[mx.array] | None], None],
+                    object.__getattribute__(model, "set_pixel_values"),
+                )(native_pixel_values)
+            else:
+                object.__setattr__(model, "_pixel_values", native_pixel_values)
         maybe_vision_ctx = contextlib.nullcontext()
     elif vision is not None and not is_native_vision:
         maybe_vision_ctx = patch_embed_tokens(
@@ -1359,6 +1628,12 @@ def mlx_generate(
                 distributed_prompt_progress_callback,
             )
     finally:
+        record_runner_phase(
+            "vision_preprocess",
+            event="clear_pixel_values_begin",
+            task_id=trace_task_id,
+            include_memory=True,
+        )
         if hasattr(model, "set_pixel_values"):
             cast(
                 Callable[[mx.array | list[mx.array] | None], None],
@@ -1366,6 +1641,12 @@ def mlx_generate(
             )(None)
         elif hasattr(model, "_pixel_values"):
             object.__setattr__(model, "_pixel_values", None)
+        record_runner_phase(
+            "vision_preprocess",
+            event="clear_pixel_values_complete",
+            task_id=trace_task_id,
+            include_memory=True,
+        )
     cache_snapshots: list[CacheSnapshot] | None = ssm_snapshots_list or None
 
     # stream_generate starts from the last token
@@ -1383,23 +1664,48 @@ def mlx_generate(
 
     logger.info(f"Decode context: {decode_context}")
     logger.info("Starting decode")
-    with _hang_debug_watch(f"decode barrier ({decode_context})"):
+    with runner_phase(
+        "decode_barrier",
+        detail="decode_mx_barrier",
+        attrs={
+            "total_prompt_tokens": len(all_prompt_tokens),
+            "uncached_prompt_tokens": len(prompt_tokens),
+            "prefix_hit_length": prefix_hit_length,
+            **_media_region_attrs(media_regions),
+            **_native_pixel_values_attrs(native_pixel_values),
+        },
+        task_id=trace_task_id,
+        include_memory=True,
+    ), _hang_debug_watch(f"decode barrier ({decode_context})"):
         mx_barrier(group)
 
-    token_generator = stream_generate(
-        model=model,
-        tokenizer=tokenizer,
-        prompt=last_token,
-        max_tokens=max_tokens,
-        sampler=sampler,
-        logits_processors=logits_processors,
-        prompt_cache=caches,
-        prefill_step_size=1,
-        kv_group_size=KV_GROUP_SIZE,
-        kv_bits=KV_BITS,
-    )
+    with runner_phase(
+        "decode_stream",
+        detail="stream_generate_setup",
+        attrs={"max_tokens": max_tokens, "last_token_count": len(last_token)},
+        task_id=trace_task_id,
+        include_memory=True,
+    ):
+        token_generator = stream_generate(
+            model=model,
+            tokenizer=tokenizer,
+            prompt=last_token,
+            max_tokens=max_tokens,
+            sampler=sampler,
+            logits_processors=logits_processors,
+            prompt_cache=caches,
+            prefill_step_size=1,
+            kv_group_size=KV_GROUP_SIZE,
+            kv_bits=KV_BITS,
+        )
     first_token_wait_started = time.perf_counter()
-    with _hang_debug_watch(f"decode first token ({decode_context})"):
+    with runner_phase(
+        "decode_wait_first_token",
+        detail="stream_generate_first_token",
+        attrs={"max_tokens": max_tokens},
+        task_id=trace_task_id,
+        include_memory=True,
+    ), _hang_debug_watch(f"decode first token ({decode_context})"):
         try:
             first_out = next(token_generator)
         except StopIteration:
@@ -1412,11 +1718,26 @@ def mlx_generate(
         "Decode produced the first response after "
         f"{time.perf_counter() - first_token_wait_started:.2f}s ({decode_context})"
     )
+    record_runner_phase(
+        "decode_stream",
+        event="first_token",
+        attrs={"wait_seconds": time.perf_counter() - first_token_wait_started},
+        task_id=trace_task_id,
+        include_memory=True,
+    )
 
     for completion_tokens, out in enumerate(
         itertools.chain([first_out], token_generator),
         start=1,
     ):
+        if completion_tokens == 1 or completion_tokens % 25 == 0:
+            record_runner_phase(
+                "decode_stream",
+                event="decode_token_progress",
+                attrs={"completion_tokens": completion_tokens},
+                task_id=trace_task_id,
+                include_memory=completion_tokens == 1,
+            )
         generated_text_parts.append(out.text)
         accumulated_text += out.text
 
@@ -1517,6 +1838,17 @@ def mlx_generate(
                     prefix_hit_length >= min_prefix_hit_length
                     and hit_ratio >= _MIN_PREFIX_HIT_RATIO_TO_UPDATE
                 ):
+                    record_runner_phase(
+                        "kv_cache_lookup",
+                        event="kv_cache_update",
+                        attrs={
+                            "matched_index": matched_index,
+                            "prefix_hit_length": prefix_hit_length,
+                            "hit_ratio": hit_ratio,
+                        },
+                        task_id=trace_task_id,
+                        include_memory=True,
+                    )
                     kv_prefix_cache.update_kv_cache(
                         matched_index,
                         full_prompt_tokens,
@@ -1526,6 +1858,16 @@ def mlx_generate(
                         media_regions=media_regions,
                     )
                 else:
+                    record_runner_phase(
+                        "kv_cache_lookup",
+                        event="kv_cache_add",
+                        attrs={
+                            "prefix_hit_length": prefix_hit_length,
+                            "hit_ratio": hit_ratio,
+                        },
+                        task_id=trace_task_id,
+                        include_memory=True,
+                    )
                     kv_prefix_cache.add_kv_cache(
                         full_prompt_tokens,
                         caches,
@@ -1547,7 +1889,22 @@ def mlx_generate(
         )
 
         if is_done:
-            with _hang_debug_watch(f"decode final barrier ({decode_context})"):
+            record_runner_phase(
+                "completion",
+                event="generation_complete",
+                attrs={
+                    "completion_tokens": completion_tokens,
+                    "finish_reason": str(finish_reason),
+                },
+                task_id=trace_task_id,
+                include_memory=True,
+            )
+            with runner_phase(
+                "decode_barrier",
+                detail="decode_final_barrier",
+                task_id=trace_task_id,
+                include_memory=True,
+            ), _hang_debug_watch(f"decode final barrier ({decode_context})"):
                 mx_barrier(group)
             break
 

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -14,6 +14,9 @@ from typing import Callable, Generator, Protocol, cast, get_args
 
 import mlx.core as mx
 from mlx_lm.generate import (
+    GenerationResponse as MlxGenerationResponse,
+)
+from mlx_lm.generate import (
     maybe_quantize_kv_cache,
     stream_generate,
 )
@@ -614,8 +617,9 @@ def _noop_quantize_cache(_cache: KVCacheType) -> None:
     return None
 
 
-def _has_pipeline_communication_layer(model: Model):
-    for layer in model.layers:
+def _has_pipeline_communication_layer(model: Model) -> bool:
+    layers = cast(list[object], getattr(model, "layers", []))
+    for layer in layers:
         if isinstance(layer, (PipelineFirstLayer, PipelineLastLayer)):
             return True
     return False
@@ -1003,6 +1007,120 @@ def prefill(
     )
     # Exclude the last snapshot
     return tokens_per_sec, num_tokens, snapshots[:-1] if snapshots else []
+
+
+def _stream_generate_without_lookahead(
+    *,
+    model: Model,
+    tokenizer: TokenizerWrapper,
+    prompt: mx.array,
+    max_tokens: int,
+    sampler: Callable[[mx.array], mx.array],
+    logits_processors: list[Callable[[mx.array, mx.array], mx.array]],
+    prompt_cache: KVCacheType,
+    kv_group_size: int | None,
+    kv_bits: int | None,
+) -> Generator[MlxGenerationResponse, None, None]:
+    """Generate tokens sequentially without scheduling a decode lookahead.
+
+    ``mlx_lm.stream_generate`` evaluates the next token before yielding the
+    current one. That is fine for local models, but the extra in-flight decode
+    forward can leave Skulk's pipeline send/recv wrappers waiting on different
+    collectives across ranks. Pipeline decode favors boring one-step-at-a-time
+    execution over speculative throughput.
+    """
+    if len(prompt) == 0:
+        raise ValueError("Decode requires at least one prompt token")
+
+    detokenizer = cast(_DetokenizerProtocol, cast(object, tokenizer.detokenizer))
+    detokenizer.reset()
+
+    quantize_cache_fn = functools.partial(
+        maybe_quantize_kv_cache,
+        quantized_kv_start=0,
+        kv_group_size=kv_group_size,
+        kv_bits=kv_bits,
+    )
+
+    token_history: mx.array | None = None
+    prompt_start = time.perf_counter()
+    if len(prompt) > 1:
+        with mx.stream(generation_stream):
+            model(prompt[:-1][None], cache=prompt_cache)
+            quantize_cache_fn(prompt_cache)
+            mx.eval([cache_entry.state for cache_entry in prompt_cache])  # type: ignore
+
+    prompt_tps = len(prompt) / max(time.perf_counter() - prompt_start, 1e-9)
+    generation_start = time.perf_counter()
+    input_tokens = prompt[-1:]
+    eos_token_ids = {int(token_id) for token_id in eos_ids_from_tokenizer(tokenizer)}
+
+    last_token = 0
+    last_logprobs = mx.zeros((1,), dtype=mx.float32)
+    finish_reason = "length"
+    generated_count = 0
+
+    for token_index in range(max_tokens):
+        with mx.stream(generation_stream):
+            logits = model(input_tokens[None], cache=prompt_cache)
+            logits = logits[:, -1, :]
+            if logits_processors:
+                token_history = (
+                    mx.concat([token_history, input_tokens])
+                    if token_history is not None
+                    else input_tokens
+                )
+                for processor in logits_processors:
+                    logits = processor(token_history, logits)
+            quantize_cache_fn(prompt_cache)
+            logprobs = logits.astype(mx.float32) - mx.logsumexp(
+                logits.astype(mx.float32), keepdims=True
+            )
+            sampled = sampler(logprobs)
+            mx.eval(sampled, logprobs)
+
+        last_token = int(sampled.item())
+        last_logprobs = logprobs.squeeze(0)
+        generated_count = token_index + 1
+
+        if last_token in eos_token_ids:
+            finish_reason = "stop"
+            break
+
+        detokenizer.add_token(last_token)
+        if generated_count == max_tokens:
+            finish_reason = "length"
+            break
+
+        yield MlxGenerationResponse(
+            text=detokenizer.last_segment,
+            token=last_token,
+            logprobs=last_logprobs,
+            from_draft=False,
+            prompt_tokens=prompt.size,
+            prompt_tps=prompt_tps,
+            generation_tokens=generated_count,
+            generation_tps=generated_count
+            / max(time.perf_counter() - generation_start, 1e-9),
+            peak_memory=mx.get_peak_memory() / 1e9,
+            finish_reason=None,
+        )
+        input_tokens = sampled
+
+    detokenizer.finalize()
+    yield MlxGenerationResponse(
+        text=detokenizer.last_segment,
+        token=last_token,
+        logprobs=last_logprobs,
+        from_draft=False,
+        prompt_tokens=prompt.size,
+        prompt_tps=prompt_tps,
+        generation_tokens=generated_count,
+        generation_tps=generated_count
+        / max(time.perf_counter() - generation_start, 1e-9),
+        peak_memory=mx.get_peak_memory() / 1e9,
+        finish_reason=finish_reason,
+    )
 
 
 def warmup_inference(
@@ -1909,18 +2027,34 @@ def mlx_generate(
         task_id=trace_task_id,
         include_memory=True,
     ):
-        token_generator = stream_generate(
-            model=model,
-            tokenizer=tokenizer,
-            prompt=last_token,
-            max_tokens=max_tokens,
-            sampler=sampler,
-            logits_processors=logits_processors,
-            prompt_cache=caches,
-            prefill_step_size=1,
-            kv_group_size=KV_GROUP_SIZE,
-            kv_bits=KV_BITS,
-        )
+        if group is not None and _has_pipeline_communication_layer(model):
+            logger.info(
+                "Using sequential pipeline decode without stream_generate lookahead"
+            )
+            token_generator = _stream_generate_without_lookahead(
+                model=model,
+                tokenizer=tokenizer,
+                prompt=last_token,
+                max_tokens=max_tokens,
+                sampler=sampler,
+                logits_processors=logits_processors,
+                prompt_cache=caches,
+                kv_group_size=KV_GROUP_SIZE,
+                kv_bits=KV_BITS,
+            )
+        else:
+            token_generator = stream_generate(
+                model=model,
+                tokenizer=tokenizer,
+                prompt=last_token,
+                max_tokens=max_tokens,
+                sampler=sampler,
+                logits_processors=logits_processors,
+                prompt_cache=caches,
+                prefill_step_size=1,
+                kv_group_size=KV_GROUP_SIZE,
+                kv_bits=KV_BITS,
+            )
     first_token_wait_started = time.perf_counter()
     with runner_phase(
         "decode_wait_first_token",

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -32,7 +32,7 @@ from exo.api.types import (
 )
 from exo.shared.constants import preferred_env_value
 from exo.shared.models.model_cards import ModelCard
-from exo.shared.tracing import trace
+from exo.shared.tracing import TraceAttrValue, record_trace_marker, trace
 from exo.shared.types.common import ModelId
 from exo.shared.types.memory import Memory
 from exo.shared.types.mlx import KVCacheType, Model
@@ -307,6 +307,23 @@ def _media_region_attrs(media_regions: list[MediaRegion]) -> dict[str, object]:
             region.content_hash[:12] for region in media_regions
         ],
     }
+
+
+def _vision_trace_attrs(vision: VisionResult | None) -> dict[str, TraceAttrValue]:
+    """Return compact trace attrs for a prepared multimodal request."""
+    if vision is None or vision.debug_info is None:
+        return {"vision_used": vision is not None}
+    return {
+        "vision_used": True,
+        **vision.debug_info.attrs(),
+    }
+
+
+def _native_pixel_values_trace_attrs(
+    pixel_values: mx.array | list[mx.array] | None,
+) -> dict[str, TraceAttrValue]:
+    """Return native pixel-value attrs typed for saved trace markers."""
+    return cast(dict[str, TraceAttrValue], _native_pixel_values_attrs(pixel_values))
 
 
 def _decode_debug_context(
@@ -1376,6 +1393,7 @@ def mlx_generate(
                     vision_processor=vision_processor,
                     tokenizer=tokenizer,
                     model=model,
+                    task_id=trace_task_id,
                 )
         except Exception:
             logger.opt(exception=True).warning(
@@ -1398,9 +1416,20 @@ def mlx_generate(
             "prompt_tokens": len(all_prompt_tokens),
             **_media_region_attrs(media_regions),
             **_native_pixel_values_attrs(vision.pixel_values if vision else None),
+            **_vision_trace_attrs(vision),
         },
         task_id=trace_task_id,
         include_memory=True,
+    )
+    record_trace_marker(
+        "vision_ready" if vision is not None else "vision_not_used",
+        trace_rank,
+        "vision",
+        task_id=trace_task_id,
+        attrs={
+            "prompt_tokens": len(all_prompt_tokens),
+            **_vision_trace_attrs(vision),
+        },
     )
 
     # Do not use the prefix cache if we are trying to do benchmarks.
@@ -1450,6 +1479,19 @@ def mlx_generate(
         },
         task_id=trace_task_id,
     )
+    record_trace_marker(
+        "kv_cache_result",
+        trace_rank,
+        "kv_cache",
+        task_id=trace_task_id,
+        attrs={
+            "prefix_hit_length": prefix_hit_length,
+            "uncached_prompt_tokens": len(prompt_tokens),
+            "total_prompt_tokens": len(all_prompt_tokens),
+            "matched_index": matched_index if matched_index is not None else -1,
+            "media_region_count": len(media_regions),
+        },
+    )
 
     logits_processors: list[Callable[[mx.array, mx.array], mx.array]] = (
         make_logits_processors(
@@ -1494,6 +1536,16 @@ def mlx_generate(
                 task_id=trace_task_id,
                 include_memory=True,
             )
+            record_trace_marker(
+                "native_reference_path_selected",
+                trace_rank,
+                "vision",
+                task_id=trace_task_id,
+                attrs={
+                    **_vision_trace_attrs(vision),
+                    "media_region_count": len(media_regions),
+                },
+            )
             yield from _mlx_generate_native_vision(
                 model=model,
                 tokenizer=tokenizer,
@@ -1521,6 +1573,16 @@ def mlx_generate(
                 **_native_pixel_values_attrs(vision.pixel_values),
             },
             task_id=trace_task_id,
+        )
+        record_trace_marker(
+            "pipeline_native_vision_path_selected",
+            trace_rank,
+            "vision",
+            task_id=trace_task_id,
+            attrs={
+                **_vision_trace_attrs(vision),
+                "media_region_count": len(media_regions),
+            },
         )
 
     is_native_vision = vision is not None and vision.pixel_values is not None
@@ -1569,6 +1631,17 @@ def mlx_generate(
             },
             task_id=trace_task_id,
             include_memory=True,
+        )
+        record_trace_marker(
+            "forced_full_prefill_fallback",
+            trace_rank,
+            "kv_cache",
+            task_id=trace_task_id,
+            attrs={
+                "prefix_hit_length": prefix_hit_length,
+                "media_region_count": len(media_regions),
+                **_native_pixel_values_trace_attrs(native_pixel_values),
+            },
         )
         assert vision is not None
         caches = make_kv_cache(model=model)

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1951,6 +1951,14 @@ def mlx_generate(
         )
     else:
         maybe_vision_ctx = contextlib.nullcontext()
+    uses_pipeline_decode = group is not None and _has_pipeline_communication_layer(model)
+    if uses_pipeline_decode:
+        prefill_prompt_tokens = (
+            prompt_tokens if len(prompt_tokens) > 1 else prompt_tokens[:0]
+        )
+    else:
+        prefill_prompt_tokens = prompt_tokens[:-1]
+
     try:
         with maybe_vision_ctx, trace(
             "prefill",
@@ -1962,7 +1970,7 @@ def mlx_generate(
                 model,
                 tokenizer,
                 sampler,
-                prompt_tokens[:-1],
+                prefill_prompt_tokens,
                 caches,
                 group,
                 on_prefill_progress,
@@ -1995,8 +2003,11 @@ def mlx_generate(
             mx.clear_cache()
     cache_snapshots: list[CacheSnapshot] | None = ssm_snapshots_list or None
 
-    # stream_generate starts from the last token
-    last_token = prompt_tokens[-2:]
+    # Pipeline prefill now advances the cache through the penultimate prompt
+    # token, so pipeline decode can begin with a single token and avoid an
+    # extra decode-mode prompt bridge collective before the first generated
+    # token.
+    last_token = prompt_tokens[-1:] if uses_pipeline_decode else prompt_tokens[-2:]
 
     max_tokens = task.max_output_tokens or MAX_TOKENS
     accumulated_text = ""

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -303,7 +303,7 @@ def _decode_debug_context(
     )
 
 
-def _should_force_native_vision_reference_path_for_request(
+def _should_force_native_vision_full_prefill_for_request(
     *,
     group: mx.distributed.Group | None,
     is_native_vision: bool,
@@ -311,12 +311,14 @@ def _should_force_native_vision_reference_path_for_request(
     media_region_count: int,
     native_pixel_values: mx.array | list[mx.array] | None,
 ) -> bool:
-    """Return whether a request should avoid the fast native-vision decode path.
+    """Return whether a distributed native-vision request should skip prefix cache.
 
     Distributed Gemma 4 follow-up turns with cached image prefixes can wedge
     during decode after the pipeline-aware path trims native pixel values to the
-    uncached suffix. In that case we prefer the slower MLX-VLM reference path
-    over a cluster-wide runner hang that requires node restarts to recover.
+    uncached suffix. The upstream MLX-VLM reference path also crashes for this
+    shape because its prompt cache contains uninitialized entries, so the stable
+    fallback is to keep Skulk's distributed path but re-prefill the full prompt
+    with every image tensor.
     """
     has_cached_multimodal_prefix = prefix_hit_length > 0 and media_region_count > 1
     has_fully_cached_native_images = prefix_hit_length > 0 and native_pixel_values is None
@@ -1294,7 +1296,7 @@ def mlx_generate(
         native_pixel_values=native_pixel_values,
     )
 
-    if _should_force_native_vision_reference_path_for_request(
+    if _should_force_native_vision_full_prefill_for_request(
         group=group,
         is_native_vision=is_native_vision,
         prefix_hit_length=prefix_hit_length,
@@ -1302,25 +1304,27 @@ def mlx_generate(
         native_pixel_values=native_pixel_values,
     ):
         logger.warning(
-            "Falling back to native mlx-vlm reference decode for a distributed "
-            "native-vision follow-up request with cached image regions to avoid "
-            f"a known decode wedge ({decode_context})"
+            "Disabling KV prefix cache for a distributed native-vision follow-up "
+            "request with cached image regions to avoid known Gemma 4 decode "
+            f"wedge/reference-cache crashes ({decode_context})"
         )
         assert vision is not None
-        yield from _mlx_generate_native_vision(
-            model=model,
-            tokenizer=tokenizer,
+        caches = make_kv_cache(model=model)
+        prompt_tokens = all_prompt_tokens
+        prefix_hit_length = 0
+        matched_index = None
+        native_pixel_values = vision.pixel_values
+        decode_context = _decode_debug_context(
             task=task,
-            all_prompt_tokens=all_prompt_tokens,
-            vision=vision,
-            sampler=sampler,
-            logits_processors=logits_processors,
-            on_prefill_progress=on_prefill_progress,
-            on_generation_token=on_generation_token,
             group=group,
             trace_task_id=trace_task_id,
+            total_prompt_tokens=len(all_prompt_tokens),
+            uncached_prompt_tokens=len(prompt_tokens),
+            prefix_hit_length=prefix_hit_length,
+            media_region_count=len(media_regions),
+            is_native_vision=is_native_vision,
+            native_pixel_values=native_pixel_values,
         )
-        return
 
     if native_pixel_values is not None:
         if hasattr(model, "set_pixel_values"):

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -308,21 +308,23 @@ def _should_force_native_vision_reference_path_for_request(
     group: mx.distributed.Group | None,
     is_native_vision: bool,
     prefix_hit_length: int,
+    media_region_count: int,
     native_pixel_values: mx.array | list[mx.array] | None,
 ) -> bool:
     """Return whether a request should avoid the fast native-vision decode path.
 
-    Distributed Gemma 4 follow-up turns with a full image-prefix cache hit can
-    wedge right after the decode handoff. In that case we prefer the slower
-    MLX-VLM reference path over a cluster-wide runner hang that requires node
-    restarts to recover.
+    Distributed Gemma 4 follow-up turns with cached image prefixes can wedge
+    during decode after the pipeline-aware path trims native pixel values to the
+    uncached suffix. In that case we prefer the slower MLX-VLM reference path
+    over a cluster-wide runner hang that requires node restarts to recover.
     """
+    has_cached_multimodal_prefix = prefix_hit_length > 0 and media_region_count > 1
+    has_fully_cached_native_images = prefix_hit_length > 0 and native_pixel_values is None
     return (
         is_native_vision
         and group is not None
         and group.size() > 1
-        and prefix_hit_length > 0
-        and native_pixel_values is None
+        and (has_cached_multimodal_prefix or has_fully_cached_native_images)
     )
 
 
@@ -1296,12 +1298,13 @@ def mlx_generate(
         group=group,
         is_native_vision=is_native_vision,
         prefix_hit_length=prefix_hit_length,
+        media_region_count=len(media_regions),
         native_pixel_values=native_pixel_values,
     ):
         logger.warning(
             "Falling back to native mlx-vlm reference decode for a distributed "
-            "native-vision request with a full image-prefix cache hit to avoid "
-            f"a known post-prefill wedge ({decode_context})"
+            "native-vision follow-up request with cached image regions to avoid "
+            f"a known decode wedge ({decode_context})"
         )
         assert vision is not None
         yield from _mlx_generate_native_vision(

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -438,6 +438,25 @@ def _slice_native_pixel_values_for_uncached_suffix(
     return mx.stack([pixel_values[idx] for idx in remaining_indices], axis=0)
 
 
+def _native_media_regions_for_uncached_suffix(
+    pixel_values: mx.array | list[mx.array],
+    media_regions: list[MediaRegion],
+    prefix_hit_length: int,
+) -> list[MediaRegion]:
+    """Return media regions aligned with cache-trimmed native pixel values."""
+    if prefix_hit_length <= 0 or not media_regions:
+        return media_regions
+
+    available_images = (
+        len(pixel_values) if isinstance(pixel_values, list) else int(pixel_values.shape[0])
+    )
+    return [
+        region
+        for idx, region in enumerate(media_regions)
+        if idx < available_images and region.end_pos > prefix_hit_length
+    ]
+
+
 def slice_native_pixel_values_for_uncached_suffix(
     pixel_values: mx.array | list[mx.array],
     media_regions: list[MediaRegion],
@@ -453,6 +472,99 @@ def slice_native_pixel_values_for_uncached_suffix(
         media_regions,
         prefix_hit_length,
     )
+
+
+def _slice_native_pixel_values_by_indices(
+    pixel_values: mx.array | list[mx.array],
+    indices: list[int],
+) -> mx.array | list[mx.array] | None:
+    """Select native pixel values by media-region order."""
+    if not indices:
+        return None
+
+    available_images = (
+        len(pixel_values) if isinstance(pixel_values, list) else int(pixel_values.shape[0])
+    )
+    valid_indices = [idx for idx in indices if idx < available_images]
+    if not valid_indices:
+        return None
+
+    if isinstance(pixel_values, list):
+        return [pixel_values[idx] for idx in valid_indices]
+
+    if valid_indices == list(range(valid_indices[0], valid_indices[-1] + 1)):
+        return pixel_values[valid_indices[0] : valid_indices[-1] + 1]
+
+    return mx.stack([pixel_values[idx] for idx in valid_indices], axis=0)
+
+
+def _native_pixel_values_for_media_range(
+    pixel_values: mx.array | list[mx.array],
+    media_regions: list[MediaRegion],
+    start_pos: int,
+    end_pos: int,
+) -> mx.array | list[mx.array] | None:
+    """Return pixel values whose media spans overlap a prompt token range."""
+    region_indices = [
+        idx
+        for idx, region in enumerate(media_regions)
+        if region.end_pos > start_pos and region.start_pos < end_pos
+    ]
+    return _slice_native_pixel_values_by_indices(pixel_values, region_indices)
+
+
+def _vision_safe_prefill_chunk_sizes(
+    total_tokens: int,
+    max_chunk_size: int,
+    media_regions: list[MediaRegion] | None = None,
+    prompt_token_offset: int = 0,
+) -> list[int]:
+    """Split prefill tokens without cutting through native image spans."""
+    real_prefill_tokens = max(total_tokens - 1, 0)
+    if real_prefill_tokens == 0:
+        return []
+
+    if max_chunk_size <= 0:
+        return [real_prefill_tokens]
+
+    sorted_regions = sorted(media_regions or [], key=lambda region: region.start_pos)
+    chunk_sizes: list[int] = []
+    start = 0
+    while start < real_prefill_tokens:
+        end = min(start + max_chunk_size, real_prefill_tokens)
+        full_start = prompt_token_offset + start
+        full_end = prompt_token_offset + end
+
+        for region in sorted_regions:
+            if region.end_pos <= full_start:
+                continue
+            if region.start_pos >= full_end:
+                break
+            if region.start_pos < full_end < region.end_pos:
+                end = min(region.end_pos - prompt_token_offset, real_prefill_tokens)
+                full_end = prompt_token_offset + end
+                break
+
+        if end <= start:
+            end = min(start + max_chunk_size, real_prefill_tokens)
+        chunk_sizes.append(end - start)
+        start = end
+
+    return chunk_sizes
+
+
+def _set_native_pixel_values(
+    model: Model,
+    pixel_values: mx.array | list[mx.array] | None,
+) -> None:
+    """Set native vision tensors on wrappers that inject them into prefill calls."""
+    if hasattr(model, "set_pixel_values"):
+        cast(
+            Callable[[mx.array | list[mx.array] | None], None],
+            object.__getattribute__(model, "set_pixel_values"),
+        )(pixel_values)
+    else:
+        object.__setattr__(model, "_pixel_values", pixel_values)
 
 
 @contextlib.contextmanager
@@ -519,6 +631,9 @@ def pipeline_parallel_prefill(
     prompt_progress_callback: Callable[[int, int], None],
     distributed_prompt_progress_callback: Callable[[], None] | None,
     group: mx.distributed.Group,
+    native_pixel_values: mx.array | list[mx.array] | None = None,
+    native_media_regions: list[MediaRegion] | None = None,
+    prompt_token_offset: int = 0,
 ) -> None:
     """Prefill the KV cache for pipeline parallel with overlapping stages.
 
@@ -560,14 +675,13 @@ def pipeline_parallel_prefill(
     rank = group.rank()
     world_size = group.size()
 
-    # Build list of real prompt chunk sizes
     total = len(prompt)
-    real_chunk_sizes: list[int] = []
-    remaining = total - 1
-    while remaining:
-        n = min(prefill_step_size, remaining)
-        real_chunk_sizes.append(n)
-        remaining -= n
+    real_chunk_sizes = _vision_safe_prefill_chunk_sizes(
+        total,
+        prefill_step_size,
+        native_media_regions if native_pixel_values is not None else None,
+        prompt_token_offset,
+    )
     n_real = len(real_chunk_sizes)
 
     # Each rank does: [rank leading dummies] [N real chunks] [world_size-1-rank trailing dummies]
@@ -606,6 +720,8 @@ def pipeline_parallel_prefill(
 
             for i in range(n_real):
                 chunk_size = real_chunk_sizes[i]
+                chunk_start = processed
+                chunk_end = processed + chunk_size
                 if i == 0 or i == n_real - 1 or i % 4 == 0:
                     record_runner_phase(
                         "prefill_pipeline",
@@ -616,6 +732,29 @@ def pipeline_parallel_prefill(
                             "chunk_size": chunk_size,
                             "processed": processed,
                             "total": total,
+                        },
+                    )
+                if native_pixel_values is not None and native_media_regions is not None:
+                    # Gemma 4 scatters image features from the start of the
+                    # provided tensor on every forward call. Pipeline chunks
+                    # therefore need chunk-local pixel values, otherwise a
+                    # later image span can be paired with image 0 again.
+                    chunk_pixel_values = _native_pixel_values_for_media_range(
+                        native_pixel_values,
+                        native_media_regions,
+                        prompt_token_offset + chunk_start,
+                        prompt_token_offset + chunk_end,
+                    )
+                    _set_native_pixel_values(model, chunk_pixel_values)
+                    record_runner_phase(
+                        "prefill_pipeline",
+                        event="pipeline_prefill_native_pixel_values",
+                        attrs={
+                            "rank": rank,
+                            "chunk_index": i,
+                            "chunk_start": prompt_token_offset + chunk_start,
+                            "chunk_end": prompt_token_offset + chunk_end,
+                            **_native_pixel_values_attrs(chunk_pixel_values),
                         },
                     )
                 model(
@@ -640,6 +779,8 @@ def pipeline_parallel_prefill(
         clear_prefill_sends()
 
     # Post-loop: process remaining 1 token + add +1 entry to match stream_generate.
+    if native_pixel_values is not None:
+        _set_native_pixel_values(model, None)
     for _ in range(2):
         with mx.stream(generation_stream):
             model(prompt[-1:][None], cache=_prompt_cache)
@@ -679,6 +820,9 @@ def prefill(
     group: mx.distributed.Group | None,
     on_prefill_progress: Callable[[int, int], None] | None,
     distributed_prompt_progress_callback: Callable[[], None] | None,
+    native_pixel_values: mx.array | list[mx.array] | None = None,
+    native_media_regions: list[MediaRegion] | None = None,
+    prompt_token_offset: int = 0,
 ) -> tuple[float, int, list[CacheSnapshot]]:
     """Prefill the KV cache with prompt tokens.
 
@@ -726,13 +870,17 @@ def prefill(
     # explicit pipeline prefill path, but short one-chunk prompts intentionally
     # suppress the distributed progress callback because there is no useful
     # cancellation window inside a millisecond-scale prefill.
-    real_prefill_tokens = max(num_tokens - 1, 0)
-    pipeline_chunks = (
-        (real_prefill_tokens + effective_prefill_step_size - 1)
-        // effective_prefill_step_size
-        if effective_prefill_step_size > 0
-        else 0
+    pipeline_chunk_sizes = (
+        _vision_safe_prefill_chunk_sizes(
+            num_tokens,
+            effective_prefill_step_size,
+            native_media_regions if native_pixel_values is not None else None,
+            prompt_token_offset,
+        )
+        if is_pipeline
+        else []
     )
+    pipeline_chunks = len(pipeline_chunk_sizes)
     use_pipeline_prefill = is_pipeline
     logger.info(
         "Prefill path selected: "
@@ -788,6 +936,9 @@ def prefill(
                     prompt_progress_callback=progress_callback,
                     distributed_prompt_progress_callback=pipeline_distributed_callback,
                     group=group,
+                    native_pixel_values=native_pixel_values,
+                    native_media_regions=native_media_regions,
+                    prompt_token_offset=prompt_token_offset,
                 )
         else:
             # Non-pipeline models can safely use upstream stream_generate for
@@ -1587,11 +1738,17 @@ def mlx_generate(
 
     is_native_vision = vision is not None and vision.pixel_values is not None
     native_pixel_values: mx.array | list[mx.array] | None = None
+    native_media_regions: list[MediaRegion] | None = None
     if is_native_vision:
         assert vision is not None
         if vision.pixel_values is None:
             raise ValueError("Native vision generation requires pixel values")
         native_pixel_values = _slice_native_pixel_values_for_uncached_suffix(
+            vision.pixel_values,
+            media_regions,
+            prefix_hit_length,
+        )
+        native_media_regions = _native_media_regions_for_uncached_suffix(
             vision.pixel_values,
             media_regions,
             prefix_hit_length,
@@ -1649,6 +1806,7 @@ def mlx_generate(
         prefix_hit_length = 0
         matched_index = None
         native_pixel_values = vision.pixel_values
+        native_media_regions = media_regions
         decode_context = _decode_debug_context(
             task=task,
             group=group,
@@ -1669,13 +1827,7 @@ def mlx_generate(
             task_id=trace_task_id,
             include_memory=True,
         ):
-            if hasattr(model, "set_pixel_values"):
-                cast(
-                    Callable[[mx.array | list[mx.array] | None], None],
-                    object.__getattribute__(model, "set_pixel_values"),
-                )(native_pixel_values)
-            else:
-                object.__setattr__(model, "_pixel_values", native_pixel_values)
+            _set_native_pixel_values(model, native_pixel_values)
         maybe_vision_ctx = contextlib.nullcontext()
     elif vision is not None and not is_native_vision:
         maybe_vision_ctx = patch_embed_tokens(
@@ -1699,6 +1851,9 @@ def mlx_generate(
                 group,
                 on_prefill_progress,
                 distributed_prompt_progress_callback,
+                native_pixel_values=native_pixel_values,
+                native_media_regions=native_media_regions,
+                prompt_token_offset=prefix_hit_length,
             )
     finally:
         record_runner_phase(
@@ -1707,13 +1862,8 @@ def mlx_generate(
             task_id=trace_task_id,
             include_memory=True,
         )
-        if hasattr(model, "set_pixel_values"):
-            cast(
-                Callable[[mx.array | list[mx.array] | None], None],
-                object.__getattribute__(model, "set_pixel_values"),
-            )(None)
-        elif hasattr(model, "_pixel_values"):
-            object.__setattr__(model, "_pixel_values", None)
+        if hasattr(model, "set_pixel_values") or hasattr(model, "_pixel_values"):
+            _set_native_pixel_values(model, None)
         record_runner_phase(
             "vision_preprocess",
             event="clear_pixel_values_complete",

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -31,6 +31,7 @@ from exo.api.types import (
 )
 from exo.shared.constants import preferred_env_value
 from exo.shared.models.model_cards import ModelCard
+from exo.shared.tracing import trace
 from exo.shared.types.common import ModelId
 from exo.shared.types.memory import Memory
 from exo.shared.types.mlx import KVCacheType, Model
@@ -1051,6 +1052,8 @@ def mlx_generate(
     distributed_prompt_progress_callback: Callable[[], None] | None = None,
     on_generation_token: Callable[[], None] | None = None,
     vision_processor: VisionProcessor | None = None,
+    trace_task_id: str | None = None,
+    trace_rank: int = 0,
 ) -> Generator[GenerationResponse]:
     # Ensure that generation stats only contains peak memory for this generation
     mx.reset_peak_memory()
@@ -1066,13 +1069,19 @@ def mlx_generate(
     vision: VisionResult | None = None
     if vision_processor is not None:
         try:
-            vision = prepare_vision(
-                images=task.images,
-                chat_template_messages=task.chat_template_messages,
-                vision_processor=vision_processor,
-                tokenizer=tokenizer,
-                model=model,
-            )
+            with trace(
+                "native_vision_preprocess",
+                trace_rank,
+                "vision",
+                task_id=trace_task_id,
+            ):
+                vision = prepare_vision(
+                    images=task.images,
+                    chat_template_messages=task.chat_template_messages,
+                    vision_processor=vision_processor,
+                    tokenizer=tokenizer,
+                    model=model,
+                )
         except Exception:
             logger.opt(exception=True).warning(
                 "Vision processing failed, falling back to text-only"
@@ -1187,7 +1196,12 @@ def mlx_generate(
     else:
         maybe_vision_ctx = contextlib.nullcontext()
     try:
-        with maybe_vision_ctx:
+        with maybe_vision_ctx, trace(
+            "prefill",
+            trace_rank,
+            "prefill",
+            task_id=trace_task_id,
+        ):
             prefill_tps, prefill_tokens, ssm_snapshots_list = prefill(
                 model,
                 tokenizer,

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import itertools
 import math
 import os
 import sys
@@ -259,6 +260,69 @@ def _should_use_native_vision_reference_path() -> bool:
 
     return not (
         mlx_version >= Version("0.31.1") and mlx_vlm_version >= Version("0.4.4")
+    )
+
+
+def _native_pixel_values_debug_state(
+    pixel_values: mx.array | list[mx.array] | None,
+) -> str:
+    """Return a compact string describing native-vision pixel injection state."""
+    if pixel_values is None:
+        return "fully_cached"
+    if isinstance(pixel_values, list):
+        return f"list[{len(pixel_values)}]"
+    return f"array{tuple(pixel_values.shape)}"
+
+
+def _decode_debug_context(
+    *,
+    task: TextGenerationTaskParams,
+    group: mx.distributed.Group | None,
+    trace_task_id: str | None,
+    total_prompt_tokens: int,
+    uncached_prompt_tokens: int,
+    prefix_hit_length: int,
+    media_region_count: int,
+    is_native_vision: bool,
+    native_pixel_values: mx.array | list[mx.array] | None,
+) -> str:
+    """Summarize the request shape around the decode handoff for hang debugging."""
+    rank = group.rank() if group is not None else 0
+    group_size = group.size() if group is not None else 1
+    return (
+        f"task_id={trace_task_id or '<unknown>'}, "
+        f"model={task.model}, "
+        f"rank={rank}, "
+        f"group_size={group_size}, "
+        f"total_prompt_tokens={total_prompt_tokens}, "
+        f"uncached_prompt_tokens={uncached_prompt_tokens}, "
+        f"prefix_hit_length={prefix_hit_length}, "
+        f"media_regions={media_region_count}, "
+        f"native_vision={is_native_vision}, "
+        f"native_pixel_values={_native_pixel_values_debug_state(native_pixel_values)}"
+    )
+
+
+def _should_force_native_vision_reference_path_for_request(
+    *,
+    group: mx.distributed.Group | None,
+    is_native_vision: bool,
+    prefix_hit_length: int,
+    native_pixel_values: mx.array | list[mx.array] | None,
+) -> bool:
+    """Return whether a request should avoid the fast native-vision decode path.
+
+    Distributed Gemma 4 follow-up turns with a full image-prefix cache hit can
+    wedge right after the decode handoff. In that case we prefer the slower
+    MLX-VLM reference path over a cluster-wide runner hang that requires node
+    restarts to recover.
+    """
+    return (
+        is_native_vision
+        and group is not None
+        and group.size() > 1
+        and prefix_hit_length > 0
+        and native_pixel_values is None
     )
 
 
@@ -873,6 +937,7 @@ def _mlx_generate_native_vision(
     on_prefill_progress: Callable[[int, int], None] | None,
     on_generation_token: Callable[[], None] | None,
     group: mx.distributed.Group | None,
+    trace_task_id: str | None = None,
 ) -> Generator[GenerationResponse]:
     """Generate for native-vision models via MLX-VLM's multimodal path.
 
@@ -917,11 +982,24 @@ def _mlx_generate_native_vision(
     final_finish_reason: FinishReason = "length"
     final_usage: Usage | None = None
     final_stats: GenerationStats | None = None
+    decode_context = _decode_debug_context(
+        task=task,
+        group=group,
+        trace_task_id=trace_task_id,
+        total_prompt_tokens=prompt_token_count,
+        uncached_prompt_tokens=prompt_token_count,
+        prefix_hit_length=0,
+        media_region_count=len(vision.media_regions),
+        is_native_vision=True,
+        native_pixel_values=vision.pixel_values,
+    )
 
+    logger.info(f"Native decode context: {decode_context}")
     logger.info("Starting native mlx-vlm multimodal decode")
-    mx_barrier(group)
+    with _hang_debug_watch(f"native decode barrier ({decode_context})"):
+        mx_barrier(group)
 
-    for token, logprobs in vlm_generate_step(
+    token_generator = vlm_generate_step(
         input_ids=all_prompt_tokens[None],
         model=model,
         pixel_values=vision.pixel_values,
@@ -932,6 +1010,26 @@ def _mlx_generate_native_vision(
         prefill_step_size=4096,
         kv_group_size=KV_GROUP_SIZE or 32,
         kv_bits=KV_BITS,
+    )
+
+    first_token_wait_started = time.perf_counter()
+    with _hang_debug_watch(f"native decode first token ({decode_context})"):
+        try:
+            first_token, first_logprobs = next(token_generator)
+        except StopIteration:
+            logger.warning(
+                "Native decode generator ended before yielding a response "
+                f"({decode_context})"
+            )
+            return
+    logger.info(
+        "Native decode produced the first response after "
+        f"{time.perf_counter() - first_token_wait_started:.2f}s ({decode_context})"
+    )
+
+    for token, logprobs in itertools.chain(
+        [(first_token, first_logprobs)],
+        token_generator,
     ):
         token_id = int(token)
 
@@ -1039,6 +1137,9 @@ def _mlx_generate_native_vision(
         stats=final_stats,
         usage=final_usage,
     )
+
+    with _hang_debug_watch(f"native decode final barrier ({decode_context})"):
+        mx_barrier(group)
 
 
 def mlx_generate(
@@ -1179,6 +1280,44 @@ def mlx_generate(
             media_regions,
             prefix_hit_length,
         )
+    decode_context = _decode_debug_context(
+        task=task,
+        group=group,
+        trace_task_id=trace_task_id,
+        total_prompt_tokens=len(all_prompt_tokens),
+        uncached_prompt_tokens=len(prompt_tokens),
+        prefix_hit_length=prefix_hit_length,
+        media_region_count=len(media_regions),
+        is_native_vision=is_native_vision,
+        native_pixel_values=native_pixel_values,
+    )
+
+    if _should_force_native_vision_reference_path_for_request(
+        group=group,
+        is_native_vision=is_native_vision,
+        prefix_hit_length=prefix_hit_length,
+        native_pixel_values=native_pixel_values,
+    ):
+        logger.warning(
+            "Falling back to native mlx-vlm reference decode for a distributed "
+            "native-vision request with a full image-prefix cache hit to avoid "
+            f"a known post-prefill wedge ({decode_context})"
+        )
+        assert vision is not None
+        yield from _mlx_generate_native_vision(
+            model=model,
+            tokenizer=tokenizer,
+            task=task,
+            all_prompt_tokens=all_prompt_tokens,
+            vision=vision,
+            sampler=sampler,
+            logits_processors=logits_processors,
+            on_prefill_progress=on_prefill_progress,
+            on_generation_token=on_generation_token,
+            group=group,
+            trace_task_id=trace_task_id,
+        )
+        return
 
     if native_pixel_values is not None:
         if hasattr(model, "set_pixel_values"):
@@ -1235,22 +1374,40 @@ def mlx_generate(
     think_start = tokenizer.think_start
     think_end = tokenizer.think_end
 
+    logger.info(f"Decode context: {decode_context}")
     logger.info("Starting decode")
-    mx_barrier(group)
+    with _hang_debug_watch(f"decode barrier ({decode_context})"):
+        mx_barrier(group)
+
+    token_generator = stream_generate(
+        model=model,
+        tokenizer=tokenizer,
+        prompt=last_token,
+        max_tokens=max_tokens,
+        sampler=sampler,
+        logits_processors=logits_processors,
+        prompt_cache=caches,
+        prefill_step_size=1,
+        kv_group_size=KV_GROUP_SIZE,
+        kv_bits=KV_BITS,
+    )
+    first_token_wait_started = time.perf_counter()
+    with _hang_debug_watch(f"decode first token ({decode_context})"):
+        try:
+            first_out = next(token_generator)
+        except StopIteration:
+            logger.warning(
+                "Decode generator ended before yielding a response "
+                f"({decode_context})"
+            )
+            return
+    logger.info(
+        "Decode produced the first response after "
+        f"{time.perf_counter() - first_token_wait_started:.2f}s ({decode_context})"
+    )
 
     for completion_tokens, out in enumerate(
-        stream_generate(
-            model=model,
-            tokenizer=tokenizer,
-            prompt=last_token,
-            max_tokens=max_tokens,
-            sampler=sampler,
-            logits_processors=logits_processors,
-            prompt_cache=caches,
-            prefill_step_size=1,
-            kv_group_size=KV_GROUP_SIZE,
-            kv_bits=KV_BITS,
-        ),
+        itertools.chain([first_out], token_generator),
         start=1,
     ):
         generated_text_parts.append(out.text)
@@ -1383,7 +1540,8 @@ def mlx_generate(
         )
 
         if is_done:
-            mx_barrier(group)
+            with _hang_debug_watch(f"decode final barrier ({decode_context})"):
+                mx_barrier(group)
             break
 
         # Limit accumulated_text to what's needed for stop sequence detection

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -868,10 +868,11 @@ def prefill(
 
     # Mirror pipeline_parallel_prefill's chunking math here by reserving the
     # final token for the post-loop pass before computing the real chunk count.
-    # This value is primarily diagnostic now: all pipeline prompts use the
-    # explicit pipeline prefill path, but short one-chunk prompts intentionally
-    # suppress the distributed progress callback because there is no useful
-    # cancellation window inside a millisecond-scale prefill.
+    # The explicit pipeline prefill path only buys us overlap once there are at
+    # least two real chunks. Single-chunk prompts keep the PR90-era
+    # stream_generate path because they do not benefit from the custom pipeline
+    # scheduler and have repeatedly been the sharpest wedge shape in Gemma 4
+    # cluster testing.
     pipeline_chunk_sizes = (
         _vision_safe_prefill_chunk_sizes(
             num_tokens,
@@ -883,14 +884,14 @@ def prefill(
         else []
     )
     pipeline_chunks = len(pipeline_chunk_sizes)
-    use_pipeline_prefill = is_pipeline
+    use_pipeline_prefill = is_pipeline and pipeline_chunks >= 2
     logger.info(
         "Prefill path selected: "
         f"{'pipeline_parallel_prefill' if use_pipeline_prefill else 'stream_generate'} "
         f"(rank={rank}, prompt_tokens={num_tokens}, is_pipeline={is_pipeline}, "
         f"prefill_step_size_input={prefill_step_size}, "
         f"prefill_step_size_effective={effective_prefill_step_size}, "
-        f"pipeline_chunks={pipeline_chunks})"
+        f"pipeline_chunks={pipeline_chunks}, pipeline_min_chunks=2)"
     )
     # Pipeline models must run in prefill mode during any prefill forward
     # pass. With is_prefill=False, pipeline wrappers can queue collectives

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1988,6 +1988,13 @@ def mlx_generate(
             task_id=trace_task_id,
             include_memory=True,
         )
+        with runner_phase(
+            "decode_stream",
+            detail="clear_prefill_mlx_cache",
+            task_id=trace_task_id,
+            include_memory=True,
+        ):
+            mx.clear_cache()
     cache_snapshots: list[CacheSnapshot] | None = ssm_snapshots_list or None
 
     # stream_generate starts from the last token

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -73,6 +73,8 @@ from exo.worker.engines.mlx.auto_parallel import (
     get_inner_model,
     get_layers,
     pipeline_auto_parallel,
+    pipeline_eval_timeout_seconds,
+    pipeline_timeout_callback,
     tensor_auto_parallel,
 )
 from exo.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
@@ -1249,10 +1251,19 @@ def mx_any(bool_: bool, group: Group | None) -> bool:
 def mx_barrier(group: Group | None):
     if group is None:
         return
-    mx.eval(
+    # Wrap the all_sum eval in eval_with_timeout so a desynced ring-collective
+    # state cannot wedge the runner indefinitely. Healthy barriers complete in
+    # milliseconds; the slowest legitimate observation is the post-prefill
+    # decode barrier at ~1s. Bound by SKULK_PIPELINE_EVAL_TIMEOUT_SECONDS so
+    # all distributed evals share the same recovery floor.
+    eval_with_timeout(
         mx.distributed.all_sum(
             mx.array(1.0), group=group, stream=mx.default_stream(mx.Device(mx.cpu))
-        )
+        ),
+        timeout_seconds=pipeline_eval_timeout_seconds(),
+        on_timeout=pipeline_timeout_callback(
+            "mx_barrier", {"group_size": group.size()}, is_prefill=False
+        ),
     )
 
 

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -77,6 +77,7 @@ from exo.worker.engines.mlx.auto_parallel import (
 )
 from exo.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
 from exo.worker.runner.bootstrap import logger
+from exo.worker.runner.diagnostics import remember_wired_limit_bytes
 
 Group = mx.distributed.Group
 
@@ -1221,6 +1222,7 @@ def set_wired_limit_for_model(model_size: Memory):
             "https://github.com/ml-explore/mlx-lm/tree/main#large-models"
         )
     mx.set_wired_limit(max_rec_size.in_bytes)
+    remember_wired_limit_bytes(max_rec_size.in_bytes)
     logger.info(f"Wired limit set to {max_rec_size}.")
 
 

--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -40,8 +40,10 @@ from transformers import AutoImageProcessor
 from exo.download.download_utils import build_model_path
 from exo.shared.constants import EXO_IMAGE_TRANSPORT_DEBUG
 from exo.shared.models.model_cards import VisionCardConfig
+from exo.shared.tracing import TraceAttrValue
 from exo.shared.types.common import ModelId
 from exo.shared.types.mlx import Model
+from exo.shared.types.tasks import TaskId
 from exo.worker.engines.mlx.cache import encode_prompt
 from exo.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
 from exo.worker.engines.mlx.utils_mlx import fix_unmatched_think_end_tokens
@@ -266,6 +268,15 @@ def _vision_transport_debug_enabled() -> bool:
     return EXO_IMAGE_TRANSPORT_DEBUG or bool(os.environ.get("EXO_VISION_DEBUG_SAVE_DIR"))
 
 
+def _vision_prompt_debug_enabled() -> bool:
+    """Return whether full prompt-shape logging is enabled for vision prompts."""
+    for env_var_name in ("SKULK_TRACE_REQUEST_SHAPES", "EXO_TRACE_REQUEST_SHAPES"):
+        value = os.environ.get(env_var_name)
+        if value is not None:
+            return value.strip().lower() not in {"", "0", "false", "no", "off"}
+    return False
+
+
 def _maybe_dump_debug_image(
     image: Image.Image,
     debug: _DecodedImageDebug,
@@ -294,6 +305,8 @@ def _maybe_dump_debug_image(
 def _format_vlm_messages(
     messages: list[JsonDict],
     model_type: str,
+    *,
+    task_id: TaskId | str | None = None,
 ) -> list[JsonDict]:
     def _count_image_parts(message: JsonDict) -> int:
         content = message.get("content")
@@ -317,6 +330,7 @@ def _format_vlm_messages(
             "image_count": image_count,
             "gemma_image_label_count": image_count if label_images else 0,
         },
+        task_id=task_id,
     )
     image_number = 1
     for msg in messages:
@@ -367,7 +381,80 @@ def _format_vlm_messages(
     return formatted
 
 
-def build_vision_prompt(
+@dataclass(frozen=True)
+class _VisionPromptDebug:
+    """Prompt rendering facts used to compare Skulk against processor templates."""
+
+    raw_prompt_chars: int
+    raw_image_placeholder_positions: list[int]
+    expanded_prompt_chars: int
+    tokens_per_image: list[int]
+    image_token: str
+
+    def attrs(self) -> dict[str, TraceAttrValue]:
+        """Return JSON-safe tracing attributes for the rendered vision prompt."""
+        return {
+            "raw_prompt_chars": self.raw_prompt_chars,
+            "raw_image_placeholder_count": len(self.raw_image_placeholder_positions),
+            "raw_image_placeholder_offsets": [
+                str(position) for position in self.raw_image_placeholder_positions
+            ],
+            "expanded_prompt_chars": self.expanded_prompt_chars,
+            "tokens_per_image": [
+                str(token_count) for token_count in self.tokens_per_image
+            ],
+            "image_token": self.image_token,
+        }
+
+
+@dataclass(frozen=True)
+class _VisionPromptBuild:
+    """Rendered prompt plus the unexpanded prompt facts that produced it."""
+
+    prompt: str
+    raw_prompt: str
+    debug: _VisionPromptDebug
+
+
+def _prompt_placeholder_positions(prompt: str, image_token: str) -> list[int]:
+    """Return character offsets for image placeholders in the unexpanded prompt."""
+    positions: list[int] = []
+    offset = 0
+    while True:
+        position = prompt.find(image_token, offset)
+        if position == -1:
+            return positions
+        positions.append(position)
+        offset = position + len(image_token)
+
+
+def _log_vision_prompt_shape(
+    label: str,
+    raw_prompt: str,
+    expanded_prompt: str,
+    attrs: dict[str, TraceAttrValue],
+) -> None:
+    """Log full raw and expanded vision prompts when request-shape tracing is on."""
+    if not _vision_prompt_debug_enabled():
+        return
+
+    payload: dict[str, TraceAttrValue] = {"label": label, **attrs}
+    logger.info(
+        "[request-shape] "
+        f"{json.dumps(payload, ensure_ascii=True, sort_keys=True)}"
+    )
+    logger.info(f"[request-shape] vision raw prompt label={label}\n{raw_prompt}")
+    logger.info(
+        f"[request-shape] vision expanded prompt label={label}\n{expanded_prompt}"
+    )
+
+
+def _diagnostic_attrs(attrs: dict[str, TraceAttrValue]) -> dict[str, object]:
+    """Adapt trace-safe attrs to the runner diagnostic helper's invariant dict."""
+    return cast(dict[str, object], attrs)
+
+
+def _build_vision_prompt_with_debug(
     tokenizer: TokenizerWrapper,
     chat_template_messages: list[JsonDict],
     n_tokens_per_image: list[int],
@@ -375,9 +462,8 @@ def build_vision_prompt(
     model_type: str | None = None,
     boi_token_id: int | None = None,
     eoi_token_id: int | None = None,
-) -> str:
-    """Build the full prompt string, expanding each image placeholder to the
-    correct number of image tokens based on the encoder's output size.
+) -> _VisionPromptBuild:
+    """Build the expanded prompt and retain the raw placeholder layout.
 
     For models that use BOI/EOI framing (Gemma 3n/4), each expanded image
     sequence is wrapped as ``BOI + (IMAGE × N) + EOI`` matching the format
@@ -402,6 +488,8 @@ def build_vision_prompt(
             tokenize=False,
             add_generation_prompt=True,
         )
+    raw_prompt = prompt
+    raw_placeholder_positions = _prompt_placeholder_positions(raw_prompt, image_token)
 
     # Decode BOI/EOI token IDs to their string form so we can insert them
     # into the prompt text before tokenization.
@@ -415,8 +503,8 @@ def build_vision_prompt(
     result: list[str] = []
     i = 0
     pad_len = len(image_token)
-    while i < len(prompt):
-        if prompt[i : i + pad_len] == image_token:
+    while i < len(raw_prompt):
+        if raw_prompt[i : i + pad_len] == image_token:
             n = (
                 n_tokens_per_image[image_idx]
                 if image_idx < len(n_tokens_per_image)
@@ -426,10 +514,45 @@ def build_vision_prompt(
             image_idx += 1
             i += pad_len
         else:
-            result.append(prompt[i])
+            result.append(raw_prompt[i])
             i += 1
 
-    return "".join(result)
+    expanded_prompt = "".join(result)
+    debug = _VisionPromptDebug(
+        raw_prompt_chars=len(raw_prompt),
+        raw_image_placeholder_positions=raw_placeholder_positions,
+        expanded_prompt_chars=len(expanded_prompt),
+        tokens_per_image=n_tokens_per_image,
+        image_token=image_token,
+    )
+    _log_vision_prompt_shape(
+        "vision",
+        raw_prompt,
+        expanded_prompt,
+        debug.attrs(),
+    )
+    return _VisionPromptBuild(prompt=expanded_prompt, raw_prompt=raw_prompt, debug=debug)
+
+
+def build_vision_prompt(
+    tokenizer: TokenizerWrapper,
+    chat_template_messages: list[JsonDict],
+    n_tokens_per_image: list[int],
+    image_token: str,
+    model_type: str | None = None,
+    boi_token_id: int | None = None,
+    eoi_token_id: int | None = None,
+) -> str:
+    """Build a full prompt string with image placeholders expanded to features."""
+    return _build_vision_prompt_with_debug(
+        tokenizer,
+        chat_template_messages,
+        n_tokens_per_image,
+        image_token,
+        model_type=model_type,
+        boi_token_id=boi_token_id,
+        eoi_token_id=eoi_token_id,
+    ).prompt
 
 
 def _pixel_value_shapes(pixel_values: mx.array | list[mx.array]) -> list[str]:
@@ -438,6 +561,21 @@ def _pixel_value_shapes(pixel_values: mx.array | list[mx.array]) -> list[str]:
     if isinstance(pixel_values, list):
         return [str(tuple(value.shape)) for value in pixel_values]
     return [str(tuple(pixel_values.shape))]
+
+
+def _image_b64_hashes(images: list[str]) -> list[str]:
+    """Return stable hashes of the base64 image payloads in request order."""
+    return [hashlib.sha256(image.encode("ascii")).hexdigest() for image in images]
+
+
+def _media_region_ranges(media_regions: list["MediaRegion"]) -> list[str]:
+    """Return compact token ranges for prompt media regions."""
+    return [f"{region.start_pos}:{region.end_pos}" for region in media_regions]
+
+
+def _media_region_hashes(media_regions: list["MediaRegion"]) -> list[str]:
+    """Return compact content hashes for prompt media regions."""
+    return [region.content_hash[:12] for region in media_regions]
 
 
 @dataclass
@@ -460,6 +598,41 @@ class VisionResult:
     embeddings: mx.array
     media_regions: list[MediaRegion]
     pixel_values: mx.array | list[mx.array] | None = None
+    debug_info: "VisionDebugInfo | None" = None
+
+
+@dataclass(frozen=True)
+class VisionDebugInfo:
+    """Compact multimodal alignment facts for traces and runner diagnostics."""
+
+    model_type: str
+    native_vision: bool
+    image_b64_hashes: list[str]
+    prompt_debug: _VisionPromptDebug
+    prompt_tokens: int
+    image_token_count: int
+    media_region_ranges: list[str]
+    media_region_hashes: list[str]
+    pixel_value_shapes: list[str]
+    vision_feature_shape: str | None = None
+
+    def attrs(self) -> dict[str, TraceAttrValue]:
+        """Return bounded JSON-safe attributes for tracing and diagnostics."""
+        attrs: dict[str, TraceAttrValue] = {
+            "vision_model_type": self.model_type,
+            "native_vision": self.native_vision,
+            "image_count": len(self.image_b64_hashes),
+            "image_b64_hashes": [h[:12] for h in self.image_b64_hashes],
+            "prompt_tokens": self.prompt_tokens,
+            "image_token_count": self.image_token_count,
+            "media_region_ranges": self.media_region_ranges,
+            "media_region_hashes": self.media_region_hashes,
+            "pixel_value_shapes": self.pixel_value_shapes,
+            **self.prompt_debug.attrs(),
+        }
+        if self.vision_feature_shape is not None:
+            attrs["vision_feature_shape"] = self.vision_feature_shape
+        return attrs
 
 
 _QUANTIZATION_SUFFIXES = (".biases", ".scales")
@@ -1216,18 +1389,27 @@ class VisionProcessor:
         chat_template_messages: list[dict[str, Any]],
         tokenizer: TokenizerWrapper,
         model: Model,
+        *,
+        task_id: TaskId | str | None = None,
     ) -> VisionResult:
         logger.info(f"Vision pipeline: {len(images)} image(s)")
         record_runner_phase(
             "vision_preprocess",
             event="vision_process_start",
             attrs={"image_count": len(images)},
+            task_id=task_id,
             include_memory=True,
         )
 
         native = has_native_vision(model)
         if native:
-            return self._process_native(images, chat_template_messages, tokenizer, model)
+            return self._process_native(
+                images,
+                chat_template_messages,
+                tokenizer,
+                model,
+                task_id=task_id,
+            )
 
         cache_key = self._image_cache_key(images)
         cached = self._feature_cache.pop(cache_key, None)
@@ -1249,10 +1431,10 @@ class VisionProcessor:
             image_token = tokenizer.decode([self.vision_config.image_token_id])
 
         formatted_messages = _format_vlm_messages(
-            chat_template_messages, self.vision_config.model_type
+            chat_template_messages, self.vision_config.model_type, task_id=task_id
         )
 
-        prompt = build_vision_prompt(
+        prompt_build = _build_vision_prompt_with_debug(
             tokenizer,
             formatted_messages,
             n_tokens_per_image,
@@ -1260,6 +1442,13 @@ class VisionProcessor:
             model_type=self.vision_config.model_type,
             boi_token_id=self.vision_config.boi_token_id,
             eoi_token_id=self.vision_config.eoi_token_id,
+        )
+        prompt = prompt_build.prompt
+        record_runner_phase(
+            "vision_preprocess",
+            event="vision_prompt_rendered",
+            attrs=_diagnostic_attrs(prompt_build.debug.attrs()),
+            task_id=task_id,
         )
 
         logger.info(
@@ -1279,6 +1468,7 @@ class VisionProcessor:
                 "image_token_count": n_image_tokens,
                 "image_count": len(images),
             },
+            task_id=task_id,
         )
         logger.info(
             f"Encoded prompt: {len(prompt_tokens)} tokens, {n_image_tokens} image pad tokens"
@@ -1309,6 +1499,25 @@ class VisionProcessor:
                     for region in media_regions
                 ],
             },
+            task_id=task_id,
+        )
+        debug_info = VisionDebugInfo(
+            model_type=self.vision_config.model_type,
+            native_vision=False,
+            image_b64_hashes=_image_b64_hashes(images),
+            prompt_debug=prompt_build.debug,
+            prompt_tokens=len(prompt_tokens),
+            image_token_count=n_image_tokens,
+            media_region_ranges=_media_region_ranges(media_regions),
+            media_region_hashes=_media_region_hashes(media_regions),
+            pixel_value_shapes=[],
+            vision_feature_shape=str(tuple(image_features.shape)),
+        )
+        record_runner_phase(
+            "vision_preprocess",
+            event="vision_alignment_debug",
+            attrs=_diagnostic_attrs(debug_info.attrs()),
+            task_id=task_id,
         )
 
         return VisionResult(
@@ -1316,6 +1525,7 @@ class VisionProcessor:
             prompt_tokens=prompt_tokens,
             embeddings=embeddings,
             media_regions=media_regions,
+            debug_info=debug_info,
         )
 
     def _process_native(
@@ -1324,6 +1534,8 @@ class VisionProcessor:
         chat_template_messages: list[dict[str, Any]],
         tokenizer: TokenizerWrapper,
         model: Model,
+        *,
+        task_id: TaskId | str | None = None,
     ) -> VisionResult:
         """Process images for models with native vision support (e.g. Gemma 4).
 
@@ -1360,12 +1572,14 @@ class VisionProcessor:
                         "raw_sha256": debug.raw_sha256[:12],
                         "rgb_sha256": debug.rgb_sha256[:12],
                     },
+                    task_id=task_id,
                 )
         else:
             with runner_phase(
                 "vision_preprocess",
                 detail="native_base64_decode",
                 attrs={"image_count": len(images)},
+                task_id=task_id,
             ):
                 pil_images = [decode_base64_image(b64) for b64 in images]
             for idx, img in enumerate(pil_images):
@@ -1374,6 +1588,7 @@ class VisionProcessor:
                     "vision_preprocess",
                     event="native_image_decoded",
                     attrs={"image_index": idx, "width": img.width, "height": img.height},
+                    task_id=task_id,
                 )
 
         processor_kwargs = (
@@ -1395,6 +1610,7 @@ class VisionProcessor:
                 "pixel_value_shapes": _pixel_value_shapes(pixel_values),
                 "tokens_per_image": [str(token_count) for token_count in n_tokens_per_image],
             },
+            task_id=task_id,
             include_memory=True,
         )
         logger.info(
@@ -1407,9 +1623,9 @@ class VisionProcessor:
             image_token = tokenizer.decode([self.vision_config.image_token_id])
 
         formatted_messages = _format_vlm_messages(
-            chat_template_messages, self.vision_config.model_type
+            chat_template_messages, self.vision_config.model_type, task_id=task_id
         )
-        prompt = build_vision_prompt(
+        prompt_build = _build_vision_prompt_with_debug(
             tokenizer,
             formatted_messages,
             n_tokens_per_image,
@@ -1417,6 +1633,13 @@ class VisionProcessor:
             model_type=self.vision_config.model_type,
             boi_token_id=self.vision_config.boi_token_id,
             eoi_token_id=self.vision_config.eoi_token_id,
+        )
+        prompt = prompt_build.prompt
+        record_runner_phase(
+            "vision_preprocess",
+            event="native_vision_prompt_rendered",
+            attrs=_diagnostic_attrs(prompt_build.debug.attrs()),
+            task_id=task_id,
         )
 
         prompt_tokens: mx.array = encode_prompt(tokenizer, prompt)
@@ -1434,6 +1657,7 @@ class VisionProcessor:
                 if self.vision_config.model_type == "gemma4" and len(images) > 1
                 else 0,
             },
+            task_id=task_id,
         )
         logger.info(
             f"Encoded prompt: {len(prompt_tokens)} tokens, {n_image_tokens} image pad tokens"
@@ -1456,6 +1680,25 @@ class VisionProcessor:
                     for region in media_regions
                 ],
             },
+            task_id=task_id,
+        )
+        debug_info = VisionDebugInfo(
+            model_type=self.vision_config.model_type,
+            native_vision=True,
+            image_b64_hashes=_image_b64_hashes(images),
+            prompt_debug=prompt_build.debug,
+            prompt_tokens=len(prompt_tokens),
+            image_token_count=n_image_tokens,
+            media_region_ranges=_media_region_ranges(media_regions),
+            media_region_hashes=_media_region_hashes(media_regions),
+            pixel_value_shapes=_pixel_value_shapes(pixel_values),
+        )
+        record_runner_phase(
+            "vision_preprocess",
+            event="native_vision_alignment_debug",
+            attrs=_diagnostic_attrs(debug_info.attrs()),
+            task_id=task_id,
+            include_memory=True,
         )
 
         # Native vision models fuse image features inside __call__ during prefill,
@@ -1468,6 +1711,7 @@ class VisionProcessor:
             embeddings=empty_embeddings,
             media_regions=media_regions,
             pixel_values=pixel_values,
+            debug_info=debug_info,
         )
 
 
@@ -1477,6 +1721,8 @@ def prepare_vision(
     vision_processor: VisionProcessor,
     tokenizer: TokenizerWrapper,
     model: Model,
+    *,
+    task_id: TaskId | str | None = None,
 ) -> VisionResult | None:
     """Top-level entry point: encode images and build the vision-augmented prompt.
 
@@ -1494,4 +1740,5 @@ def prepare_vision(
         chat_template_messages=chat_template_messages,
         tokenizer=tokenizer,
         model=model,
+        task_id=task_id,
     )

--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -46,6 +46,7 @@ from exo.worker.engines.mlx.cache import encode_prompt
 from exo.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
 from exo.worker.engines.mlx.utils_mlx import fix_unmatched_think_end_tokens
 from exo.worker.runner.bootstrap import logger
+from exo.worker.runner.diagnostics import record_runner_phase, runner_phase
 
 JsonDict = dict[str, object]
 MxArrayInput = (
@@ -307,6 +308,16 @@ def _format_vlm_messages(
     formatted: list[JsonDict] = []
     image_count = sum(_count_image_parts(msg) for msg in messages)
     label_images = model_type in {"gemma3n", "gemma4"} and image_count > 1
+    record_runner_phase(
+        "vision_preprocess",
+        event="format_vlm_messages",
+        attrs={
+            "model_type": model_type,
+            "message_count": len(messages),
+            "image_count": image_count,
+            "gemma_image_label_count": image_count if label_images else 0,
+        },
+    )
     image_number = 1
     for msg in messages:
         role = str(msg.get("role", "user"))
@@ -419,6 +430,14 @@ def build_vision_prompt(
             i += 1
 
     return "".join(result)
+
+
+def _pixel_value_shapes(pixel_values: mx.array | list[mx.array]) -> list[str]:
+    """Return compact tensor shape strings for diagnostics."""
+
+    if isinstance(pixel_values, list):
+        return [str(tuple(value.shape)) for value in pixel_values]
+    return [str(tuple(pixel_values.shape))]
 
 
 @dataclass
@@ -839,7 +858,16 @@ class VisionEncoder:
     ) -> tuple[mx.array | list[mx.array], mx.array | None, list[int]]:
         """Public interface to image preprocessing (pixel_values + token counts)."""
         self.ensure_processor_loaded()
-        return self._preprocess_images(pil_images, processor_kwargs=processor_kwargs)
+        with runner_phase(
+            "vision_preprocess",
+            detail="preprocess_images",
+            attrs={
+                "image_count": len(pil_images),
+                "processor_kwargs": list((processor_kwargs or {}).keys()),
+            },
+            include_memory=True,
+        ):
+            return self._preprocess_images(pil_images, processor_kwargs=processor_kwargs)
 
     def encode_images(self, images: list[str]) -> tuple[mx.array, list[int]]:
         """Encode base64 images into feature tensors and per-image token counts."""
@@ -847,12 +875,32 @@ class VisionEncoder:
         assert self._vision_tower is not None
         assert self._processor is not None
 
-        pil_images = [decode_base64_image(b64) for b64 in images]
+        with runner_phase(
+            "vision_preprocess",
+            detail="base64_decode",
+            attrs={"image_count": len(images)},
+        ):
+            pil_images = [decode_base64_image(b64) for b64 in images]
         for idx, img in enumerate(pil_images):
             logger.info(f"Image {idx}: {img.width}x{img.height} mode={img.mode}")
+            record_runner_phase(
+                "vision_preprocess",
+                event="image_decoded",
+                attrs={"image_index": idx, "width": img.width, "height": img.height},
+            )
 
         pixel_values, grid_thw, n_tokens_per_image = self._preprocess_images(
             pil_images
+        )
+        record_runner_phase(
+            "vision_preprocess",
+            event="image_preprocessed",
+            attrs={
+                "image_count": len(pil_images),
+                "pixel_value_shapes": _pixel_value_shapes(pixel_values),
+                "tokens_per_image": [str(token_count) for token_count in n_tokens_per_image],
+            },
+            include_memory=True,
         )
         hidden_states = self._run_vision_tower(pixel_values, grid_thw)
 
@@ -1170,6 +1218,12 @@ class VisionProcessor:
         model: Model,
     ) -> VisionResult:
         logger.info(f"Vision pipeline: {len(images)} image(s)")
+        record_runner_phase(
+            "vision_preprocess",
+            event="vision_process_start",
+            attrs={"image_count": len(images)},
+            include_memory=True,
+        )
 
         native = has_native_vision(model)
         if native:
@@ -1217,6 +1271,15 @@ class VisionProcessor:
         n_image_tokens = int(
             mx.sum(mx.equal(prompt_tokens, self.vision_config.image_token_id)).item()
         )
+        record_runner_phase(
+            "vision_preprocess",
+            event="image_token_expansion",
+            attrs={
+                "prompt_tokens": len(prompt_tokens),
+                "image_token_count": n_image_tokens,
+                "image_count": len(images),
+            },
+        )
         logger.info(
             f"Encoded prompt: {len(prompt_tokens)} tokens, {n_image_tokens} image pad tokens"
         )
@@ -1235,6 +1298,17 @@ class VisionProcessor:
             self.vision_config.image_token_id,
             boi_token_id=self.vision_config.boi_token_id,
             eoi_token_id=self.vision_config.eoi_token_id,
+        )
+        record_runner_phase(
+            "vision_preprocess",
+            event="media_regions_ready",
+            attrs={
+                "media_region_count": len(media_regions),
+                "media_region_lengths": [
+                    str(region.end_pos - region.start_pos)
+                    for region in media_regions
+                ],
+            },
         )
 
         return VisionResult(
@@ -1275,10 +1349,32 @@ class VisionProcessor:
                     f"rgb_sha256={debug.rgb_sha256[:12]}..."
                 )
                 _maybe_dump_debug_image(img, debug, idx)
+                record_runner_phase(
+                    "vision_preprocess",
+                    event="native_image_decoded",
+                    attrs={
+                        "image_index": idx,
+                        "width": img.width,
+                        "height": img.height,
+                        "raw_bytes": debug.raw_bytes,
+                        "raw_sha256": debug.raw_sha256[:12],
+                        "rgb_sha256": debug.rgb_sha256[:12],
+                    },
+                )
         else:
-            pil_images = [decode_base64_image(b64) for b64 in images]
+            with runner_phase(
+                "vision_preprocess",
+                detail="native_base64_decode",
+                attrs={"image_count": len(images)},
+            ):
+                pil_images = [decode_base64_image(b64) for b64 in images]
             for idx, img in enumerate(pil_images):
                 logger.debug(f"Image {idx}: {img.width}x{img.height} mode={img.mode}")
+                record_runner_phase(
+                    "vision_preprocess",
+                    event="native_image_decoded",
+                    attrs={"image_index": idx, "width": img.width, "height": img.height},
+                )
 
         processor_kwargs = (
             _gemma4_native_processor_kwargs(chat_template_messages, processor)
@@ -1289,6 +1385,17 @@ class VisionProcessor:
         pixel_values, _grid_thw, n_tokens_per_image = self._encoder.preprocess_images(
             pil_images,
             processor_kwargs=processor_kwargs,
+        )
+        record_runner_phase(
+            "vision_preprocess",
+            event="native_image_preprocessed",
+            attrs={
+                "image_count": len(images),
+                "processor_kwargs": list(processor_kwargs.keys()),
+                "pixel_value_shapes": _pixel_value_shapes(pixel_values),
+                "tokens_per_image": [str(token_count) for token_count in n_tokens_per_image],
+            },
+            include_memory=True,
         )
         logger.info(
             f"Native vision: preprocessed {len(images)} image(s), "
@@ -1317,6 +1424,17 @@ class VisionProcessor:
         n_image_tokens = int(
             mx.sum(mx.equal(prompt_tokens, self.vision_config.image_token_id)).item()
         )
+        record_runner_phase(
+            "vision_preprocess",
+            event="native_image_token_expansion",
+            attrs={
+                "prompt_tokens": len(prompt_tokens),
+                "image_token_count": n_image_tokens,
+                "gemma_image_label_count": len(images)
+                if self.vision_config.model_type == "gemma4" and len(images) > 1
+                else 0,
+            },
+        )
         logger.info(
             f"Encoded prompt: {len(prompt_tokens)} tokens, {n_image_tokens} image pad tokens"
         )
@@ -1327,6 +1445,17 @@ class VisionProcessor:
             self.vision_config.image_token_id,
             boi_token_id=self.vision_config.boi_token_id,
             eoi_token_id=self.vision_config.eoi_token_id,
+        )
+        record_runner_phase(
+            "vision_preprocess",
+            event="native_media_regions_ready",
+            attrs={
+                "media_region_count": len(media_regions),
+                "media_region_lengths": [
+                    str(region.end_pos - region.start_pos)
+                    for region in media_regions
+                ],
+            },
         )
 
         # Native vision models fuse image features inside __call__ during prefill,

--- a/src/exo/worker/engines/mlx/vision.py
+++ b/src/exo/worker/engines/mlx/vision.py
@@ -294,7 +294,20 @@ def _format_vlm_messages(
     messages: list[JsonDict],
     model_type: str,
 ) -> list[JsonDict]:
+    def _count_image_parts(message: JsonDict) -> int:
+        content = message.get("content")
+        if not isinstance(content, list):
+            return 0
+        return sum(
+            1
+            for raw_part in cast(list[object], content)
+            if str(_object_dict(raw_part).get("type", "")) in {"image", "image_url"}
+        )
+
     formatted: list[JsonDict] = []
+    image_count = sum(_count_image_parts(msg) for msg in messages)
+    label_images = model_type in {"gemma3n", "gemma4"} and image_count > 1
+    image_number = 1
     for msg in messages:
         role = str(msg.get("role", "user"))
         content = msg.get("content")
@@ -318,7 +331,16 @@ def _format_vlm_messages(
                         {"type": "text", "text": str(part.get("text", ""))}
                     )
                 elif part_type in {"image", "image_url"}:
-                    normalized_parts.append({"type": "image"})
+                    image_part: JsonDict = {"type": "image"}
+                    if label_images:
+                        # Gemma 4 has been observed to answer from an earlier
+                        # image when multiple bare image placeholders are present
+                        # in chat history. Stable chronological labels make
+                        # "the latest image" unambiguous without changing the
+                        # image tensor order.
+                        image_part["label"] = f"Image {image_number}"
+                    image_number += 1
+                    normalized_parts.append(image_part)
             formatted.append({"role": role, "content": normalized_parts})
             continue
 

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -189,6 +189,28 @@ def _log_image_payload_debug(
     _log_image_transport(message)
 
 
+def resolve_cached_vlm_images(
+    image_cache: dict[str, str],
+    image_hashes: dict[int, str],
+) -> tuple[dict[int, str], list[tuple[int, str]]]:
+    """Resolve cached VLM image hashes without treating cache misses as fatal."""
+    by_index: dict[int, str] = {}
+    missing: list[tuple[int, str]] = []
+    for image_index, image_hash in image_hashes.items():
+        cached_image = image_cache.get(image_hash)
+        if cached_image is None:
+            missing.append((image_index, image_hash))
+            continue
+        by_index[image_index] = cached_image
+        _log_image_payload_debug(
+            "Worker resolved cached VLM",
+            image_index,
+            cached_image,
+            expected_b64_sha256=image_hash,
+        )
+    return by_index, missing
+
+
 class Worker:
     def __init__(
         self,
@@ -469,17 +491,30 @@ class Worker:
                     or task.task_params.total_input_chunks > 0
                 ):
                     cmd_id = task.command_id
-                    by_index: dict[int, str] = {}
-
-                    for idx, h in task.task_params.image_hashes.items():
-                        assert h in self.image_cache
-                        by_index[idx] = self.image_cache[h]
-                        _log_image_payload_debug(
-                            "Worker resolved cached VLM",
-                            idx,
-                            by_index[idx],
-                            expected_b64_sha256=h,
+                    by_index, missing_cached_images = resolve_cached_vlm_images(
+                        self.image_cache,
+                        task.task_params.image_hashes,
+                    )
+                    if missing_cached_images:
+                        missing = ", ".join(
+                            f"{idx}:{image_hash[:12]}"
+                            for idx, image_hash in missing_cached_images
                         )
+                        logger.error(
+                            "TextGeneration VLM task references missing cached "
+                            f"image(s); failing task instead of crashing worker "
+                            f"(task_id={task.task_id}, command_id={cmd_id}, "
+                            f"model={task.task_params.model}, missing={missing})"
+                        )
+                        self.input_chunk_buffer.pop(cmd_id, None)
+                        self.input_chunk_counts.pop(cmd_id, None)
+                        await self.event_sender.send(
+                            TaskStatusUpdated(
+                                task_id=task.task_id,
+                                task_status=TaskStatus.Failed,
+                            )
+                        )
+                        continue
 
                     if task.task_params.total_input_chunks > 0:
                         chunk_buffer = self.input_chunk_buffer.get(cmd_id, {})

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -22,6 +22,7 @@ from exo.shared.types.commands import (
     StartDownload,
 )
 from exo.shared.types.common import CommandId, NodeId, SystemId
+from exo.shared.types.diagnostics import RunnerSupervisorDiagnostics
 from exo.shared.types.events import (
     CustomModelCardAdded,
     CustomModelCardDeleted,
@@ -558,6 +559,11 @@ class Worker:
         self.runners[task.bound_instance.bound_runner_id] = runner
         self._tg.start_soon(runner.run)
         return runner
+
+    def collect_runner_diagnostics(self) -> list[RunnerSupervisorDiagnostics]:
+        """Return live read-only diagnostics for local runner supervisors."""
+
+        return [runner.diagnostics() for runner in self.runners.values()]
 
     async def _maybe_evict_shard(self, shard: ShardMetadata | None) -> None:
         """Evict staged shard files after runner teardown if configured."""

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -22,7 +22,10 @@ from exo.shared.types.commands import (
     StartDownload,
 )
 from exo.shared.types.common import CommandId, NodeId, SystemId
-from exo.shared.types.diagnostics import RunnerSupervisorDiagnostics
+from exo.shared.types.diagnostics import (
+    RunnerSupervisorDiagnostics,
+    RunnerTaskCancelResponse,
+)
 from exo.shared.types.events import (
     CustomModelCardAdded,
     CustomModelCardDeleted,
@@ -47,6 +50,7 @@ from exo.shared.types.tasks import (
     Shutdown,
     StartWarmup,
     Task,
+    TaskId,
     TaskStatus,
     TextGeneration,
 )
@@ -599,6 +603,50 @@ class Worker:
         """Return live read-only diagnostics for local runner supervisors."""
 
         return [runner.diagnostics() for runner in self.runners.values()]
+
+    async def cancel_runner_task(
+        self,
+        runner_id: RunnerId,
+        task_id: TaskId,
+    ) -> RunnerTaskCancelResponse:
+        """Request cooperative cancellation for one live task on one runner."""
+
+        runner = self.runners.get(runner_id)
+        if runner is None:
+            raise KeyError(f"Runner not found on this node: {runner_id}")
+
+        if task_id in runner.completed:
+            return RunnerTaskCancelResponse(
+                node_id=self.node_id,
+                runner_id=runner_id,
+                task_id=task_id,
+                status="already_completed",
+                message="Task already completed; no cancellation was sent.",
+            )
+        if task_id in runner.cancelled:
+            return RunnerTaskCancelResponse(
+                node_id=self.node_id,
+                runner_id=runner_id,
+                task_id=task_id,
+                status="already_cancelled",
+                message="Task was already marked cancelled on this runner.",
+            )
+        if task_id not in runner.in_progress and task_id not in runner.pending:
+            raise KeyError(
+                f"Task {task_id} is not pending or in progress on runner {runner_id}"
+            )
+
+        await runner.cancel_task(task_id)
+        return RunnerTaskCancelResponse(
+            node_id=self.node_id,
+            runner_id=runner_id,
+            task_id=task_id,
+            status="cancel_requested",
+            message=(
+                "Cooperative cancellation requested on the live runner. "
+                "Native or wedged work may continue until the runner observes it."
+            ),
+        )
 
     async def _maybe_evict_shard(self, shard: ShardMetadata | None) -> None:
         """Evict staged shard files after runner teardown if configured."""

--- a/src/exo/worker/plan.py
+++ b/src/exo/worker/plan.py
@@ -2,6 +2,11 @@
 
 from collections.abc import Mapping, Sequence
 
+from exo.shared.models.model_cards import (
+    OutputParserType,
+    PromptRendererType,
+    ToolCallFormat,
+)
 from exo.shared.types.chunks import InputImageChunk
 from exo.shared.types.common import CommandId, NodeId
 from exo.shared.types.tasks import (
@@ -40,6 +45,7 @@ from exo.shared.types.worker.runners import (
     RunnerStatus,
     RunnerWarmingUp,
 )
+from exo.shared.types.worker.shards import ShardMetadata
 from exo.worker.runner.runner_supervisor import RunnerSupervisor
 
 
@@ -247,6 +253,17 @@ def _ready_to_warmup(
         world_size = shard.world_size
 
         is_runner_loaded = isinstance(runner.status, RunnerLoaded)
+        peer_warmup_statuses: tuple[type[RunnerStatus], ...]
+        rank_zero_peer_warmup_statuses: tuple[type[RunnerStatus], ...]
+        if _uses_independent_distributed_warmup(shard):
+            # Gemma 4 distributed synthetic warmup is intentionally skipped by
+            # the runner, so each shard can advance from Loaded to Ready without
+            # needing peers to remain parked in WarmingUp.
+            peer_warmup_statuses = (RunnerLoaded, RunnerWarmingUp, RunnerReady)
+            rank_zero_peer_warmup_statuses = (RunnerWarmingUp, RunnerReady)
+        else:
+            peer_warmup_statuses = (RunnerLoaded, RunnerWarmingUp)
+            rank_zero_peer_warmup_statuses = (RunnerWarmingUp,)
 
         assert device_rank < world_size
         assert device_rank >= 0
@@ -255,7 +272,7 @@ def _ready_to_warmup(
         accepting_ranks_ready = device_rank > 0 and all(
             isinstance(
                 all_runners.get(global_runner_id, None),
-                (RunnerLoaded, RunnerWarmingUp),
+                peer_warmup_statuses,
             )
             for global_runner_id in shard_assignments.runner_to_shard
         )
@@ -264,7 +281,7 @@ def _ready_to_warmup(
         connecting_rank_ready = device_rank == 0 and all(
             isinstance(
                 all_runners.get(global_runner_id, None),
-                RunnerWarmingUp,
+                rank_zero_peer_warmup_statuses,
             )
             for global_runner_id in shard_assignments.runner_to_shard
             if global_runner_id != runner_id
@@ -274,6 +291,30 @@ def _ready_to_warmup(
             return StartWarmup(instance_id=instance.instance_id)
 
     return None
+
+
+def _uses_independent_distributed_warmup(shard: ShardMetadata) -> bool:
+    """Return whether distributed warmup is independently skippable per shard."""
+    if shard.world_size <= 1:
+        return False
+
+    model_card = shard.model_card
+    normalized_model_id = str(model_card.model_id).lower().replace("_", "-")
+    if "gemma-4" in normalized_model_id or "gemma4" in normalized_model_id:
+        return True
+
+    if model_card.vision is not None and model_card.vision.model_type == "gemma4":
+        return True
+
+    runtime = model_card.runtime
+    if runtime is not None and (
+        runtime.prompt_renderer == PromptRendererType.Gemma4
+        or runtime.output_parser == OutputParserType.Gemma4
+    ):
+        return True
+
+    tooling = model_card.tooling
+    return tooling is not None and tooling.tool_call_format == ToolCallFormat.Gemma4
 
 
 def _pending_tasks(

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -5,11 +5,16 @@ import signal
 
 import loguru
 
+from exo.shared.types.diagnostics import RunnerDiagnosticContext, RunnerDiagnosticUpdate
 from exo.shared.types.events import Event, RunnerStatusUpdated
 from exo.shared.types.tasks import Task, TaskId
 from exo.shared.types.worker.instances import BoundInstance
 from exo.shared.types.worker.runners import RunnerFailed
 from exo.utils.channels import ClosedResourceError, MpReceiver, MpSender
+from exo.worker.runner.diagnostics import (
+    configure_runner_diagnostics,
+    record_runner_phase,
+)
 
 logger: "loguru.Logger" = loguru.logger
 
@@ -57,6 +62,7 @@ def _metal_cleanup_signal_handler(signum: int, _frame: object) -> None:
 def entrypoint(
     bound_instance: BoundInstance,
     event_sender: MpSender[Event],
+    diagnostic_sender: MpSender[RunnerDiagnosticUpdate],
     task_receiver: MpReceiver[Task],
     cancel_receiver: MpReceiver[TaskId],
     _logger: "loguru.Logger",
@@ -79,6 +85,23 @@ def entrypoint(
         os.environ["MLX_METAL_FAST_SYNCH"] = "0"
 
     logger.info(f"Fast synch flag: {os.environ['MLX_METAL_FAST_SYNCH']}")
+    shard = bound_instance.bound_shard
+    configure_runner_diagnostics(
+        diagnostic_sender,
+        RunnerDiagnosticContext(
+            node_id=str(bound_instance.bound_node_id),
+            runner_id=str(bound_instance.bound_runner_id),
+            pid=os.getpid(),
+            instance_id=str(bound_instance.instance.instance_id),
+            model_id=str(shard.model_card.model_id),
+            rank=shard.device_rank,
+            world_size=shard.world_size,
+            start_layer=shard.start_layer,
+            end_layer=shard.end_layer,
+            n_layers=shard.n_layers,
+        ),
+    )
+    record_runner_phase("created", event="process_started", include_memory=True)
 
     # Import main after setting global logger - this lets us just import logger from this module
     try:
@@ -110,6 +133,12 @@ def entrypoint(
     except ClosedResourceError:
         logger.warning("Runner communication closed unexpectedly")
     except Exception as e:
+        record_runner_phase(
+            "error",
+            event="runner_crashed",
+            detail=f"{type(e).__name__}: {e}",
+            include_memory=True,
+        )
         logger.opt(exception=e).warning(
             f"Runner {bound_instance.bound_runner_id} crashed with critical exception {e}"
         )
@@ -123,11 +152,24 @@ def entrypoint(
         # Safety net: release Metal resources on any exit path, even if the
         # signal handler didn't fire (e.g. parent was SIGKILL'd and we got
         # a broken pipe, or an unexpected exception during load).
+        record_runner_phase(
+            "shutdown_cleanup",
+            event="metal_cleanup_begin",
+            include_memory=True,
+        )
         _release_metal_resources()
+        record_runner_phase(
+            "shutdown_cleanup",
+            event="metal_cleanup_complete",
+            include_memory=True,
+        )
         try:
             event_sender.close()
             task_receiver.close()
+            diagnostic_sender.close()
         finally:
             event_sender.join()
             task_receiver.join()
+            # Diagnostics are best-effort and must never delay Metal cleanup.
+            # Closing is enough; do not wait for a full diagnostic queue to drain.
             logger.info("bye from the runner")

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -7,6 +7,8 @@ import time
 
 import loguru
 
+from exo.shared.constants import preferred_env_value
+from exo.shared.models.model_cards import RuntimeCapabilityCardConfig
 from exo.shared.types.diagnostics import RunnerDiagnosticContext, RunnerDiagnosticUpdate
 from exo.shared.types.events import Event, RunnerStatusUpdated
 from exo.shared.types.tasks import Task, TaskId
@@ -22,6 +24,46 @@ logger: "loguru.Logger" = loguru.logger
 
 # Set by signal handler so the layer-by-layer loading loop can bail early.
 shutdown_requested: bool = False
+
+
+FAST_SYNCH_CLUSTER_DEFAULT: bool = True
+"""Cluster-wide default for ``MLX_METAL_FAST_SYNCH`` when neither the operator
+nor the model card has expressed a preference. Currently True for backwards
+compatibility with existing deployments. Flipping this default is tracked
+under the env-var → typed-config migration; do not flip without measuring
+the perf delta on a representative workload first."""
+
+
+def resolve_metal_fast_synch(card_runtime: RuntimeCapabilityCardConfig | None) -> bool:
+    """Resolve the effective ``MLX_METAL_FAST_SYNCH`` setting for this runner.
+
+    Priority order, highest to lowest:
+
+    1. **Operator override.** ``SKULK_FAST_SYNCH`` (or legacy ``EXO_FAST_SYNCH``)
+       set to ``"on"`` or ``"off"``. Set by the CLI ``--fast-synch`` /
+       ``--no-fast-synch`` flags or directly in the runner environment.
+       This is the escape hatch when a card preference is wrong in the field.
+    2. **Model card.** ``runtime.metal_fast_synch`` on the bound shard's model
+       card. Pinned per-model when the model is known to deadlock or
+       known to benefit measurably from FAST_SYNCH.
+    3. **Cluster default.** ``FAST_SYNCH_CLUSTER_DEFAULT`` (True today).
+
+    Returns ``True`` when ``MLX_METAL_FAST_SYNCH`` should be ``"1"``.
+    """
+    override = preferred_env_value("SKULK_FAST_SYNCH", "EXO_FAST_SYNCH")
+    if override is not None:
+        normalized = override.strip().lower()
+        if normalized == "on":
+            return True
+        if normalized == "off":
+            return False
+        # Anything else (empty string, "auto", garbage) falls through to the
+        # next layer rather than silently picking a value. The CLI surface
+        # only ever sets "on" or "off", so reaching this branch means
+        # someone set the env var by hand to an unknown value.
+    if card_runtime is not None and card_runtime.metal_fast_synch is not None:
+        return card_runtime.metal_fast_synch
+    return FAST_SYNCH_CLUSTER_DEFAULT
 
 
 def _release_metal_resources() -> None:
@@ -129,14 +171,13 @@ def entrypoint(
     soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     resource.setrlimit(resource.RLIMIT_NOFILE, (min(max(soft, 2048), hard), hard))
 
-    fast_synch_override = os.environ.get("EXO_FAST_SYNCH")
-    if fast_synch_override != "off":
-        os.environ["MLX_METAL_FAST_SYNCH"] = "1"
-    else:
-        os.environ["MLX_METAL_FAST_SYNCH"] = "0"
-
-    logger.info(f"Fast synch flag: {os.environ['MLX_METAL_FAST_SYNCH']}")
     shard = bound_instance.bound_shard
+    fast_synch_enabled = resolve_metal_fast_synch(shard.model_card.runtime)
+    os.environ["MLX_METAL_FAST_SYNCH"] = "1" if fast_synch_enabled else "0"
+    logger.info(
+        f"Fast synch flag: {os.environ['MLX_METAL_FAST_SYNCH']} "
+        f"(model={shard.model_card.model_id})"
+    )
     configure_runner_diagnostics(
         diagnostic_sender,
         RunnerDiagnosticContext(

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -2,6 +2,8 @@ import gc
 import os
 import resource
 import signal
+import threading
+import time
 
 import loguru
 
@@ -36,6 +38,49 @@ def _release_metal_resources() -> None:
     except Exception:
         pass
     gc.collect()
+
+
+def _install_parent_death_watchdog(initial_ppid: int, poll_seconds: float = 1.0) -> None:
+    """Self-terminate the runner when the agent supervisor dies.
+
+    The runner is a ``mp.Process(daemon=True)`` child of the agent. ``daemon=True``
+    only kills the child on a *clean* Python interpreter exit in the parent;
+    when the agent receives SIGKILL the child is reparented to launchd (pid 1
+    on macOS) and continues holding 4-5 GB of unified GPU memory until killed
+    explicitly. Without this watchdog, killing the agent leaves wired Metal
+    memory allocated, which is the failure mode that today forces a node
+    restart.
+
+    A dedicated daemon thread polls ``os.getppid()`` once per second; if it
+    changes from the original supervisor pid we run a best-effort
+    ``mx.clear_cache()`` and ``os._exit(1)``. We use ``os._exit`` rather than
+    ``sys.exit`` so we bypass any Python-level finally/atexit hooks that could
+    block on broken multiprocessing pipes.
+    """
+
+    def watchdog() -> None:
+        while True:
+            time.sleep(poll_seconds)
+            try:
+                current_ppid = os.getppid()
+            except OSError:
+                continue
+            if current_ppid != initial_ppid:
+                logger.warning(
+                    f"Runner parent died (ppid {initial_ppid} -> {current_ppid}); "
+                    "self-terminating to release Metal/GPU memory."
+                )
+                _release_metal_resources()
+                # Bypass interpreter shutdown to avoid hanging on broken
+                # multiprocessing pipes back to the now-dead supervisor.
+                os._exit(1)
+
+    thread = threading.Thread(
+        target=watchdog,
+        name="runner-parent-death-watchdog",
+        daemon=True,
+    )
+    thread.start()
 
 
 def _metal_cleanup_signal_handler(signum: int, _frame: object) -> None:
@@ -74,6 +119,12 @@ def entrypoint(
     # triggers Metal cleanup instead of an abrupt death that leaks wired RAM.
     signal.signal(signal.SIGTERM, _metal_cleanup_signal_handler)
     signal.signal(signal.SIGINT, _metal_cleanup_signal_handler)
+
+    # Backstop for SIGKILL of the supervisor: signal handlers above only fire
+    # for graceful agent shutdown. If the agent is SIGKILLed we get reparented
+    # to launchd, never receive a signal, and orphan ~5 GB of wired Metal
+    # memory. The watchdog detects reparenting and self-exits cleanly.
+    _install_parent_death_watchdog(initial_ppid=os.getppid())
 
     soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     resource.setrlimit(resource.RLIMIT_NOFILE, (min(max(soft, 2048), hard), hard))

--- a/src/exo/worker/runner/diagnostics.py
+++ b/src/exo/worker/runner/diagnostics.py
@@ -1,0 +1,223 @@
+"""Local-only runner diagnostic flight-recorder helpers.
+
+This module intentionally bypasses the event-sourced cluster state. It is an
+always-on, bounded, best-effort signal path from runner subprocesses back to
+their supervisors so wedged native/MLX phases remain visible even when traces
+are disabled or cannot flush.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator, Sequence
+from datetime import datetime, timezone
+from importlib import import_module
+from typing import cast
+
+from anyio import ClosedResourceError, WouldBlock
+
+from exo.shared.types.diagnostics import (
+    MlxMemorySnapshot,
+    RunnerDiagnosticContext,
+    RunnerDiagnosticUpdate,
+    RunnerDiagnosticValue,
+    RunnerPhaseName,
+)
+from exo.shared.types.memory import Memory
+from exo.shared.types.tasks import TaskId
+from exo.utils.channels import MpSender
+
+_diagnostic_sender: MpSender[RunnerDiagnosticUpdate] | None = None
+_diagnostic_context: RunnerDiagnosticContext | None = None
+_known_wired_limit_bytes: int | None = None
+
+
+def _now_utc_iso() -> str:
+    """Return the current UTC timestamp for diagnostic events."""
+
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def configure_runner_diagnostics(
+    sender: MpSender[RunnerDiagnosticUpdate] | None,
+    context: RunnerDiagnosticContext,
+) -> None:
+    """Configure process-local runner diagnostic emission.
+
+    Args:
+        sender: Multiprocessing sender owned by the runner subprocess.
+        context: Stable identity fields to attach to every diagnostic event.
+    """
+
+    global _diagnostic_context, _diagnostic_sender
+    _diagnostic_sender = sender
+    _diagnostic_context = context
+
+
+def remember_wired_limit_bytes(value: int | None) -> None:
+    """Remember the last configured MLX wired limit when the caller knows it."""
+
+    global _known_wired_limit_bytes
+    _known_wired_limit_bytes = value
+
+
+def _memory_from_callable(module: object, name: str) -> Memory | None:
+    getter = getattr(module, name, None)
+    if not callable(getter):
+        return None
+    try:
+        value = getter()
+    except Exception:
+        return None
+    if isinstance(value, (int, float)):
+        return Memory.from_bytes(int(value))
+    return None
+
+
+def capture_mlx_memory_snapshot() -> MlxMemorySnapshot | None:
+    """Return a best-effort MLX/Metal memory snapshot for the current process."""
+
+    for module_name in ("mlx.core", "mlx.core.metal"):
+        try:
+            module = import_module(module_name)
+        except Exception:
+            continue
+
+        active = _memory_from_callable(module, "get_active_memory")
+        cache = _memory_from_callable(module, "get_cache_memory")
+        peak = _memory_from_callable(module, "get_peak_memory")
+        if active is None and cache is None and peak is None:
+            continue
+        return MlxMemorySnapshot(
+            generated_at=_now_utc_iso(),
+            active=active,
+            cache=cache,
+            peak=peak,
+            wired_limit=Memory.from_bytes(_known_wired_limit_bytes)
+            if _known_wired_limit_bytes is not None
+            else None,
+            source=module_name,
+        )
+    return None
+
+
+def _normalize_attr_value(value: object) -> RunnerDiagnosticValue | None:
+    """Coerce diagnostic attrs into the bounded JSON-safe schema."""
+
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return value
+    if isinstance(value, (list, tuple)):
+        normalized = [str(item) for item in cast(Sequence[object], value)]
+        return normalized
+    if value is None:
+        return None
+    return str(value)
+
+
+def normalize_attrs(attrs: dict[str, object] | None) -> dict[str, RunnerDiagnosticValue]:
+    """Return attrs filtered to values supported by diagnostic models."""
+
+    if attrs is None:
+        return {}
+    normalized: dict[str, RunnerDiagnosticValue] = {}
+    for key, value in attrs.items():
+        normalized_value = _normalize_attr_value(value)
+        if normalized_value is not None:
+            normalized[str(key)] = normalized_value
+    return normalized
+
+
+def _task_id_string(task_id: TaskId | str | None) -> str | None:
+    return None if task_id is None else str(task_id)
+
+
+def record_runner_phase(
+    phase: RunnerPhaseName,
+    *,
+    event: str = "phase",
+    detail: str | None = None,
+    attrs: dict[str, object] | None = None,
+    task_id: TaskId | str | None = None,
+    command_id: str | None = None,
+    include_memory: bool = False,
+) -> None:
+    """Emit one non-blocking runner diagnostic update if configured."""
+
+    if _diagnostic_sender is None or _diagnostic_context is None:
+        return
+
+    update = RunnerDiagnosticUpdate(
+        at=_now_utc_iso(),
+        phase=phase,
+        event=event,
+        detail=detail,
+        attrs=normalize_attrs(attrs),
+        context=_diagnostic_context.model_copy(update={"pid": os.getpid()}),
+        task_id=_task_id_string(task_id),
+        command_id=command_id,
+        mlx_memory=capture_mlx_memory_snapshot() if include_memory else None,
+    )
+    with contextlib.suppress(WouldBlock, ClosedResourceError, OSError, ValueError):
+        _diagnostic_sender.send_nowait(update)
+
+
+@contextlib.contextmanager
+def runner_phase(
+    phase: RunnerPhaseName,
+    *,
+    detail: str | None = None,
+    attrs: dict[str, object] | None = None,
+    task_id: TaskId | str | None = None,
+    command_id: str | None = None,
+    include_memory: bool = False,
+) -> Iterator[None]:
+    """Record phase entry and exit around a runner operation."""
+
+    record_runner_phase(
+        phase,
+        event="enter",
+        detail=detail,
+        attrs=attrs,
+        task_id=task_id,
+        command_id=command_id,
+        include_memory=include_memory,
+    )
+    try:
+        yield
+    except BaseException as exc:
+        if type(exc).__name__ == "PrefillCancelled":
+            record_runner_phase(
+                "cancel_observed",
+                event="prefill_cancelled",
+                detail=detail,
+                attrs=attrs,
+                task_id=task_id,
+                command_id=command_id,
+                include_memory=True,
+            )
+        else:
+            record_runner_phase(
+                "error",
+                event="exception",
+                detail=f"{type(exc).__name__}: {exc}",
+                attrs=attrs,
+                task_id=task_id,
+                command_id=command_id,
+                include_memory=True,
+            )
+        raise
+    else:
+        record_runner_phase(
+            phase,
+            event="exit",
+            detail=detail,
+            attrs=attrs,
+            task_id=task_id,
+            command_id=command_id,
+            include_memory=include_memory,
+        )

--- a/src/exo/worker/runner/embeddings/runner.py
+++ b/src/exo/worker/runner/embeddings/runner.py
@@ -12,6 +12,13 @@ from typing import Any
 import torch
 from transformers import AutoModel, AutoTokenizer
 
+from exo.shared.tracing import (
+    begin_trace_session,
+    bind_trace_session,
+    pop_trace_session,
+    record_trace_marker,
+    trace,
+)
 from exo.shared.types.chunks import EmbeddingChunk, ErrorChunk
 from exo.shared.types.events import (
     ChunkGenerated,
@@ -19,6 +26,8 @@ from exo.shared.types.events import (
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskStatusUpdated,
+    TraceEventData,
+    TracesCollected,
 )
 from exo.shared.types.tasks import (
     CANCEL_ALL_TASKS,
@@ -52,31 +61,39 @@ def _get_device() -> torch.device:
 
 
 def _forward(
-    model: Any, tokenizer: Any, texts: list[str], device: torch.device
+    model: Any,
+    tokenizer: Any,
+    texts: list[str],
+    device: torch.device,
+    *,
+    rank: int,
 ) -> tuple[list[list[float]], int]:
     """Run embedding forward pass: tokenize -> model -> mean pool -> L2 normalize."""
-    inputs = tokenizer(
-        texts,
-        return_tensors="pt",
-        padding=True,
-        truncation=True,
-        max_length=512,
-    )
+    with trace("tokenize", rank, "embedding"):
+        inputs = tokenizer(
+            texts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=512,
+        )
     token_count = int(inputs["attention_mask"].sum().item())
     inputs = {k: v.to(device) for k, v in inputs.items()}
 
-    with torch.no_grad():
+    with trace("forward", rank, "embedding"), torch.no_grad():
         outputs = model(**inputs)
 
     # Mean pooling over non-padding tokens
-    attention_mask = inputs["attention_mask"].unsqueeze(-1)
-    hidden_states = outputs.last_hidden_state
-    summed = (hidden_states * attention_mask).sum(dim=1)
-    counts = attention_mask.sum(dim=1).clamp(min=1)
-    embeddings = summed / counts
+    with trace("pooling", rank, "embedding"):
+        attention_mask = inputs["attention_mask"].unsqueeze(-1)
+        hidden_states = outputs.last_hidden_state
+        summed = (hidden_states * attention_mask).sum(dim=1)
+        counts = attention_mask.sum(dim=1).clamp(min=1)
+        embeddings = summed / counts
 
     # L2 normalize
-    embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+    with trace("normalization", rank, "embedding"):
+        embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
 
     result: list[list[float]] = embeddings.tolist()
     return result, token_count
@@ -203,10 +220,36 @@ class Runner:
                 assert self.model is not None and self.tokenizer is not None
                 model_id = self.shard_metadata.model_card.model_id
 
-                try:
-                    result_embeddings, token_count = _forward(
-                        self.model, self.tokenizer, task_params.input_texts, self.device
+                if task.trace_enabled:
+                    begin_trace_session(
+                        task.task_id,
+                        rank=self.shard_metadata.device_rank,
+                        node_id=str(self.bound_instance.bound_node_id),
+                        model_id=str(model_id),
+                        task_kind="embedding",
+                        tags=["embedding"],
                     )
+                    record_trace_marker(
+                        "queued",
+                        self.shard_metadata.device_rank,
+                        task_id=task.task_id,
+                    )
+
+                try:
+                    with bind_trace_session(task.task_id):
+                        result_embeddings, token_count = _forward(
+                            self.model,
+                            self.tokenizer,
+                            task_params.input_texts,
+                            self.device,
+                            rank=self.shard_metadata.device_rank,
+                        )
+                    if task.trace_enabled:
+                        record_trace_marker(
+                            "finish",
+                            self.shard_metadata.device_rank,
+                            task_id=task.task_id,
+                        )
                     self.event_sender.send(
                         ChunkGenerated(
                             command_id=command_id,
@@ -218,6 +261,14 @@ class Runner:
                         )
                     )
                 except Exception as exc:
+                    if task.trace_enabled:
+                        record_trace_marker(
+                            "error",
+                            self.shard_metadata.device_rank,
+                            task_id=task.task_id,
+                            tags=["error"],
+                            attrs={"message": str(exc)},
+                        )
                     logger.opt(exception=exc).warning("embedding forward pass failed")
                     self.event_sender.send(
                         ChunkGenerated(
@@ -228,6 +279,30 @@ class Runner:
                             ),
                         )
                     )
+                finally:
+                    if task.trace_enabled:
+                        traces = pop_trace_session(task.task_id)
+                        self.event_sender.send(
+                            TracesCollected(
+                                task_id=task.task_id,
+                                rank=self.shard_metadata.device_rank,
+                                traces=[
+                                    TraceEventData(
+                                        name=trace_event.name,
+                                        start_us=trace_event.start_us,
+                                        duration_us=trace_event.duration_us,
+                                        rank=trace_event.rank,
+                                        category=trace_event.category,
+                                        node_id=trace_event.node_id,
+                                        model_id=trace_event.model_id,
+                                        task_kind=trace_event.task_kind,
+                                        tags=list(trace_event.tags),
+                                        attrs=trace_event.attrs,
+                                    )
+                                    for trace_event in traces
+                                ],
+                            )
+                        )
 
                 self.current_status = RunnerReady()
 

--- a/src/exo/worker/runner/embeddings/runner.py
+++ b/src/exo/worker/runner/embeddings/runner.py
@@ -163,7 +163,9 @@ class Runner:
                 was_cancelled = (task.task_id in self.cancelled_tasks) or (
                     CANCEL_ALL_TASKS in self.cancelled_tasks
                 )
-                if not was_cancelled:
+                if was_cancelled:
+                    self.send_task_status(task, TaskStatus.Cancelled)
+                else:
                     self.send_task_status(task, TaskStatus.Complete)
                 self.update_status(self.current_status)
 

--- a/src/exo/worker/runner/image_models/runner.py
+++ b/src/exo/worker/runner/image_models/runner.py
@@ -5,9 +5,14 @@ from typing import TYPE_CHECKING, Literal
 import mlx.core as mx
 
 from exo.api.types import ImageGenerationStats
-from exo.shared.constants import EXO_MAX_CHUNK_SIZE, EXO_TRACING_ENABLED
+from exo.shared.constants import EXO_MAX_CHUNK_SIZE
 from exo.shared.models.model_cards import ModelTask
-from exo.shared.tracing import clear_trace_buffer, get_trace_buffer
+from exo.shared.tracing import (
+    begin_trace_session,
+    bind_trace_session,
+    pop_trace_session,
+    record_trace_marker,
+)
 from exo.shared.types.chunks import ErrorChunk, ImageChunk
 from exo.shared.types.common import CommandId, ModelId
 from exo.shared.types.events import (
@@ -115,29 +120,29 @@ def _send_traces_if_enabled(
     task_id: TaskId,
     rank: int,
 ) -> None:
-    if not EXO_TRACING_ENABLED:
-        return
-
-    traces = get_trace_buffer()
-    if traces:
-        trace_data = [
-            TraceEventData(
-                name=t.name,
-                start_us=t.start_us,
-                duration_us=t.duration_us,
-                rank=t.rank,
-                category=t.category,
-            )
-            for t in traces
-        ]
-        event_sender.send(
-            TracesCollected(
-                task_id=task_id,
-                rank=rank,
-                traces=trace_data,
-            )
+    traces = pop_trace_session(task_id)
+    trace_data = [
+        TraceEventData(
+            name=t.name,
+            start_us=t.start_us,
+            duration_us=t.duration_us,
+            rank=t.rank,
+            category=t.category,
+            node_id=t.node_id,
+            model_id=t.model_id,
+            task_kind=t.task_kind,
+            tags=list(t.tags),
+            attrs=t.attrs,
         )
-    clear_trace_buffer()
+        for t in traces
+    ]
+    event_sender.send(
+        TracesCollected(
+            task_id=task_id,
+            rank=rank,
+            traces=trace_data,
+        )
+    )
 
 
 def _send_image_chunk(
@@ -315,38 +320,65 @@ class Runner:
                 self.update_status(RunnerRunning())
                 self.acknowledge_task(task)
 
+                if task.trace_enabled:
+                    begin_trace_session(
+                        task.task_id,
+                        rank=self.device_rank,
+                        node_id=str(self.bound_instance.bound_node_id),
+                        model_id=str(self.shard_metadata.model_card.model_id),
+                        task_kind="image",
+                        tags=["image_generation"],
+                    )
+                    record_trace_marker(
+                        "queued",
+                        self.device_rank,
+                        task_id=task.task_id,
+                        attrs={"request_type": "generate"},
+                    )
+
                 try:
                     image_index = 0
-                    for response in generate_image(
-                        model=self.image_model, task=task_params
-                    ):
-                        is_primary_output = _is_primary_output_node(self.shard_metadata)
+                    with bind_trace_session(task.task_id):
+                        for response in generate_image(
+                            model=self.image_model, task=task_params
+                        ):
+                            is_primary_output = _is_primary_output_node(
+                                self.shard_metadata
+                            )
 
-                        if is_primary_output:
-                            match response:
-                                case PartialImageResponse():
-                                    logger.info(
-                                        f"sending partial ImageChunk {response.partial_index}/{response.total_partials}"
-                                    )
-                                    _process_image_response(
-                                        response,
-                                        command_id,
-                                        self.shard_metadata,
-                                        self.event_sender,
-                                        image_index,
-                                    )
-                                case ImageGenerationResponse():
-                                    logger.info("sending final ImageChunk")
-                                    _process_image_response(
-                                        response,
-                                        command_id,
-                                        self.shard_metadata,
-                                        self.event_sender,
-                                        image_index,
-                                    )
-                                    image_index += 1
+                            if is_primary_output:
+                                match response:
+                                    case PartialImageResponse():
+                                        logger.info(
+                                            f"sending partial ImageChunk {response.partial_index}/{response.total_partials}"
+                                        )
+                                        _process_image_response(
+                                            response,
+                                            command_id,
+                                            self.shard_metadata,
+                                            self.event_sender,
+                                            image_index,
+                                        )
+                                    case ImageGenerationResponse():
+                                        logger.info("sending final ImageChunk")
+                                        _process_image_response(
+                                            response,
+                                            command_id,
+                                            self.shard_metadata,
+                                            self.event_sender,
+                                            image_index,
+                                        )
+                                        image_index += 1
                 # can we make this more explicit?
                 except Exception as e:
+                    if task.trace_enabled:
+                        record_trace_marker(
+                            "error",
+                            self.device_rank,
+                            task_id=task.task_id,
+                            tags=["error"],
+                            attrs={"message": str(e)},
+                        )
                     if _is_primary_output_node(self.shard_metadata):
                         self.event_sender.send(
                             ChunkGenerated(
@@ -360,9 +392,15 @@ class Runner:
                         )
                     raise
                 finally:
-                    _send_traces_if_enabled(
-                        self.event_sender, task.task_id, self.device_rank
-                    )
+                    if task.trace_enabled:
+                        record_trace_marker(
+                            "finish",
+                            self.device_rank,
+                            task_id=task.task_id,
+                        )
+                        _send_traces_if_enabled(
+                            self.event_sender, task.task_id, self.device_rank
+                        )
 
                 self.current_status = RunnerReady()
                 logger.info("runner ready")
@@ -376,35 +414,60 @@ class Runner:
                 self.update_status(RunnerRunning())
                 self.acknowledge_task(task)
 
+                if task.trace_enabled:
+                    begin_trace_session(
+                        task.task_id,
+                        rank=self.device_rank,
+                        node_id=str(self.bound_instance.bound_node_id),
+                        model_id=str(self.shard_metadata.model_card.model_id),
+                        task_kind="image",
+                        tags=["image_edit"],
+                    )
+                    record_trace_marker(
+                        "queued",
+                        self.device_rank,
+                        task_id=task.task_id,
+                        attrs={"request_type": "edit"},
+                    )
+
                 try:
                     image_index = 0
-                    for response in generate_image(
-                        model=self.image_model, task=task_params
-                    ):
-                        if _is_primary_output_node(self.shard_metadata):
-                            match response:
-                                case PartialImageResponse():
-                                    logger.info(
-                                        f"sending partial ImageChunk {response.partial_index}/{response.total_partials}"
-                                    )
-                                    _process_image_response(
-                                        response,
-                                        command_id,
-                                        self.shard_metadata,
-                                        self.event_sender,
-                                        image_index,
-                                    )
-                                case ImageGenerationResponse():
-                                    logger.info("sending final ImageChunk")
-                                    _process_image_response(
-                                        response,
-                                        command_id,
-                                        self.shard_metadata,
-                                        self.event_sender,
-                                        image_index,
-                                    )
-                                    image_index += 1
+                    with bind_trace_session(task.task_id):
+                        for response in generate_image(
+                            model=self.image_model, task=task_params
+                        ):
+                            if _is_primary_output_node(self.shard_metadata):
+                                match response:
+                                    case PartialImageResponse():
+                                        logger.info(
+                                            f"sending partial ImageChunk {response.partial_index}/{response.total_partials}"
+                                        )
+                                        _process_image_response(
+                                            response,
+                                            command_id,
+                                            self.shard_metadata,
+                                            self.event_sender,
+                                            image_index,
+                                        )
+                                    case ImageGenerationResponse():
+                                        logger.info("sending final ImageChunk")
+                                        _process_image_response(
+                                            response,
+                                            command_id,
+                                            self.shard_metadata,
+                                            self.event_sender,
+                                            image_index,
+                                        )
+                                        image_index += 1
                 except Exception as e:
+                    if task.trace_enabled:
+                        record_trace_marker(
+                            "error",
+                            self.device_rank,
+                            task_id=task.task_id,
+                            tags=["error"],
+                            attrs={"message": str(e)},
+                        )
                     if _is_primary_output_node(self.shard_metadata):
                         self.event_sender.send(
                             ChunkGenerated(
@@ -418,9 +481,15 @@ class Runner:
                         )
                     raise
                 finally:
-                    _send_traces_if_enabled(
-                        self.event_sender, task.task_id, self.device_rank
-                    )
+                    if task.trace_enabled:
+                        record_trace_marker(
+                            "finish",
+                            self.device_rank,
+                            task_id=task.task_id,
+                        )
+                        _send_traces_if_enabled(
+                            self.event_sender, task.task_id, self.device_rank
+                        )
 
                 self.current_status = RunnerReady()
                 logger.info("runner ready")

--- a/src/exo/worker/runner/image_models/runner.py
+++ b/src/exo/worker/runner/image_models/runner.py
@@ -252,7 +252,9 @@ class Runner:
                 was_cancelled = (task.task_id in self.cancelled_tasks) or (
                     CANCEL_ALL_TASKS in self.cancelled_tasks
                 )
-                if not was_cancelled:
+                if was_cancelled:
+                    self.send_task_status(task, TaskStatus.Cancelled)
+                else:
                     self.send_task_status(task, TaskStatus.Complete)
                 self.update_status(self.current_status)
 

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -34,6 +34,7 @@ from exo.worker.engines.mlx.utils_mlx import (
 )
 from exo.worker.engines.mlx.vision import VisionProcessor
 from exo.worker.runner.bootstrap import logger
+from exo.worker.runner.diagnostics import record_runner_phase, runner_phase
 
 from .model_output_parsers import apply_all_parsers
 from .tool_parsers import ToolParser
@@ -172,9 +173,23 @@ class SequentialGenerator(InferenceGenerator):
 
     def agree_on_tasks(self) -> None:
         """Agree between all ranks about the task ordering (some may have received in different order or not at all)."""
-        agreed, different = mx_all_gather_tasks(self._maybe_queue, self.group)
+        with runner_phase(
+            "task_agreement",
+            detail="mx_all_gather_tasks",
+            attrs={"candidate_count": len(self._maybe_queue)},
+        ):
+            agreed, different = mx_all_gather_tasks(self._maybe_queue, self.group)
         self._queue.extend(task for task in self._maybe_queue if task in agreed)
         self._maybe_queue = [task for task in self._maybe_queue if task in different]
+        record_runner_phase(
+            "task_agreement",
+            event="tasks_agreed",
+            attrs={
+                "agreed_count": len(agreed),
+                "different_count": len(different),
+                "queued_count": len(self._queue),
+            },
+        )
 
     def agree_on_cancellations(self) -> None:
         """Agree between all ranks about which tasks to cancel."""
@@ -185,6 +200,11 @@ class SequentialGenerator(InferenceGenerator):
                 continue
             if task_id in self._all_tasks:
                 self._maybe_cancel.append(self._all_tasks[task_id])
+                record_runner_phase(
+                    "cancel_requested",
+                    event="cancel_pipe_observed",
+                    task_id=task_id,
+                )
 
         if mx_any(has_cancel_all, self.group):
             self._cancelled_tasks.add(CANCEL_ALL_TASKS)
@@ -192,6 +212,12 @@ class SequentialGenerator(InferenceGenerator):
         agreed, different = mx_all_gather_tasks(self._maybe_cancel, self.group)
         self._cancelled_tasks.update(task.task_id for task in agreed)
         self._maybe_cancel = list(different)
+        if agreed:
+            record_runner_phase(
+                "cancel_observed",
+                event="cancellations_agreed",
+                attrs={"task_ids": [str(task.task_id) for task in agreed]},
+            )
 
     def step(
         self,
@@ -222,6 +248,13 @@ class SequentialGenerator(InferenceGenerator):
             if task.task_id not in self._first_token_seen:
                 self._first_token_seen.add(task.task_id)
                 self._decode_started_us[task.task_id] = now_us()
+                record_runner_phase(
+                    "decode_stream",
+                    event="first_token",
+                    task_id=task.task_id,
+                    command_id=str(task.command_id),
+                    include_memory=True,
+                )
                 record_trace_marker(
                     "first_token",
                     self.device_rank,
@@ -231,6 +264,13 @@ class SequentialGenerator(InferenceGenerator):
 
         except (StopIteration, PrefillCancelled):
             self._record_decode_span(task.task_id)
+            record_runner_phase(
+                "completion",
+                event="decode_complete",
+                task_id=task.task_id,
+                command_id=str(task.command_id),
+                include_memory=True,
+            )
             output.append((task.task_id, Finished()))
             self._active = None
             if self._queue:
@@ -249,6 +289,13 @@ class SequentialGenerator(InferenceGenerator):
 
     def _start_next(self) -> None:
         task = self._queue.popleft()
+        record_runner_phase(
+            "task_submission",
+            event="queue_admitted",
+            task_id=task.task_id,
+            command_id=str(task.command_id),
+            attrs={"queue_depth": len(self._queue), "batch_size": 1},
+        )
         record_trace_marker(
             "admitted_to_batch",
             self.device_rank,
@@ -266,20 +313,26 @@ class SequentialGenerator(InferenceGenerator):
         if task.task_params.bench:
             output_generator = queue.gen()
         else:
-            output_generator = apply_all_parsers(
-                queue.gen(),
-                apply_chat_template(
-                    self.tokenizer, task.task_params, model_card=self.model_card
-                ),
-                self.tool_parser,
-                self.tokenizer,
-                type(self.model),
-                self.model_id,
-                task.task_params.tools,
-                self.model_card,
-                trace_task_id=task.task_id,
-                trace_rank=self.device_rank,
-            )
+            with runner_phase(
+                "parser",
+                detail="apply_all_parsers",
+                task_id=task.task_id,
+                command_id=str(task.command_id),
+            ):
+                output_generator = apply_all_parsers(
+                    queue.gen(),
+                    apply_chat_template(
+                        self.tokenizer, task.task_params, model_card=self.model_card
+                    ),
+                    self.tool_parser,
+                    self.tokenizer,
+                    type(self.model),
+                    self.model_id,
+                    task.task_params.tools,
+                    self.model_card,
+                    trace_task_id=task.task_id,
+                    trace_rank=self.device_rank,
+                )
         self._active = _ActiveSequentialTask(
             task=task,
             mlx_generator=mlx_gen,
@@ -309,7 +362,16 @@ class SequentialGenerator(InferenceGenerator):
 
     def _build_generator(self, task: TextGeneration) -> Generator[GenerationResponse]:
         _check_for_debug_prompts(task.task_params)
-        with trace(
+        with runner_phase(
+            "prompt_build",
+            detail="apply_chat_template",
+            task_id=task.task_id,
+            command_id=str(task.command_id),
+            attrs={
+                "image_count": task.task_params.image_count,
+                "input_messages": len(task.task_params.input),
+            },
+        ), trace(
             "prompt_build",
             self.device_rank,
             "prompt",
@@ -452,9 +514,23 @@ class BatchGenerator(InferenceGenerator):
 
     def agree_on_tasks(self) -> None:
         """Agree between all ranks about the task ordering (some may have received in different order or not at all)."""
-        agreed, different = mx_all_gather_tasks(self._maybe_queue, self.group)
+        with runner_phase(
+            "task_agreement",
+            detail="batch_mx_all_gather_tasks",
+            attrs={"candidate_count": len(self._maybe_queue)},
+        ):
+            agreed, different = mx_all_gather_tasks(self._maybe_queue, self.group)
         self._queue.extend(task for task in self._maybe_queue if task in agreed)
         self._maybe_queue = [task for task in self._maybe_queue if task in different]
+        record_runner_phase(
+            "task_agreement",
+            event="batch_tasks_agreed",
+            attrs={
+                "agreed_count": len(agreed),
+                "different_count": len(different),
+                "queued_count": len(self._queue),
+            },
+        )
 
     def agree_on_cancellations(self) -> None:
         """Agree between all ranks about which tasks to cancel."""
@@ -465,6 +541,11 @@ class BatchGenerator(InferenceGenerator):
                 continue
             if task_id in self._all_tasks:
                 self._maybe_cancel.append(self._all_tasks[task_id])
+                record_runner_phase(
+                    "cancel_requested",
+                    event="batch_cancel_pipe_observed",
+                    task_id=task_id,
+                )
 
         if mx_any(has_cancel_all, self.group):
             self._cancelled_tasks.add(CANCEL_ALL_TASKS)
@@ -472,6 +553,12 @@ class BatchGenerator(InferenceGenerator):
         agreed, different = mx_all_gather_tasks(self._maybe_cancel, self.group)
         self._cancelled_tasks.update(task.task_id for task in agreed)
         self._maybe_cancel = list(different)
+        if agreed:
+            record_runner_phase(
+                "cancel_observed",
+                event="batch_cancellations_agreed",
+                attrs={"task_ids": [str(task.task_id) for task in agreed]},
+            )
 
     def step(
         self,
@@ -484,6 +571,16 @@ class BatchGenerator(InferenceGenerator):
         # Submit any queued tasks to the engine
         while self._queue and len(self._active_tasks) < EXO_MAX_CONCURRENT_REQUESTS:
             task = self._queue.popleft()
+            record_runner_phase(
+                "task_submission",
+                event="batch_queue_admitted",
+                task_id=task.task_id,
+                command_id=str(task.command_id),
+                attrs={
+                    "queue_depth": len(self._queue),
+                    "batch_size": len(self._active_tasks) + 1,
+                },
+            )
             record_trace_marker(
                 "admitted_to_batch",
                 self.device_rank,
@@ -564,6 +661,13 @@ class BatchGenerator(InferenceGenerator):
             if task.task_id not in self._first_token_seen:
                 self._first_token_seen.add(task.task_id)
                 self._decode_started_us[task.task_id] = now_us()
+                record_runner_phase(
+                    "decode_stream",
+                    event="batch_first_token",
+                    task_id=task.task_id,
+                    command_id=str(task.command_id),
+                    include_memory=True,
+                )
                 record_trace_marker(
                     "first_token",
                     self.device_rank,
@@ -574,6 +678,13 @@ class BatchGenerator(InferenceGenerator):
             # check if original response was terminal and append a Finished()
             if response.finish_reason is not None:
                 self._record_decode_span(task.task_id)
+                record_runner_phase(
+                    "completion",
+                    event="batch_decode_complete",
+                    task_id=task.task_id,
+                    command_id=str(task.command_id),
+                    include_memory=True,
+                )
                 output.append((task.task_id, Finished()))
                 del self._active_tasks[uid]
 
@@ -595,6 +706,13 @@ class BatchGenerator(InferenceGenerator):
             if task.task_id in self._cancelled_tasks or cancel_all:
                 uids_to_cancel.append(uid)
                 results.append((task.task_id, Cancelled()))
+                record_runner_phase(
+                    "cancel_observed",
+                    event="batch_cancel_applied",
+                    task_id=task.task_id,
+                    command_id=str(task.command_id),
+                    include_memory=True,
+                )
                 self._record_decode_span(task.task_id)
                 del self._active_tasks[uid]
 
@@ -631,7 +749,16 @@ class BatchGenerator(InferenceGenerator):
 
     def _start_task(self, task: TextGeneration) -> int:
         _check_for_debug_prompts(task.task_params)
-        with trace(
+        with runner_phase(
+            "prompt_build",
+            detail="batch_apply_chat_template",
+            task_id=task.task_id,
+            command_id=str(task.command_id),
+            attrs={
+                "image_count": task.task_params.image_count,
+                "input_messages": len(task.task_params.input),
+            },
+        ), trace(
             "prompt_build",
             self.device_rank,
             "prompt",

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -10,6 +10,7 @@ from mlx_lm.tokenizer_utils import TokenizerWrapper
 
 from exo.shared.constants import EXO_MAX_CONCURRENT_REQUESTS
 from exo.shared.models.model_cards import ModelCard
+from exo.shared.tracing import now_us, record_shared_span, record_trace_marker, trace
 from exo.shared.types.chunks import ErrorChunk, PrefillProgressChunk
 from exo.shared.types.common import ModelId
 from exo.shared.types.events import ChunkGenerated, Event
@@ -59,6 +60,21 @@ class GeneratorQueue[T]:
                 yield None
             else:
                 yield self._q.popleft()
+
+
+@dataclass
+class _ActiveSequentialTask:
+    task: TextGeneration
+    mlx_generator: Generator[GenerationResponse]
+    queue: GeneratorQueue[GenerationResponse]
+    output_generator: Generator[GenerationResponse | ToolCallResponse | None]
+
+
+@dataclass
+class _ActiveBatchTask:
+    task: TextGeneration
+    queue: GeneratorQueue[GenerationResponse]
+    output_generator: Generator[GenerationResponse | ToolCallResponse | None]
 
 
 class InferenceGenerator(ABC):
@@ -132,19 +148,10 @@ class SequentialGenerator(InferenceGenerator):
     _maybe_cancel: list[TextGeneration] = field(default_factory=list, init=False)
     _all_tasks: dict[TaskId, TextGeneration] = field(default_factory=dict, init=False)
     _queue: deque[TextGeneration] = field(default_factory=deque, init=False)
-    _active: (
-        tuple[
-            TextGeneration,
-            # mlx generator that does work
-            Generator[GenerationResponse],
-            # queue that the 1st generator should push to and 3rd generator should pull from
-            GeneratorQueue[GenerationResponse],
-            # generator to get parsed outputs
-            Generator[GenerationResponse | ToolCallResponse | None],
-        ]
-        | None
-    ) = field(default=None, init=False)
+    _active: _ActiveSequentialTask | None = field(default=None, init=False)
     _logged_first_request_shape: bool = field(default=False, init=False)
+    _decode_started_us: dict[TaskId, int] = field(default_factory=dict, init=False)
+    _first_token_seen: set[TaskId] = field(default_factory=set, init=False)
 
     def warmup(self):
         self.check_for_cancel_every = warmup_inference(
@@ -201,24 +208,36 @@ class SequentialGenerator(InferenceGenerator):
 
         assert self._active is not None
 
-        task, mlx_gen, queue, output_generator = self._active
+        active = self._active
+        task = active.task
         output: list[
             tuple[TaskId, GenerationResponse | ToolCallResponse | Cancelled | Finished]
         ] = []
         try:
-            response = next(mlx_gen)
-            queue.push(response)
+            response = next(active.mlx_generator)
+            active.queue.push(response)
             # drain potentially many responses every time
-            while (parsed := next(output_generator, None)) is not None:
+            while (parsed := next(active.output_generator, None)) is not None:
                 output.append((task.task_id, parsed))
+            if task.task_id not in self._first_token_seen:
+                self._first_token_seen.add(task.task_id)
+                self._decode_started_us[task.task_id] = now_us()
+                record_trace_marker(
+                    "first_token",
+                    self.device_rank,
+                    category="decode",
+                    task_id=task.task_id,
+                )
 
         except (StopIteration, PrefillCancelled):
+            self._record_decode_span(task.task_id)
             output.append((task.task_id, Finished()))
             self._active = None
             if self._queue:
                 self._start_next()
 
         except Exception as e:
+            self._record_decode_span(task.task_id)
             self._send_error(task, e)
             self._active = None
             raise
@@ -230,6 +249,13 @@ class SequentialGenerator(InferenceGenerator):
 
     def _start_next(self) -> None:
         task = self._queue.popleft()
+        record_trace_marker(
+            "admitted_to_batch",
+            self.device_rank,
+            task_id=task.task_id,
+            category="lifecycle",
+            attrs={"batch_size": 1},
+        )
         try:
             mlx_gen = self._build_generator(task)
         except Exception as e:
@@ -251,10 +277,24 @@ class SequentialGenerator(InferenceGenerator):
                 self.model_id,
                 task.task_params.tools,
                 self.model_card,
+                trace_task_id=task.task_id,
+                trace_rank=self.device_rank,
             )
-        self._active = (task, mlx_gen, queue, output_generator)
+        self._active = _ActiveSequentialTask(
+            task=task,
+            mlx_generator=mlx_gen,
+            queue=queue,
+            output_generator=output_generator,
+        )
 
     def _send_error(self, task: TextGeneration, e: Exception) -> None:
+        record_trace_marker(
+            "error",
+            self.device_rank,
+            task_id=task.task_id,
+            tags=["error"],
+            attrs={"message": str(e)},
+        )
         if self.device_rank == 0:
             self.event_sender.send(
                 ChunkGenerated(
@@ -269,9 +309,15 @@ class SequentialGenerator(InferenceGenerator):
 
     def _build_generator(self, task: TextGeneration) -> Generator[GenerationResponse]:
         _check_for_debug_prompts(task.task_params)
-        prompt = apply_chat_template(
-            self.tokenizer, task.task_params, model_card=self.model_card
-        )
+        with trace(
+            "prompt_build",
+            self.device_rank,
+            "prompt",
+            task_id=task.task_id,
+        ):
+            prompt = apply_chat_template(
+                self.tokenizer, task.task_params, model_card=self.model_card
+            )
         if not self._logged_first_request_shape:
             log_request_shape(
                 "first-live-request",
@@ -330,10 +376,26 @@ class SequentialGenerator(InferenceGenerator):
             on_generation_token=on_generation_token,
             group=self.group,
             vision_processor=self.vision_processor,
+            trace_task_id=task.task_id,
+            trace_rank=self.device_rank,
         )
 
     def close(self) -> None:
         del self.model, self.tokenizer, self.group
+
+    def _record_decode_span(self, task_id: TaskId) -> None:
+        start_us = self._decode_started_us.pop(task_id, None)
+        self._first_token_seen.discard(task_id)
+        if start_us is None:
+            return
+        record_shared_span(
+            [task_id],
+            name="decode",
+            start_us=start_us,
+            duration_us=max(now_us() - start_us, 0),
+            rank=self.device_rank,
+            category="decode",
+        )
 
 
 @dataclass(eq=False)
@@ -357,15 +419,10 @@ class BatchGenerator(InferenceGenerator):
     _all_tasks: dict[TaskId, TextGeneration] = field(default_factory=dict, init=False)
     _queue: deque[TextGeneration] = field(default_factory=deque, init=False)
     _mlx_gen: ExoBatchGenerator = field(init=False)
-    _active_tasks: dict[
-        int,
-        tuple[
-            TextGeneration,
-            GeneratorQueue[GenerationResponse],
-            Generator[GenerationResponse | ToolCallResponse | None],
-        ],
-    ] = field(default_factory=dict, init=False)
+    _active_tasks: dict[int, _ActiveBatchTask] = field(default_factory=dict, init=False)
     _logged_first_request_shape: bool = field(default=False, init=False)
+    _decode_started_us: dict[TaskId, int] = field(default_factory=dict, init=False)
+    _first_token_seen: set[TaskId] = field(default_factory=set, init=False)
 
     def __post_init__(self) -> None:
         self._mlx_gen = ExoBatchGenerator(
@@ -427,6 +484,13 @@ class BatchGenerator(InferenceGenerator):
         # Submit any queued tasks to the engine
         while self._queue and len(self._active_tasks) < EXO_MAX_CONCURRENT_REQUESTS:
             task = self._queue.popleft()
+            record_trace_marker(
+                "admitted_to_batch",
+                self.device_rank,
+                task_id=task.task_id,
+                category="lifecycle",
+                attrs={"batch_size": len(self._active_tasks) + 1},
+            )
             try:
                 uid = self._start_task(task)
             except PrefillCancelled:
@@ -450,13 +514,37 @@ class BatchGenerator(InferenceGenerator):
                     self.model_id,
                     task.task_params.tools,
                     self.model_card,
+                    trace_task_id=task.task_id,
+                    trace_rank=self.device_rank,
                 )
-            self._active_tasks[uid] = (task, queue, output_generator)
+            self._active_tasks[uid] = _ActiveBatchTask(
+                task=task,
+                queue=queue,
+                output_generator=output_generator,
+            )
 
         if not self._mlx_gen.has_work:
             return self._apply_cancellations()
 
+        shared_task_ids = [active.task.task_id for active in self._active_tasks.values()]
+        decode_step_start_us = now_us()
         results = self._mlx_gen.step()
+        decode_step_duration_us = max(now_us() - decode_step_start_us, 0)
+        if shared_task_ids:
+            record_shared_span(
+                shared_task_ids,
+                name="decode_step",
+                start_us=decode_step_start_us,
+                duration_us=decode_step_duration_us,
+                rank=self.device_rank,
+                category="decode",
+                tags=["shared"],
+                attrs={
+                    "shared_span": True,
+                    "batch_size": len(shared_task_ids),
+                    "participant_task_ids": [str(task_id) for task_id in shared_task_ids],
+                },
+            )
 
         output: list[
             tuple[TaskId, GenerationResponse | ToolCallResponse | Cancelled | Finished]
@@ -467,14 +555,25 @@ class BatchGenerator(InferenceGenerator):
                 logger.warning(f"{uid=} not found in active tasks")
                 continue
 
-            task, queue, output_generator = self._active_tasks[uid]
-            queue.push(response)
+            active = self._active_tasks[uid]
+            task = active.task
+            active.queue.push(response)
             # If a generator fails to parse for some reason and returns early, we should not crash
-            while (parsed := next(output_generator, None)) is not None:
+            while (parsed := next(active.output_generator, None)) is not None:
                 output.append((task.task_id, parsed))
+            if task.task_id not in self._first_token_seen:
+                self._first_token_seen.add(task.task_id)
+                self._decode_started_us[task.task_id] = now_us()
+                record_trace_marker(
+                    "first_token",
+                    self.device_rank,
+                    category="decode",
+                    task_id=task.task_id,
+                )
 
             # check if original response was terminal and append a Finished()
             if response.finish_reason is not None:
+                self._record_decode_span(task.task_id)
                 output.append((task.task_id, Finished()))
                 del self._active_tasks[uid]
 
@@ -491,10 +590,12 @@ class BatchGenerator(InferenceGenerator):
         uids_to_cancel: list[int] = []
         results: list[tuple[TaskId, Cancelled]] = []
 
-        for uid, (task, _, _) in list(self._active_tasks.items()):
+        for uid, active in list(self._active_tasks.items()):
+            task = active.task
             if task.task_id in self._cancelled_tasks or cancel_all:
                 uids_to_cancel.append(uid)
                 results.append((task.task_id, Cancelled()))
+                self._record_decode_span(task.task_id)
                 del self._active_tasks[uid]
 
         if uids_to_cancel:
@@ -509,6 +610,13 @@ class BatchGenerator(InferenceGenerator):
         return results
 
     def _send_error(self, task: TextGeneration, e: Exception) -> None:
+        record_trace_marker(
+            "error",
+            self.device_rank,
+            task_id=task.task_id,
+            tags=["error"],
+            attrs={"message": str(e)},
+        )
         if self.device_rank == 0:
             self.event_sender.send(
                 ChunkGenerated(
@@ -523,9 +631,15 @@ class BatchGenerator(InferenceGenerator):
 
     def _start_task(self, task: TextGeneration) -> int:
         _check_for_debug_prompts(task.task_params)
-        prompt = apply_chat_template(
-            self.tokenizer, task.task_params, model_card=self.model_card
-        )
+        with trace(
+            "prompt_build",
+            self.device_rank,
+            "prompt",
+            task_id=task.task_id,
+        ):
+            prompt = apply_chat_template(
+                self.tokenizer, task.task_params, model_card=self.model_card
+            )
         if not self._logged_first_request_shape:
             log_request_shape(
                 "first-live-request",
@@ -574,13 +688,29 @@ class BatchGenerator(InferenceGenerator):
                 self.agree_on_tasks()
 
         return self._mlx_gen.submit(
+            task_id=task.task_id,
             task_params=task.task_params,
             prompt=prompt,
             on_prefill_progress=on_prefill_progress,
             distributed_prompt_progress_callback=distributed_prompt_progress_callback,
             on_generation_token=on_generation_token,
+            trace_rank=self.device_rank,
         )
 
     def close(self) -> None:
         self._mlx_gen.close()
         del self.model, self.tokenizer, self.group
+
+    def _record_decode_span(self, task_id: TaskId) -> None:
+        start_us = self._decode_started_us.pop(task_id, None)
+        self._first_token_seen.discard(task_id)
+        if start_us is None:
+            return
+        record_shared_span(
+            [task_id],
+            name="decode",
+            start_us=start_us,
+            duration_us=max(now_us() - start_us, 0),
+            rank=self.device_rank,
+            category="decode",
+        )

--- a/src/exo/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/exo/worker/runner/llm_inference/model_output_parsers.py
@@ -21,6 +21,7 @@ from exo.shared.models.model_cards import (
     OutputParserType,
     ReasoningFormat,
 )
+from exo.shared.tracing import record_trace_marker
 from exo.shared.types.common import ModelId
 from exo.shared.types.mlx import Model
 from exo.shared.types.worker.runner_response import GenerationResponse, ToolCallResponse
@@ -95,6 +96,8 @@ def apply_all_parsers(
     model_id: ModelId,
     tools: list[dict[str, Any]] | None,
     model_card: ModelCard | None = None,
+    trace_task_id: str | None = None,
+    trace_rank: int = 0,
 ) -> Generator[ParserChunk]:
     mlx_generator = receiver
     mlx_generator = _trace_generation_stream("raw", model_id, mlx_generator)
@@ -129,7 +132,13 @@ def apply_all_parsers(
     ):
         mlx_generator = parse_deepseek_v32(mlx_generator)
     elif tool_parser:
-        mlx_generator = parse_tool_calls(mlx_generator, tool_parser, tools)
+        mlx_generator = parse_tool_calls(
+            mlx_generator,
+            tool_parser,
+            tools,
+            trace_task_id=trace_task_id,
+            trace_rank=trace_rank,
+        )
 
     mlx_generator = _trace_generation_stream("post-all-parsers", model_id, mlx_generator)
     return mlx_generator
@@ -665,6 +674,9 @@ def parse_tool_calls(
     responses: Generator[ParserChunk],
     tool_parser: ToolParser,
     tools: list[dict[str, Any]] | None,
+    *,
+    trace_task_id: str | None = None,
+    trace_rank: int = 0,
 ) -> Generator[ParserChunk]:
     in_tool_call = False
     tool_call_text_parts: list[str] = []
@@ -694,11 +706,29 @@ def parse_tool_calls(
 
             if parsed is None:
                 logger.warning(f"tool call parsing failed for text {combined}")
+                if trace_task_id is not None:
+                    record_trace_marker(
+                        "tool_call_parse_error",
+                        trace_rank,
+                        category="tooling",
+                        task_id=trace_task_id,
+                        tags=["tool_call", "error"],
+                        attrs={"raw_length": len(combined)},
+                    )
                 yield response.model_copy(
                     update={"text": combined, "token": 0, "finish_reason": "error"}
                 )
                 break
 
+            if trace_task_id is not None:
+                record_trace_marker(
+                    "tool_call_parsed",
+                    trace_rank,
+                    category="tooling",
+                    task_id=trace_task_id,
+                    tags=["tool_call"],
+                    attrs={"tool_call_count": len(parsed)},
+                )
             yield ToolCallResponse(
                 tool_calls=parsed, usage=response.usage, stats=response.stats
             )

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -72,6 +72,7 @@ from exo.worker.engines.mlx.utils_mlx import (
 )
 from exo.worker.engines.mlx.vision import VisionProcessor
 from exo.worker.runner.bootstrap import logger
+from exo.worker.runner.diagnostics import record_runner_phase, runner_phase
 from exo.worker.runner.llm_inference.batch_generator import (
     BatchGenerator,
     InferenceGenerator,
@@ -184,6 +185,7 @@ class Runner:
             TaskId,
             TextGeneration,
         ] = {}
+        self._generator_step_count = 0
 
         logger.info("runner created")
         self.update_status(RunnerIdle())
@@ -233,6 +235,14 @@ class Runner:
         )
 
     def acknowledge_task(self, task: Task):
+        command_id = str(task.command_id) if isinstance(task, TextGeneration) else None
+        record_runner_phase(
+            "task_submission",
+            event="task_acknowledged",
+            detail=task.__class__.__name__,
+            task_id=task.task_id,
+            command_id=command_id,
+        )
         self.event_sender.send(TaskAcknowledged(task_id=task.task_id))
 
     def main(self):
@@ -258,7 +268,13 @@ class Runner:
                 self.update_status(RunnerConnecting())
                 self.acknowledge_task(task)
 
-                self.generator.group = initialize_mlx(self.bound_instance)
+                with runner_phase(
+                    "connect_group",
+                    detail="initialize_mlx",
+                    task_id=task.task_id,
+                    include_memory=True,
+                ):
+                    self.generator.group = initialize_mlx(self.bound_instance)
 
                 self.send_task_status(task.task_id, TaskStatus.Complete)
                 self.update_status(RunnerConnected())
@@ -299,18 +315,31 @@ class Runner:
                 assert (
                     ModelTask.TextGeneration in self.shard_metadata.model_card.tasks
                 ), f"Incorrect model task(s): {self.shard_metadata.model_card.tasks}"
-                (
-                    self.generator.inference_model,
-                    self.generator.tokenizer,
-                    self.generator.vision_processor,
-                ) = load_mlx_items(
-                    self.bound_instance,
-                    self.generator.group,
-                    on_timeout=on_model_load_timeout,
-                    on_layer_loaded=on_layer_loaded,
-                )
+                with runner_phase(
+                    "load_model",
+                    detail="load_mlx_items",
+                    task_id=task.task_id,
+                    include_memory=True,
+                ):
+                    (
+                        self.generator.inference_model,
+                        self.generator.tokenizer,
+                        self.generator.vision_processor,
+                    ) = load_mlx_items(
+                        self.bound_instance,
+                        self.generator.group,
+                        on_timeout=on_model_load_timeout,
+                        on_layer_loaded=on_layer_loaded,
+                    )
 
-                self.generator = self.generator.build()
+                    self.generator = self.generator.build()
+                record_runner_phase(
+                    "load_model",
+                    event="loaded",
+                    detail="builder_complete",
+                    task_id=task.task_id,
+                    include_memory=True,
+                )
 
                 self.send_task_status(task.task_id, TaskStatus.Complete)
                 self.update_status(RunnerLoaded())
@@ -339,7 +368,14 @@ class Runner:
                         "or set it to 0 to restore synthetic warmup)"
                     )
                 else:
-                    warmup_generator.warmup()
+                    with runner_phase(
+                        "warmup",
+                        detail="warmup_generator",
+                        task_id=task.task_id,
+                        attrs={"group_size": group_size},
+                        include_memory=True,
+                    ):
+                        warmup_generator.warmup()
 
                 logger.info(
                     f"runner initialized in {time.time() - self.setup_start_time} seconds"
@@ -347,6 +383,12 @@ class Runner:
 
                 self.send_task_status(task.task_id, TaskStatus.Complete)
                 self.update_status(RunnerReady())
+                record_runner_phase(
+                    "idle",
+                    event="runner_ready",
+                    task_id=task.task_id,
+                    include_memory=True,
+                )
                 logger.info(f"runner ready ({self._lifecycle_context()})")
 
             case TextGeneration() if isinstance(self.current_status, RunnerReady):
@@ -365,19 +407,48 @@ class Runner:
 
     def shutdown(self, task: Task):
         logger.info("runner shutting down")
+        record_runner_phase(
+            "shutdown_cleanup",
+            event="runner_shutdown_requested",
+            task_id=task.task_id,
+            include_memory=True,
+        )
         self.update_status(RunnerShuttingDown())
         self.acknowledge_task(task)
         if isinstance(self.generator, InferenceGenerator):
             self.generator.close()
+        record_runner_phase(
+            "shutdown_cleanup",
+            event="clear_cache_begin",
+            task_id=task.task_id,
+            include_memory=True,
+        )
         mx.clear_cache()
         import gc
 
         gc.collect()
+        record_runner_phase(
+            "shutdown_cleanup",
+            event="clear_cache_complete",
+            task_id=task.task_id,
+            include_memory=True,
+        )
         self.send_task_status(task.task_id, TaskStatus.Complete)
         self.update_status(RunnerShutdown())
 
     def submit_text_generation(self, task: TextGeneration):
         assert isinstance(self.generator, InferenceGenerator)
+        record_runner_phase(
+            "task_submission",
+            event="submit_text_generation",
+            detail=self._summarize_text_generation_task(task),
+            task_id=task.task_id,
+            command_id=str(task.command_id),
+            attrs={
+                "images": len(task.task_params.images),
+                "cached_image_indices": sorted(task.task_params.image_hashes.keys()),
+            },
+        )
         if task.trace_enabled:
             begin_trace_session(
                 task.task_id,
@@ -431,7 +502,29 @@ class Runner:
         self.submit_text_generation(starting_task)
 
         while self.active_tasks:
+            self._generator_step_count += 1
+            active_ids = [str(task_id) for task_id in self.active_tasks]
+            if self._generator_step_count == 1 or self._generator_step_count % 25 == 0:
+                record_runner_phase(
+                    "decode_stream",
+                    event="generator_step_enter",
+                    attrs={
+                        "active_task_ids": active_ids,
+                        "active_task_count": len(active_ids),
+                        "step_count": self._generator_step_count,
+                    },
+                )
             results = self.generator.step()
+            if self._generator_step_count == 1 or self._generator_step_count % 25 == 0:
+                record_runner_phase(
+                    "decode_stream",
+                    event="generator_step_exit",
+                    attrs={
+                        "active_task_ids": active_ids,
+                        "active_task_count": len(active_ids),
+                        "step_count": self._generator_step_count,
+                    },
+                )
 
             finished: list[TaskId] = []
             for task_id, result in results:
@@ -442,6 +535,13 @@ class Runner:
                             record_trace_marker(
                                 "cancel", self.device_rank, task_id=task_id
                             )
+                        record_runner_phase(
+                            "cancel_observed",
+                            event="cancelled_result",
+                            task_id=task_id,
+                            command_id=str(task.command_id) if task is not None else None,
+                            include_memory=True,
+                        )
                         self.send_task_status(task_id, TaskStatus.Cancelled)
                         finished.append(task_id)
                     case Finished():
@@ -450,6 +550,13 @@ class Runner:
                             record_trace_marker(
                                 "finish", self.device_rank, task_id=task_id
                             )
+                        record_runner_phase(
+                            "completion",
+                            event="finished_result",
+                            task_id=task_id,
+                            command_id=str(task.command_id) if task is not None else None,
+                            include_memory=True,
+                        )
                         self.send_task_status(task_id, TaskStatus.Complete)
                         finished.append(task_id)
                     case _:
@@ -487,6 +594,7 @@ class Runner:
                 pass
 
         self.update_status(RunnerReady())
+        record_runner_phase("idle", event="runner_ready", include_memory=True)
         logger.info("runner ready")
 
         return ExitCode.AllTasksComplete

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -14,18 +14,25 @@ from exo.shared.models.model_cards import (
     PromptRendererType,
     ToolCallFormat,
 )
+from exo.shared.tracing import (
+    begin_trace_session,
+    pop_trace_session,
+    record_trace_marker,
+)
 from exo.shared.types.chunks import (
     ErrorChunk,
     TokenChunk,
     ToolCallChunk,
 )
-from exo.shared.types.common import CommandId, ModelId
+from exo.shared.types.common import ModelId
 from exo.shared.types.events import (
     ChunkGenerated,
     Event,
     RunnerStatusUpdated,
     TaskAcknowledged,
     TaskStatusUpdated,
+    TraceEventData,
+    TracesCollected,
 )
 from exo.shared.types.mlx import Model
 from exo.shared.types.tasks import (
@@ -355,8 +362,42 @@ class Runner:
 
     def submit_text_generation(self, task: TextGeneration):
         assert isinstance(self.generator, InferenceGenerator)
+        if task.trace_enabled:
+            begin_trace_session(
+                task.task_id,
+                rank=self.device_rank,
+                node_id=str(self.bound_instance.bound_node_id),
+                model_id=str(self.model_id),
+                task_kind="text",
+                tags=["text_generation"],
+            )
+            record_trace_marker("queued", self.device_rank, task_id=task.task_id)
         self.active_tasks[task.task_id] = task
         self.generator.submit(task)
+
+    def _flush_trace_session(self, task_id: TaskId) -> None:
+        traces = pop_trace_session(task_id)
+        self.event_sender.send(
+            TracesCollected(
+                task_id=task_id,
+                rank=self.device_rank,
+                traces=[
+                    TraceEventData(
+                        name=trace_event.name,
+                        start_us=trace_event.start_us,
+                        duration_us=trace_event.duration_us,
+                        rank=trace_event.rank,
+                        category=trace_event.category,
+                        node_id=trace_event.node_id,
+                        model_id=trace_event.model_id,
+                        task_kind=trace_event.task_kind,
+                        tags=list(trace_event.tags),
+                        attrs=trace_event.attrs,
+                    )
+                    for trace_event in traces
+                ],
+            )
+        )
 
     def handle_generation_tasks(self, starting_task: TextGeneration):
         assert isinstance(self.current_status, RunnerReady)
@@ -380,16 +421,29 @@ class Runner:
             for task_id, result in results:
                 match result:
                     case Cancelled():
+                        task = self.active_tasks.get(task_id)
+                        if task is not None and task.trace_enabled:
+                            record_trace_marker(
+                                "cancel", self.device_rank, task_id=task_id
+                            )
                         finished.append(task_id)
                     case Finished():
+                        task = self.active_tasks.get(task_id)
+                        if task is not None and task.trace_enabled:
+                            record_trace_marker(
+                                "finish", self.device_rank, task_id=task_id
+                            )
                         self.send_task_status(task_id, TaskStatus.Complete)
                         finished.append(task_id)
                     case _:
                         self.send_response(
-                            result, self.active_tasks[task_id].command_id
+                            result, self.active_tasks[task_id]
                         )
 
             for task_id in finished:
+                task = self.active_tasks.get(task_id)
+                if task is not None and task.trace_enabled:
+                    self._flush_trace_session(task_id)
                 self.active_tasks.pop(task_id, None)
 
             try:
@@ -423,14 +477,22 @@ class Runner:
     def send_response(
         self,
         response: GenerationResponse | ToolCallResponse,
-        command_id: CommandId,
+        task: TextGeneration,
     ):
         match response:
             case GenerationResponse():
+                if response.finish_reason == "error" and task.trace_enabled:
+                    record_trace_marker(
+                        "error",
+                        self.device_rank,
+                        task_id=task.task_id,
+                        tags=["error"],
+                        attrs={"message": response.text},
+                    )
                 if self.device_rank == 0 and response.finish_reason == "error":
                     self.event_sender.send(
                         ChunkGenerated(
-                            command_id=command_id,
+                            command_id=task.command_id,
                             chunk=ErrorChunk(
                                 error_message=response.text,
                                 model=self.model_id,
@@ -446,7 +508,7 @@ class Runner:
                     )
                     self.event_sender.send(
                         ChunkGenerated(
-                            command_id=command_id,
+                            command_id=task.command_id,
                             chunk=TokenChunk(
                                 model=self.model_id,
                                 text=response.text,
@@ -461,10 +523,19 @@ class Runner:
                         )
                     )
             case ToolCallResponse():
+                if task.trace_enabled:
+                    record_trace_marker(
+                        "tool_call_emitted",
+                        self.device_rank,
+                        task_id=task.task_id,
+                        category="tooling",
+                        tags=["tool_call"],
+                        attrs={"tool_call_count": len(response.tool_calls)},
+                    )
                 if self.device_rank == 0:
                     self.event_sender.send(
                         ChunkGenerated(
-                            command_id=command_id,
+                            command_id=task.command_id,
                             chunk=ToolCallChunk(
                                 tool_calls=response.tool_calls,
                                 model=self.model_id,

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -442,6 +442,7 @@ class Runner:
                             record_trace_marker(
                                 "cancel", self.device_rank, task_id=task_id
                             )
+                        self.send_task_status(task_id, TaskStatus.Cancelled)
                         finished.append(task_id)
                     case Finished():
                         task = self.active_tasks.get(task_id)

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -82,13 +82,25 @@ from .batch_generator import Cancelled, Finished
 from .tool_parsers import make_mlx_parser
 
 
-def _should_skip_llm_warmup(group_size: int) -> bool:
+def _should_skip_llm_warmup(
+    group_size: int,
+    model_id: ModelId,
+    model_card: ModelCard | None,
+) -> bool:
     """Return whether the synthetic warmup request should be bypassed.
 
-    Distributed warmup uses barriers and collectives, so skipping it on only
-    one rank can strand peers inside warmup coordination. The debug bypass is
-    therefore limited to single-node groups.
+    Gemma 4 distributed warmup has proven less reliable than the actual request
+    path in MLX/VLM pipeline mode. Bypass only that known-problem family by
+    default; the env escape hatch remains constrained to single-node runs so a
+    partially configured cluster cannot strand peers in warmup collectives.
     """
+    if group_size > 1 and _is_gemma4_model(model_id, model_card):
+        logger.warning(
+            "Skipping distributed Gemma 4 synthetic warmup; marking runner ready "
+            f"(model_id={model_id}, group_size={group_size})"
+        )
+        return True
+
     # Temporary escape hatch for debug sessions where we want runners to reach
     # Ready without issuing the synthetic warmup request. Normal behavior keeps
     # warmup enabled unless SKULK_SKIP_LLM_WARMUP=1 is set explicitly.
@@ -316,7 +328,11 @@ class Runner:
                 group_size = (
                     warmup_generator.group.size() if warmup_generator.group else 1
                 )
-                if _should_skip_llm_warmup(group_size):
+                if _should_skip_llm_warmup(
+                    group_size,
+                    self.model_id,
+                    self.shard_metadata.model_card,
+                ):
                     logger.warning(
                         "Skipping LLM warmup and marking runner ready "
                         "(temporary debug bypass; unset SKULK_SKIP_LLM_WARMUP "

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import time
 from dataclasses import dataclass
@@ -486,6 +487,30 @@ class Runner:
             )
         )
 
+    def _flush_unfinished_trace_sessions(self) -> None:
+        """Best-effort flush of any active traced tasks still in flight.
+
+        Runs on the exception/abort path of ``handle_generation_tasks``. Without
+        it, a raised ``generator.step()`` (parsing exception, model error,
+        Shutdown received mid-flight) would leave ``_trace_sessions`` entries
+        behind on the runner *and* cause the master to wait forever for
+        ``TracesCollected`` from this rank — leaking the cluster trace into
+        ``_pending_traces`` permanently. The aborted marker tells the
+        downstream merge that this rank's trace is not a clean completion.
+        """
+        for task_id, task in list(self.active_tasks.items()):
+            if not task.trace_enabled:
+                continue
+            with contextlib.suppress(Exception):
+                record_trace_marker(
+                    "aborted",
+                    self.device_rank,
+                    task_id=task_id,
+                    tags=["error", "trace_abort"],
+                )
+            with contextlib.suppress(Exception):
+                self._flush_trace_session(task_id)
+
     def handle_generation_tasks(self, starting_task: TextGeneration):
         assert isinstance(self.current_status, RunnerReady)
         assert isinstance(self.generator, InferenceGenerator)
@@ -501,6 +526,20 @@ class Runner:
 
         self.submit_text_generation(starting_task)
 
+        try:
+            return self._run_generation_loop()
+        finally:
+            # Flush traces on every exit path including exceptions —
+            # without this the master's _pending_traces leaks forever for
+            # any task that was traced when step() raised.
+            self._flush_unfinished_trace_sessions()
+
+    def _run_generation_loop(self) -> "ExitCode":
+        # Re-assert here so type narrowing flows into the loop body — the
+        # caller already asserts these but pyright narrowing doesn't
+        # transit a method-call boundary.
+        assert isinstance(self.current_status, RunnerRunning)
+        assert isinstance(self.generator, InferenceGenerator)
         while self.active_tasks:
             self._generator_step_count += 1
             active_ids = [str(task_id) for task_id in self.active_tasks]

--- a/src/exo/worker/runner/runner_supervisor.py
+++ b/src/exo/worker/runner/runner_supervisor.py
@@ -17,7 +17,12 @@ from loguru import logger
 
 from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.diagnostics import (
+    MlxMemorySnapshot,
+    RunnerDiagnosticContext,
+    RunnerDiagnosticUpdate,
+    RunnerFlightRecorderEntry,
     RunnerLifecycleMilestone,
+    RunnerPhaseName,
     RunnerSupervisorDiagnostics,
     RunnerTaskDiagnostics,
 )
@@ -97,6 +102,7 @@ class RunnerSupervisor:
     runner_process: mp.Process
     initialize_timeout: float
     _ev_recv: MpReceiver[Event]
+    _diag_recv: MpReceiver[RunnerDiagnosticUpdate]
     _task_sender: MpSender[Task]
     _event_sender: Sender[Event]
     _cancel_sender: MpSender[TaskId]
@@ -117,6 +123,17 @@ class RunnerSupervisor:
     _milestones: deque[RunnerLifecycleMilestone] = field(
         default_factory=lambda: deque(maxlen=32), init=False
     )
+    _phase: RunnerPhaseName = field(default="created", init=False)
+    _phase_started_at: str = field(default_factory=_now_utc_iso, init=False)
+    _phase_started_monotonic: float = field(default_factory=time.monotonic, init=False)
+    _last_progress_at: str | None = field(default=None, init=False)
+    _active_task_id: str | None = field(default=None, init=False)
+    _active_command_id: str | None = field(default=None, init=False)
+    _phase_detail: str | None = field(default=None, init=False)
+    _last_mlx_memory: MlxMemorySnapshot | None = field(default=None, init=False)
+    _flight_recorder: deque[RunnerFlightRecorderEntry] = field(
+        default_factory=lambda: deque(maxlen=128), init=False
+    )
 
     def __post_init__(self) -> None:
         """Seed the lifecycle buffer with runner-supervisor construction."""
@@ -132,6 +149,7 @@ class RunnerSupervisor:
         initialize_timeout: float = 400,
     ) -> Self:
         ev_send, ev_recv = mp_channel[Event]()
+        diag_send, diag_recv = mp_channel[RunnerDiagnosticUpdate](max_buffer_size=256)
         task_sender, task_recv = mp_channel[Task]()
         cancel_sender, cancel_recv = mp_channel[TaskId]()
 
@@ -140,6 +158,7 @@ class RunnerSupervisor:
             args=(
                 bound_instance,
                 ev_send,
+                diag_send,
                 task_recv,
                 cancel_recv,
                 logger,
@@ -155,6 +174,7 @@ class RunnerSupervisor:
             runner_process=runner_process,
             initialize_timeout=initialize_timeout,
             _ev_recv=ev_recv,
+            _diag_recv=diag_recv,
             _task_sender=task_sender,
             _cancel_sender=cancel_sender,
             _event_sender=event_sender,
@@ -173,12 +193,15 @@ class RunnerSupervisor:
             async with self._tg as tg:
                 tg.start_soon(self._watch_runner)
                 tg.start_soon(self._forward_events)
+                tg.start_soon(self._forward_diagnostics)
         finally:
             logger.info("Runner supervisor shutting down")
             if not self._cancel_watch_runner.cancel_called:
                 self._cancel_watch_runner.cancel()
             with contextlib.suppress(ClosedResourceError):
                 self._ev_recv.close()
+            with contextlib.suppress(ClosedResourceError):
+                self._diag_recv.close()
             with contextlib.suppress(ClosedResourceError):
                 self._task_sender.close()
             with contextlib.suppress(ClosedResourceError):
@@ -249,6 +272,12 @@ class RunnerSupervisor:
             return
         self.cancelled.add(task_id)
         self._record_milestone("cancel_requested", str(task_id))
+        self._record_supervisor_phase(
+            "cancel_requested",
+            event="supervisor_cancel_requested",
+            detail=str(task_id),
+            task_id=str(task_id),
+        )
         with anyio.move_on_after(0.5) as scope:
             try:
                 await self._cancel_sender.send_async(task_id)
@@ -326,6 +355,16 @@ class RunnerSupervisor:
             for tid in self.pending:
                 self.pending[tid].set()
 
+    async def _forward_diagnostics(self) -> None:
+        """Consume local-only runner diagnostic updates without forwarding them."""
+
+        try:
+            with self._diag_recv as diagnostics:
+                async for update in diagnostics:
+                    self._apply_diagnostic_update(update)
+        except (ClosedResourceError, BrokenResourceError):
+            return
+
     async def _watch_runner(self) -> None:
         with self._cancel_watch_runner:
             while True:
@@ -397,6 +436,77 @@ class RunnerSupervisor:
             RunnerLifecycleMilestone(at=_now_utc_iso(), name=name, detail=detail)
         )
 
+    def _diagnostic_context(self) -> RunnerDiagnosticContext:
+        """Build the stable runner context used by supervisor-authored entries."""
+
+        return RunnerDiagnosticContext(
+            node_id=str(self.bound_instance.bound_node_id),
+            runner_id=str(self.bound_instance.bound_runner_id),
+            pid=self.runner_process.pid,
+            instance_id=str(self.bound_instance.instance.instance_id),
+            model_id=str(self.shard_metadata.model_card.model_id),
+            rank=self.shard_metadata.device_rank,
+            world_size=self.shard_metadata.world_size,
+            start_layer=self.shard_metadata.start_layer,
+            end_layer=self.shard_metadata.end_layer,
+            n_layers=self.shard_metadata.n_layers,
+        )
+
+    def _record_supervisor_phase(
+        self,
+        phase: RunnerPhaseName,
+        *,
+        event: str,
+        detail: str | None = None,
+        task_id: str | None = None,
+        command_id: str | None = None,
+    ) -> None:
+        """Record a supervisor-authored phase entry when runner IPC cannot help."""
+
+        update = RunnerDiagnosticUpdate(
+            at=_now_utc_iso(),
+            phase=phase,
+            event=event,
+            detail=detail,
+            context=self._diagnostic_context(),
+            task_id=task_id,
+            command_id=command_id,
+        )
+        self._apply_diagnostic_update(update)
+
+    def _apply_diagnostic_update(self, update: RunnerDiagnosticUpdate) -> None:
+        """Update live supervisor diagnostics from one runner diagnostic event."""
+
+        if update.phase != self._phase:
+            self._phase = update.phase
+            self._phase_started_at = update.at
+            self._phase_started_monotonic = time.monotonic()
+        self._last_progress_at = update.at
+        if update.task_id is not None:
+            self._active_task_id = update.task_id
+        if update.command_id is not None:
+            self._active_command_id = update.command_id
+        self._phase_detail = update.detail
+        if update.mlx_memory is not None:
+            self._last_mlx_memory = update.mlx_memory
+        self._flight_recorder.append(
+            RunnerFlightRecorderEntry(
+                at=update.at,
+                phase=update.phase,
+                event=update.event,
+                detail=update.detail,
+                attrs=update.attrs,
+                context=update.context,
+                task_id=update.task_id,
+                command_id=update.command_id,
+                mlx_memory=update.mlx_memory,
+            )
+        )
+        self._record_milestone(
+            f"phase:{update.phase}",
+            update.detail or update.event,
+        )
+
     def _task_diagnostics(self, task: Task) -> RunnerTaskDiagnostics:
         """Return a compact diagnostics view for a runner task."""
 
@@ -437,6 +547,15 @@ class RunnerSupervisor:
             status_kind=self.status.__class__.__name__,
             status_since=self._status_since,
             seconds_in_status=time.monotonic() - self._status_since_monotonic,
+            phase=self._phase,
+            phase_started_at=self._phase_started_at,
+            seconds_in_phase=time.monotonic() - self._phase_started_monotonic,
+            last_progress_at=self._last_progress_at,
+            active_task_id=self._active_task_id,
+            active_command_id=self._active_command_id,
+            phase_detail=self._phase_detail,
+            last_mlx_memory=self._last_mlx_memory,
+            flight_recorder=list(self._flight_recorder),
             pending_task_ids=[str(task_id) for task_id in self.pending],
             in_progress_tasks=[
                 self._task_diagnostics(task) for task in self.in_progress.values()

--- a/src/exo/worker/runner/runner_supervisor.py
+++ b/src/exo/worker/runner/runner_supervisor.py
@@ -1,7 +1,10 @@
 import contextlib
 import multiprocessing as mp
 import signal
+import time
+from collections import deque
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Self
 
 import anyio
@@ -13,6 +16,11 @@ from anyio import (
 from loguru import logger
 
 from exo.shared.types.chunks import ErrorChunk
+from exo.shared.types.diagnostics import (
+    RunnerLifecycleMilestone,
+    RunnerSupervisorDiagnostics,
+    RunnerTaskDiagnostics,
+)
 from exo.shared.types.events import (
     ChunkGenerated,
     Event,
@@ -27,6 +35,7 @@ from exo.shared.types.tasks import (
     Task,
     TaskId,
     TaskStatus,
+    TextEmbedding,
     TextGeneration,
 )
 from exo.shared.types.worker.instances import BoundInstance
@@ -47,6 +56,12 @@ from exo.worker.runner.bootstrap import entrypoint
 
 PREFILL_TIMEOUT_SECONDS = 60
 DECODE_TIMEOUT_SECONDS = 5
+
+
+def _now_utc_iso() -> str:
+    """Return a compact UTC timestamp for live runner diagnostics."""
+
+    return datetime.now(tz=timezone.utc).isoformat()
 
 
 def _summarize_task(task: Task) -> str:
@@ -87,6 +102,19 @@ class RunnerSupervisor:
     _cancel_watch_runner: anyio.CancelScope = field(
         default_factory=anyio.CancelScope, init=False
     )
+    _status_since: str = field(default_factory=_now_utc_iso, init=False)
+    _status_since_monotonic: float = field(default_factory=time.monotonic, init=False)
+    _last_task_sent_at: str | None = field(default=None, init=False)
+    _last_event_received_at: str | None = field(default=None, init=False)
+    _last_event_type: str | None = field(default=None, init=False)
+    _milestones: deque[RunnerLifecycleMilestone] = field(
+        default_factory=lambda: deque(maxlen=32), init=False
+    )
+
+    def __post_init__(self) -> None:
+        """Seed the lifecycle buffer with runner-supervisor construction."""
+
+        self._record_milestone("supervisor_created", self.status.__class__.__name__)
 
     @classmethod
     def create(
@@ -128,7 +156,12 @@ class RunnerSupervisor:
         return self
 
     async def run(self):
+        self._record_milestone("process_start_requested")
         self.runner_process.start()
+        self._record_milestone(
+            "process_started",
+            f"pid={self.runner_process.pid}",
+        )
         try:
             async with self._tg as tg:
                 tg.start_soon(self._watch_runner)
@@ -167,6 +200,7 @@ class RunnerSupervisor:
             self.runner_process.close()
 
     def shutdown(self):
+        self._record_milestone("shutdown_requested")
         self._tg.cancel_tasks()
 
     async def start_task(self, task: Task):
@@ -184,11 +218,20 @@ class RunnerSupervisor:
         event = anyio.Event()
         self.pending[task.task_id] = event
         self.in_progress[task.task_id] = task
+        self._last_task_sent_at = _now_utc_iso()
+        self._record_milestone(
+            "task_sent",
+            f"{task.__class__.__name__}:{task.task_id}",
+        )
         try:
             await self._task_sender.send_async(task)
         except ClosedResourceError:
             self.in_progress.pop(task.task_id, None)
             logger.warning(f"Task {task} dropped, runner closed communication.")
+            self._record_milestone(
+                "task_send_failed",
+                f"{task.__class__.__name__}:{task.task_id}",
+            )
             return
         await event.wait()
 
@@ -198,6 +241,7 @@ class RunnerSupervisor:
             self.cancelled.add(task_id)
             return
         self.cancelled.add(task_id)
+        self._record_milestone("cancel_requested", str(task_id))
         with anyio.move_on_after(0.5) as scope:
             try:
                 await self._cancel_sender.send_async(task_id)
@@ -214,10 +258,20 @@ class RunnerSupervisor:
         try:
             with self._ev_recv as events:
                 async for event in events:
+                    self._last_event_received_at = _now_utc_iso()
+                    self._last_event_type = event.__class__.__name__
+                    self._record_milestone("event_received", self._last_event_type)
                     if isinstance(event, RunnerStatusUpdated):
                         self.status = event.runner_status
+                        self._status_since = _now_utc_iso()
+                        self._status_since_monotonic = time.monotonic()
+                        self._record_milestone(
+                            "status_changed",
+                            event.runner_status.__class__.__name__,
+                        )
                     if isinstance(event, TaskAcknowledged):
                         self.pending.pop(event.task_id).set()
+                        self._record_milestone("task_acknowledged", str(event.task_id))
                         continue
                     if (
                         isinstance(event, TaskStatusUpdated)
@@ -236,6 +290,7 @@ class RunnerSupervisor:
                         )
                         self.in_progress.pop(event.task_id, None)
                         self.completed.add(event.task_id)
+                        self._record_milestone("task_completed", str(event.task_id))
                     await self._event_sender.send(event)
         except (ClosedResourceError, BrokenResourceError) as e:
             await self._check_runner(e)
@@ -251,6 +306,7 @@ class RunnerSupervisor:
                     await self._check_runner(RuntimeError("Runner found to be dead"))
 
     async def _check_runner(self, e: Exception) -> None:
+        self._record_milestone("runner_check", e.__class__.__name__)
         if not self._cancel_watch_runner.cancel_called:
             self._cancel_watch_runner.cancel()
         logger.info("Checking runner's status")
@@ -305,3 +361,62 @@ class RunnerSupervisor:
                 "Event sender already closed, unable to report runner failure"
             )
         self.shutdown()
+
+    def _record_milestone(self, name: str, detail: str | None = None) -> None:
+        """Append a bounded live milestone for diagnostics."""
+
+        self._milestones.append(
+            RunnerLifecycleMilestone(at=_now_utc_iso(), name=name, detail=detail)
+        )
+
+    def _task_diagnostics(self, task: Task) -> RunnerTaskDiagnostics:
+        """Return a compact diagnostics view for a runner task."""
+
+        command_id: str | None = None
+        model_id = str(self.shard_metadata.model_card.model_id)
+        if isinstance(
+            task,
+            (TextGeneration, ImageGeneration, ImageEdits, TextEmbedding),
+        ):
+            command_id = str(task.command_id)
+            model_id = str(task.task_params.model)
+        return RunnerTaskDiagnostics(
+            task_id=str(task.task_id),
+            task_kind=task.__class__.__name__,
+            task_status=str(task.task_status.value),
+            instance_id=str(task.instance_id),
+            command_id=command_id,
+            runner_id=str(self.bound_instance.bound_runner_id),
+            model_id=model_id,
+        )
+
+    def diagnostics(self) -> RunnerSupervisorDiagnostics:
+        """Return live read-only diagnostics for this runner supervisor."""
+
+        return RunnerSupervisorDiagnostics(
+            runner_id=str(self.bound_instance.bound_runner_id),
+            instance_id=str(self.bound_instance.instance.instance_id),
+            node_id=str(self.bound_instance.bound_node_id),
+            model_id=str(self.shard_metadata.model_card.model_id),
+            device_rank=self.shard_metadata.device_rank,
+            world_size=self.shard_metadata.world_size,
+            start_layer=self.shard_metadata.start_layer,
+            end_layer=self.shard_metadata.end_layer,
+            n_layers=self.shard_metadata.n_layers,
+            pid=self.runner_process.pid,
+            process_alive=self.runner_process.is_alive(),
+            exit_code=self.runner_process.exitcode,
+            status_kind=self.status.__class__.__name__,
+            status_since=self._status_since,
+            seconds_in_status=time.monotonic() - self._status_since_monotonic,
+            pending_task_ids=[str(task_id) for task_id in self.pending],
+            in_progress_tasks=[
+                self._task_diagnostics(task) for task in self.in_progress.values()
+            ],
+            completed_task_count=len(self.completed),
+            cancelled_task_ids=[str(task_id) for task_id in self.cancelled],
+            last_task_sent_at=self._last_task_sent_at,
+            last_event_received_at=self._last_event_received_at,
+            last_event_type=self._last_event_type,
+            milestones=list(self._milestones),
+        )

--- a/src/exo/worker/runner/runner_supervisor.py
+++ b/src/exo/worker/runner/runner_supervisor.py
@@ -26,6 +26,7 @@ from exo.shared.types.events import (
     Event,
     RunnerStatusUpdated,
     TaskAcknowledged,
+    TaskDeleted,
     TaskStatusUpdated,
 )
 from exo.shared.types.tasks import (
@@ -56,6 +57,12 @@ from exo.worker.runner.bootstrap import entrypoint
 
 PREFILL_TIMEOUT_SECONDS = 60
 DECODE_TIMEOUT_SECONDS = 5
+_TERMINAL_TASK_STATUSES = {
+    TaskStatus.Cancelled,
+    TaskStatus.Complete,
+    TaskStatus.Failed,
+    TaskStatus.TimedOut,
+}
 
 
 def _now_utc_iso() -> str:
@@ -270,12 +277,14 @@ class RunnerSupervisor:
                             event.runner_status.__class__.__name__,
                         )
                     if isinstance(event, TaskAcknowledged):
-                        self.pending.pop(event.task_id).set()
+                        pending = self.pending.pop(event.task_id, None)
+                        if pending is not None:
+                            pending.set()
                         self._record_milestone("task_acknowledged", str(event.task_id))
                         continue
                     if (
                         isinstance(event, TaskStatusUpdated)
-                        and event.task_status == TaskStatus.Complete
+                        and event.task_status in _TERMINAL_TASK_STATUSES
                     ):
                         # If a task has just been completed, we should be working on it.
                         assert isinstance(
@@ -289,8 +298,27 @@ class RunnerSupervisor:
                             ),
                         )
                         self.in_progress.pop(event.task_id, None)
-                        self.completed.add(event.task_id)
-                        self._record_milestone("task_completed", str(event.task_id))
+                        if event.task_status == TaskStatus.Complete:
+                            self.completed.add(event.task_id)
+                            self._record_milestone("task_completed", str(event.task_id))
+                        elif event.task_status == TaskStatus.Cancelled:
+                            self.cancelled.add(event.task_id)
+                            self._record_milestone("task_cancelled", str(event.task_id))
+                        else:
+                            self._record_milestone(
+                                "task_terminal",
+                                f"{event.task_status.value}:{event.task_id}",
+                            )
+                        await self._event_sender.send(event)
+                        if event.task_status == TaskStatus.Cancelled:
+                            # Cancelled tasks need an explicit event-sourced delete
+                            # because local API cleanup suppresses TaskFinished
+                            # until the runner has acknowledged cancellation.
+                            self._record_milestone("task_deleted", str(event.task_id))
+                            await self._event_sender.send(
+                                TaskDeleted(task_id=event.task_id)
+                            )
+                        continue
                     await self._event_sender.send(event)
         except (ClosedResourceError, BrokenResourceError) as e:
             await self._check_runner(e)

--- a/src/exo/worker/tests/unittests/test_mlx/test_gemma4_prompt.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_gemma4_prompt.py
@@ -47,3 +47,20 @@ def test_render_gemma4_prompt_keeps_think_marker_when_thinking_enabled():
 
     assert prompt.startswith("<bos><|turn>system\n<|think|><turn|>\n")
     assert prompt.endswith("<|turn>model\n")
+
+
+def test_render_gemma4_prompt_includes_optional_image_labels():
+    prompt = render_gemma4_prompt(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "compare"},
+                    {"type": "image", "label": "Image 1"},
+                ],
+            }
+        ],
+        add_generation_prompt=False,
+    )
+
+    assert "compare\n\nImage 1:\n<|image|>\n\n" in prompt

--- a/src/exo/worker/tests/unittests/test_mlx/test_gemma4_prompt.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_gemma4_prompt.py
@@ -1,3 +1,8 @@
+from typing import cast
+
+from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+from exo.worker.engines.mlx import vision as vision_module
 from exo.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
 
 
@@ -64,3 +69,36 @@ def test_render_gemma4_prompt_includes_optional_image_labels():
     )
 
     assert "compare\nImage 1:\n<|image|>" in prompt
+
+
+class _GemmaPromptTokenizer:
+    def decode(self, _token_ids: list[int]) -> str:
+        raise AssertionError("Gemma 4 prompt debug test should not decode BOI/EOI")
+
+
+def test_build_vision_prompt_debug_records_raw_placeholder_offsets():
+    built = vision_module._build_vision_prompt_with_debug(  # pyright: ignore[reportPrivateUsage]
+        cast(TokenizerWrapper, cast(object, _GemmaPromptTokenizer())),
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "before"},
+                    {"type": "image"},
+                    {"type": "text", "text": "after"},
+                ],
+            }
+        ],
+        [3],
+        "<|image|>",
+        model_type="gemma4",
+    )
+
+    raw_placeholder = built.raw_prompt.index("<|image|>")
+    assert built.raw_prompt.count("<|image|>") == 1
+    assert built.prompt.count("<|image|>") == 3
+    assert built.debug.raw_image_placeholder_positions == [raw_placeholder]
+    assert built.debug.tokens_per_image == [3]
+    assert built.debug.attrs()["raw_image_placeholder_offsets"] == [
+        str(raw_placeholder)
+    ]

--- a/src/exo/worker/tests/unittests/test_mlx/test_gemma4_prompt.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_gemma4_prompt.py
@@ -71,6 +71,35 @@ def test_render_gemma4_prompt_includes_optional_image_labels():
     assert "compare\nImage 1:\n<|image|>" in prompt
 
 
+def test_render_gemma4_prompt_unlabeled_image_matches_reference_shape():
+    """Unlabeled images sit flush against adjacent text — that's the reference.
+
+    The Gemma 4 chat template is trained with no separator between ``<|image|>``
+    and the surrounding text in the unlabeled case (which is the common
+    single-image shape). Earlier review feedback suggested inserting a
+    newline boundary; doing so breaks ``test_multimodal_prompt_matches_reference_shape``
+    because the model was trained on the no-separator form. This test pins
+    that expectation so future "tidy up the rendering" attempts don't
+    silently regress multimodal instruction fidelity.
+    """
+    prompt = render_gemma4_prompt(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "before"},
+                    {"type": "image"},
+                    {"type": "text", "text": "after"},
+                ],
+            }
+        ],
+        add_generation_prompt=False,
+    )
+
+    # Reference shape: ``before<|image|>after`` with no inserted boundary.
+    assert "before<|image|>after" in prompt
+
+
 class _GemmaPromptTokenizer:
     def decode(self, _token_ids: list[int]) -> str:
         raise AssertionError("Gemma 4 prompt debug test should not decode BOI/EOI")

--- a/src/exo/worker/tests/unittests/test_mlx/test_gemma4_prompt.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_gemma4_prompt.py
@@ -45,7 +45,7 @@ def test_render_gemma4_prompt_keeps_think_marker_when_thinking_enabled():
         enable_thinking=True,
     )
 
-    assert prompt.startswith("<bos><|turn>system\n<|think|><turn|>\n")
+    assert prompt.startswith("<bos><|turn>system\n<|think|>\n<turn|>\n")
     assert prompt.endswith("<|turn>model\n")
 
 
@@ -63,4 +63,4 @@ def test_render_gemma4_prompt_includes_optional_image_labels():
         add_generation_prompt=False,
     )
 
-    assert "compare\n\nImage 1:\n<|image|>\n\n" in prompt
+    assert "compare\nImage 1:\n<|image|>" in prompt

--- a/src/exo/worker/tests/unittests/test_mlx/test_generation_limits.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_generation_limits.py
@@ -5,7 +5,7 @@ from exo.worker.engines.mlx.constants import DEFAULT_MAX_OUTPUT_TOKENS, MAX_TOKE
 
 def test_default_max_output_tokens_is_a_conservative_generation_budget() -> None:
     """Default generation budget should not mirror long model context windows."""
-    assert DEFAULT_MAX_OUTPUT_TOKENS == 2048
+    assert DEFAULT_MAX_OUTPUT_TOKENS == 4096
 
     if (
         "SKULK_MAX_OUTPUT_TOKENS" not in os.environ

--- a/src/exo/worker/tests/unittests/test_mlx/test_generation_limits.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_generation_limits.py
@@ -1,0 +1,14 @@
+import os
+
+from exo.worker.engines.mlx.constants import DEFAULT_MAX_OUTPUT_TOKENS, MAX_TOKENS
+
+
+def test_default_max_output_tokens_is_a_conservative_generation_budget() -> None:
+    """Default generation budget should not mirror long model context windows."""
+    assert DEFAULT_MAX_OUTPUT_TOKENS == 2048
+
+    if (
+        "SKULK_MAX_OUTPUT_TOKENS" not in os.environ
+        and "EXO_MAX_TOKENS" not in os.environ
+    ):
+        assert MAX_TOKENS == DEFAULT_MAX_OUTPUT_TOKENS

--- a/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -938,6 +938,130 @@ def test_mlx_generate_reuses_distributed_single_fully_cached_native_image(
     assert model.pixel_values is None
 
 
+def test_mlx_generate_pipeline_decode_starts_from_single_prompt_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pipeline decode should not run an extra decode-mode prompt bridge."""
+
+    class _FakePrefixCache:
+        def get_kv_cache(
+            self,
+            _model: object,
+            _prompt_tokens: object,
+            media_regions: list[MediaRegion] | None = None,
+        ) -> tuple[KVCacheType, mx.array, int]:
+            assert media_regions is not None
+            return cast(KVCacheType, []), mx.array([5, 6, 7, 8]), 0
+
+        def add_kv_cache(self, *args: object, **kwargs: object) -> None:
+            return None
+
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3, 4, 5, 6, 7, 8]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[MediaRegion("first", 1, 4)],
+        pixel_values=mx.array([[10.0]]),
+    )
+
+    def _fake_prepare_vision(**_kwargs: object) -> VisionResult:
+        return vision
+
+    class _FakeModel:
+        def __init__(self) -> None:
+            self.pixel_values: mx.array | None = None
+
+        def set_pixel_values(self, pixel_values: mx.array | None) -> None:
+            self.pixel_values = pixel_values
+
+    def _fake_prefill(
+        model: _FakeModel,
+        _tokenizer: object,
+        _sampler: object,
+        prompt_tokens: mx.array,
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[float, int, list[CacheSnapshot]]:
+        assert model.pixel_values is None
+        assert prompt_tokens.tolist() == [5, 6, 7, 8]
+        return 0.0, len(prompt_tokens), []
+
+    def _fake_pipeline_decode(*_args: object, **kwargs: object):
+        prompt = cast(mx.array, kwargs["prompt"])
+        assert prompt.tolist() == [8]
+        yield GenerationResponse(text="ok", token=101, usage=None)
+
+    def _fail_stream_generate(*_args: object, **_kwargs: object):
+        raise AssertionError("pipeline decode should use the no-lookahead generator")
+
+    def _fake_has_pipeline_layer(_model: Model) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prepare_vision",
+        _fake_prepare_vision,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._should_use_native_vision_reference_path",
+        cast(Callable[[], bool], lambda: False),
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._has_pipeline_communication_layer",
+        _fake_has_pipeline_layer,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prefill",
+        _fake_prefill,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._stream_generate_without_lookahead",
+        _fake_pipeline_decode,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.stream_generate",
+        _fail_stream_generate,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.mx_barrier",
+        _noop_barrier,
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        chat_template_messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "first"},
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "and now?"},
+        ],
+        images=["ignored-a"],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+
+    model = _FakeModel()
+    responses = list(
+        mlx_generate(
+            model=cast(Model, cast(object, model)),
+            tokenizer=_fake_tokenizer(),
+            task=task,
+            prompt="<bos>",
+            kv_prefix_cache=cast(KVPrefixCache, cast(object, _FakePrefixCache())),
+            group=_fake_group(),
+            vision_processor=_fake_vision_processor(),
+        )
+    )
+
+    assert [response.text for response in responses] == ["ok"]
+    assert model.pixel_values is None
+
+
 def test_mlx_generate_full_prefills_distributed_cached_native_image_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -671,10 +671,10 @@ def test_mlx_generate_skips_embedding_patch_when_native_images_are_fully_cached(
     assert model.seen_pixel_values is None
 
 
-def test_mlx_generate_uses_reference_path_for_distributed_fully_cached_native_images(
+def test_mlx_generate_full_prefills_distributed_fully_cached_native_images(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Distributed fully cached native-image follow-ups should avoid the fast path."""
+    """Distributed fully cached native-image follow-ups should skip prefix cache."""
 
     class _FakePrefixCache:
         def get_kv_cache(
@@ -706,11 +706,42 @@ def test_mlx_generate_uses_reference_path_for_distributed_fully_cached_native_im
     def _fake_prepare_vision(**_kwargs: object) -> VisionResult:
         return vision
 
-    def _fake_native_generate(**_kwargs: object):
-        yield GenerationResponse(text="native", token=101, usage=None)
+    class _FakeModel:
+        def __init__(self) -> None:
+            self.pixel_values: list[mx.array] | mx.array | None = None
+            self.seen_pixel_values: list[mx.array] | mx.array | None = None
 
-    def _fail_stream_generate(*_args: object, **_kwargs: object):
-        raise AssertionError("distributed fully-cached follow-ups should use the reference path")
+        def set_pixel_values(self, pixel_values: list[mx.array] | mx.array | None) -> None:
+            self.pixel_values = pixel_values
+            if pixel_values is not None:
+                self.seen_pixel_values = pixel_values
+
+    def _fake_make_kv_cache(**_kwargs: object) -> KVCacheType:
+        return cast(KVCacheType, [])
+
+    def _fake_prefill(
+        model: _FakeModel,
+        _tokenizer: object,
+        _sampler: object,
+        prompt_tokens: mx.array,
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[float, int, list[CacheSnapshot]]:
+        assert isinstance(model.pixel_values, list)
+        assert [pixel_value.tolist() for pixel_value in model.pixel_values] == [
+            [10.0],
+            [20.0],
+        ]
+        assert prompt_tokens.tolist() == [1, 2, 3, 4, 5, 6, 7]
+        return 0.0, len(prompt_tokens), []
+
+    def _fake_stream_generate(*_args: object, **_kwargs: object):
+        yield GenerationResponse(text="ok", token=101, usage=None)
+
+    def _fail_native_generate(**_kwargs: object):
+        raise AssertionError(
+            "distributed fully-cached follow-ups should stay on the pipeline path"
+        )
 
     monkeypatch.setattr(
         "exo.worker.engines.mlx.generator.generate.prepare_vision",
@@ -722,11 +753,19 @@ def test_mlx_generate_uses_reference_path_for_distributed_fully_cached_native_im
     )
     monkeypatch.setattr(
         "exo.worker.engines.mlx.generator.generate._mlx_generate_native_vision",
-        _fake_native_generate,
+        _fail_native_generate,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.make_kv_cache",
+        _fake_make_kv_cache,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prefill",
+        _fake_prefill,
     )
     monkeypatch.setattr(
         "exo.worker.engines.mlx.generator.generate.stream_generate",
-        _fail_stream_generate,
+        _fake_stream_generate,
     )
     monkeypatch.setattr(
         "exo.worker.engines.mlx.generator.generate.mx_barrier",
@@ -758,9 +797,10 @@ def test_mlx_generate_uses_reference_path_for_distributed_fully_cached_native_im
         temperature=0.0,
     )
 
+    model = _FakeModel()
     responses = list(
         mlx_generate(
-            model=_fake_model(),
+            model=cast(Model, cast(object, model)),
             tokenizer=_fake_tokenizer(),
             task=task,
             prompt="<bos>",
@@ -770,13 +810,15 @@ def test_mlx_generate_uses_reference_path_for_distributed_fully_cached_native_im
         )
     )
 
-    assert [response.text for response in responses] == ["native"]
+    assert [response.text for response in responses] == ["ok"]
+    assert model.seen_pixel_values is not None
+    assert model.pixel_values is None
 
 
-def test_mlx_generate_uses_reference_path_for_distributed_cached_native_image_prefix(
+def test_mlx_generate_full_prefills_distributed_cached_native_image_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Distributed native-image follow-ups with new images should avoid the fast path."""
+    """Distributed native-image follow-ups with cached prefixes should re-prefill."""
 
     class _FakePrefixCache:
         def get_kv_cache(
@@ -808,17 +850,41 @@ def test_mlx_generate_uses_reference_path_for_distributed_cached_native_image_pr
     def _fake_prepare_vision(**_kwargs: object) -> VisionResult:
         return vision
 
-    def _fake_native_generate(**_kwargs: object):
-        yield GenerationResponse(text="native", token=101, usage=None)
+    class _FakeModel:
+        def __init__(self) -> None:
+            self.pixel_values: list[mx.array] | mx.array | None = None
+            self.seen_pixel_values: list[mx.array] | mx.array | None = None
 
-    def _fail_prefill(*_args: object, **_kwargs: object):
-        raise AssertionError(
-            "distributed cached-image follow-ups should use the reference path"
-        )
+        def set_pixel_values(self, pixel_values: list[mx.array] | mx.array | None) -> None:
+            self.pixel_values = pixel_values
+            if pixel_values is not None:
+                self.seen_pixel_values = pixel_values
 
-    def _fail_stream_generate(*_args: object, **_kwargs: object):
+    def _fake_make_kv_cache(**_kwargs: object) -> KVCacheType:
+        return cast(KVCacheType, [])
+
+    def _fake_prefill(
+        model: _FakeModel,
+        _tokenizer: object,
+        _sampler: object,
+        prompt_tokens: mx.array,
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[float, int, list[CacheSnapshot]]:
+        assert isinstance(model.pixel_values, list)
+        assert [pixel_value.tolist() for pixel_value in model.pixel_values] == [
+            [10.0],
+            [20.0],
+        ]
+        assert prompt_tokens.tolist() == [1, 2, 3, 4, 5, 6, 7]
+        return 0.0, len(prompt_tokens), []
+
+    def _fake_stream_generate(*_args: object, **_kwargs: object):
+        yield GenerationResponse(text="ok", token=101, usage=None)
+
+    def _fail_native_generate(**_kwargs: object):
         raise AssertionError(
-            "distributed cached-image follow-ups should use the reference path"
+            "distributed cached-image follow-ups should stay on the pipeline path"
         )
 
     monkeypatch.setattr(
@@ -831,15 +897,19 @@ def test_mlx_generate_uses_reference_path_for_distributed_cached_native_image_pr
     )
     monkeypatch.setattr(
         "exo.worker.engines.mlx.generator.generate._mlx_generate_native_vision",
-        _fake_native_generate,
+        _fail_native_generate,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.make_kv_cache",
+        _fake_make_kv_cache,
     )
     monkeypatch.setattr(
         "exo.worker.engines.mlx.generator.generate.prefill",
-        _fail_prefill,
+        _fake_prefill,
     )
     monkeypatch.setattr(
         "exo.worker.engines.mlx.generator.generate.stream_generate",
-        _fail_stream_generate,
+        _fake_stream_generate,
     )
     monkeypatch.setattr(
         "exo.worker.engines.mlx.generator.generate.mx_barrier",
@@ -871,9 +941,10 @@ def test_mlx_generate_uses_reference_path_for_distributed_cached_native_image_pr
         temperature=0.0,
     )
 
+    model = _FakeModel()
     responses = list(
         mlx_generate(
-            model=_fake_model(),
+            model=cast(Model, cast(object, model)),
             tokenizer=_fake_tokenizer(),
             task=task,
             prompt="<bos>",
@@ -883,4 +954,6 @@ def test_mlx_generate_uses_reference_path_for_distributed_cached_native_image_pr
         )
     )
 
-    assert [response.text for response in responses] == ["native"]
+    assert [response.text for response in responses] == ["ok"]
+    assert model.seen_pixel_values is not None
+    assert model.pixel_values is None

--- a/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -815,6 +815,129 @@ def test_mlx_generate_full_prefills_distributed_fully_cached_native_images(
     assert model.pixel_values is None
 
 
+def test_mlx_generate_reuses_distributed_single_fully_cached_native_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-image cached follow-ups should avoid the full-prefill fallback."""
+
+    class _FakePrefixCache:
+        def get_kv_cache(
+            self,
+            _model: object,
+            _prompt_tokens: object,
+            media_regions: list[MediaRegion] | None = None,
+        ) -> tuple[KVCacheType, mx.array, int]:
+            assert media_regions is not None
+            return cast(KVCacheType, []), mx.array([5, 6, 7, 8]), 0
+
+        def add_kv_cache(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def update_kv_cache(self, *args: object, **kwargs: object) -> None:
+            return None
+
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3, 4, 5, 6, 7, 8]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[MediaRegion("first", 1, 4)],
+        pixel_values=mx.array([[10.0]]),
+    )
+
+    def _fake_prepare_vision(**_kwargs: object) -> VisionResult:
+        return vision
+
+    class _FakeModel:
+        def __init__(self) -> None:
+            self.pixel_values: mx.array | None = None
+            self.saw_non_none_pixel_values = False
+
+        def set_pixel_values(self, pixel_values: mx.array | None) -> None:
+            self.pixel_values = pixel_values
+            self.saw_non_none_pixel_values = (
+                self.saw_non_none_pixel_values or pixel_values is not None
+            )
+
+    def _fail_make_kv_cache(**_kwargs: object) -> KVCacheType:
+        raise AssertionError("single-image cached follow-ups should reuse prefix cache")
+
+    def _fake_prefill(
+        model: _FakeModel,
+        _tokenizer: object,
+        _sampler: object,
+        prompt_tokens: mx.array,
+        *_args: object,
+        **_kwargs: object,
+    ) -> tuple[float, int, list[CacheSnapshot]]:
+        assert model.pixel_values is None
+        assert prompt_tokens.tolist() == [5, 6, 7]
+        return 0.0, len(prompt_tokens), []
+
+    def _fake_stream_generate(*_args: object, **_kwargs: object):
+        yield GenerationResponse(text="ok", token=101, usage=None)
+
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prepare_vision",
+        _fake_prepare_vision,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._should_use_native_vision_reference_path",
+        cast(Callable[[], bool], lambda: False),
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.make_kv_cache",
+        _fail_make_kv_cache,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prefill",
+        _fake_prefill,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.stream_generate",
+        _fake_stream_generate,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.mx_barrier",
+        _noop_barrier,
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        chat_template_messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "first"},
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "and now?"},
+        ],
+        images=["ignored-a"],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+
+    model = _FakeModel()
+    responses = list(
+        mlx_generate(
+            model=cast(Model, cast(object, model)),
+            tokenizer=_fake_tokenizer(),
+            task=task,
+            prompt="<bos>",
+            kv_prefix_cache=cast(KVPrefixCache, cast(object, _FakePrefixCache())),
+            group=_fake_group(),
+            vision_processor=_fake_vision_processor(),
+        )
+    )
+
+    assert [response.text for response in responses] == ["ok"]
+    assert model.saw_non_none_pixel_values is False
+    assert model.pixel_values is None
+
+
 def test_mlx_generate_full_prefills_distributed_cached_native_image_prefix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -104,6 +104,26 @@ def _identity_sampler(logits: mx.array) -> mx.array:
     return logits
 
 
+class _FakeGroup:
+    def __init__(self, rank: int = 0, size: int = 3) -> None:
+        self._rank = rank
+        self._size = size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+
+def _fake_group() -> mx.distributed.Group:
+    return cast(mx.distributed.Group, cast(object, _FakeGroup()))
+
+
+def _noop_barrier(_group: object) -> None:
+    return None
+
+
 def _empty_cache_list(**_kwargs: object) -> list[object]:
     return []
 
@@ -649,3 +669,105 @@ def test_mlx_generate_skips_embedding_patch_when_native_images_are_fully_cached(
 
     assert [response.text for response in responses] == ["ok"]
     assert model.seen_pixel_values is None
+
+
+def test_mlx_generate_uses_reference_path_for_distributed_fully_cached_native_images(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Distributed fully cached native-image follow-ups should avoid the fast path."""
+
+    class _FakePrefixCache:
+        def get_kv_cache(
+            self,
+            _model: object,
+            _prompt_tokens: object,
+            media_regions: list[MediaRegion] | None = None,
+        ) -> tuple[KVCacheType, mx.array, int]:
+            assert media_regions is not None
+            return cast(KVCacheType, []), mx.array([7, 8]), 0
+
+        def add_kv_cache(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def update_kv_cache(self, *args: object, **kwargs: object) -> None:
+            return None
+
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3, 4, 5, 6, 7, 8]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[
+            MediaRegion("first", 1, 4),
+            MediaRegion("second", 5, 6),
+        ],
+        pixel_values=[mx.array([10.0]), mx.array([20.0])],
+    )
+
+    def _fake_prepare_vision(**_kwargs: object) -> VisionResult:
+        return vision
+
+    def _fake_native_generate(**_kwargs: object):
+        yield GenerationResponse(text="native", token=101, usage=None)
+
+    def _fail_stream_generate(*_args: object, **_kwargs: object):
+        raise AssertionError("distributed fully-cached follow-ups should use the reference path")
+
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prepare_vision",
+        _fake_prepare_vision,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._should_use_native_vision_reference_path",
+        cast(Callable[[], bool], lambda: False),
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._mlx_generate_native_vision",
+        _fake_native_generate,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.stream_generate",
+        _fail_stream_generate,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.mx_barrier",
+        _noop_barrier,
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        chat_template_messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "first"},
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "second"},
+                ],
+            },
+        ],
+        images=["ignored-a", "ignored-b"],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+
+    responses = list(
+        mlx_generate(
+            model=_fake_model(),
+            tokenizer=_fake_tokenizer(),
+            task=task,
+            prompt="<bos>",
+            kv_prefix_cache=cast(KVPrefixCache, cast(object, _FakePrefixCache())),
+            group=_fake_group(),
+            vision_processor=_fake_vision_processor(),
+        )
+    )
+
+    assert [response.text for response in responses] == ["native"]

--- a/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -771,3 +771,116 @@ def test_mlx_generate_uses_reference_path_for_distributed_fully_cached_native_im
     )
 
     assert [response.text for response in responses] == ["native"]
+
+
+def test_mlx_generate_uses_reference_path_for_distributed_cached_native_image_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Distributed native-image follow-ups with new images should avoid the fast path."""
+
+    class _FakePrefixCache:
+        def get_kv_cache(
+            self,
+            _model: object,
+            _prompt_tokens: object,
+            media_regions: list[MediaRegion] | None = None,
+        ) -> tuple[KVCacheType, mx.array, int]:
+            assert media_regions is not None
+            return cast(KVCacheType, []), mx.array([5, 6, 7, 8]), 0
+
+        def add_kv_cache(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def update_kv_cache(self, *args: object, **kwargs: object) -> None:
+            return None
+
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3, 4, 5, 6, 7, 8]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[
+            MediaRegion("first", 1, 4),
+            MediaRegion("second", 5, 8),
+        ],
+        pixel_values=[mx.array([10.0]), mx.array([20.0])],
+    )
+
+    def _fake_prepare_vision(**_kwargs: object) -> VisionResult:
+        return vision
+
+    def _fake_native_generate(**_kwargs: object):
+        yield GenerationResponse(text="native", token=101, usage=None)
+
+    def _fail_prefill(*_args: object, **_kwargs: object):
+        raise AssertionError(
+            "distributed cached-image follow-ups should use the reference path"
+        )
+
+    def _fail_stream_generate(*_args: object, **_kwargs: object):
+        raise AssertionError(
+            "distributed cached-image follow-ups should use the reference path"
+        )
+
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prepare_vision",
+        _fake_prepare_vision,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._should_use_native_vision_reference_path",
+        cast(Callable[[], bool], lambda: False),
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate._mlx_generate_native_vision",
+        _fake_native_generate,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.prefill",
+        _fail_prefill,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.stream_generate",
+        _fail_stream_generate,
+    )
+    monkeypatch.setattr(
+        "exo.worker.engines.mlx.generator.generate.mx_barrier",
+        _noop_barrier,
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        chat_template_messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "first"},
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "second"},
+                ],
+            },
+        ],
+        images=["ignored-a", "ignored-b"],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+
+    responses = list(
+        mlx_generate(
+            model=_fake_model(),
+            tokenizer=_fake_tokenizer(),
+            task=task,
+            prompt="<bos>",
+            kv_prefix_cache=cast(KVPrefixCache, cast(object, _FakePrefixCache())),
+            group=_fake_group(),
+            vision_processor=_fake_vision_processor(),
+        )
+    )
+
+    assert [response.text for response in responses] == ["native"]

--- a/src/exo/worker/tests/unittests/test_mlx/test_prefill_path_selection.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_prefill_path_selection.py
@@ -11,6 +11,7 @@ from mlx_lm.tokenizer_utils import TokenizerWrapper
 
 from exo.shared.types.mlx import KVCacheType, Model
 from exo.worker.engines.mlx.generator import generate as generate_module
+from exo.worker.engines.mlx.vision import MediaRegion
 
 
 class _FakeCache:
@@ -38,6 +39,35 @@ class _FakeModel:
         self.layers: list[object] = []
 
 
+class _FakeStateCache:
+    @property
+    def state(self) -> mx.array:
+        return mx.array([0])
+
+
+class _VisionChunkModel:
+    def __init__(self) -> None:
+        self.pixel_values: list[mx.array] | mx.array | None = None
+        self.pixel_value_calls: list[list[float]] = []
+
+    def set_pixel_values(self, pixel_values: list[mx.array] | mx.array | None) -> None:
+        self.pixel_values = pixel_values
+
+    def __call__(self, *_args: object, **_kwargs: object) -> mx.array:
+        pixel_values = self.pixel_values
+        if pixel_values is None:
+            self.pixel_value_calls.append([])
+        elif isinstance(pixel_values, list):
+            self.pixel_value_calls.append(
+                [float(value.item()) for value in pixel_values]
+            )
+        else:
+            self.pixel_value_calls.append(
+                [float(value.item()) for value in pixel_values]
+            )
+        return mx.zeros((1, 1))
+
+
 def _identity_sampler(logits: mx.array) -> mx.array:
     return logits
 
@@ -59,6 +89,10 @@ def _fake_cache_list(cache: _FakeCache) -> KVCacheType:
 
 
 def _noop_barrier(_group: object) -> None:
+    return None
+
+
+def _noop_prefill_sends() -> None:
     return None
 
 
@@ -223,6 +257,48 @@ def test_prefill_uses_pipeline_parallel_path_for_short_pipeline_prompts(
     assert prefill_tps >= 0.0
     assert fake_cache.trim_calls == [2]
     assert prefill_mode_calls == [True, False]
+
+
+def test_pipeline_prefill_slices_native_pixel_values_per_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chunked native-vision prefill should align each image with its token span."""
+
+    monkeypatch.setattr(generate_module, "clear_prefill_sends", _noop_prefill_sends)
+    monkeypatch.setattr(generate_module, "flush_prefill_sends", _noop_prefill_sends)
+
+    model = _VisionChunkModel()
+    pixel_values = [
+        mx.array([10.0]),
+        mx.array([20.0]),
+        mx.array([30.0]),
+        mx.array([40.0]),
+    ]
+
+    generate_module.pipeline_parallel_prefill(
+        model=cast(Model, cast(object, model)),
+        prompt=mx.array(list(range(2190))),
+        prompt_cache=cast(KVCacheType, [_FakeStateCache()]),
+        prefill_step_size=4096,
+        kv_group_size=None,
+        kv_bits=None,
+        prompt_progress_callback=lambda _processed, _total: None,
+        distributed_prompt_progress_callback=None,
+        group=_fake_group(),
+        native_pixel_values=pixel_values,
+        native_media_regions=[
+            MediaRegion("first", 9, 281),
+            MediaRegion("second", 633, 907),
+            MediaRegion("third", 977, 1245),
+            MediaRegion("fourth", 1891, 2169),
+        ],
+    )
+
+    assert model.pixel_value_calls[:2] == [
+        [10.0, 20.0, 30.0],
+        [40.0],
+    ]
+    assert model.pixel_value_calls[-2:] == [[], []]
 
 
 def test_prefill_uses_pipeline_parallel_path_at_single_chunk_boundary(

--- a/src/exo/worker/tests/unittests/test_mlx/test_prefill_path_selection.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_prefill_path_selection.py
@@ -68,6 +68,35 @@ class _VisionChunkModel:
         return mx.zeros((1, 1))
 
 
+class _DecodeStepModel:
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    def __call__(self, tokens: mx.array, *_args: object, **_kwargs: object) -> mx.array:
+        self.calls.append(int(mx.reshape(tokens, (-1,))[0].item()))
+        return mx.zeros((1, tokens.shape[-1], 32))
+
+
+class _FakeDetokenizer:
+    def __init__(self) -> None:
+        self.last_segment = ""
+
+    def reset(self) -> None:
+        self.last_segment = ""
+
+    def add_token(self, token: int) -> None:
+        self.last_segment = f"token-{token}"
+
+    def finalize(self) -> None:
+        self.last_segment = ""
+
+
+class _DecodeTokenizer:
+    def __init__(self) -> None:
+        self.detokenizer = _FakeDetokenizer()
+        self.eos_token_ids: set[int] = set()
+
+
 def _identity_sampler(logits: mx.array) -> mx.array:
     return logits
 
@@ -299,6 +328,33 @@ def test_pipeline_prefill_slices_native_pixel_values_per_chunk(
         [40.0],
     ]
     assert model.pixel_value_calls[-2:] == [[], []]
+
+
+def test_pipeline_decode_without_lookahead_yields_before_second_decode_step() -> None:
+    """Pipeline decode should not schedule token N+1 before yielding token N."""
+
+    model = _DecodeStepModel()
+    sampled_tokens = [mx.array([10]), mx.array([11])]
+
+    def _sampler(_logprobs: mx.array) -> mx.array:
+        return sampled_tokens.pop(0)
+
+    generator = generate_module._stream_generate_without_lookahead(  # pyright: ignore[reportPrivateUsage]
+        model=cast(Model, cast(object, model)),
+        tokenizer=cast(TokenizerWrapper, cast(object, _DecodeTokenizer())),
+        prompt=mx.array([1, 2]),
+        max_tokens=2,
+        sampler=_sampler,
+        logits_processors=[],
+        prompt_cache=cast(KVCacheType, [_FakeStateCache()]),
+        kv_group_size=None,
+        kv_bits=None,
+    )
+
+    first = next(generator)
+
+    assert first.token == 10
+    assert model.calls == [1, 2]
 
 
 def test_prefill_uses_pipeline_parallel_path_at_single_chunk_boundary(

--- a/src/exo/worker/tests/unittests/test_mlx/test_prefill_path_selection.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_prefill_path_selection.py
@@ -218,15 +218,15 @@ def test_prefill_uses_pipeline_parallel_path_for_long_pipeline_prompts(
     assert prefill_mode_calls == [True, False]
 
 
-def test_prefill_uses_pipeline_parallel_path_for_short_pipeline_prompts(
+def test_prefill_uses_stream_generate_path_for_short_pipeline_prompts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Short pipeline prompts must avoid upstream stream_generate prefill.
+    """Short pipeline prompts use the PR90-era stream_generate prefill path.
 
-    ``mlx_lm.generate_step`` prefetches a decode step before yielding even with
-    ``max_tokens=1``. In pipeline mode that hidden prefetch can leave sends/recvs
-    in flight, so short prompts use Skulk's explicit pipeline prefill path while
-    suppressing distributed progress callbacks.
+    Single-chunk prompts do not benefit from the explicit pipeline prefill
+    scheduler, and this shape has repeatedly surfaced Gemma 4 cluster wedges.
+    Keep those prompts on the older stream_generate path while preserving
+    pipeline-prefill mode on the wrappers.
     """
     calls: list[str] = []
     fake_cache = _FakeCache()
@@ -279,8 +279,8 @@ def test_prefill_uses_pipeline_parallel_path_for_short_pipeline_prompts(
         distributed_prompt_progress_callback=_fail_distributed_callback,
     )
 
-    assert calls == ["pipeline_parallel_prefill"]
-    assert "stream_generate" not in calls
+    assert calls == ["stream_generate"]
+    assert "pipeline_parallel_prefill" not in calls
     assert prefill_tokens == 23
     assert snapshots == []
     assert prefill_tps >= 0.0
@@ -357,10 +357,10 @@ def test_pipeline_decode_without_lookahead_yields_before_second_decode_step() ->
     assert model.calls == [1, 2]
 
 
-def test_prefill_uses_pipeline_parallel_path_at_single_chunk_boundary(
+def test_prefill_uses_stream_generate_path_at_single_chunk_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Prompts with one real pipeline chunk still use explicit pipeline prefill."""
+    """Prompts with one real pipeline chunk still avoid explicit pipeline prefill."""
     calls: list[str] = []
     fake_cache = _FakeCache()
     prefill_mode_calls: list[bool] = []
@@ -399,7 +399,7 @@ def test_prefill_uses_pipeline_parallel_path_at_single_chunk_boundary(
         distributed_prompt_progress_callback=None,
     )
 
-    assert calls == ["pipeline_parallel_prefill"]
+    assert calls == ["stream_generate"]
     assert prefill_tokens == 1366
     assert snapshots == []
     assert prefill_tps >= 0.0

--- a/src/exo/worker/tests/unittests/test_plan/test_warmup.py
+++ b/src/exo/worker/tests/unittests/test_plan/test_warmup.py
@@ -1,4 +1,5 @@
 import exo.worker.plan as plan_mod
+from exo.shared.models.model_cards import ModelId
 from exo.shared.types.tasks import StartWarmup
 from exo.shared.types.worker.instances import BoundInstance
 from exo.shared.types.worker.runners import (
@@ -23,6 +24,8 @@ from exo.worker.tests.unittests.conftest import (
     get_mlx_ring_instance,
     get_pipeline_shard_metadata,
 )
+
+GEMMA4_MODEL_ID = ModelId("mlx-community/gemma-4-26b-a4b-it-4bit")
 
 
 def test_plan_starts_warmup_for_accepting_rank_when_all_loaded_or_warming():
@@ -111,6 +114,45 @@ def test_plan_does_not_start_warmup_for_accepting_rank_when_peer_is_ready():
     assert result is None
 
 
+def test_plan_starts_gemma4_warmup_for_accepting_rank_when_peer_is_ready():
+    """
+    Gemma 4 distributed warmup is independently skipped by the runner, so a
+    fast peer reaching Ready must not strand remaining Loaded ranks.
+    """
+    shard0 = get_pipeline_shard_metadata(GEMMA4_MODEL_ID, device_rank=0, world_size=3)
+    shard1 = get_pipeline_shard_metadata(GEMMA4_MODEL_ID, device_rank=1, world_size=3)
+    shard2 = get_pipeline_shard_metadata(GEMMA4_MODEL_ID, device_rank=2, world_size=3)
+    instance = get_mlx_ring_instance(
+        instance_id=INSTANCE_1_ID,
+        model_id=GEMMA4_MODEL_ID,
+        node_to_runner={NODE_A: RUNNER_1_ID, NODE_B: RUNNER_2_ID, NODE_C: RUNNER_3_ID},
+        runner_to_shard={RUNNER_1_ID: shard0, RUNNER_2_ID: shard1, RUNNER_3_ID: shard2},
+    )
+
+    bound_instance = BoundInstance(
+        instance=instance, bound_runner_id=RUNNER_2_ID, bound_node_id=NODE_B
+    )
+    local_runner = FakeRunnerSupervisor(
+        bound_instance=bound_instance, status=RunnerLoaded()
+    )
+
+    result = plan_mod.plan(
+        node_id=NODE_B,
+        runners={RUNNER_2_ID: local_runner},  # type: ignore
+        global_download_status={NODE_A: []},
+        instances={INSTANCE_1_ID: instance},
+        all_runners={
+            RUNNER_1_ID: RunnerReady(),
+            RUNNER_2_ID: RunnerLoaded(),
+            RUNNER_3_ID: RunnerLoaded(),
+        },
+        tasks={},
+    )
+
+    assert isinstance(result, StartWarmup)
+    assert result.instance_id == INSTANCE_1_ID
+
+
 def test_plan_starts_warmup_for_rank_zero_after_others_warming():
     """
     For device_rank == 0, StartWarmup should only be emitted once all the
@@ -190,6 +232,45 @@ def test_plan_does_not_start_warmup_for_rank_zero_after_other_rank_is_ready():
     )
 
     assert result is None
+
+
+def test_plan_starts_gemma4_warmup_for_rank_zero_after_others_ready():
+    """
+    Rank zero can finish Gemma 4 skipped warmup after non-zero peers have
+    already moved from WarmingUp to Ready.
+    """
+    shard0 = get_pipeline_shard_metadata(GEMMA4_MODEL_ID, device_rank=0, world_size=3)
+    shard1 = get_pipeline_shard_metadata(GEMMA4_MODEL_ID, device_rank=1, world_size=3)
+    shard2 = get_pipeline_shard_metadata(GEMMA4_MODEL_ID, device_rank=2, world_size=3)
+    instance = get_mlx_ring_instance(
+        instance_id=INSTANCE_1_ID,
+        model_id=GEMMA4_MODEL_ID,
+        node_to_runner={NODE_A: RUNNER_1_ID, NODE_B: RUNNER_2_ID, NODE_C: RUNNER_3_ID},
+        runner_to_shard={RUNNER_1_ID: shard0, RUNNER_2_ID: shard1, RUNNER_3_ID: shard2},
+    )
+
+    bound_instance = BoundInstance(
+        instance=instance, bound_runner_id=RUNNER_1_ID, bound_node_id=NODE_A
+    )
+    local_runner = FakeRunnerSupervisor(
+        bound_instance=bound_instance, status=RunnerLoaded()
+    )
+
+    result = plan_mod.plan(
+        node_id=NODE_A,
+        runners={RUNNER_1_ID: local_runner},  # type: ignore
+        global_download_status={NODE_A: []},
+        instances={INSTANCE_1_ID: instance},
+        all_runners={
+            RUNNER_1_ID: RunnerLoaded(),
+            RUNNER_2_ID: RunnerReady(),
+            RUNNER_3_ID: RunnerReady(),
+        },
+        tasks={},
+    )
+
+    assert isinstance(result, StartWarmup)
+    assert result.instance_id == INSTANCE_1_ID
 
 
 def test_plan_does_not_start_warmup_for_non_zero_rank_until_all_loaded_or_warming():

--- a/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
@@ -9,6 +9,7 @@ import pytest
 import exo.worker.runner.llm_inference.batch_generator as mlx_batch_generator
 import exo.worker.runner.llm_inference.model_output_parsers as mlx_model_output_parsers
 import exo.worker.runner.llm_inference.runner as mlx_runner
+from exo.shared.models.model_cards import ModelId
 from exo.shared.types.chunks import TokenChunk
 from exo.shared.types.events import (
     ChunkGenerated,
@@ -235,10 +236,15 @@ class MockDistributedGroup:
         return 2
 
 
-def _run(tasks: Iterable[Task], send_after_ready: list[Task] | None = None):
+def _run(
+    tasks: Iterable[Task],
+    send_after_ready: list[Task] | None = None,
+    *,
+    model_id: ModelId = MODEL_A_ID,
+):
     bound_instance = get_bound_mlx_ring_instance(
         instance_id=INSTANCE_1_ID,
-        model_id=MODEL_A_ID,
+        model_id=model_id,
         runner_id=RUNNER_1_ID,
         node_id=NODE_A,
     )
@@ -403,6 +409,35 @@ def test_distributed_warmup_skip_env_is_ignored(
     events = _run([INIT_TASK, LOAD_TASK, WARMUP_TASK, SHUTDOWN_TASK])
 
     assert warmup_calls == 1
+    assert any(
+        isinstance(event, RunnerStatusUpdated)
+        and isinstance(event.runner_status, RunnerReady)
+        for event in events
+    )
+
+
+def test_distributed_gemma4_warmup_is_bypassed(
+    patch_out_mlx: pytest.MonkeyPatch, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SKULK_SKIP_LLM_WARMUP", raising=False)
+    monkeypatch.setattr(mlx_runner, "initialize_mlx", make_nothin(MockDistributedGroup()))
+
+    warmup_calls = 0
+
+    def fake_warmup(self: object) -> None:
+        del self
+        nonlocal warmup_calls
+        warmup_calls += 1
+
+    monkeypatch.setattr(mlx_batch_generator.BatchGenerator, "warmup", fake_warmup)
+    monkeypatch.setattr(mlx_batch_generator.SequentialGenerator, "warmup", fake_warmup)
+
+    events = _run(
+        [INIT_TASK, LOAD_TASK, WARMUP_TASK, SHUTDOWN_TASK],
+        model_id=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+    )
+
+    assert warmup_calls == 0
     assert any(
         isinstance(event, RunnerStatusUpdated)
         and isinstance(event.runner_status, RunnerReady)

--- a/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
@@ -150,11 +150,14 @@ class FakeExoBatchGenerator:
 
     def submit(
         self,
+        task_id: object = None,
         task_params: object = None,
         prompt: object = None,
         on_prefill_progress: object = None,
         distributed_prompt_progress_callback: object = None,
         on_generation_token: object = None,
+        trace_rank: object = None,
+        **_kwargs: object,
     ) -> int:
         uid = self._uid_counter
         self._uid_counter += 1

--- a/src/exo/worker/tests/unittests/test_runner/test_resolve_metal_fast_synch.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_resolve_metal_fast_synch.py
@@ -1,0 +1,105 @@
+"""Tests for the per-model FAST_SYNCH resolver.
+
+The resolver decides ``MLX_METAL_FAST_SYNCH`` for a runner by combining an
+operator-supplied env override, a model-card preference, and the cluster
+default. The kernel-panic failure mode that motivated this resolver
+(gemma-4 + ring + multinode multimodal load) is severe enough that the
+priority order is load-bearing — anything that downgrades the operator
+override or silently ignores a card preference can re-introduce the
+panic on a fresh deployment.
+"""
+
+import pytest
+
+from exo.shared.models.model_cards import RuntimeCapabilityCardConfig
+from exo.worker.runner.bootstrap import (
+    FAST_SYNCH_CLUSTER_DEFAULT,
+    resolve_metal_fast_synch,
+)
+
+
+def test_returns_cluster_default_when_no_override_or_card(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SKULK_FAST_SYNCH", raising=False)
+    monkeypatch.delenv("EXO_FAST_SYNCH", raising=False)
+    assert resolve_metal_fast_synch(None) is FAST_SYNCH_CLUSTER_DEFAULT
+
+
+def test_card_preference_overrides_cluster_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SKULK_FAST_SYNCH", raising=False)
+    monkeypatch.delenv("EXO_FAST_SYNCH", raising=False)
+    runtime_off = RuntimeCapabilityCardConfig(metal_fast_synch=False)
+    runtime_on = RuntimeCapabilityCardConfig(metal_fast_synch=True)
+    assert resolve_metal_fast_synch(runtime_off) is False
+    assert resolve_metal_fast_synch(runtime_on) is True
+
+
+def test_card_none_falls_through_to_cluster_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SKULK_FAST_SYNCH", raising=False)
+    monkeypatch.delenv("EXO_FAST_SYNCH", raising=False)
+    runtime_silent = RuntimeCapabilityCardConfig(metal_fast_synch=None)
+    assert resolve_metal_fast_synch(runtime_silent) is FAST_SYNCH_CLUSTER_DEFAULT
+
+
+@pytest.mark.parametrize("value", ["on", "ON", " on ", "On"])
+def test_skulk_env_on_forces_true(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("SKULK_FAST_SYNCH", value)
+    monkeypatch.delenv("EXO_FAST_SYNCH", raising=False)
+    runtime_off = RuntimeCapabilityCardConfig(metal_fast_synch=False)
+    # Operator override beats card preference, even when the card says off.
+    assert resolve_metal_fast_synch(runtime_off) is True
+
+
+@pytest.mark.parametrize("value", ["off", "OFF", " off ", "Off"])
+def test_skulk_env_off_forces_false(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("SKULK_FAST_SYNCH", value)
+    monkeypatch.delenv("EXO_FAST_SYNCH", raising=False)
+    runtime_on = RuntimeCapabilityCardConfig(metal_fast_synch=True)
+    # Operator override beats card preference, even when the card says on.
+    assert resolve_metal_fast_synch(runtime_on) is False
+
+
+def test_legacy_exo_env_still_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SKULK_FAST_SYNCH", raising=False)
+    monkeypatch.setenv("EXO_FAST_SYNCH", "off")
+    assert resolve_metal_fast_synch(None) is False
+
+
+def test_skulk_env_wins_over_legacy_exo_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SKULK_FAST_SYNCH", "on")
+    monkeypatch.setenv("EXO_FAST_SYNCH", "off")
+    assert resolve_metal_fast_synch(None) is True
+
+
+def test_unknown_env_value_falls_through_to_card(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Garbage in env should not silently pick a value — fall through.
+
+    This protects against a typo in operator scripts (e.g. ``FAST_SYNCH=no``
+    or ``=true``) silently selecting the wrong behavior. We only honor
+    explicit ``on`` / ``off``; anything else flows to the card layer.
+    """
+    monkeypatch.setenv("SKULK_FAST_SYNCH", "auto")
+    monkeypatch.delenv("EXO_FAST_SYNCH", raising=False)
+    runtime_off = RuntimeCapabilityCardConfig(metal_fast_synch=False)
+    assert resolve_metal_fast_synch(runtime_off) is False
+
+
+def test_unknown_env_value_with_no_card_falls_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SKULK_FAST_SYNCH", "yes")
+    monkeypatch.delenv("EXO_FAST_SYNCH", raising=False)
+    assert resolve_metal_fast_synch(None) is FAST_SYNCH_CLUSTER_DEFAULT

--- a/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
@@ -7,6 +7,7 @@ import pytest
 from exo.shared.models.model_cards import ModelId
 from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.common import CommandId, NodeId
+from exo.shared.types.diagnostics import RunnerDiagnosticContext, RunnerDiagnosticUpdate
 from exo.shared.types.events import (
     ChunkGenerated,
     Event,
@@ -24,6 +25,7 @@ from exo.worker.tests.unittests.conftest import get_bound_mlx_ring_instance
 
 
 class _DeadProcess:
+    pid = 123
     exitcode = -6
 
     def start(self) -> None:
@@ -48,6 +50,7 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
     task_sender, _ = mp_channel[Task]()
     cancel_sender, _ = mp_channel[TaskId]()
     _, ev_recv = mp_channel[Event]()
+    _, diag_recv = mp_channel[RunnerDiagnosticUpdate]()
 
     bound_instance: BoundInstance = get_bound_mlx_ring_instance(
         instance_id=InstanceId("instance-a"),
@@ -62,6 +65,7 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
         runner_process=cast("mp.Process", cast(object, _DeadProcess())),
         initialize_timeout=400,
         _ev_recv=ev_recv,
+        _diag_recv=diag_recv,
         _task_sender=task_sender,
         _event_sender=event_sender,
         _cancel_sender=cancel_sender,
@@ -105,6 +109,7 @@ async def test_cancelled_task_event_clears_in_progress_and_emits_delete() -> Non
     task_sender, _ = mp_channel[Task]()
     cancel_sender, _ = mp_channel[TaskId]()
     ev_send, ev_recv = mp_channel[Event]()
+    _, diag_recv = mp_channel[RunnerDiagnosticUpdate]()
 
     bound_instance: BoundInstance = get_bound_mlx_ring_instance(
         instance_id=InstanceId("instance-a"),
@@ -119,6 +124,7 @@ async def test_cancelled_task_event_clears_in_progress_and_emits_delete() -> Non
         runner_process=cast("mp.Process", cast(object, _DeadProcess())),
         initialize_timeout=400,
         _ev_recv=ev_recv,
+        _diag_recv=diag_recv,
         _task_sender=task_sender,
         _event_sender=event_sender,
         _cancel_sender=cancel_sender,
@@ -158,3 +164,59 @@ async def test_cancelled_task_event_clears_in_progress_and_emits_delete() -> Non
     event_sender.close()
     with anyio.move_on_after(0.1):
         await event_receiver.aclose()
+
+
+@pytest.mark.asyncio
+async def test_runner_flight_recorder_retains_newest_entries() -> None:
+    event_sender, _ = channel[Event]()
+    task_sender, _ = mp_channel[Task]()
+    cancel_sender, _ = mp_channel[TaskId]()
+    _, ev_recv = mp_channel[Event]()
+    _, diag_recv = mp_channel[RunnerDiagnosticUpdate]()
+
+    bound_instance: BoundInstance = get_bound_mlx_ring_instance(
+        instance_id=InstanceId("instance-a"),
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runner_id=RunnerId("runner-a"),
+        node_id=NodeId("node-a"),
+    )
+    supervisor = RunnerSupervisor(
+        shard_metadata=bound_instance.bound_shard,
+        bound_instance=bound_instance,
+        runner_process=cast("mp.Process", cast(object, _DeadProcess())),
+        initialize_timeout=400,
+        _ev_recv=ev_recv,
+        _diag_recv=diag_recv,
+        _task_sender=task_sender,
+        _event_sender=event_sender,
+        _cancel_sender=cancel_sender,
+    )
+    context = RunnerDiagnosticContext(
+        node_id="node-a",
+        runner_id="runner-a",
+        pid=123,
+        instance_id="instance-a",
+        model_id="mlx-community/Llama-3.2-1B-Instruct-4bit",
+        rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=30,
+        n_layers=30,
+    )
+
+    for idx in range(140):
+        supervisor._apply_diagnostic_update(  # pyright: ignore[reportPrivateUsage]
+            RunnerDiagnosticUpdate(
+                at=f"2026-04-23T00:00:{idx:02d}+00:00",
+                phase="decode_stream",
+                event=f"token_{idx}",
+                context=context,
+                task_id="task-a",
+            )
+        )
+
+    diagnostics = supervisor.diagnostics()
+    assert diagnostics.phase == "decode_stream"
+    assert len(diagnostics.flight_recorder) == 128
+    assert diagnostics.flight_recorder[0].event == "token_12"
+    assert diagnostics.flight_recorder[-1].event == "token_139"

--- a/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_runner_supervisor.py
@@ -7,11 +7,17 @@ import pytest
 from exo.shared.models.model_cards import ModelId
 from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.common import CommandId, NodeId
-from exo.shared.types.events import ChunkGenerated, Event, RunnerStatusUpdated
-from exo.shared.types.tasks import Task, TaskId, TextGeneration
+from exo.shared.types.events import (
+    ChunkGenerated,
+    Event,
+    RunnerStatusUpdated,
+    TaskDeleted,
+    TaskStatusUpdated,
+)
+from exo.shared.types.tasks import Task, TaskId, TaskStatus, TextGeneration
 from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
 from exo.shared.types.worker.instances import BoundInstance, InstanceId
-from exo.shared.types.worker.runners import RunnerFailed, RunnerId
+from exo.shared.types.worker.runners import RunnerFailed, RunnerId, RunnerRunning
 from exo.utils.channels import channel, mp_channel
 from exo.worker.runner.runner_supervisor import RunnerSupervisor
 from exo.worker.tests.unittests.conftest import get_bound_mlx_ring_instance
@@ -87,6 +93,67 @@ async def test_check_runner_emits_error_chunk_for_inflight_text_generation() -> 
 
     assert isinstance(got_status, RunnerStatusUpdated)
     assert isinstance(got_status.runner_status, RunnerFailed)
+
+    event_sender.close()
+    with anyio.move_on_after(0.1):
+        await event_receiver.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_task_event_clears_in_progress_and_emits_delete() -> None:
+    event_sender, event_receiver = channel[Event]()
+    task_sender, _ = mp_channel[Task]()
+    cancel_sender, _ = mp_channel[TaskId]()
+    ev_send, ev_recv = mp_channel[Event]()
+
+    bound_instance: BoundInstance = get_bound_mlx_ring_instance(
+        instance_id=InstanceId("instance-a"),
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runner_id=RunnerId("runner-a"),
+        node_id=NodeId("node-a"),
+    )
+
+    supervisor = RunnerSupervisor(
+        shard_metadata=bound_instance.bound_shard,
+        bound_instance=bound_instance,
+        runner_process=cast("mp.Process", cast(object, _DeadProcess())),
+        initialize_timeout=400,
+        _ev_recv=ev_recv,
+        _task_sender=task_sender,
+        _event_sender=event_sender,
+        _cancel_sender=cancel_sender,
+    )
+    supervisor.status = RunnerRunning()
+
+    task = TextGeneration(
+        task_id=TaskId("task-a"),
+        instance_id=bound_instance.instance.instance_id,
+        command_id=CommandId("cmd-a"),
+        task_params=TextGenerationTaskParams(
+            model=bound_instance.bound_shard.model_card.model_id,
+            input=[InputMessage(role="user", content="hi")],
+            stream=True,
+        ),
+    )
+    supervisor.in_progress[task.task_id] = task
+    forwarded_cancel: Event | None = None
+    forwarded_delete: Event | None = None
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(supervisor._forward_events)  # pyright: ignore[reportPrivateUsage]
+        ev_send.send(TaskStatusUpdated(task_id=task.task_id, task_status=TaskStatus.Cancelled))
+        forwarded_cancel = await event_receiver.receive()
+        forwarded_delete = await event_receiver.receive()
+        tg.cancel_scope.cancel()
+
+    ev_send.close()
+
+    assert isinstance(forwarded_cancel, TaskStatusUpdated)
+    assert forwarded_cancel.task_status == TaskStatus.Cancelled
+    assert isinstance(forwarded_delete, TaskDeleted)
+    assert forwarded_delete.task_id == task.task_id
+    assert task.task_id not in supervisor.in_progress
+    assert task.task_id in supervisor.cancelled
 
     event_sender.close()
     with anyio.move_on_after(0.1):

--- a/src/exo/worker/tests/unittests/test_runner/test_trace_session_leak.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_trace_session_leak.py
@@ -1,0 +1,142 @@
+# type: ignore
+"""Regression test for the trace-session leak in handle_generation_tasks.
+
+Before the fix, an exception inside ``self.generator.step()`` would bubble
+out of ``handle_generation_tasks`` without flushing any active traced
+tasks. The runner would leak ``_trace_sessions`` entries, and — worse —
+the master would wait forever for ``TracesCollected`` from this rank,
+leaving the cluster trace in ``_pending_traces`` permanently.
+
+This test exercises the helper directly without standing up the heavy
+runner constructor: the contract is that for every traced active task,
+the helper emits an ``aborted`` marker and flushes the session.
+"""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+from exo.shared import tracing
+from exo.shared.types.tasks import TaskId
+from exo.worker.runner.llm_inference.runner import Runner
+
+
+def _make_traced_task(task_id: TaskId) -> MagicMock:
+    """Minimal traced-task stub — only the fields the helper reads."""
+    task = MagicMock()
+    task.task_id = task_id
+    task.trace_enabled = True
+    task.command_id = "cmd"
+    return task
+
+
+def _make_untraced_task(task_id: TaskId) -> MagicMock:
+    task = MagicMock()
+    task.task_id = task_id
+    task.trace_enabled = False
+    return task
+
+
+def _seed_session(task_id: str, *, rank: int = 0) -> None:
+    tracing.begin_trace_session(
+        cast(object, task_id),
+        rank=rank,
+        node_id="node-test",
+        model_id="test-model",
+        task_kind="text",
+        tags=["text_generation"],
+    )
+
+
+def test_flush_unfinished_trace_sessions_emits_marker_and_pops_session() -> None:
+    """For each traced active task, helper records ``aborted`` and pops session."""
+    task_id = TaskId("task-traced-1")
+    _seed_session(str(task_id))
+    assert tracing.has_trace_session(task_id)
+
+    fake_runner = MagicMock()
+    fake_runner.active_tasks = {task_id: _make_traced_task(task_id)}
+    fake_runner.device_rank = 0
+    fake_runner._flush_trace_session = MagicMock()
+
+    Runner._flush_unfinished_trace_sessions(  # pyright: ignore[reportPrivateUsage]
+        cast(Runner, fake_runner)
+    )
+
+    # Aborted marker recorded onto the session before the flush.
+    session_events = tracing.collect_trace_session(task_id)
+    assert any(
+        event.name == "aborted" and "trace_abort" in event.tags
+        for event in session_events
+    ), f"expected aborted marker; got {[e.name for e in session_events]}"
+
+    # The runner's flush was invoked exactly once for this task.
+    fake_runner._flush_trace_session.assert_called_once_with(task_id)
+
+    # Cleanup so test isolation holds — the helper does not pop the session
+    # itself (that's the runner's _flush_trace_session responsibility, which
+    # we mocked above), so we explicitly clear here.
+    tracing.clear_trace_session(task_id)
+
+
+def test_flush_unfinished_trace_sessions_skips_untraced_tasks() -> None:
+    """Tasks with ``trace_enabled=False`` must not produce trace markers or flushes."""
+    task_id = TaskId("task-untraced-1")
+
+    fake_runner = MagicMock()
+    fake_runner.active_tasks = {task_id: _make_untraced_task(task_id)}
+    fake_runner.device_rank = 0
+    fake_runner._flush_trace_session = MagicMock()
+
+    Runner._flush_unfinished_trace_sessions(  # pyright: ignore[reportPrivateUsage]
+        cast(Runner, fake_runner)
+    )
+
+    fake_runner._flush_trace_session.assert_not_called()
+
+
+def test_flush_unfinished_trace_sessions_handles_marker_failures() -> None:
+    """If ``record_trace_marker`` somehow raises, the flush still happens.
+
+    The helper uses ``contextlib.suppress`` on both the marker and the
+    flush. We can't easily make ``record_trace_marker`` raise here, but
+    a session that has already been popped (so the marker silently
+    no-ops) still needs the flush call so the runner gets a chance to
+    notify the master with whatever events did make it in.
+    """
+    task_id = TaskId("task-no-session")
+    # Deliberately do not seed a session — record_trace_marker will be a
+    # no-op (the implementation guards on session presence).
+
+    fake_runner = MagicMock()
+    fake_runner.active_tasks = {task_id: _make_traced_task(task_id)}
+    fake_runner.device_rank = 0
+    fake_runner._flush_trace_session = MagicMock()
+
+    Runner._flush_unfinished_trace_sessions(  # pyright: ignore[reportPrivateUsage]
+        cast(Runner, fake_runner)
+    )
+
+    fake_runner._flush_trace_session.assert_called_once_with(task_id)
+
+
+def test_flush_helper_iterates_all_traced_tasks() -> None:
+    """When multiple tasks are traced, every one of them gets aborted+flushed."""
+    task_ids = [TaskId(f"task-multi-{i}") for i in range(3)]
+    for tid in task_ids:
+        _seed_session(str(tid))
+
+    fake_runner = MagicMock()
+    fake_runner.active_tasks = {tid: _make_traced_task(tid) for tid in task_ids}
+    fake_runner.device_rank = 0
+    fake_runner._flush_trace_session = MagicMock()
+
+    Runner._flush_unfinished_trace_sessions(  # pyright: ignore[reportPrivateUsage]
+        cast(Runner, fake_runner)
+    )
+
+    assert fake_runner._flush_trace_session.call_count == 3
+    flushed_ids = {call.args[0] for call in fake_runner._flush_trace_session.call_args_list}
+    assert flushed_ids == set(task_ids)
+
+    for tid in task_ids:
+        tracing.clear_trace_session(tid)

--- a/src/exo/worker/tests/unittests/test_worker_vlm_image_cache.py
+++ b/src/exo/worker/tests/unittests/test_worker_vlm_image_cache.py
@@ -1,0 +1,11 @@
+from exo.worker.main import resolve_cached_vlm_images
+
+
+def test_resolve_cached_vlm_images_reports_missing_hashes() -> None:
+    resolved, missing = resolve_cached_vlm_images(
+        {"hash-a": "image-a"},
+        {0: "hash-a", 1: "hash-b"},
+    )
+
+    assert resolved == {0: "image-a"}
+    assert missing == [(1, "hash-b")]

--- a/tests/test_gemma_vision.py
+++ b/tests/test_gemma_vision.py
@@ -720,7 +720,7 @@ class TestGemma4DynamicVisionPooling:
 class TestFormatVlmMessages:
     """Gemma prompts should preserve multimodal ordering instead of flattening."""
 
-    def test_gemma4_preserves_interleaving(self):
+    def test_gemma4_preserves_interleaving_and_labels_multiple_images(self):
         messages = [
             {
                 "role": "user",
@@ -740,9 +740,32 @@ class TestFormatVlmMessages:
                 "role": "user",
                 "content": [
                     {"type": "text", "text": "first"},
-                    {"type": "image"},
+                    {"type": "image", "label": "Image 1"},
                     {"type": "text", "text": "second"},
+                    {"type": "image", "label": "Image 2"},
+                ],
+            }
+        ]
+
+    def test_gemma4_does_not_label_single_image(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url"},
+                    {"type": "text", "text": "what do you see?"},
+                ],
+            }
+        ]
+
+        formatted = _format_vlm_messages(messages, "gemma4")
+
+        assert formatted == [
+            {
+                "role": "user",
+                "content": [
                     {"type": "image"},
+                    {"type": "text", "text": "what do you see?"},
                 ],
             }
         ]

--- a/tests/test_gemma_vision.py
+++ b/tests/test_gemma_vision.py
@@ -26,6 +26,7 @@ from exo.shared.models.model_cards import (
 from exo.shared.types.common import ModelId
 from exo.shared.types.memory import Memory
 from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+from exo.worker.engines.mlx import vision as vision_module
 from exo.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
 from exo.worker.engines.mlx.utils_mlx import apply_chat_template
 from exo.worker.engines.mlx.vision import _find_media_regions, _format_vlm_messages
@@ -392,12 +393,22 @@ class TestGemma4ReferencePromptRenderer:
             model_type=None,
             boi_token_id=None,
             eoi_token_id=None,
-        ) -> str:
+        ):
             captured["model_type"] = model_type
-            return "<|image|>"
+            return vision_module._VisionPromptBuild(  # pyright: ignore[reportPrivateUsage]
+                prompt="<|image|>",
+                raw_prompt="<|image|>",
+                debug=vision_module._VisionPromptDebug(  # pyright: ignore[reportPrivateUsage]
+                    raw_prompt_chars=len("<|image|>"),
+                    raw_image_placeholder_positions=[0],
+                    expanded_prompt_chars=len("<|image|>"),
+                    tokens_per_image=list(n_tokens_per_image),
+                    image_token=image_token,
+                ),
+            )
 
         monkeypatch.setattr(
-            "exo.worker.engines.mlx.vision.build_vision_prompt",
+            "exo.worker.engines.mlx.vision._build_vision_prompt_with_debug",
             _fake_build_vision_prompt,
         )
         monkeypatch.setattr(

--- a/tests/test_gemma_vision.py
+++ b/tests/test_gemma_vision.py
@@ -224,7 +224,7 @@ class TestGemma4ReferencePromptRenderer:
 
         assert (
             prompt
-            == "<bos><|turn>user\n\n\n<|image|>\n\nwhat do you see?<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
+            == "<bos><|turn>user\n<|image|>what do you see?<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
         )
 
     def test_thinking_requires_explicit_enable(self):
@@ -238,7 +238,7 @@ class TestGemma4ReferencePromptRenderer:
 
         assert (
             prompt
-            == "<bos><|turn>system\n<|think|><turn|>\n<|turn>user\nHi<turn|>\n<|turn>model\n"
+            == "<bos><|turn>system\n<|think|>\n<turn|>\n<|turn>user\nHi<turn|>\n<|turn>model\n"
         )
 
     def test_apply_chat_template_uses_reference_renderer_for_plain_gemma4(self):
@@ -351,7 +351,7 @@ class TestGemma4ReferencePromptRenderer:
 
         assert (
             prompt
-            == "<bos><|turn>user\n\n\n<|image><|image|><|image|><|image|><image|>\n\nwhat do you see?<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
+            == "<bos><|turn>user\n<|image><|image|><|image|><|image|><image|>what do you see?<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
         )
 
     def test_process_native_forwards_gemma4_model_type_to_prompt_builder(

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -154,8 +154,10 @@ If this fails with `404 No instance found for model ...`, the placement is not r
 - `GET /v1/traces/cluster/{task_id}/stats`
 - `GET /v1/traces/cluster/{task_id}/raw`
 - `GET /v1/diagnostics/node`
+- `POST /v1/diagnostics/node/runners/{runner_id}/cancel`
 - `GET /v1/diagnostics/cluster`
 - `GET /v1/diagnostics/cluster/{node_id}`
+- `POST /v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel`
 
 For the full interactive reference with request/response schemas, see the [API Reference](/api/skulk-api).
 
@@ -771,8 +773,10 @@ Returns stored events from the API-side event log.
 ### Diagnostics
 
 - `GET /v1/diagnostics/node`
+- `POST /v1/diagnostics/node/runners/{runner_id}/cancel`
 - `GET /v1/diagnostics/cluster`
 - `GET /v1/diagnostics/cluster/{node_id}`
+- `POST /v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel`
 
 Use these endpoints when a node appears stuck loading, warming up, decoding, or
 shutting down and you need a read-only snapshot without SSHing into every node.
@@ -781,17 +785,23 @@ Behavior notes:
 
 - `GET /v1/diagnostics/node` returns the local node's runtime/config facts,
   resources, process tree, live runner-supervisor state, and placement analysis.
+- `POST /v1/diagnostics/node/runners/{runner_id}/cancel` requests cooperative
+  cancellation for one task that the local runner supervisor still knows about.
 - `GET /v1/diagnostics/cluster` fans out to reachable peer APIs and returns
   partial results when some peers are unavailable.
 - `GET /v1/diagnostics/cluster/{node_id}` proxies one reachable peer bundle or
   returns the local bundle if `node_id` is the current API node.
+- `POST /v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel` proxies
+  the same cooperative live-runner cancellation request to a reachable peer.
 - Placement diagnostics explicitly include whether the current master is part of
   each model placement, which helps investigate hangs where the master is not
   one of the inference ranks.
 - The dashboard node-card bug icon uses these endpoints to open a live
   diagnostics drawer for any reachable node.
-- These endpoints are read-only. They do not kill, restart, cancel, or mutate
-  runners.
+- Runner cancellation is best-effort only. A wedged native/MLX runner may
+  ignore the request and still require stronger intervention.
+- Diagnostics endpoints do not currently kill or restart runners; the only
+  mutating diagnostics action is the cooperative task-cancel request above.
 
 Example:
 
@@ -799,6 +809,12 @@ Example:
 curl http://localhost:52415/v1/diagnostics/node
 curl http://localhost:52415/v1/diagnostics/cluster
 curl http://localhost:52415/v1/diagnostics/cluster/<node_id>
+curl -X POST http://localhost:52415/v1/diagnostics/node/runners/<runner_id>/cancel \
+  -H 'content-type: application/json' \
+  -d '{"taskId":"<task_id>"}'
+curl -X POST http://localhost:52415/v1/diagnostics/cluster/<node_id>/runners/<runner_id>/cancel \
+  -H 'content-type: application/json' \
+  -d '{"taskId":"<task_id>"}'
 ```
 
 ### Traces

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -142,11 +142,17 @@ If this fails with `404 No instance found for model ...`, the placement is not r
 - `GET /store/models/{model_id}/optimize/status`
 - `GET /filesystem/browse`
 - `GET /node/identity`
+- `GET /v1/tracing`
+- `PUT /v1/tracing`
 - `GET /v1/traces`
+- `GET /v1/traces/cluster`
 - `POST /v1/traces/delete`
 - `GET /v1/traces/{task_id}`
 - `GET /v1/traces/{task_id}/stats`
 - `GET /v1/traces/{task_id}/raw`
+- `GET /v1/traces/cluster/{task_id}`
+- `GET /v1/traces/cluster/{task_id}/stats`
+- `GET /v1/traces/cluster/{task_id}/raw`
 
 For the full interactive reference with request/response schemas, see the [API Reference](/api/skulk-api).
 
@@ -761,17 +767,113 @@ Returns stored events from the API-side event log.
 
 ### Traces
 
+- `GET /v1/tracing`
+- `PUT /v1/tracing`
 - `GET /v1/traces`
+- `GET /v1/traces/cluster`
 - `POST /v1/traces/delete`
 - `GET /v1/traces/{task_id}`
 - `GET /v1/traces/{task_id}/stats`
 - `GET /v1/traces/{task_id}/raw`
+- `GET /v1/traces/cluster/{task_id}`
+- `GET /v1/traces/cluster/{task_id}/stats`
+- `GET /v1/traces/cluster/{task_id}/raw`
 
 Use these endpoints when you are debugging generation behavior, cluster execution, or performance.
+
+Behavior notes:
+
+- `GET /v1/tracing` returns whether runtime tracing is currently enabled for new
+  requests across the live cluster session.
+- `PUT /v1/tracing` toggles tracing cluster-wide for new requests only. It does
+  not retroactively trace in-flight work.
+- `GET /v1/traces*` reads local trace artifacts stored on the current node.
+- `GET /v1/traces/cluster*` fans out to reachable peer APIs, deduplicates by
+  `task_id`, and proxies read-only trace access from any reachable node.
+- `POST /v1/traces/delete` remains local-only in v1 even when cluster browsing
+  is enabled.
+
+### Runtime tracing control
+
+**GET** `/v1/tracing`
+
+Returns the current cluster tracing state:
+
+```json
+{"enabled": false}
+```
+
+**PUT** `/v1/tracing`
+
+Enable or disable tracing for new requests across the current cluster session.
+
+Request body:
+
+```json
+{"enabled": true}
+```
+
+Response body:
+
+```json
+{"enabled": true}
+```
+
+Operational notes:
+
+- this is a runtime toggle, not a restart-required config edit
+- it applies to new requests only
+- it does not retroactively trace work already in flight
+- the dashboard traces page uses this same API
+
+### Local trace endpoints
+
+These endpoints operate on trace artifacts stored on the current node:
+
+- `GET /v1/traces` lists local trace artifacts with metadata such as task kind,
+  model, source nodes, and tool-activity tags
+- `GET /v1/traces/{task_id}` returns structured trace events for one task
+- `GET /v1/traces/{task_id}/stats` returns aggregated timing summaries
+- `GET /v1/traces/{task_id}/raw` downloads Chrome-trace-compatible JSON
+- `POST /v1/traces/delete` deletes one or more local trace artifacts
+
+Example:
+
+```bash
+curl http://localhost:52415/v1/traces
+curl http://localhost:52415/v1/traces/<task_id>/stats
+curl -OJ http://localhost:52415/v1/traces/<task_id>/raw
+```
+
+### Cluster trace endpoints
+
+These endpoints let a dashboard or script on any reachable node browse traces
+across the cluster:
+
+- `GET /v1/traces/cluster`
+- `GET /v1/traces/cluster/{task_id}`
+- `GET /v1/traces/cluster/{task_id}/stats`
+- `GET /v1/traces/cluster/{task_id}/raw`
+
+Operational notes:
+
+- cluster browsing is read-only in v1
+- the API fans out to reachable peer APIs and deduplicates traces by `task_id`
+- if some peers are unreachable, cluster results may be partial
+- source node metadata in responses tells you which nodes contributed trace content
+
+Example:
+
+```bash
+curl http://localhost:52415/v1/traces/cluster
+curl http://localhost:52415/v1/traces/cluster/<task_id>/stats
+curl -OJ http://localhost:52415/v1/traces/cluster/<task_id>/raw
+```
 
 ## Helpful Next Docs
 
 - [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md)
+- [Tracing and debugging](tracing)
 - [Model store guide](model-store)
 - [Architecture overview](architecture)
 - [API Reference](/api/skulk-api)

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -222,7 +222,7 @@ for chunk in stream:
 | `top_p` | number | Nucleus sampling. |
 | `top_k` | integer | Top-k sampling. |
 | `min_p` | number | Minimum-probability threshold. |
-| `max_tokens` | integer | Max generated tokens. |
+| `max_tokens` | integer | Max generated tokens. When omitted, Skulk uses a conservative backend default of 2048 generated tokens; operators can override that default with `SKULK_MAX_OUTPUT_TOKENS`. |
 | `stop` | string or array | Stop sequences. |
 | `seed` | integer | Reproducibility helper. |
 | `frequency_penalty` | number | Frequency penalty. |

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -157,6 +157,7 @@ If this fails with `404 No instance found for model ...`, the placement is not r
 - `POST /v1/diagnostics/node/capture`
 - `POST /v1/diagnostics/node/runners/{runner_id}/cancel`
 - `GET /v1/diagnostics/cluster`
+- `GET /v1/diagnostics/cluster/timeline`
 - `GET /v1/diagnostics/cluster/{node_id}`
 - `POST /v1/diagnostics/cluster/{node_id}/capture`
 - `POST /v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel`
@@ -778,6 +779,7 @@ Returns stored events from the API-side event log.
 - `POST /v1/diagnostics/node/capture`
 - `POST /v1/diagnostics/node/runners/{runner_id}/cancel`
 - `GET /v1/diagnostics/cluster`
+- `GET /v1/diagnostics/cluster/timeline`
 - `GET /v1/diagnostics/cluster/{node_id}`
 - `POST /v1/diagnostics/cluster/{node_id}/capture`
 - `POST /v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel`
@@ -801,6 +803,16 @@ Behavior notes:
   cancellation for one task that the local runner supervisor still knows about.
 - `GET /v1/diagnostics/cluster` fans out to reachable peer APIs and returns
   partial results when some peers are unavailable.
+- `GET /v1/diagnostics/cluster/timeline` stitches every reachable node's
+  runner-supervisor diagnostics into one cross-rank chronological view. The
+  response carries a per-runner synopsis sorted by `(modelId, deviceRank)`
+  and every flight-recorder entry across all ranks merged and sorted by `at`.
+  Use this when debugging a distributed deadlock: the rank-disagreement
+  signature ("rank 0 entered `pipeline_last_eval_output` at T while rank 1
+  is still in `pipeline_first_recv_like`") is invisible from any single
+  node's local diagnostics but obvious top-to-bottom in the merged timeline.
+  Unreachable peers are returned in `unreachableNodes` instead of failing
+  the request.
 - `GET /v1/diagnostics/cluster/{node_id}` proxies one reachable peer bundle or
   returns the local bundle if `node_id` is the current API node.
 - `POST /v1/diagnostics/cluster/{node_id}/capture` proxies the same on-demand
@@ -826,6 +838,7 @@ Example:
 ```bash
 curl http://localhost:52415/v1/diagnostics/node
 curl http://localhost:52415/v1/diagnostics/cluster
+curl http://localhost:52415/v1/diagnostics/cluster/timeline
 curl http://localhost:52415/v1/diagnostics/cluster/<node_id>
 curl -X POST http://localhost:52415/v1/diagnostics/node/capture \
   -H 'content-type: application/json' \

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -154,9 +154,11 @@ If this fails with `404 No instance found for model ...`, the placement is not r
 - `GET /v1/traces/cluster/{task_id}/stats`
 - `GET /v1/traces/cluster/{task_id}/raw`
 - `GET /v1/diagnostics/node`
+- `POST /v1/diagnostics/node/capture`
 - `POST /v1/diagnostics/node/runners/{runner_id}/cancel`
 - `GET /v1/diagnostics/cluster`
 - `GET /v1/diagnostics/cluster/{node_id}`
+- `POST /v1/diagnostics/cluster/{node_id}/capture`
 - `POST /v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel`
 
 For the full interactive reference with request/response schemas, see the [API Reference](/api/skulk-api).
@@ -773,9 +775,11 @@ Returns stored events from the API-side event log.
 ### Diagnostics
 
 - `GET /v1/diagnostics/node`
+- `POST /v1/diagnostics/node/capture`
 - `POST /v1/diagnostics/node/runners/{runner_id}/cancel`
 - `GET /v1/diagnostics/cluster`
 - `GET /v1/diagnostics/cluster/{node_id}`
+- `POST /v1/diagnostics/cluster/{node_id}/capture`
 - `POST /v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel`
 
 Use these endpoints when a node appears stuck loading, warming up, decoding, or
@@ -784,13 +788,23 @@ shutting down and you need a read-only snapshot without SSHing into every node.
 Behavior notes:
 
 - `GET /v1/diagnostics/node` returns the local node's runtime/config facts,
-  resources, process tree, live runner-supervisor state, and placement analysis.
+  resources, process tree, live runner-supervisor state, flight-recorder phase
+  state, and placement analysis.
+- `POST /v1/diagnostics/node/capture` collects an on-demand local diagnostic
+  bundle. Body fields are `runnerId`, `taskId`, `includeProcessSamples`, and
+  `sampleDurationSeconds`; all are optional. When a runner/task is provided,
+  the response includes that runner's bounded flight recorder, latest MLX
+  memory snapshot, and best-effort macOS `sample`, `vmmap -summary`, and
+  `footprint -p` output. Sampling failures are returned as structured partial
+  failures instead of failing the bundle.
 - `POST /v1/diagnostics/node/runners/{runner_id}/cancel` requests cooperative
   cancellation for one task that the local runner supervisor still knows about.
 - `GET /v1/diagnostics/cluster` fans out to reachable peer APIs and returns
   partial results when some peers are unavailable.
 - `GET /v1/diagnostics/cluster/{node_id}` proxies one reachable peer bundle or
   returns the local bundle if `node_id` is the current API node.
+- `POST /v1/diagnostics/cluster/{node_id}/capture` proxies the same on-demand
+  capture request to a reachable peer node.
 - `POST /v1/diagnostics/cluster/{node_id}/runners/{runner_id}/cancel` proxies
   the same cooperative live-runner cancellation request to a reachable peer.
 - Placement diagnostics explicitly include whether the current master is part of
@@ -798,10 +812,14 @@ Behavior notes:
   one of the inference ranks.
 - The dashboard node-card bug icon uses these endpoints to open a live
   diagnostics drawer for any reachable node.
+- The diagnostics drawer prefers `Capture bundle` before cancellation so
+  operators can collect phase, MLX memory, and process samples before changing
+  the runner state.
 - Runner cancellation is best-effort only. A wedged native/MLX runner may
   ignore the request and still require stronger intervention.
-- Diagnostics endpoints do not currently kill or restart runners; the only
-  mutating diagnostics action is the cooperative task-cancel request above.
+- Diagnostics endpoints do not currently kill or restart runners. Capture is
+  read-only; the only mutating diagnostics action is the cooperative task-cancel
+  request above.
 
 Example:
 
@@ -809,6 +827,12 @@ Example:
 curl http://localhost:52415/v1/diagnostics/node
 curl http://localhost:52415/v1/diagnostics/cluster
 curl http://localhost:52415/v1/diagnostics/cluster/<node_id>
+curl -X POST http://localhost:52415/v1/diagnostics/node/capture \
+  -H 'content-type: application/json' \
+  -d '{"runnerId":"<runner_id>","taskId":"<task_id>"}'
+curl -X POST http://localhost:52415/v1/diagnostics/cluster/<node_id>/capture \
+  -H 'content-type: application/json' \
+  -d '{"runnerId":"<runner_id>","includeProcessSamples":true}'
 curl -X POST http://localhost:52415/v1/diagnostics/node/runners/<runner_id>/cancel \
   -H 'content-type: application/json' \
   -d '{"taskId":"<task_id>"}'

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -153,6 +153,9 @@ If this fails with `404 No instance found for model ...`, the placement is not r
 - `GET /v1/traces/cluster/{task_id}`
 - `GET /v1/traces/cluster/{task_id}/stats`
 - `GET /v1/traces/cluster/{task_id}/raw`
+- `GET /v1/diagnostics/node`
+- `GET /v1/diagnostics/cluster`
+- `GET /v1/diagnostics/cluster/{node_id}`
 
 For the full interactive reference with request/response schemas, see the [API Reference](/api/skulk-api).
 
@@ -764,6 +767,39 @@ Operational note:
 **GET** `/events`
 
 Returns stored events from the API-side event log.
+
+### Diagnostics
+
+- `GET /v1/diagnostics/node`
+- `GET /v1/diagnostics/cluster`
+- `GET /v1/diagnostics/cluster/{node_id}`
+
+Use these endpoints when a node appears stuck loading, warming up, decoding, or
+shutting down and you need a read-only snapshot without SSHing into every node.
+
+Behavior notes:
+
+- `GET /v1/diagnostics/node` returns the local node's runtime/config facts,
+  resources, process tree, live runner-supervisor state, and placement analysis.
+- `GET /v1/diagnostics/cluster` fans out to reachable peer APIs and returns
+  partial results when some peers are unavailable.
+- `GET /v1/diagnostics/cluster/{node_id}` proxies one reachable peer bundle or
+  returns the local bundle if `node_id` is the current API node.
+- Placement diagnostics explicitly include whether the current master is part of
+  each model placement, which helps investigate hangs where the master is not
+  one of the inference ranks.
+- The dashboard node-card bug icon uses these endpoints to open a live
+  diagnostics drawer for any reachable node.
+- These endpoints are read-only. They do not kill, restart, cancel, or mutate
+  runners.
+
+Example:
+
+```bash
+curl http://localhost:52415/v1/diagnostics/node
+curl http://localhost:52415/v1/diagnostics/cluster
+curl http://localhost:52415/v1/diagnostics/cluster/<node_id>
+```
 
 ### Traces
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -223,7 +223,7 @@ for chunk in stream:
 | `top_p` | number | Nucleus sampling. |
 | `top_k` | integer | Top-k sampling. |
 | `min_p` | number | Minimum-probability threshold. |
-| `max_tokens` | integer | Max generated tokens. When omitted, Skulk uses a conservative backend default of 2048 generated tokens; operators can override that default with `SKULK_MAX_OUTPUT_TOKENS`. |
+| `max_tokens` | integer | Max generated tokens. When omitted, Skulk uses a backend default of 4096 generated tokens (`DEFAULT_MAX_OUTPUT_TOKENS`); operators can override that default with `SKULK_MAX_OUTPUT_TOKENS` (or the legacy `EXO_MAX_TOKENS`). |
 | `stop` | string or array | Stop sequences. |
 | `seed` | integer | Reproducibility helper. |
 | `frequency_penalty` | number | Frequency penalty. |

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -227,7 +227,22 @@ and the [API guide](api-guide).
 ## Debugging MLX Hangs
 
 When a model appears to stall during warmup, prefill, or distributed generation,
-Skulk can emit phase-specific hang diagnostics from the runner process.
+Skulk keeps an always-on, local-only runner flight recorder. Each runner
+supervisor retains the last 128 phase updates outside the event log, so these
+breadcrumbs remain available even when tracing is disabled or a task never
+finishes. The diagnostics drawer and `/v1/diagnostics/*` APIs expose the current
+phase, time in phase, active task/command, latest MLX memory snapshot, and recent
+flight-recorder entries.
+
+For deeper evidence collection before cancelling a stuck task, use
+`POST /v1/diagnostics/node/capture` or
+`POST /v1/diagnostics/cluster/{node_id}/capture`. Capture bundles include the
+live node diagnostics, matched runner flight recorder, current process tree, and
+best-effort macOS `sample`, `vmmap -summary`, and `footprint -p` output for the
+runner process. Sampling is on-demand only and failures are included as partial
+results.
+
+Skulk can also emit phase-specific stack diagnostics from the runner process.
 
 Set these environment variables before starting `skulk`:
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -204,6 +204,26 @@ The key pieces:
 
 This is opt-in. Without the logging config, skulk behaves identically to before.
 
+## Where Tracing Fits
+
+Skulk also has a separate tracing surface for debugging live inference work.
+
+The important user-facing model is:
+
+- tracing is off by default
+- you turn it on at runtime from the dashboard traces view
+- the toggle applies cluster-wide for new requests
+- traces can be browsed from any reachable node through cluster trace endpoints
+- local trace deletion remains local-only in v1
+
+Tracing is meant for targeted debugging sessions, not as a permanently enabled
+always-on telemetry pipeline. When you need it, use the dashboard bug icon or
+the `/v1/tracing` API to enable it, reproduce the workload, then inspect the
+result through the traces UI or the `/v1/traces*` endpoints.
+
+For operator workflow and endpoint details, read [Tracing and debugging](tracing)
+and the [API guide](api-guide).
+
 ## Debugging MLX Hangs
 
 When a model appears to stall during warmup, prefill, or distributed generation,

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -23,6 +23,7 @@ If you are getting oriented, start with these pages:
 - [API guide](api-guide) for the happy path: place a model, then call the API
 - [Model store guide](model-store) for shared model storage and download workflows
 - [KV cache backends](kv-cache-backends) for backend and runtime tuning
+- [Tracing and debugging](tracing) for runtime tracing, cluster browsing, and operator workflow
 - [Model cards](model-cards) for the metadata and capability declarations Skulk uses to describe models
 - [Model capabilities](model-capabilities) for how declarative card fields become runtime behavior
 - [Release notes 1.0.2](release-notes/1.0.2) for the latest branch stabilization and model-support work
@@ -33,6 +34,7 @@ If you are getting oriented, start with these pages:
 - I want to browse the backend API: [API Reference](/api/skulk-api)
 - I want frontend and TypeScript symbols: [TypeScript API](https://foxlight-foundation.github.io/Skulk/typedoc/)
 - I want implementation context before I integrate: [Architecture overview](architecture)
+- I want to debug live inference: [Tracing and debugging](tracing)
 
 ## What Lives Here
 

--- a/website/docs/model-store.md
+++ b/website/docs/model-store.md
@@ -100,7 +100,7 @@ model_store:
   staging:
     enabled: true
     node_cache_path: ~/.skulk/staging
-    cleanup_on_deactivate: true
+    cleanup_on_deactivate: false
 
   node_overrides:
     mac-studio-1:
@@ -159,7 +159,11 @@ Where a node stages files before loading them.
 
 ### `model_store.staging.cleanup_on_deactivate`
 
-If `true`, staged files are cleaned up when instances are shut down.
+If `true`, staged files are cleaned up when instances are shut down. The
+recommended default is `false`, which keeps the local staging cache warm so
+large models do not need to be copied from the store again on every placement.
+Use `POST /store/purge-staging` when you intentionally want to reclaim disk
+space.
 
 ## Typical Flow
 
@@ -255,9 +259,19 @@ Remember that store registration only tracks artifacts and metadata. Actual
 image understanding still depends on launching the model and sending a
 multimodal request through the chat APIs.
 
+### Placements are slow even though the model is already in the store
+
+Check whether `cleanup_on_deactivate` is enabled. If it is `true`, each model
+deactivation removes the local staged copy, so the next placement must copy the
+model from the store host again before MLX can load it. Set it to `false` for
+normal clusters and purge staging caches explicitly when disk pressure requires
+it.
+
 ### Staged files are not being cleaned up
 
-Check `cleanup_on_deactivate` and any `node_overrides` that may disable cleanup for a specific machine.
+This is usually expected. Skulk keeps staged files by default so repeated
+placements are warm. If you need disk space back, either enable
+`cleanup_on_deactivate` for that node or use the model-store purge action.
 
 ## Good Defaults for Most Clusters
 

--- a/website/docs/tracing.md
+++ b/website/docs/tracing.md
@@ -1,0 +1,124 @@
+---
+id: tracing
+title: Tracing and Debugging
+sidebar_position: 5
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+This guide explains how to use Skulk's runtime tracing feature.
+
+The short version:
+
+- tracing is off by default
+- you turn it on from the dashboard traces view or via `PUT /v1/tracing`
+- the toggle applies to new requests across the current cluster session
+- image, text-generation, and embedding requests can all produce traces
+- traces can be browsed from any reachable node through the cluster trace view
+
+## How To Turn It On
+
+In the dashboard:
+
+1. click the bug icon in the toolbar
+2. open the **Traces** page
+3. use the tracing toggle card at the top of the page
+
+The UI copy intentionally says:
+
+- **Applies to new requests on all nodes**
+
+That is the correct mental model. Tracing is a runtime cluster toggle, but it
+does not retroactively attach to work that was already running before you
+enabled it.
+
+You can also control it through the API:
+
+```bash
+curl http://localhost:52415/v1/tracing
+
+curl -X PUT http://localhost:52415/v1/tracing \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled": true}'
+```
+
+## What Gets Traced
+
+Tracing is no longer image-only.
+
+Skulk can now emit traces for:
+
+- image generation and image edits
+- text generation
+- text embeddings
+
+The trace metadata includes:
+
+- task kind
+- model ID
+- source node information
+- tags
+- arbitrary attributes for richer debugging views
+
+Tool-related text-generation activity is also marked so the traces page can
+filter for tool activity.
+
+## Local vs Cluster Browsing
+
+The traces page supports two browsing scopes:
+
+- **Local**: show trace artifacts saved on the current node
+- **Cluster**: fan out to reachable peer APIs, deduplicate by `task_id`, and
+  browse traces from any reachable node
+
+This distinction matters:
+
+- browsing is available from any reachable node in cluster scope
+- deletion is still local-only in v1
+- if some peers are offline or unreachable, cluster results may be partial
+
+## API Surface
+
+Runtime tracing control:
+
+- `GET /v1/tracing`
+- `PUT /v1/tracing`
+
+Local trace browsing:
+
+- `GET /v1/traces`
+- `GET /v1/traces/{task_id}`
+- `GET /v1/traces/{task_id}/stats`
+- `GET /v1/traces/{task_id}/raw`
+- `POST /v1/traces/delete`
+
+Cluster trace browsing:
+
+- `GET /v1/traces/cluster`
+- `GET /v1/traces/cluster/{task_id}`
+- `GET /v1/traces/cluster/{task_id}/stats`
+- `GET /v1/traces/cluster/{task_id}/raw`
+
+For request and response details, see the [API guide](api-guide) and the
+interactive [API Reference](/api/skulk-api).
+
+## Common Workflow
+
+When you want to debug a live problem:
+
+1. open the traces page
+2. enable tracing
+3. reproduce the workload
+4. refresh the traces list
+5. inspect local or cluster scope as needed
+6. use filters for task kind, model, source node, category, or tool activity
+7. download the raw trace JSON or open it in Perfetto when you need timeline detail
+
+## Operator Notes
+
+- tracing is meant for debugging sessions, not as a permanent always-on mode
+- enabling tracing affects new requests only
+- the old env-var path still exists as a hidden developer boot override, but it
+  is no longer the normal user workflow
+- cluster browsing is read-only in v1
+- local deletion remains explicit and local-only in v1

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -24,6 +24,7 @@ const sidebars: SidebarsConfig = {
         "build-and-runtime",
         "model-store",
         "kv-cache-backends",
+        "tracing",
         "model-cards",
         "model-capabilities",
         {


### PR DESCRIPTION
## Summary
- replace env-var-first tracing with a cluster runtime toggle carried through command/event/state
- add task-scoped tracing plus image, text, and embedding coverage with cluster trace browsing from any reachable node
- update the dashboard, API surface, tests, and user-facing docs for the new tracing workflow

## Validation
- uv run basedpyright
- uv run ruff check
- nix --extra-experimental-features 'nix-command flakes' fmt\n- uv run pytest\n- cd dashboard-react && npm run build\n- cd website && npm run build