### PR TITLE
feat(dashboard): observability panel scaffold + nav unification

### DIFF
--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -9,7 +9,7 @@ import { TopologyGraph } from './components/topology/TopologyGraph';
 import { ConnectionBanner } from './components/status/ConnectionBanner';
 import { ToastContainer } from './components/status/ToastContainer';
 import { NetworkMesh } from './components/common/NetworkMesh';
-import { DiagnosticsDrawer } from './components/layout/DiagnosticsDrawer';
+import { ObservabilityPanel } from './components/observability/ObservabilityPanel';
 import { SettingsPanel } from './components/layout/SettingsPanel';
 import { ModelStorePage } from './components/pages/DownloadsPage';
 import { ChatView } from './components/pages/ChatView';
@@ -120,8 +120,10 @@ export function App() {
     thunderboltBridgeCycles,
   } = useClusterState();
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [diagnosticsNodeId, setDiagnosticsNodeId] = useState<string | null>(null);
   const [storeDownloads, setStoreDownloads] = useState<StoreDownload[]>([]);
+  // Observability panel state lives on the global UI store so any component (toolbar
+  // nav, per-node bug icons, future cross-links) can open the panel to a specific tab.
+  const openObservability = useUIStore((s) => s.openObservability);
   const activeRoute = useUIStore((s) => s.activeRoute);
   const panelOpen = useUIStore((s) => s.panelOpen);
   const historyPanelOpen = useUIStore((s) => s.historyPanelOpen);
@@ -420,7 +422,7 @@ export function App() {
             ) : topology ? (
               <TopologyGraph
                 data={topology}
-                onInspectNode={setDiagnosticsNodeId}
+                onInspectNode={(nodeId) => openObservability('node', nodeId)}
               />
             ) : (
               <EmptyState>
@@ -437,10 +439,7 @@ export function App() {
           )}
         </ContentRow>
         <ToastContainer />
-        <DiagnosticsDrawer
-          nodeId={diagnosticsNodeId}
-          onClose={() => setDiagnosticsNodeId(null)}
-        />
+        <ObservabilityPanel />
         <SettingsPanel open={settingsOpen} onClose={() => setSettingsOpen(false)} />
       </Shell>
     </ThemeProvider>

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -231,7 +231,7 @@ const SidebarIcon = () => <FiSidebar size={18} />;
 const ClusterIcon = () => <MdHub size={16} />;
 const StoreIcon = () => <FiDatabase size={16} />;
 const ChatIcon = () => <FiMessageSquare size={16} />;
-const TraceIcon = () => <VscBug size={16} />;
+const ObservabilityIcon = () => <VscBug size={16} />;
 const SettingsIcon = () => <FiSettings size={16} />;
 
 function ProgressCircle({ count, percentage }: { count: number; percentage: number }) {
@@ -286,6 +286,12 @@ export function HeaderNav({
   const theme = useTheme() as Theme;
   const themeName = useUIStore((s) => s.theme);
   const toggleTheme = useUIStore((s) => s.toggleTheme);
+  // Observability panel is global UI state — the button toggles it open/closed and
+  // visually reflects whether it's currently visible. Distinct from `activeRoute`
+  // because the panel overlays the current route rather than navigating away.
+  const observabilityPanelOpen = useUIStore((s) => s.observabilityPanelOpen);
+  const openObservability = useUIStore((s) => s.openObservability);
+  const closeObservability = useUIStore((s) => s.closeObservability);
   const navigate = (route: NavRoute) => {
     onNavigate?.(route);
     if (route === 'cluster') onHome?.();
@@ -381,14 +387,15 @@ export function HeaderNav({
         </Button>
 
         <Button
-          variant={activeRoute === 'traces' ? 'outline' : 'ghost'}
+          variant={observabilityPanelOpen ? 'outline' : 'ghost'}
           size="lg"
           icon
-          onClick={() => navigate('traces')}
-          aria-label="Traces"
-          title="Traces"
+          onClick={() => (observabilityPanelOpen ? closeObservability() : openObservability())}
+          aria-label="Observability"
+          aria-pressed={observabilityPanelOpen}
+          title="Observability"
         >
-          <TraceIcon />
+          <ObservabilityIcon />
         </Button>
 
         <Button variant="ghost" size="lg" icon onClick={() => onOpenSettings?.()} aria-label="Settings">

--- a/dashboard-react/src/components/observability/LiveTab.tsx
+++ b/dashboard-react/src/components/observability/LiveTab.tsx
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+
+/**
+ * Live tab placeholder. Phase 3 (#120) wires this to:
+ *
+ * - Cluster health header (hang-rate counter, tracing toggle, master id, connectivity)
+ * - Cross-rank flight-recorder timeline (`/v1/diagnostics/cluster/timeline`)
+ * - Live event stream tail (`/events`)
+ *
+ * Phase 1 ships the panel scaffold only; the Live tab is intentionally an empty
+ * affordance so the navigation pattern is testable end-to-end before the heavy
+ * visualization work lands.
+ */
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px 12px;
+`;
+
+const Heading = styled.h3`
+  margin: 0;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Body = styled.p`
+  margin: 0;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  line-height: 1.55;
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const Coming = styled.div`
+  margin-top: 8px;
+  padding: 12px 14px;
+  border: 1px dashed ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.radii.md};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+export function LiveTab() {
+  return (
+    <Wrap>
+      <Heading>Live cluster health</Heading>
+      <Body>
+        This view will show the cross-rank flight-recorder timeline, hang-rate counter,
+        cluster-wide tracing toggle, and live event stream tail. Right now it's the empty
+        scaffold delivered in Phase 1 of the observability consolidation.
+      </Body>
+      <Coming>
+        Coming in Phase 3 (issue #120). Underlying data is already exposed at{' '}
+        <code>/v1/diagnostics/cluster/timeline</code>; this tab just hasn't rendered it yet.
+      </Coming>
+    </Wrap>
+  );
+}

--- a/dashboard-react/src/components/observability/NodeTab.tsx
+++ b/dashboard-react/src/components/observability/NodeTab.tsx
@@ -11,54 +11,34 @@ import type {
   RunnerSupervisorDiagnostics,
 } from '../../types/diagnostics';
 
-/** Props for the read-only node diagnostics drawer. */
-export interface DiagnosticsDrawerProps {
-  /** Node ID to inspect. Pass null to close the drawer. */
+/**
+ * "Node" tab body for the observability panel — read-only diagnostics for one cluster
+ * node. Replaces the standalone DiagnosticsDrawer that used to render with its own
+ * overlay; the panel now provides the framing (resizable width, header, close button)
+ * and this component is just the data rendering.
+ *
+ * If `nodeId` is null the tab renders an empty-state hint pointing the operator at the
+ * topology view to pick a node. The data fetch only fires when a node is selected.
+ */
+export interface NodeTabProps {
+  /** Node ID to inspect. Null when the operator hasn't picked a node yet. */
   nodeId: string | null;
-  /** Called when the user closes the drawer. */
-  onClose: () => void;
 }
 
-const Overlay = styled.div`
-  position: fixed;
-  inset: 0;
-  z-index: 70;
-  background: ${({ theme }) => theme.colors.overlay};
-  display: flex;
-  justify-content: flex-end;
-`;
-
-const Drawer = styled.aside`
-  width: min(560px, 100vw);
-  height: 100%;
-  background: ${({ theme }) => theme.colors.surfaceElevated};
-  border-left: 1px solid ${({ theme }) => theme.colors.borderStrong};
-  box-shadow: -18px 0 48px ${({ theme }) => theme.colors.shadowStrong};
-  padding: 22px;
-  overflow: auto;
-`;
-
-const Header = styled.div`
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 18px;
-`;
-
-const Title = styled.h2`
-  margin: 0;
-  font-family: ${({ theme }) => theme.fonts.body};
-  font-size: ${({ theme }) => theme.fontSizes.xl};
-  color: ${({ theme }) => theme.colors.text};
-`;
-
 const Subtitle = styled.div`
-  margin-top: 4px;
+  margin: 0 0 14px;
   font-family: ${({ theme }) => theme.fonts.mono};
   font-size: ${({ theme }) => theme.fontSizes.xs};
   color: ${({ theme }) => theme.colors.textMuted};
   word-break: break-all;
+`;
+
+const EmptyHint = styled.div`
+  padding: 24px 12px;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  line-height: 1.55;
 `;
 
 const Section = styled.section`
@@ -277,7 +257,7 @@ function recorderLine(entry: RunnerFlightRecorderEntry): string {
   ].filter(Boolean).join(' · ');
 }
 
-export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
+export function NodeTab({ nodeId }: NodeTabProps) {
   const [diagnostics, setDiagnostics] = useState<NodeDiagnostics | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -327,7 +307,13 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
     return () => controller.abort();
   }, [nodeId, reloadToken]);
 
-  if (!nodeId) return null;
+  if (!nodeId) {
+    return (
+      <EmptyHint>
+        Click any node in the topology view to inspect its diagnostics here.
+      </EmptyHint>
+    );
+  }
 
   const runtime = diagnostics?.runtime;
   const currentMemory = diagnostics?.resources.currentMemory;
@@ -411,15 +397,8 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
   }
 
   return (
-    <Overlay onClick={onClose}>
-      <Drawer onClick={(event) => event.stopPropagation()}>
-        <Header>
-          <div>
-            <Title>Node Diagnostics</Title>
-            <Subtitle>{runtime?.friendlyName ?? runtime?.hostname ?? shortId(nodeId)} · {shortId(nodeId)}</Subtitle>
-          </div>
-          <Button variant="ghost" size="sm" onClick={onClose}>Close</Button>
-        </Header>
+    <>
+      <Subtitle>{runtime?.friendlyName ?? runtime?.hostname ?? shortId(nodeId)} · {shortId(nodeId)}</Subtitle>
 
         {loading && <Section><Value>Loading diagnostics…</Value></Section>}
         {error && <Section><Warning>{error}</Warning></Section>}
@@ -637,7 +616,6 @@ export function DiagnosticsDrawer({ nodeId, onClose }: DiagnosticsDrawerProps) {
             </Section>
           </>
         )}
-      </Drawer>
-    </Overlay>
+    </>
   );
 }

--- a/dashboard-react/src/components/observability/ObservabilityPanel.tsx
+++ b/dashboard-react/src/components/observability/ObservabilityPanel.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { FiX } from 'react-icons/fi';
+import { Button } from '../common/Button';
+import { useUIStore, type ObservabilityTab } from '../../stores/uiStore';
+import { LiveTab } from './LiveTab';
+import { NodeTab } from './NodeTab';
+import { TracesTab } from './TracesTab';
+
+/**
+ * Right-side resizable panel that hosts every observability surface — live cluster
+ * health, per-node deep dive, saved trace browsing — under one nav entry.
+ *
+ * Architecture decisions worth knowing:
+ *
+ * - The panel **overlays** the current route's content rather than replacing it.
+ *   Operators in chat / model store / topology can glance at observability without
+ *   losing their place.
+ * - The panel is **side-docked, no backdrop**. The topology view stays interactive so
+ *   the panel and the spatial cluster picture are usable simultaneously.
+ * - Width is **operator-controlled** (drag the left edge) and **persisted to
+ *   localStorage** outside the sessionStorage UI state — operators settle on a width
+ *   and shouldn't redo it on every refresh.
+ * - All panel state lives on the global Zustand store so any component can open the
+ *   panel to a specific tab/node. The toolbar nav button calls `openObservability()`
+ *   without args; per-node bug icons call `openObservability('node', nodeId)`.
+ */
+
+const Aside = styled.aside<{ $width: number }>`
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: ${({ $width }) => $width}px;
+  background: ${({ theme }) => theme.colors.surfaceElevated};
+  border-left: 1px solid ${({ theme }) => theme.colors.borderStrong};
+  box-shadow: -18px 0 48px ${({ theme }) => theme.colors.shadowStrong};
+  display: flex;
+  flex-direction: column;
+  /*
+   * Z-index sits above the topology + main content but below modal dialogs.
+   * The DiagnosticsDrawer it replaces used 70; we sit just below at 65 so future
+   * modal work can layer on top without arguing with the panel.
+   */
+  z-index: 65;
+`;
+
+/**
+ * Drag handle on the left edge of the panel. Sits in front of `Aside`'s left border
+ * with a slightly wider hit area than its visible footprint so the cursor catches it
+ * reliably.
+ */
+const ResizeHandle = styled.div`
+  position: absolute;
+  left: -4px;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  cursor: ew-resize;
+  /* Subtle hover hint without being distracting. */
+  &:hover {
+    background: ${({ theme }) => theme.colors.goldDim};
+    opacity: 0.4;
+  }
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 10px;
+  gap: 12px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const TabBar = styled.div`
+  display: flex;
+  gap: 4px;
+  padding: 8px 12px 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+const TabButton = styled.button<{ $active: boolean }>`
+  all: unset;
+  cursor: pointer;
+  padding: 6px 14px 8px;
+  border-radius: ${({ theme }) => theme.radii.sm} ${({ theme }) => theme.radii.sm} 0 0;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  color: ${({ $active, theme }) => ($active ? theme.colors.gold : theme.colors.textSecondary)};
+  border-bottom: 2px solid
+    ${({ $active, theme }) => ($active ? theme.colors.gold : 'transparent')};
+  transition: color 0.15s, border-color 0.15s;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.text};
+  }
+
+  /* Visible focus ring for keyboard users — 'all: unset' strips the default. */
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.goldDim};
+    outline-offset: 2px;
+  }
+`;
+
+const Body = styled.div`
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px 18px;
+`;
+
+const TAB_ORDER: { key: ObservabilityTab; label: string }[] = [
+  { key: 'live', label: 'Live' },
+  { key: 'node', label: 'Node' },
+  { key: 'traces', label: 'Traces' },
+];
+
+export function ObservabilityPanel() {
+  const open = useUIStore((s) => s.observabilityPanelOpen);
+  const activeTab = useUIStore((s) => s.observabilityActiveTab);
+  const width = useUIStore((s) => s.observabilityPanelWidth);
+  const selectedNodeId = useUIStore((s) => s.observabilitySelectedNodeId);
+  const setTab = useUIStore((s) => s.setObservabilityTab);
+  const setWidth = useUIStore((s) => s.setObservabilityPanelWidth);
+  const close = useUIStore((s) => s.closeObservability);
+
+  // Drag-to-resize: capture pointer at the handle; resizing computes width from
+  // the cursor's distance from the right edge of the viewport. Using a ref for
+  // the live width during drag avoids re-rendering the entire panel on every
+  // pointermove event — we only commit to the store on pointerup.
+  const draggingRef = useRef(false);
+  const dragWidthRef = useRef<number>(width);
+
+  // Begin a resize drag. Store-side commit happens on pointerup; in-flight
+  // updates set the panel width via DOM directly to keep things smooth.
+  const onResizeStart = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      draggingRef.current = true;
+      dragWidthRef.current = width;
+      // Capture the pointer so we keep getting events even if the cursor
+      // briefly leaves the handle's hitbox during fast drags.
+      (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    },
+    [width],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const onMove = (event: PointerEvent) => {
+      if (!draggingRef.current) return;
+      const next = window.innerWidth - event.clientX;
+      dragWidthRef.current = next;
+      // Live preview via inline style on the panel; final commit lands on up.
+      const panel = document.getElementById('observability-panel');
+      if (panel) panel.style.width = `${next}px`;
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      setWidth(dragWidthRef.current);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+  }, [open, setWidth]);
+
+  // Esc closes the panel — operators expect this for any modal-like surface.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, close]);
+
+  if (!open) return null;
+
+  return (
+    <Aside $width={width} id="observability-panel" aria-label="Observability panel">
+      <ResizeHandle
+        onPointerDown={onResizeStart}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize observability panel"
+      />
+      <Header>
+        <Title>Observability</Title>
+        <Button variant="ghost" size="sm" onClick={close} aria-label="Close observability panel">
+          <FiX size={16} />
+        </Button>
+      </Header>
+      <TabBar role="tablist" aria-label="Observability views">
+        {TAB_ORDER.map((tab) => (
+          <TabButton
+            key={tab.key}
+            $active={activeTab === tab.key}
+            role="tab"
+            aria-selected={activeTab === tab.key}
+            aria-controls={`observability-panel-${tab.key}`}
+            id={`observability-tab-${tab.key}`}
+            onClick={() => setTab(tab.key)}
+          >
+            {tab.label}
+          </TabButton>
+        ))}
+      </TabBar>
+      <Body
+        role="tabpanel"
+        id={`observability-panel-${activeTab}`}
+        aria-labelledby={`observability-tab-${activeTab}`}
+      >
+        {activeTab === 'live' && <LiveTab />}
+        {activeTab === 'node' && <NodeTab nodeId={selectedNodeId} />}
+        {activeTab === 'traces' && <TracesTab />}
+      </Body>
+    </Aside>
+  );
+}

--- a/dashboard-react/src/components/observability/ObservabilityPanel.tsx
+++ b/dashboard-react/src/components/observability/ObservabilityPanel.tsx
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { FiX } from 'react-icons/fi';
 import { Button } from '../common/Button';
-import { useUIStore, type ObservabilityTab } from '../../stores/uiStore';
+import {
+  useUIStore,
+  type ObservabilityTab,
+  OBSERVABILITY_WIDTH_MIN,
+  OBSERVABILITY_WIDTH_MAX,
+} from '../../stores/uiStore';
 import { LiveTab } from './LiveTab';
 import { NodeTab } from './NodeTab';
 import { TracesTab } from './TracesTab';
@@ -133,9 +138,11 @@ export function ObservabilityPanel() {
   const close = useUIStore((s) => s.closeObservability);
 
   // Drag-to-resize: capture pointer at the handle; resizing computes width from
-  // the cursor's distance from the right edge of the viewport. Using a ref for
-  // the live width during drag avoids re-rendering the entire panel on every
-  // pointermove event — we only commit to the store on pointerup.
+  // the cursor's distance from the right edge of the viewport. We hold an Aside
+  // ref instead of looking the element up via getElementById in the pointermove
+  // hot path, both to avoid the lookup cost and to keep the contract local
+  // (this component owns the element it mutates during drag).
+  const asideRef = useRef<HTMLElement | null>(null);
   const draggingRef = useRef(false);
   const dragWidthRef = useRef<number>(width);
 
@@ -157,15 +164,30 @@ export function ObservabilityPanel() {
     if (!open) return;
     const onMove = (event: PointerEvent) => {
       if (!draggingRef.current) return;
-      const next = window.innerWidth - event.clientX;
+      // Clamp during live preview, not just at commit time. Without this the
+      // pointer leaving the viewport would set the inline width to negative or
+      // wildly large values and the panel would visibly flicker off-screen
+      // even though the eventual store commit clamps. Using the same range
+      // here keeps the live preview and the persisted state visually identical.
+      const raw = window.innerWidth - event.clientX;
+      const next = Math.max(
+        OBSERVABILITY_WIDTH_MIN,
+        Math.min(OBSERVABILITY_WIDTH_MAX, raw),
+      );
       dragWidthRef.current = next;
       // Live preview via inline style on the panel; final commit lands on up.
-      const panel = document.getElementById('observability-panel');
-      if (panel) panel.style.width = `${next}px`;
+      if (asideRef.current) asideRef.current.style.width = `${next}px`;
     };
     const onUp = () => {
       if (!draggingRef.current) return;
       draggingRef.current = false;
+      // Clear the inline style BEFORE committing the store update. Inline
+      // styles beat styled-components' generated CSS rules on specificity, so
+      // leaving an inline width here would silently override every subsequent
+      // state-driven width change (including from `setObservabilityPanelWidth`
+      // and from any other component that touches the store). Clearing first
+      // hands width control back to the styled-component template literal.
+      if (asideRef.current) asideRef.current.style.width = '';
       setWidth(dragWidthRef.current);
     };
     window.addEventListener('pointermove', onMove);
@@ -191,7 +213,12 @@ export function ObservabilityPanel() {
   if (!open) return null;
 
   return (
-    <Aside $width={width} id="observability-panel" aria-label="Observability panel">
+    <Aside
+      $width={width}
+      ref={asideRef}
+      id="observability-panel"
+      aria-label="Observability panel"
+    >
       <ResizeHandle
         onPointerDown={onResizeStart}
         role="separator"

--- a/dashboard-react/src/components/observability/ObservabilityPanel.tsx
+++ b/dashboard-react/src/components/observability/ObservabilityPanel.tsx
@@ -43,11 +43,22 @@ const Aside = styled.aside<{ $width: number }>`
   display: flex;
   flex-direction: column;
   /*
-   * Z-index sits above the topology + main content but below modal dialogs.
-   * The DiagnosticsDrawer it replaces used 70; we sit just below at 65 so future
-   * modal work can layer on top without arguing with the panel.
+   * Z-index sits above the topology + main content but BELOW any modal-style
+   * surface. SettingsPanel uses 40 (backdrop) and 50 (drawer); operators
+   * routinely open Settings while the observability panel is visible, and a
+   * panel that floats above the Settings drawer makes Settings appear broken
+   * (the higher-z panel covers part or all of the modal). 35 keeps the panel
+   * above topology content (which uses z-index in the 1-20 range) and below
+   * the modal stack, so the SettingsPanel backdrop dims-and-covers the panel
+   * the way a modal should.
+   *
+   * The toolbar's bug icon (HeaderNav body z=20) is covered by the panel
+   * while it's open, which mirrors the prior DiagnosticsDrawer (z=70)
+   * behavior. Operators close via Esc, the panel's X button, or via the
+   * topology bug icon — the toolbar icon is not the canonical close
+   * affordance.
    */
-  z-index: 65;
+  z-index: 35;
 `;
 
 /**

--- a/dashboard-react/src/components/observability/TracesTab.tsx
+++ b/dashboard-react/src/components/observability/TracesTab.tsx
@@ -1,0 +1,87 @@
+import styled from 'styled-components';
+import { Button } from '../common/Button';
+import { useUIStore } from '../../stores/uiStore';
+
+/**
+ * Traces tab placeholder. Phase 2 (#119) replaces this body with:
+ *
+ * - The trace list (currently lives in `TracesPage`)
+ * - A custom Skulk-native waterfall renderer for the selected trace, replacing
+ *   today's "open in Perfetto" popup which sends trace data to Google's hosted
+ *   web app and routinely fails to popup blockers.
+ *
+ * For Phase 1 the tab keeps trace browsing reachable by sending the user back to
+ * the existing `traces` route. The route itself is removed from the top nav (the
+ * Observability button replaces the old `Traces` icon) but the route is still
+ * registered, so the page renders normally when navigated to.
+ */
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px 12px;
+`;
+
+const Heading = styled.h3`
+  margin: 0;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Body = styled.p`
+  margin: 0;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  line-height: 1.55;
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const Actions = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+`;
+
+const Coming = styled.div`
+  margin-top: 8px;
+  padding: 12px 14px;
+  border: 1px dashed ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.radii.md};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+export function TracesTab() {
+  const setActiveRoute = useUIStore((s) => s.setActiveRoute);
+  const setSelectedTraceTaskId = useUIStore((s) => s.setSelectedTraceTaskId);
+  const closeObservability = useUIStore((s) => s.closeObservability);
+
+  const openLegacyTraces = () => {
+    setSelectedTraceTaskId(null);
+    setActiveRoute('traces');
+    closeObservability();
+  };
+
+  return (
+    <Wrap>
+      <Heading>Saved traces</Heading>
+      <Body>
+        Inline trace browsing is coming with a Skulk-native waterfall renderer in
+        Phase 2 — replacing the current Perfetto popup integration with something
+        that doesn't ship trace data to a third-party web app and isn't fragile to
+        popup blockers.
+      </Body>
+      <Actions>
+        <Button variant="outline" size="sm" onClick={openLegacyTraces}>
+          Open trace browser (legacy view)
+        </Button>
+      </Actions>
+      <Coming>
+        Coming in Phase 2 (issue #119).
+      </Coming>
+    </Wrap>
+  );
+}

--- a/dashboard-react/src/stores/uiStore.ts
+++ b/dashboard-react/src/stores/uiStore.ts
@@ -4,6 +4,16 @@ import type { NavRoute } from '../components/layout/HeaderNav';
 import type { ThemeName } from '../theme';
 
 const THEME_STORAGE_KEY = 'skulk-theme';
+const OBSERVABILITY_WIDTH_KEY = 'skulk-observability-panel-width';
+/** Default width of the right-side observability panel, in pixels. */
+const OBSERVABILITY_WIDTH_DEFAULT = 560;
+/** Hard floor on the panel width — narrower than this and the content stops being legible. */
+const OBSERVABILITY_WIDTH_MIN = 360;
+/** Hard ceiling — any wider and the panel would consume the whole viewport on most screens. */
+const OBSERVABILITY_WIDTH_MAX = 1200;
+
+/** Tabs available inside the observability panel. */
+export type ObservabilityTab = 'live' | 'node' | 'traces';
 
 /** Read the persisted theme preference from localStorage, falling back to OS preference. */
 function loadInitialTheme(): ThemeName {
@@ -31,6 +41,34 @@ function persistTheme(name: ThemeName): void {
   }
 }
 
+function clampPanelWidth(value: number): number {
+  if (Number.isNaN(value)) return OBSERVABILITY_WIDTH_DEFAULT;
+  return Math.max(OBSERVABILITY_WIDTH_MIN, Math.min(OBSERVABILITY_WIDTH_MAX, Math.round(value)));
+}
+
+/** Read the persisted observability panel width from localStorage, clamped to [min, max]. */
+function loadInitialObservabilityWidth(): number {
+  if (typeof window === 'undefined') return OBSERVABILITY_WIDTH_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(OBSERVABILITY_WIDTH_KEY);
+    if (raw === null) return OBSERVABILITY_WIDTH_DEFAULT;
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed)) return clampPanelWidth(parsed);
+  } catch {
+    /* ignore */
+  }
+  return OBSERVABILITY_WIDTH_DEFAULT;
+}
+
+function persistObservabilityWidth(width: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(OBSERVABILITY_WIDTH_KEY, String(clampPanelWidth(width)));
+  } catch {
+    /* ignore */
+  }
+}
+
 export interface UIState {
   activeRoute: NavRoute;
   selectedTraceTaskId: string | null;
@@ -42,6 +80,26 @@ export interface UIState {
   /** Active color theme. Persisted to localStorage outside the sessionStorage `persist` block. */
   theme: ThemeName;
 
+  /**
+   * Whether the observability panel (right-side dock) is visible. The panel overlays the
+   * current route's content rather than being a route itself, so the user can keep
+   * working in topology / chat / model store while glancing at observability data.
+   */
+  observabilityPanelOpen: boolean;
+  /** Active tab inside the observability panel. */
+  observabilityActiveTab: ObservabilityTab;
+  /**
+   * Width of the observability panel in pixels. Persisted to localStorage outside the
+   * sessionStorage `persist` block so it survives across sessions — operators settle
+   * on a width that suits their displays and shouldn't have to redo it on every refresh.
+   */
+  observabilityPanelWidth: number;
+  /**
+   * Node ID currently focused in the panel's "Node" tab. Independent of `panelOpen`
+   * so closing the panel and reopening it returns to the same node.
+   */
+  observabilitySelectedNodeId: string | null;
+
   setActiveRoute: (route: NavRoute) => void;
   setSelectedTraceTaskId: (taskId: string | null) => void;
   setPanelOpen: (open: boolean) => void;
@@ -51,6 +109,21 @@ export interface UIState {
   setExpandedThinking: (conversationId: string, messageIds: string[]) => void;
   setTheme: (name: ThemeName) => void;
   toggleTheme: () => void;
+
+  /**
+   * Open the observability panel. If a tab is provided the panel switches to it; if a
+   * nodeId is provided (typical when the user clicks the per-node bug icon) the panel
+   * additionally selects the Node tab and remembers the node selection.
+   */
+  openObservability: (tab?: ObservabilityTab, nodeId?: string) => void;
+  closeObservability: () => void;
+  setObservabilityTab: (tab: ObservabilityTab) => void;
+  /**
+   * Set the observability panel width. Clamped to the safe range and persisted to
+   * localStorage outside the sessionStorage `persist` block.
+   */
+  setObservabilityPanelWidth: (width: number) => void;
+  setObservabilitySelectedNodeId: (nodeId: string | null) => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -64,6 +137,11 @@ export const useUIStore = create<UIState>()(
       chatScrollTop: 0,
       expandedThinking: {},
       theme: loadInitialTheme(),
+
+      observabilityPanelOpen: false,
+      observabilityActiveTab: 'live',
+      observabilityPanelWidth: loadInitialObservabilityWidth(),
+      observabilitySelectedNodeId: null,
 
       setActiveRoute: (route) => set({ activeRoute: route }),
       setSelectedTraceTaskId: (taskId) => set({ selectedTraceTaskId: taskId }),
@@ -85,12 +163,34 @@ export const useUIStore = create<UIState>()(
           persistTheme(next);
           return { theme: next };
         }),
+
+      openObservability: (tab, nodeId) =>
+        set((s) => ({
+          observabilityPanelOpen: true,
+          // If the caller named a tab, switch to it; otherwise — and this is the
+          // case for the toolbar icon — keep whatever tab the operator last left
+          // open. Default lands on 'live' on first ever open via the initial state.
+          observabilityActiveTab: tab ?? s.observabilityActiveTab,
+          // Remember the node only when one is explicitly given. Reopening the panel
+          // without a nodeId should return to the previously focused node, not clear it.
+          observabilitySelectedNodeId: nodeId ?? s.observabilitySelectedNodeId,
+        })),
+      closeObservability: () => set({ observabilityPanelOpen: false }),
+      setObservabilityTab: (tab) => set({ observabilityActiveTab: tab }),
+      setObservabilityPanelWidth: (width) => {
+        const clamped = clampPanelWidth(width);
+        persistObservabilityWidth(clamped);
+        set({ observabilityPanelWidth: clamped });
+      },
+      setObservabilitySelectedNodeId: (nodeId) =>
+        set({ observabilitySelectedNodeId: nodeId }),
     }),
     {
       name: 'skulk-ui',
       storage: createJSONStorage(() => sessionStorage),
-      // Theme lives in localStorage so it survives across sessions; exclude it from
-      // the sessionStorage-backed persist block.
+      // Theme + observabilityPanelWidth live in localStorage so they survive
+      // across sessions; everything else uses sessionStorage so a fresh tab
+      // starts with sensible defaults rather than inheriting stale state.
       partialize: (state) => ({
         activeRoute: state.activeRoute,
         selectedTraceTaskId: state.selectedTraceTaskId,
@@ -98,6 +198,9 @@ export const useUIStore = create<UIState>()(
         historyPanelOpen: state.historyPanelOpen,
         chatScrollTop: state.chatScrollTop,
         expandedThinking: state.expandedThinking,
+        observabilityPanelOpen: state.observabilityPanelOpen,
+        observabilityActiveTab: state.observabilityActiveTab,
+        observabilitySelectedNodeId: state.observabilitySelectedNodeId,
       }),
     },
   ),

--- a/dashboard-react/src/stores/uiStore.ts
+++ b/dashboard-react/src/stores/uiStore.ts
@@ -7,10 +7,17 @@ const THEME_STORAGE_KEY = 'skulk-theme';
 const OBSERVABILITY_WIDTH_KEY = 'skulk-observability-panel-width';
 /** Default width of the right-side observability panel, in pixels. */
 const OBSERVABILITY_WIDTH_DEFAULT = 560;
-/** Hard floor on the panel width — narrower than this and the content stops being legible. */
-const OBSERVABILITY_WIDTH_MIN = 360;
-/** Hard ceiling — any wider and the panel would consume the whole viewport on most screens. */
-const OBSERVABILITY_WIDTH_MAX = 1200;
+/**
+ * Hard floor on the panel width — narrower than this and the content stops being
+ * legible. Exported because the resize handler clamps during live drag preview, not
+ * just at commit time, so the live width and the persisted width share one range.
+ */
+export const OBSERVABILITY_WIDTH_MIN = 360;
+/**
+ * Hard ceiling — any wider and the panel would consume the whole viewport on most
+ * screens. Exported for the same reason as the min.
+ */
+export const OBSERVABILITY_WIDTH_MAX = 1200;
 
 /** Tabs available inside the observability panel. */
 export type ObservabilityTab = 'live' | 'node' | 'traces';


### PR DESCRIPTION
Closes #118 — Phase 1 of the observability consolidation umbrella #123.

## What

Replaces the dashboard's two bug icons (toolbar → Traces, per-node → DiagnosticsDrawer) with one resizable right-side Observability panel. The panel hosts three tabs:

- **Live** — placeholder (Phase 3 #120 lands cross-rank timeline + hang counter + tracing toggle + event-stream tail)
- **Node** — ports the existing DiagnosticsDrawer body verbatim. Same data, same actions (Capture bundle / Cancel task). No behavior change.
- **Traces** — placeholder. "Open trace browser" sends the operator to the existing `traces` route so trace browsing isn't regressed during the transition. Phase 2 #119 lands the Skulk-native waterfall + removes Perfetto.

The toolbar's `VscBug` icon now toggles the panel open/closed instead of navigating to the Traces route.

## Architecture decisions

- **Panel state on the global Zustand UI store** — `observabilityPanelOpen`, `observabilityActiveTab`, `observabilityPanelWidth`, `observabilitySelectedNodeId`. Any component can call `openObservability(tab, nodeId?)`. The toolbar icon opens with no args (preserves last-active tab); per-node bug icons in topology open with `('node', nodeId)`.
- **Side-docked, no backdrop.** Topology stays interactive while the panel is open.
- **Width persisted to localStorage** outside the sessionStorage persist block — operators settle on a width and shouldn't redo it. Clamped to `[360, 1200]` px.
- **Drag-to-resize** via left-edge handle, with pointer capture for smooth drags. Live preview via direct DOM update during drag; commit to store on pointerup.
- **Esc closes the panel.** Tab buttons have a focus-visible outline since `all: unset` strips the default.
- **Hover affordances on topology nodes are unchanged** per the design call — quick glance stays, panel is for deeper inspection.

## Files

- `dashboard-react/src/stores/uiStore.ts` — panel state + actions, localStorage persistence helpers
- `dashboard-react/src/components/observability/ObservabilityPanel.tsx` — new, panel container + tab strip + resize logic
- `dashboard-react/src/components/observability/NodeTab.tsx` — rename of `DiagnosticsDrawer.tsx` with Overlay/Drawer wrap stripped (panel provides framing) and an empty-state hint when no node is selected
- `dashboard-react/src/components/observability/LiveTab.tsx` — placeholder
- `dashboard-react/src/components/observability/TracesTab.tsx` — placeholder with "Open trace browser" link to the existing route
- `dashboard-react/src/components/layout/HeaderNav.tsx` — toolbar icon toggles panel instead of navigating
- `dashboard-react/src/App.tsx` — mounts `<ObservabilityPanel />` in place of the old `<DiagnosticsDrawer />`; routes the topology bug click through `openObservability('node', nodeId)`
- `dashboard-react/src/components/layout/DiagnosticsDrawer.tsx` — deleted (renamed to NodeTab.tsx; git tracks the rename)

## Validation

| Check | Result |
|---|---|
| `npx tsc --noEmit` | clean for changed files |
| `npm run lint` | clean for changed files (54 pre-existing errors in unrelated files are unchanged) |
| `npm run build` | succeeds |
| `uv run basedpyright` | 0 errors |
| `uv run ruff check` | clean |
| `uv run pytest` | 667 passed, no regressions |

## Manual test plan

- [ ] Click toolbar bug icon → panel opens to Live tab (or last-active tab on subsequent opens)
- [ ] Click bug icon on a node in topology → panel opens to Node tab focused on that node
- [ ] Switch tabs inside the panel — selected node persists across tab changes
- [ ] Drag left edge of panel → width resizes smoothly, persists across reloads
- [ ] Hard refresh — panel width restored from localStorage; panel itself starts closed (sessionStorage)
- [ ] Esc key with panel open → panel closes
- [ ] "Open trace browser (legacy view)" in Traces tab → navigates to existing `traces` route, panel closes
- [ ] Capture bundle / Cancel task buttons in Node tab still work (same backend endpoints as before)
- [ ] No backdrop covers the topology — clicking outside the panel doesn't close it (intentional; close via X or Esc)

## Out of scope (sibling phases under #123)

- Live tab content → Phase 3 #120
- Custom waterfall + Perfetto removal → Phase 2 #119
- Debug knobs in settings → Phase 4 #121 (blocks on #110)
- Grafana bridge → Phase 5 #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)