### PR TITLE
Autostart, crash recovery, Tailscale connectivity, and Operator panel (Phases 1–3 of #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-03
+
 ### Added
 
 - Headless-resilience deployment kit: a systemd user unit
@@ -21,11 +23,40 @@ This project records release notes here and mirrors public-facing notes in
   before component boot and exits with `EX_TEMPFAIL` (75) when the API
   port is held by a previous instance, so the service supervisor can
   retry with backoff instead of producing a confusing bind error mid-run.
+- Tailscale connectivity layer (`exo.connectivity.tailscale`): detection via
+  `tailscale status --json`, `TailscaleConnectivityConfig` in `skulk.yaml`,
+  `GET /v1/connectivity/tailscale` API endpoint, and a status row in the
+  dashboard's Node tab Runtime section. Cluster nodes can now span multiple
+  physical networks over Tailscale (or Headscale).
+- Operator panel — a mobile-first `/operator` route in the dashboard for
+  remote cluster control: cluster-wide memory/GPU/temperature summary, per-node
+  health cards, and a tap-twice-to-confirm node restart button that calls
+  `POST /admin/restart`.
+- `copyToClipboard()` helper (`dashboard-react/src/utils/clipboard.ts`) with
+  a `document.execCommand` fallback so copy affordances work over plain HTTP,
+  not just `localhost` or HTTPS.
 - Operator-facing "Run Skulk as a service" guide at
   `website/docs/run-skulk-as-a-service.md` — quickstart-first,
   copy-paste install per platform, day-to-day operations table, reboot
   verification, troubleshooting, uninstall, and an advanced
   system-level systemd variant for niche server setups.
+- Tailscale setup and troubleshooting guide at `website/docs/tailscale.md`.
+
+### Fixed
+
+- Dashboard `crypto.randomUUID()` replaced with the `uuid` npm package so chat
+  session IDs generate correctly over plain HTTP (secure-context restriction).
+- `StartLimitBurst` / `StartLimitIntervalSec` moved from `[Service]` to `[Unit]`
+  in `skulk.service` — these directives are silently ignored in `[Service]`.
+- API port preflight now gated behind `spawn_api` so `--no-api` worker nodes
+  don't fail a port check they'll never bind.
+- macOS log directory corrected to `~/.skulk/logs` in both the installer script
+  and the ops-table in the user guide (was incorrectly `~/.cache/skulk/logs`).
+- Tailscale status fields serialized as camelCase (`selfIp`, `dnsName`) to
+  match FastAPI's default `by_alias=True` encoding; dashboard hook updated to
+  match.
+- Removed the unwanted selected-bar highlight (blue stroke) from the trace
+  waterfall renderer.
 
 ## [1.0.3] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Added
+
+- Headless-resilience deployment kit: a systemd user unit
+  (`deployment/systemd/skulk.service`) with `Restart=on-failure` plus
+  start-limit backoff, a macOS LaunchAgent
+  (`deployment/launchd/foundation.foxlight.skulk.plist`) with conditional
+  `KeepAlive`, and one-shot installers for each
+  (`deployment/install/install-systemd.sh`, `install-launchd.sh`). The
+  Linux installer enables user lingering so headless boxes autostart Skulk
+  across reboots without an active login session.
+- Startup port preflight (`exo.startup_recovery.preflight_api_port`) runs
+  before component boot and exits with `EX_TEMPFAIL` (75) when the API
+  port is held by a previous instance, so the service supervisor can
+  retry with backoff instead of producing a confusing bind error mid-run.
+- Operator-facing "Run Skulk as a service" guide at
+  `website/docs/run-skulk-as-a-service.md` — quickstart-first,
+  copy-paste install per platform, day-to-day operations table, reboot
+  verification, troubleshooting, uninstall, and an advanced
+  system-level systemd variant for niche server setups.
+
 ## [1.0.3] - 2026-05-02
 
 ### Added

--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard-react",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@reduxjs/toolkit": "^2.11.2",
@@ -21,7 +21,8 @@
         "react-icons": "^5.6.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.13.2",
-        "styled-components": "^6.3.12"
+        "styled-components": "^6.3.12",
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.0.2",
@@ -37,6 +38,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/styled-components": "^5.1.36",
+        "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/browser-playwright": "^4.1.1",
         "@vitest/coverage-v8": "^4.1.1",
@@ -2554,6 +2556,13 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7707,6 +7716,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard-react",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -26,7 +26,8 @@
     "react-icons": "^5.6.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.13.2",
-    "styled-components": "^6.3.12"
+    "styled-components": "^6.3.12",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.2",
@@ -42,6 +43,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/styled-components": "^5.1.36",
+    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser-playwright": "^4.1.1",
     "@vitest/coverage-v8": "^4.1.1",

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -13,6 +13,7 @@ import { ObservabilityPanel } from './components/observability/ObservabilityPane
 import { SettingsPanel } from './components/layout/SettingsPanel';
 import { ModelStorePage } from './components/pages/DownloadsPage';
 import { ChatView } from './components/pages/ChatView';
+import { OperatorPage } from './components/pages/OperatorPage';
 import { InstancePanel, type InstanceCardData } from './components/layout/InstancePanel';
 import { ConversationPanel } from './components/layout/ConversationPanel';
 import { addToast } from './hooks/useToast';
@@ -396,6 +397,8 @@ export function App() {
               />
             ) : activeRoute === 'chat' ? (
               <ChatView readyInstances={instanceCards} />
+            ) : activeRoute === 'operator' ? (
+              <OperatorPage />
             ) : topology ? (
               <TopologyGraph
                 data={topology}

--- a/dashboard-react/src/components/chat/ChatMessages.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { copyToClipboard } from '../../utils/clipboard';
 import styled, { css, keyframes, useTheme } from 'styled-components';
 import type { Theme } from '../../theme';
 import type { ChatMessage } from '../../types/chat';
@@ -412,7 +413,7 @@ export function ChatMessages({
   }, [getScrollParent, updateScrollState]);
 
   const copyMessage = useCallback((id: string, content: string) => {
-    navigator.clipboard.writeText(content);
+    void copyToClipboard(content);
     setCopiedId(id);
     setTimeout(() => setCopiedId(null), 2000);
   }, []);

--- a/dashboard-react/src/components/display/MarkdownContent.tsx
+++ b/dashboard-react/src/components/display/MarkdownContent.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { copyToClipboard } from '../../utils/clipboard';
 import { Marked } from 'marked';
 import hljs from 'highlight.js';
 import katex from 'katex';
@@ -257,7 +258,7 @@ export function MarkdownContent({ content, className }: MarkdownContentProps) {
     const target = e.target as HTMLElement;
     if (target.classList.contains('mc-copy-btn')) {
       const code = decodeURIComponent(target.getAttribute('data-code') || '');
-      navigator.clipboard.writeText(code).then(() => {
+      void copyToClipboard(code).then(() => {
         const original = target.textContent;
         target.textContent = '✓ Copied';
         setTimeout(() => { target.textContent = original; }, 2000);

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -1,5 +1,5 @@
 import styled, { css, useTheme } from 'styled-components';
-import { FiSettings, FiMenu, FiX, FiSidebar, FiDatabase, FiMessageSquare, FiSun, FiMoon, FiActivity } from 'react-icons/fi';
+import { FiSettings, FiMenu, FiX, FiSidebar, FiDatabase, FiMessageSquare, FiSun, FiMoon } from 'react-icons/fi';
 import { MdHub } from 'react-icons/md';
 import { VscBug } from 'react-icons/vsc';
 import { Button } from '../common/Button';
@@ -239,7 +239,7 @@ const SidebarIcon = () => <FiSidebar size={18} />;
 const ClusterIcon = () => <MdHub size={16} />;
 const StoreIcon = () => <FiDatabase size={16} />;
 const ChatIcon = () => <FiMessageSquare size={16} />;
-const OperatorIcon = () => <FiActivity size={16} />;
+
 const ObservabilityIcon = () => <VscBug size={16} />;
 const SettingsIcon = () => <FiSettings size={16} />;
 
@@ -352,10 +352,6 @@ export function HeaderNav({
 
         <NavLink $active={activeRoute === 'chat'} onClick={() => navigate('chat')}>
           <ChatIcon /> Chat
-        </NavLink>
-
-        <NavLink $active={activeRoute === 'operator'} onClick={() => navigate('operator')}>
-          <OperatorIcon /> Operator
         </NavLink>
 
         {instanceCount > 0 && (

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -1,5 +1,5 @@
 import styled, { css, useTheme } from 'styled-components';
-import { FiSettings, FiMenu, FiX, FiSidebar, FiDatabase, FiMessageSquare, FiSun, FiMoon } from 'react-icons/fi';
+import { FiSettings, FiMenu, FiX, FiSidebar, FiDatabase, FiMessageSquare, FiSun, FiMoon, FiActivity } from 'react-icons/fi';
 import { MdHub } from 'react-icons/md';
 import { VscBug } from 'react-icons/vsc';
 import { Button } from '../common/Button';
@@ -8,7 +8,7 @@ import type { Theme } from '../../theme';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { uiActions } from '../../store/slices/uiSlice';
 
-export type NavRoute = 'cluster' | 'model-store' | 'chat';
+export type NavRoute = 'cluster' | 'model-store' | 'chat' | 'operator';
 
 export interface HeaderNavProps {
   showHome?: boolean;
@@ -239,6 +239,7 @@ const SidebarIcon = () => <FiSidebar size={18} />;
 const ClusterIcon = () => <MdHub size={16} />;
 const StoreIcon = () => <FiDatabase size={16} />;
 const ChatIcon = () => <FiMessageSquare size={16} />;
+const OperatorIcon = () => <FiActivity size={16} />;
 const ObservabilityIcon = () => <VscBug size={16} />;
 const SettingsIcon = () => <FiSettings size={16} />;
 
@@ -351,6 +352,10 @@ export function HeaderNav({
 
         <NavLink $active={activeRoute === 'chat'} onClick={() => navigate('chat')}>
           <ChatIcon /> Chat
+        </NavLink>
+
+        <NavLink $active={activeRoute === 'operator'} onClick={() => navigate('operator')}>
+          <OperatorIcon /> Operator
         </NavLink>
 
         {instanceCount > 0 && (

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -157,15 +157,14 @@ const WarningCircle = styled.div<{ $level: 'error' | 'warning' }>`
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: ${({ $level, theme}) => $level === 'error' ? theme.colors.error : theme.colors.warning};
+  background: ${({ $level, theme}) => $level === 'error' ? theme.colors.errorFill : theme.colors.warningFill};
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 14px;
   font-weight: 700;
   font-family: ${({ theme }) => theme.fonts.body};
-  /* Always white — sits on a saturated red/amber circle in both palettes. */
-  color: #ffffff;
+  color: ${({ $level, theme}) => $level === 'error' ? theme.colors.errorOnFill : theme.colors.warningOnFill};
 `;
 
 const WarningTooltip = styled.div`

--- a/dashboard-react/src/components/observability/NodeTab.tsx
+++ b/dashboard-react/src/components/observability/NodeTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
+import { useTailscaleStatus } from '../../hooks/useTailscaleStatus';
 import styled from 'styled-components';
 import { Button } from '../common/Button';
 import { CenteredSpinner, Spinner } from '../common/Spinner';
@@ -324,6 +325,7 @@ function recorderLine(entry: RunnerFlightRecorderEntry): string {
 
 export function NodeTab({ nodeId }: NodeTabProps) {
   const cluster = useClusterState();
+  const tailscale = useTailscaleStatus();
   const dispatch = useAppDispatch();
   const setSelectedNodeId = (nodeId: string | null) =>
     dispatch(uiActions.setObservabilitySelectedNodeId(nodeId));
@@ -560,6 +562,16 @@ export function NodeTab({ nodeId }: NodeTabProps) {
               <Row><Key>CWD</Key><Value>{runtime.cwd}</Value></Row>
               <Row><Key>Config</Key><Value $warn={!runtime.configFileExists}>{runtime.configPath} {runtime.configFileExists ? '' : '(missing)'}</Value></Row>
               <Row><Key>Logging</Key><Value>{runtime.structuredLoggingConfigured ? 'centralized enabled' : 'not configured'}</Value></Row>
+              <Row>
+                <Key>Tailscale</Key>
+                <Value $warn={tailscale !== null && !tailscale.running}>
+                  {tailscale === null
+                    ? '…'
+                    : tailscale.running
+                      ? `${tailscale.self_ip ?? '?'} · ${tailscale.dns_name ?? tailscale.hostname ?? '?'}`
+                      : 'not running'}
+                </Value>
+              </Row>
             </Section>
 
             <Section>

--- a/dashboard-react/src/components/observability/NodeTab.tsx
+++ b/dashboard-react/src/components/observability/NodeTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { copyToClipboard } from '../../utils/clipboard';
 import styled from 'styled-components';
 import { Button } from '../common/Button';
 import { CenteredSpinner, Spinner } from '../common/Spinner';
@@ -503,7 +504,7 @@ export function NodeTab({ nodeId }: NodeTabProps) {
 
   async function copyCaptureBundle() {
     if (!captureBundle) return;
-    await navigator.clipboard.writeText(JSON.stringify(captureBundle, null, 2));
+    await copyToClipboard(JSON.stringify(captureBundle, null, 2));
   }
 
   function downloadCaptureBundle() {

--- a/dashboard-react/src/components/observability/NodeTab.tsx
+++ b/dashboard-react/src/components/observability/NodeTab.tsx
@@ -568,7 +568,7 @@ export function NodeTab({ nodeId }: NodeTabProps) {
                   {tailscale === null
                     ? '…'
                     : tailscale.running
-                      ? `${tailscale.self_ip ?? '?'} · ${tailscale.dns_name ?? tailscale.hostname ?? '?'}`
+                      ? `${tailscale.selfIp ?? '?'} · ${tailscale.dnsName ?? tailscale.hostname ?? '?'}`
                       : 'not running'}
                 </Value>
               </Row>

--- a/dashboard-react/src/components/observability/TraceWaterfall.tsx
+++ b/dashboard-react/src/components/observability/TraceWaterfall.tsx
@@ -445,9 +445,9 @@ function EventBar({
         width={width}
         height={height}
         fill={color}
-        fillOpacity={selected ? 1 : 0.85}
-        stroke={selected ? 'currentColor' : 'rgba(0, 0, 0, 0.35)'}
-        strokeWidth={selected ? 1.5 : 0.5}
+        fillOpacity={0.85}
+        stroke="rgba(0, 0, 0, 0.35)"
+        strokeWidth={0.5}
         rx={2}
         ry={2}
       >

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import styled from 'styled-components';
 import { ChatMessages } from '../chat/ChatMessages';
 import { ChatForm } from '../chat/ChatForm';
@@ -567,7 +568,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
     }
 
     const userMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       role: 'user',
       content: text,
       timestamp: Date.now(),
@@ -762,7 +763,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
 
         for (const toolCall of iterationToolCalls) {
           const toolName = toolCall.function?.name ?? 'unknown';
-          const toolCallId = toolCall.id || crypto.randomUUID();
+          const toolCallId = toolCall.id || uuidv4();
           let toolOutput: string;
 
           try {
@@ -824,7 +825,7 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
 
     if (finalAssistantContent || fullThinking) {
       const assistantMsg: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         role: 'assistant',
         content: finalAssistantContent,
         timestamp: Date.now(),

--- a/dashboard-react/src/components/pages/OperatorPage.tsx
+++ b/dashboard-react/src/components/pages/OperatorPage.tsx
@@ -1,0 +1,348 @@
+import { useState, useCallback } from 'react';
+import styled from 'styled-components';
+import { useGetRawStateQuery, useGetLocalNodeIdQuery, useRestartNodeMutation } from '../../store/endpoints/cluster';
+import { addToast } from '../../hooks/useToast';
+
+/* ── Types ─────────────────────────────────────────────────── */
+
+interface NodeSummary {
+  nodeId: string;
+  name: string;
+  memTotalBytes: number;
+  memUsedBytes: number;
+  gpuUsage: number | null;
+  temp: number | null;
+}
+
+/* ── Styled components ─────────────────────────────────────── */
+
+const Page = styled.div`
+  padding: 16px;
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const SectionTitle = styled.h2`
+  margin: 0 0 4px;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const SummaryRow = styled.div`
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+`;
+
+const Stat = styled.div`
+  flex: 1;
+  min-width: 100px;
+  background: ${({ theme }) => theme.colors.surface};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.radii.md};
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const StatLabel = styled.span`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const StatValue = styled.span<{ $ok?: boolean; $warn?: boolean }>`
+  font-size: ${({ theme }) => theme.fontSizes.xl};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  font-weight: 700;
+  color: ${({ $ok, $warn, theme }) =>
+    $ok ? theme.colors.healthy : $warn ? theme.colors.warning : theme.colors.text};
+`;
+
+const NodeCard = styled.div`
+  background: ${({ theme }) => theme.colors.surface};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.radii.lg};
+  overflow: hidden;
+`;
+
+const NodeCardHeader = styled.div`
+  padding: 14px 16px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+const NodeName = styled.span`
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.text};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const NodeCardBody = styled.div`
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const MetricRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+`;
+
+const MetricLabel = styled.span`
+  font-size: ${({ theme }) => theme.fontSizes.xs};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const MetricValue = styled.span`
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const MemBar = styled.div`
+  height: 4px;
+  background: ${({ theme }) => theme.colors.borderStrong};
+  border-radius: 2px;
+  overflow: hidden;
+`;
+
+const MemFill = styled.div<{ $pct: number }>`
+  height: 100%;
+  width: ${({ $pct }) => $pct}%;
+  background: ${({ $pct, theme }) =>
+    $pct > 85 ? theme.colors.error : $pct > 65 ? theme.colors.warning : theme.colors.healthy};
+  border-radius: 2px;
+  transition: width 0.3s ease;
+`;
+
+const RestartButton = styled.button<{ $confirming: boolean; $disabled: boolean }>`
+  all: unset;
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  flex-shrink: 0;
+  padding: 8px 16px;
+  border-radius: ${({ theme }) => theme.radii.md};
+  border: 1px solid ${({ $confirming, theme }) =>
+    $confirming ? theme.colors.error : theme.colors.border};
+  background: ${({ $confirming, theme }) =>
+    $confirming ? theme.colors.errorBg : 'transparent'};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ $confirming, $disabled, theme }) =>
+    $disabled ? theme.colors.textMuted : $confirming ? theme.colors.error : theme.colors.textSecondary};
+  transition: all 0.15s;
+  white-space: nowrap;
+  min-width: 90px;
+  text-align: center;
+
+  &:hover:not([disabled]) {
+    border-color: ${({ theme }) => theme.colors.error};
+    color: ${({ theme }) => theme.colors.error};
+  }
+
+  &:active:not([disabled]) {
+    opacity: 0.8;
+  }
+`;
+
+const EmptyState = styled.div`
+  padding: 48px 16px;
+  text-align: center;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-family: ${({ theme }) => theme.fonts.mono};
+  color: ${({ theme }) => theme.colors.textMuted};
+  text-transform: uppercase;
+  letter-spacing: 2px;
+`;
+
+/* ── Helpers ───────────────────────────────────────────────── */
+
+function fmtBytes(bytes: number): string {
+  const gb = bytes / (1024 ** 3);
+  return gb >= 1 ? `${gb.toFixed(1)} GB` : `${(bytes / (1024 ** 2)).toFixed(0)} MB`;
+}
+
+/* ── NodeCard component ────────────────────────────────────── */
+
+interface NodeCardProps {
+  node: NodeSummary;
+  localNodeId: string | undefined;
+}
+
+function NodeRestartCard({ node, localNodeId }: NodeCardProps) {
+  const [confirming, setConfirming] = useState(false);
+  const [restartNode, { isLoading }] = useRestartNodeMutation();
+
+  const handlePress = useCallback(async () => {
+    if (!confirming) {
+      setConfirming(true);
+      // Auto-cancel confirmation after 3 s if user doesn't tap again
+      setTimeout(() => setConfirming(false), 3000);
+      return;
+    }
+    setConfirming(false);
+    try {
+      await restartNode({ nodeId: node.nodeId }).unwrap();
+      addToast({ type: 'success', message: `Restart sent to ${node.name}` });
+    } catch {
+      addToast({ type: 'error', message: `Failed to restart ${node.name}` });
+    }
+  }, [confirming, node.nodeId, node.name, restartNode]);
+
+  const memPct = node.memTotalBytes > 0
+    ? Math.round((node.memUsedBytes / node.memTotalBytes) * 100)
+    : 0;
+
+  const isLocal = node.nodeId === localNodeId;
+
+  return (
+    <NodeCard>
+      <NodeCardHeader>
+        <NodeName title={node.nodeId}>{node.name}{isLocal ? ' (this node)' : ''}</NodeName>
+        <RestartButton
+          $confirming={confirming}
+          $disabled={isLoading}
+          onClick={handlePress}
+          aria-label={confirming ? 'Tap again to confirm restart' : `Restart ${node.name}`}
+          title={confirming ? 'Tap again to confirm' : 'Restart node'}
+        >
+          {isLoading ? '…' : confirming ? 'Confirm?' : 'Restart'}
+        </RestartButton>
+      </NodeCardHeader>
+      <NodeCardBody>
+        {node.memTotalBytes > 0 && (
+          <>
+            <MetricRow>
+              <MetricLabel>Memory</MetricLabel>
+              <MetricValue>
+                {fmtBytes(node.memUsedBytes)} / {fmtBytes(node.memTotalBytes)} ({memPct}%)
+              </MetricValue>
+            </MetricRow>
+            <MemBar>
+              <MemFill $pct={memPct} />
+            </MemBar>
+          </>
+        )}
+        {node.gpuUsage !== null && (
+          <MetricRow>
+            <MetricLabel>GPU</MetricLabel>
+            <MetricValue>{node.gpuUsage.toFixed(0)}%</MetricValue>
+          </MetricRow>
+        )}
+        {node.temp !== null && (
+          <MetricRow>
+            <MetricLabel>Temp</MetricLabel>
+            <MetricValue>{node.temp.toFixed(0)} °C</MetricValue>
+          </MetricRow>
+        )}
+      </NodeCardBody>
+    </NodeCard>
+  );
+}
+
+/* ── Page component ────────────────────────────────────────── */
+
+/**
+ * Mobile-first operator panel. Shows cluster health at a glance and exposes
+ * per-node restart buttons for headless / remote operation over Tailscale.
+ */
+export function OperatorPage() {
+  const { data, isLoading } = useGetRawStateQuery(undefined, {
+    pollingInterval: 5000,
+  });
+  const { data: localNodeId } = useGetLocalNodeIdQuery();
+
+  // Build node summaries from raw state
+  const nodes: NodeSummary[] = [];
+  if (data?.topology?.nodes) {
+    for (const nodeId of data.topology.nodes) {
+      if (!nodeId) continue;
+      const identity = data.nodeIdentities?.[nodeId];
+      const name = identity?.friendlyName ?? nodeId.slice(0, 12);
+      const mem = data.nodeMemory?.[nodeId];
+      const sys = data.nodeSystem?.[nodeId];
+
+      const memTotalBytes = mem?.ramTotal?.inBytes ?? 0;
+      const memAvailBytes = mem?.ramAvailable?.inBytes ?? 0;
+      const memUsedBytes = Math.max(memTotalBytes - memAvailBytes, 0);
+
+      nodes.push({
+        nodeId,
+        name,
+        memTotalBytes,
+        memUsedBytes,
+        gpuUsage: sys?.gpuUsage ?? null,
+        temp: sys?.temp ?? null,
+      });
+    }
+  }
+
+  // Cluster-level summary stats
+  const instanceCount = data?.instances ? Object.keys(data.instances).length : 0;
+  const runnerCount = data?.runners ? Object.keys(data.runners).length : 0;
+  const nodeCount = nodes.length;
+
+  if (isLoading && nodes.length === 0) {
+    return (
+      <Page>
+        <EmptyState>Loading cluster state…</EmptyState>
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      <SectionTitle>Cluster</SectionTitle>
+      <SummaryRow>
+        <Stat>
+          <StatLabel>Nodes</StatLabel>
+          <StatValue $ok={nodeCount > 0}>{nodeCount}</StatValue>
+        </Stat>
+        <Stat>
+          <StatLabel>Instances</StatLabel>
+          <StatValue $ok={instanceCount > 0}>{instanceCount}</StatValue>
+        </Stat>
+        <Stat>
+          <StatLabel>Runners</StatLabel>
+          <StatValue>{runnerCount}</StatValue>
+        </Stat>
+      </SummaryRow>
+
+      <SectionTitle>Nodes</SectionTitle>
+
+      {nodes.length === 0 ? (
+        <EmptyState>No nodes visible</EmptyState>
+      ) : (
+        nodes.map((node) => (
+          <NodeRestartCard
+            key={node.nodeId}
+            node={node}
+            localNodeId={localNodeId}
+          />
+        ))
+      )}
+    </Page>
+  );
+}

--- a/dashboard-react/src/components/pages/OperatorPage.tsx
+++ b/dashboard-react/src/components/pages/OperatorPage.tsx
@@ -196,6 +196,7 @@ function NodeRestartCard({ node, localNodeId }: NodeCardProps) {
   const [restartNode, { isLoading }] = useRestartNodeMutation();
 
   const handlePress = useCallback(async () => {
+    if (isLoading) return;
     if (!confirming) {
       setConfirming(true);
       // Auto-cancel confirmation after 3 s if user doesn't tap again
@@ -209,7 +210,7 @@ function NodeRestartCard({ node, localNodeId }: NodeCardProps) {
     } catch {
       addToast({ type: 'error', message: `Failed to restart ${node.name}` });
     }
-  }, [confirming, node.nodeId, node.name, restartNode]);
+  }, [confirming, isLoading, node.nodeId, node.name, restartNode]);
 
   const memPct = node.memTotalBytes > 0
     ? Math.round((node.memUsedBytes / node.memTotalBytes) * 100)
@@ -224,6 +225,7 @@ function NodeRestartCard({ node, localNodeId }: NodeCardProps) {
         <RestartButton
           $confirming={confirming}
           $disabled={isLoading}
+          disabled={isLoading}
           onClick={handlePress}
           aria-label={confirming ? 'Tap again to confirm restart' : `Restart ${node.name}`}
           title={confirming ? 'Tap again to confirm' : 'Restart node'}

--- a/dashboard-react/src/hooks/useTailscaleStatus.ts
+++ b/dashboard-react/src/hooks/useTailscaleStatus.ts
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
 
-/** Snapshot of the local node's Tailscale connectivity state as returned by GET /v1/connectivity/tailscale. */
+/** Snapshot of the local node's Tailscale connectivity state as returned by GET /v1/connectivity/tailscale.
+ *  FastAPI serializes FrozenModel fields via jsonable_encoder with by_alias=True,
+ *  so snake_case Python field names arrive as camelCase JSON keys.
+ */
 export interface TailscaleStatus {
   running: boolean;
-  self_ip: string | null;
+  selfIp: string | null;
   hostname: string | null;
-  dns_name: string | null;
+  dnsName: string | null;
   tailnet: string | null;
   version: string | null;
 }

--- a/dashboard-react/src/hooks/useTailscaleStatus.ts
+++ b/dashboard-react/src/hooks/useTailscaleStatus.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+/** Snapshot of the local node's Tailscale connectivity state as returned by GET /v1/connectivity/tailscale. */
+export interface TailscaleStatus {
+  running: boolean;
+  self_ip: string | null;
+  hostname: string | null;
+  dns_name: string | null;
+  tailnet: string | null;
+  version: string | null;
+}
+
+/**
+ * Fetches Tailscale status from the local node's API once on mount.
+ * Returns null while loading or if the request fails.
+ */
+export function useTailscaleStatus(): TailscaleStatus | null {
+  const [status, setStatus] = useState<TailscaleStatus | null>(null);
+
+  useEffect(() => {
+    fetch('/v1/connectivity/tailscale')
+      .then(r => r.ok ? r.json() as Promise<TailscaleStatus> : null)
+      .then(data => setStatus(data))
+      .catch(() => setStatus(null));
+  }, []);
+
+  return status;
+}

--- a/dashboard-react/src/store/endpoints/cluster.ts
+++ b/dashboard-react/src/store/endpoints/cluster.ts
@@ -99,6 +99,11 @@ export interface RawLocalNodeIdentityResponse {
  * polls always). The transform stays out of the cache so consumers can read
  * the raw shape and run their own derivations.
  */
+export interface RestartNodeResponse {
+  status: 'restarting' | 'restart_sent' | 'restart_already_pending';
+  nodeId: string;
+}
+
 export const clusterApi = apiSlice.injectEndpoints({
   endpoints: (build) => ({
     getRawState: build.query<RawStateResponse, void>({
@@ -114,6 +119,12 @@ export const clusterApi = apiSlice.injectEndpoints({
     getLocalNodeIdentity: build.query<RawLocalNodeIdentityResponse, void>({
       query: () => '/node/identity',
     }),
+    restartNode: build.mutation<RestartNodeResponse, { nodeId?: string }>({
+      query: ({ nodeId }) => ({
+        url: nodeId ? `/admin/restart?node_id=${encodeURIComponent(nodeId)}` : '/admin/restart',
+        method: 'POST',
+      }),
+    }),
   }),
 });
 
@@ -121,4 +132,5 @@ export const {
   useGetRawStateQuery,
   useGetLocalNodeIdQuery,
   useGetLocalNodeIdentityQuery,
+  useRestartNodeMutation,
 } = clusterApi;

--- a/dashboard-react/src/store/endpoints/cluster.ts
+++ b/dashboard-react/src/store/endpoints/cluster.ts
@@ -101,7 +101,7 @@ export interface RawLocalNodeIdentityResponse {
  */
 export interface RestartNodeResponse {
   status: 'restarting' | 'restart_sent' | 'restart_already_pending';
-  nodeId: string;
+  node_id: string;
 }
 
 export const clusterApi = apiSlice.injectEndpoints({

--- a/dashboard-react/src/utils/clipboard.ts
+++ b/dashboard-react/src/utils/clipboard.ts
@@ -1,0 +1,19 @@
+/** Copy text to clipboard with a fallback for non-secure HTTP contexts. */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  // execCommand is deprecated but works on plain HTTP where clipboard API is unavailable.
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.cssText = 'position:fixed;opacity:0;pointer-events:none';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try {
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}

--- a/deployment/install/install-launchd.sh
+++ b/deployment/install/install-launchd.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Install the Skulk LaunchAgent on macOS.
+#
+# LaunchAgents (not LaunchDaemons) are used because:
+#   - Metal access requires a graphical user session
+#   - LaunchAgents inherit the user's shell PATH via login-shell wrapper
+#   - the daemon variant would need root + a separate user-context shim
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/deployment/launchd/foundation.foxlight.skulk.plist"
+TARGET_DIR="$HOME/Library/LaunchAgents"
+TARGET="$TARGET_DIR/foundation.foxlight.skulk.plist"
+LABEL="foundation.foxlight.skulk"
+
+if [[ "$OSTYPE" != darwin* ]]; then
+    echo "error: install-launchd.sh is for macOS. On Linux use install-systemd.sh." >&2
+    exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "error: 'uv' not found on PATH. Install uv first (https://docs.astral.sh/uv/) and re-run." >&2
+    exit 1
+fi
+
+# Capture the user's PATH from a login shell so the same `uv` resolution
+# Skulk uses interactively is what the agent gets.
+USER_PATH="$(/bin/bash -lc 'echo -n $PATH')"
+LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/skulk/logs"
+# Skulk uses ~/.skulk-prefixed XDG paths when SKULK_HOME is set; otherwise
+# $XDG_CACHE_HOME (or ~/.cache on macOS where XDG isn't conventional).
+# Match the SKULK_LOG_DIR resolution in src/exo/shared/constants.py.
+mkdir -p "$LOG_DIR"
+mkdir -p "$TARGET_DIR"
+
+sed -e "s|__SKULK_REPO__|$REPO_ROOT|g" \
+    -e "s|__SKULK_LOG_DIR__|$LOG_DIR|g" \
+    -e "s|__USER_PATH__|$USER_PATH|g" \
+    "$TEMPLATE" > "$TARGET"
+
+echo "Installed agent: $TARGET"
+
+# bootstrap is the modern equivalent of `load`. We unload first so a re-run
+# of this installer cleanly replaces an existing agent.
+if launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1; then
+    launchctl bootout "gui/$(id -u)" "$TARGET" 2>/dev/null || true
+fi
+launchctl bootstrap "gui/$(id -u)" "$TARGET"
+launchctl enable "gui/$(id -u)/$LABEL"
+launchctl kickstart -k "gui/$(id -u)/$LABEL"
+
+echo
+echo "Skulk LaunchAgent is installed and running."
+echo "  status: launchctl print gui/$(id -u)/$LABEL"
+echo "  logs:   tail -f $LOG_DIR/skulk.stderr.log"
+echo "  stop:   launchctl bootout gui/$(id -u) $TARGET"
+echo "  remove: launchctl bootout gui/$(id -u) $TARGET && rm $TARGET"

--- a/deployment/install/install-launchd.sh
+++ b/deployment/install/install-launchd.sh
@@ -27,10 +27,10 @@ fi
 # Capture the user's PATH from a login shell so the same `uv` resolution
 # Skulk uses interactively is what the agent gets.
 USER_PATH="$(/bin/bash -lc 'echo -n $PATH')"
-LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/skulk/logs"
-# Skulk uses ~/.skulk-prefixed XDG paths when SKULK_HOME is set; otherwise
-# $XDG_CACHE_HOME (or ~/.cache on macOS where XDG isn't conventional).
-# Match the SKULK_LOG_DIR resolution in src/exo/shared/constants.py.
+# On macOS, _get_xdg_dir() in src/exo/shared/constants.py returns ~/.skulk
+# for all XDG dirs (sys.platform != "linux" branch), so SKULK_LOG_DIR is
+# always ~/.skulk/logs on macOS regardless of XDG_CACHE_HOME.
+LOG_DIR="$HOME/.skulk/logs"
 mkdir -p "$LOG_DIR"
 mkdir -p "$TARGET_DIR"
 

--- a/deployment/install/install-systemd.sh
+++ b/deployment/install/install-systemd.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Install the Skulk user-level systemd service.
+#
+# User-level (not system-level) is the default because:
+#   - it matches the macOS LaunchAgent model
+#   - GPU/Metal-equivalent compute typically requires a logged-in user session
+#   - linger (`loginctl enable-linger`) gives autostart on boot for headless
+#     machines without the broader blast radius of a system unit
+#
+# For true server-style deployments where Skulk should run regardless of any
+# user session, see website/docs/deployment/headless-resilience.md for the
+# system-unit variant.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$REPO_ROOT/deployment/systemd/skulk.service"
+TARGET_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+TARGET="$TARGET_DIR/skulk.service"
+
+if [[ "$OSTYPE" != linux-gnu* ]]; then
+    echo "error: install-systemd.sh is for Linux. On macOS use install-launchd.sh." >&2
+    exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "error: 'uv' not found on PATH. Install uv first (https://docs.astral.sh/uv/) and re-run." >&2
+    exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+    echo "error: 'systemctl' not found. This installer requires systemd." >&2
+    exit 1
+fi
+
+mkdir -p "$TARGET_DIR"
+
+# Substitute the repo path placeholder. We use sed with a non-/ delimiter so
+# paths containing / don't need escaping.
+sed "s|__SKULK_REPO__|$REPO_ROOT|g" "$TEMPLATE" > "$TARGET"
+
+echo "Installed unit: $TARGET"
+
+systemctl --user daemon-reload
+
+# Enable linger so the user manager keeps running across logout/reboot. Without
+# this, user services stop when the user logs out — defeating the headless use
+# case. Already-enabled lingering is a no-op.
+if command -v loginctl >/dev/null 2>&1; then
+    if ! loginctl show-user "$USER" 2>/dev/null | grep -q "Linger=yes"; then
+        echo "Enabling user lingering so Skulk runs without an active login session..."
+        if ! loginctl enable-linger "$USER" 2>/dev/null; then
+            echo "warn: failed to enable linger (may need sudo). Run manually:" >&2
+            echo "       sudo loginctl enable-linger $USER" >&2
+        fi
+    fi
+fi
+
+systemctl --user enable --now skulk.service
+
+echo
+echo "Skulk service is enabled and running."
+echo "  status: systemctl --user status skulk"
+echo "  logs:   journalctl --user -u skulk -f"
+echo "  stop:   systemctl --user stop skulk"
+echo "  remove: systemctl --user disable --now skulk && rm $TARGET"

--- a/deployment/launchd/foundation.foxlight.skulk.plist
+++ b/deployment/launchd/foundation.foxlight.skulk.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>foundation.foxlight.skulk</string>
+
+    <!-- A login shell finds `uv` regardless of how launchd was loaded
+         (e.g. brew install path on Apple Silicon). Skulk's CLI entry
+         point is `skulk = "exo.main:main"` per pyproject.toml. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>exec uv run skulk</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__SKULK_REPO__</string>
+
+    <!-- Run at user login (LaunchAgent) and keep alive on crash, but
+         not on clean exit. SuccessfulExit=false means launchd treats
+         exit 0 as "stay stopped" and any non-zero as "relaunch".
+         Crashed=true also relaunches on signal-induced termination. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <!-- Throttle relaunch to avoid a tight loop when the cause is a
+         config error. Matches the systemd unit's RestartSec=10. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- Interactive ProcessType is the default for LaunchAgents and
+         ensures Metal / window-server access works the same way it
+         does for `uv run skulk` from Terminal.app. -->
+    <key>ProcessType</key>
+    <string>Interactive</string>
+
+    <!-- Logs land alongside the existing Skulk log directory so
+         operators have one place to look. The install script ensures
+         the directory exists before bootstrap. -->
+    <key>StandardOutPath</key>
+    <string>__SKULK_LOG_DIR__/skulk.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>__SKULK_LOG_DIR__/skulk.stderr.log</string>
+
+    <!-- Inherit the user's shell PATH so `uv` and any tool-version
+         shims resolve. EnvironmentVariables is the only PATH escape
+         hatch launchd offers without using launchctl setenv globally. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__USER_PATH__</string>
+    </dict>
+</dict>
+</plist>

--- a/deployment/systemd/skulk.service
+++ b/deployment/systemd/skulk.service
@@ -6,6 +6,11 @@ Documentation=https://github.com/Foxlight-Foundation/Skulk
 # model store paths are mounted (matters on systems with delayed mounts).
 After=network-online.target local-fs.target
 Wants=network-online.target
+# StartLimitBurst/StartLimitIntervalSec are unit-level directives — they
+# must live in [Unit], not [Service], or systemd silently ignores them.
+# 5 crashes within 5 minutes trips the limit and stops restart attempts.
+StartLimitBurst=5
+StartLimitIntervalSec=300
 
 [Service]
 Type=simple
@@ -27,12 +32,10 @@ TimeoutStopSec=30
 # Crash recovery: only restart on abnormal exit. Planned shutdowns
 # (`systemctl --user stop skulk` → SIGTERM → exit 0) stay stopped.
 # `RestartSec` avoids a tight loop when the cause is a config error;
-# `StartLimitBurst`/`StartLimitIntervalSec` then bail after repeated
+# the [Unit] StartLimitBurst/StartLimitIntervalSec bail after repeated
 # failure so a broken config doesn't burn the node.
 Restart=on-failure
 RestartSec=10
-StartLimitBurst=5
-StartLimitIntervalSec=300
 
 # MLX engines and the libp2p stack each open many file descriptors and
 # memory-map model shards. The defaults (1024 / system rlimit) are too

--- a/deployment/systemd/skulk.service
+++ b/deployment/systemd/skulk.service
@@ -1,0 +1,51 @@
+[Unit]
+Description=Skulk distributed inference node
+Documentation=https://github.com/Foxlight-Foundation/Skulk
+# Network-online ensures DNS / outbound connectivity is available before
+# Skulk attempts libp2p bootstrap. local-fs ensures $HOME/.skulk and the
+# model store paths are mounted (matters on systems with delayed mounts).
+After=network-online.target local-fs.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=__SKULK_REPO__
+
+# uv is the canonical runtime path per AGENTS.md. The wrapper invokes it
+# from a login shell so PATH and any user-shell setup (e.g. mise, asdf,
+# pyenv) are available regardless of how systemd was started.
+ExecStart=/bin/bash -lc 'exec uv run skulk'
+
+# SIGTERM is what `Skulk._signal` already handles via task-group cancel.
+# `mixed` sends SIGTERM to the main process and SIGKILL to remaining
+# children only if they outlive TimeoutStopSec — important because Skulk
+# spawns runner subprocesses that hold MLX state.
+KillSignal=SIGTERM
+KillMode=mixed
+TimeoutStopSec=30
+
+# Crash recovery: only restart on abnormal exit. Planned shutdowns
+# (`systemctl --user stop skulk` → SIGTERM → exit 0) stay stopped.
+# `RestartSec` avoids a tight loop when the cause is a config error;
+# `StartLimitBurst`/`StartLimitIntervalSec` then bail after repeated
+# failure so a broken config doesn't burn the node.
+Restart=on-failure
+RestartSec=10
+StartLimitBurst=5
+StartLimitIntervalSec=300
+
+# MLX engines and the libp2p stack each open many file descriptors and
+# memory-map model shards. The defaults (1024 / system rlimit) are too
+# tight for a node hosting multi-GB models.
+LimitNOFILE=65536
+LimitMEMLOCK=infinity
+
+# Logging: stdout/stderr flow to the journal. The Vector sidecar
+# (deployment/logging/vector.yaml) is responsible for shipping the
+# JSON-on-stdout stream when centralized logging is enabled.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=skulk
+
+[Install]
+WantedBy=default.target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exo"
-version = "1.0.3"
+version = "1.1.0"
 description = "Exo"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -145,6 +145,7 @@ from exo.api.types.openai_responses import (
     ResponsesRequest,
     ResponsesResponse,
 )
+from exo.connectivity.tailscale import TailscaleStatus, query_tailscale_status
 from exo.master.image_store import ImageStore
 from exo.master.placement import place_instance as get_instance_placements
 from exo.shared.apply import apply
@@ -1168,6 +1169,15 @@ class API:
             summary="Get node identity and preferred IP",
             description="Return the node ID, hostname, and preferred LAN IP address that the dashboard uses during setup.",
         )(self.get_node_identity)
+        self.app.get(
+            "/v1/connectivity/tailscale",
+            tags=["Connectivity"],
+            summary="Get Tailscale status",
+            description=(
+                "Return whether tailscaled is running on this node and, if so, the node's "
+                "Tailscale IP, hostname, DNS name, and tailnet."
+            ),
+        )(self.get_tailscale_status)
 
     async def place_instance(self, payload: PlaceInstanceParams):
         command = PlaceInstance(
@@ -4434,6 +4444,16 @@ class API:
                 "ipAddress": ip,
             }
         )
+
+    async def get_tailscale_status(self) -> TailscaleStatus:
+        """Return the local node's Tailscale connectivity state.
+
+        Queries tailscaled via ``tailscale status --json``.  Returns a
+        ``TailscaleStatus`` with ``running=False`` when tailscale is not
+        installed or tailscaled is not running.
+        """
+
+        return await query_tailscale_status()
 
     async def get_store_downloads(self) -> JSONResponse:
         if self._store_client is None:

--- a/src/exo/connectivity/__init__.py
+++ b/src/exo/connectivity/__init__.py
@@ -1,0 +1,1 @@
+"""Cluster connectivity helpers."""

--- a/src/exo/connectivity/tailscale.py
+++ b/src/exo/connectivity/tailscale.py
@@ -1,0 +1,131 @@
+# pyright: reportAny=false
+"""Tailscale connectivity helpers.
+
+Queries the local ``tailscale status --json`` output to discover whether
+tailscaled is running, the node's Tailscale IP, and tailnet membership.  The
+module is intentionally thin — it does not manage Tailscale, only reads its
+state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, final
+
+from loguru import logger
+from pydantic import Field
+
+from exo.utils.pydantic_ext import FrozenModel
+
+
+@final
+class TailscaleStatus(FrozenModel):
+    """Snapshot of the local node's Tailscale connectivity state.
+
+    All fields except ``running`` are ``None`` when tailscaled is not running
+    or is not installed.
+
+    Attributes:
+        running: ``True`` only when tailscaled reports ``BackendState ==
+            "Running"``.
+        self_ip: The node's Tailscale IPv4 address (``100.x.x.x`` range).
+            ``None`` when not running or not assigned.
+        hostname: The node's hostname as registered in the tailnet.
+        dns_name: The node's fully-qualified Tailscale MagicDNS name, e.g.
+            ``my-node.tailnet-abc.ts.net``.  Trailing dot stripped.
+        tailnet: The tailnet name derived from ``dns_name``, e.g.
+            ``tailnet-abc.ts.net``.  ``None`` when dns_name is absent or
+            cannot be parsed.
+        version: The tailscale client version string.
+    """
+
+    running: bool = Field(description="True when tailscaled reports BackendState == 'Running'.")
+    self_ip: str | None = Field(default=None, description="Node's Tailscale IPv4 address (100.x.x.x).")
+    hostname: str | None = Field(default=None, description="Node hostname in the tailnet.")
+    dns_name: str | None = Field(default=None, description="Fully-qualified Tailscale MagicDNS name.")
+    tailnet: str | None = Field(default=None, description="Tailnet name derived from dns_name.")
+    version: str | None = Field(default=None, description="Tailscale client version string.")
+
+
+def parse_status_json(raw: dict[str, Any]) -> TailscaleStatus:
+    """Parse a ``tailscale status --json`` dict into a ``TailscaleStatus``.
+
+    Handles missing keys gracefully — any absent field produces ``None``.
+    """
+
+    running = raw.get("BackendState") == "Running"
+
+    self_node: dict[str, Any] = raw.get("Self") or {}
+    tailscale_ips: list[str] = self_node.get("TailscaleIPs") or []
+    self_ip = next(
+        (ip for ip in tailscale_ips if ip.startswith("100.")),
+        None,
+    )
+
+    hostname: str | None = self_node.get("HostName") or None
+
+    raw_dns = self_node.get("DNSName") or None
+    dns_name = raw_dns.rstrip(".") if raw_dns else None
+
+    tailnet: str | None = None
+    if dns_name:
+        # "my-node.tailnet-abc.ts.net" → strip "my-node." prefix
+        parts = dns_name.split(".", 1)
+        tailnet = parts[1] if len(parts) == 2 else None
+
+    version: str | None = raw.get("Version") or None
+
+    return TailscaleStatus(
+        running=running,
+        self_ip=self_ip,
+        hostname=hostname,
+        dns_name=dns_name,
+        tailnet=tailnet,
+        version=version,
+    )
+
+
+async def query_tailscale_status() -> TailscaleStatus:
+    """Query tailscaled and return the node's current Tailscale state.
+
+    Runs ``tailscale status --json`` as a subprocess.  Returns a
+    ``TailscaleStatus`` with ``running=False`` on any error: tailscale not
+    installed, tailscaled not running, or the command timing out.
+    """
+
+    _not_running = TailscaleStatus(running=False)
+
+    try:
+        process = await asyncio.wait_for(
+            asyncio.create_subprocess_exec(
+                "tailscale",
+                "status",
+                "--json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            ),
+            timeout=3.0,
+        )
+        stdout, _ = await asyncio.wait_for(process.communicate(), timeout=3.0)
+    except FileNotFoundError:
+        logger.debug("tailscale binary not found; Tailscale not installed")
+        return _not_running
+    except TimeoutError:
+        logger.debug("tailscale status timed out")
+        return _not_running
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(f"tailscale status failed: {exc}")
+        return _not_running
+
+    if process.returncode != 0:
+        logger.debug(f"tailscale status exited {process.returncode}")
+        return _not_running
+
+    try:
+        raw = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        logger.debug(f"tailscale status JSON parse error: {exc}")
+        return _not_running
+
+    return parse_status_json(raw)

--- a/src/exo/connectivity/tests/test_tailscale.py
+++ b/src/exo/connectivity/tests/test_tailscale.py
@@ -1,0 +1,59 @@
+# pyright: reportAny=false
+"""Tests for TailscaleStatus JSON parsing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from exo.connectivity.tailscale import parse_status_json
+
+_FULL_STATUS: dict[str, Any] = {
+    "Version": "1.66.1-t82d4e3b99-g7b76cfb8f",
+    "BackendState": "Running",
+    "Self": {
+        "HostName": "my-node",
+        "DNSName": "my-node.tailnet-abc.ts.net.",
+        "TailscaleIPs": ["100.101.102.103", "fd7a:115c:a1e0::1"],
+    },
+}
+
+
+def test_running_status_parses_correctly() -> None:
+    status = parse_status_json(_FULL_STATUS)
+    assert status.running is True
+    assert status.self_ip == "100.101.102.103"
+    assert status.hostname == "my-node"
+    assert status.dns_name == "my-node.tailnet-abc.ts.net"
+    assert status.tailnet == "tailnet-abc.ts.net"
+    assert status.version == "1.66.1-t82d4e3b99-g7b76cfb8f"
+
+
+def test_dns_name_trailing_dot_stripped() -> None:
+    self_override: dict[str, Any] = {**_FULL_STATUS["Self"], "DNSName": "my-node.tailnet-abc.ts.net."}
+    raw: dict[str, Any] = {**_FULL_STATUS, "Self": self_override}
+    status = parse_status_json(raw)
+    assert status.dns_name == "my-node.tailnet-abc.ts.net"
+    assert status.dns_name is not None and not status.dns_name.endswith(".")
+
+
+def test_tailnet_derived_from_dns_name() -> None:
+    self_override: dict[str, Any] = {**_FULL_STATUS["Self"], "DNSName": "myhost.example-corp.ts.net"}
+    raw: dict[str, Any] = {**_FULL_STATUS, "Self": self_override}
+    status = parse_status_json(raw)
+    assert status.tailnet == "example-corp.ts.net"
+
+
+def test_not_running_returns_running_false() -> None:
+    raw: dict[str, Any] = {"BackendState": "Stopped", "Self": {}}
+    status = parse_status_json(raw)
+    assert status.running is False
+
+
+def test_missing_self_returns_nones() -> None:
+    raw: dict[str, Any] = {"BackendState": "Running"}
+    status = parse_status_json(raw)
+    assert status.running is True
+    assert status.self_ip is None
+    assert status.hostname is None
+    assert status.dns_name is None
+    assert status.tailnet is None

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -25,6 +25,7 @@ from exo.shared.logging import logger_cleanup, logger_setup
 from exo.shared.types.commands import ForwarderDownloadCommand, SyncConfig
 from exo.shared.types.common import NodeId, SessionId, SystemId
 from exo.shared.types.state_sync import StateSyncMessage
+from exo.startup_recovery import preflight_api_port
 from exo.store.config import (
     ExoConfig,
     load_exo_config,
@@ -680,6 +681,8 @@ def main():
     )
     logger.info("Starting Skulk")
     logger.info(f"LIBP2P_NAMESPACE: {os.environ.get('SKULK_LIBP2P_NAMESPACE', os.getenv('EXO_LIBP2P_NAMESPACE'))}")
+
+    preflight_api_port(args.api_port)
 
     if args.offline:
         logger.info("Running in OFFLINE mode — no internet checks, local models only")

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -684,7 +684,8 @@ def main():
     logger.info("Starting Skulk")
     logger.info(f"LIBP2P_NAMESPACE: {os.environ.get('SKULK_LIBP2P_NAMESPACE', os.getenv('EXO_LIBP2P_NAMESPACE'))}")
 
-    preflight_api_port(args.api_port)
+    if args.spawn_api:
+        preflight_api_port(args.api_port)
 
     # Tailscale: if configured, query tailscaled and merge bootstrap peers.
     _ts_config = (

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -14,6 +14,7 @@ from pydantic import PositiveInt
 
 import exo.routing.topics as topics
 from exo.api.main import API
+from exo.connectivity.tailscale import query_tailscale_status
 from exo.download.coordinator import DownloadCoordinator
 from exo.download.impl_shard_downloader import exo_shard_downloader
 from exo.master.main import Master
@@ -667,6 +668,7 @@ def main():
     # fall back gracefully — logging will start without the JSON sink and
     # the validation error is logged once the logger is up.
     _log_cfg = None
+    _early_config: ExoConfig | None = None
     try:
         _early_config = load_exo_config()
         _log_cfg = _early_config.logging if _early_config else None
@@ -683,6 +685,34 @@ def main():
     logger.info(f"LIBP2P_NAMESPACE: {os.environ.get('SKULK_LIBP2P_NAMESPACE', os.getenv('EXO_LIBP2P_NAMESPACE'))}")
 
     preflight_api_port(args.api_port)
+
+    # Tailscale: if configured, query tailscaled and merge bootstrap peers.
+    _ts_config = (
+        _early_config.connectivity.tailscale
+        if _early_config and _early_config.connectivity
+        else None
+    )
+    if _ts_config and _ts_config.enabled:
+        import asyncio as _asyncio
+        _ts_status = _asyncio.run(query_tailscale_status())
+        if _ts_status.running:
+            logger.info(
+                f"Tailscale: running | IP {_ts_status.self_ip} | {_ts_status.dns_name}"
+            )
+        else:
+            logger.warning(
+                "Tailscale connectivity configured but tailscaled is not running"
+            )
+        if _ts_config.bootstrap_peers:
+            _seen = set(args.bootstrap_peers)
+            _extra = [p for p in _ts_config.bootstrap_peers if p not in _seen]
+            if _extra:
+                args = args.model_copy(
+                    update={"bootstrap_peers": args.bootstrap_peers + _extra}
+                )
+                logger.info(
+                    f"Tailscale: added {len(_extra)} bootstrap peer(s) from config"
+                )
 
     if args.offline:
         logger.info("Running in OFFLINE mode — no internet checks, local models only")

--- a/src/exo/startup_recovery.py
+++ b/src/exo/startup_recovery.py
@@ -1,0 +1,75 @@
+"""Startup integrity checks run before Skulk's components come up.
+
+The cluster is event-sourced and most "stale state" recovers naturally:
+
+* The event log uses per-record framing, so a partial-write at process death
+  is detected and dropped at replay (`exo.shared.event_log`).
+* Runner subprocesses die with the parent, so MLX/Metal heap state is
+  reclaimed by the kernel.
+* libp2p reconnects from scratch on every startup; there is no on-disk peer
+  state that needs cleanup.
+
+What does *not* recover automatically is socket reuse: when Skulk is killed
+hard (kernel OOM, `kill -9`, sudden power loss with networking still up via
+WoL, or a fast crash-and-relaunch via systemd/launchd), the API port can sit
+in `TIME_WAIT` for tens of seconds and the new process's bind fails with a
+confusing "address already in use" error.
+
+This module preflights the API port and produces a clear actionable log line
+plus a non-zero exit, which is the contract systemd/launchd want for
+restart-with-backoff to do its job.
+"""
+
+from __future__ import annotations
+
+import errno
+import socket
+import sys
+from typing import Final
+
+from loguru import logger
+
+# Brief grace before failing — covers the common case of a fast restart where
+# the previous process's TIME_WAIT entry is about to clear. Longer than this
+# and we want the supervisor (systemd/launchd) to take over with its own
+# backoff so the operator gets honest feedback instead of a wedged "starting"
+# state.
+_API_PORT_GRACE_SECONDS: Final[float] = 5.0
+
+
+def preflight_api_port(api_port: int) -> None:
+    """Verify the API port is bindable; on failure log and exit non-zero.
+
+    Calls `socket(...).bind(("0.0.0.0", api_port))` with `SO_REUSEADDR`
+    matching what the actual API server uses, so the check has the same
+    bind semantics as the eventual production listener. The socket is
+    closed immediately — this is a probe, not a reservation.
+    """
+
+    deadline_attempts = max(1, int(_API_PORT_GRACE_SECONDS))
+    last_error: OSError | None = None
+
+    for attempt in range(deadline_attempts):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                probe.bind(("0.0.0.0", api_port))
+            return
+        except OSError as exception:
+            last_error = exception
+            if exception.errno == errno.EADDRINUSE and attempt + 1 < deadline_attempts:
+                # Common in supervisor-driven restarts. Sleep a beat and retry
+                # before escalating to the supervisor's own backoff.
+                import time
+
+                time.sleep(1.0)
+                continue
+            break
+
+    assert last_error is not None
+    logger.critical(
+        f"API port {api_port} is not bindable: {last_error}. "
+        f"This usually means a previous Skulk instance is still releasing the port. "
+        f"Exiting; the service supervisor (systemd/launchd) will retry with backoff."
+    )
+    sys.exit(75)  # EX_TEMPFAIL — supervisor should treat this as transient.

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -72,6 +72,7 @@ from pathlib import Path
 from typing import Literal, final
 
 import yaml
+from pydantic import Field
 
 from exo.utils.pydantic_ext import FrozenModel
 
@@ -231,6 +232,43 @@ class ModelStoreConfig(FrozenModel):
 
 
 @final
+class TailscaleConnectivityConfig(FrozenModel):
+    """Tailscale connectivity settings.
+
+    When present and ``enabled`` is ``True``, Skulk queries tailscaled at
+    startup, logs the node's Tailscale IP and tailnet name, and merges
+    ``bootstrap_peers`` into the libp2p peer list so nodes can discover each
+    other across the Tailscale overlay network.
+
+    Attributes:
+        enabled: Master switch.  ``False`` disables all Tailscale-aware
+            behaviour while preserving the config section for reference.
+        bootstrap_peers: libp2p multiaddrs using Tailscale IPs, e.g.
+            ``/ip4/100.101.102.103/tcp/52416``.  These are merged with any
+            peers supplied via ``--bootstrap-peers`` or
+            ``EXO_BOOTSTRAP_PEERS``.
+    """
+
+    enabled: bool = Field(default=True, description="Master switch for Tailscale-aware behaviour.")
+    bootstrap_peers: list[str] = Field(
+        default_factory=list,
+        description="libp2p multiaddrs with Tailscale IPs, e.g. /ip4/100.x.x.x/tcp/52416.",
+    )
+
+
+@final
+class ConnectivityConfig(FrozenModel):
+    """Cluster connectivity settings.
+
+    Attributes:
+        tailscale: Tailscale overlay network settings.  ``None`` means the
+            Tailscale integration is disabled.
+    """
+
+    tailscale: TailscaleConnectivityConfig | None = None
+
+
+@final
 class ExoConfig(FrozenModel):
     """Root configuration model for ``exo.yaml``.
 
@@ -245,6 +283,9 @@ class ExoConfig(FrozenModel):
             defaults.
         logging: Centralized logging configuration (enabled toggle, ingest
             URL).  ``None`` disables remote log shipping.
+        connectivity: Cluster connectivity settings.  ``None`` means all
+            connectivity options use their defaults (mDNS + CLI bootstrap peers
+            only).
         hf_token: HuggingFace API token.  Stripped from ``GET /config``
             responses for security.
     """
@@ -253,6 +294,7 @@ class ExoConfig(FrozenModel):
     inference: "InferenceConfig | None" = None
     logging: "LoggingConfig | None" = None
     tracing: "TracingConfig | None" = None
+    connectivity: ConnectivityConfig | None = None
     hf_token: str | None = None
 
 

--- a/src/exo/tests/test_startup_recovery.py
+++ b/src/exo/tests/test_startup_recovery.py
@@ -1,0 +1,48 @@
+"""Tests for the startup port preflight."""
+
+from __future__ import annotations
+
+import socket
+from typing import cast
+
+import pytest
+
+from exo.startup_recovery import preflight_api_port
+
+
+def _port_of(sock: socket.socket) -> int:
+    sockname = cast(tuple[str, int], sock.getsockname())
+    return sockname[1]
+
+
+def _grab_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("0.0.0.0", 0))
+        return _port_of(probe)
+
+
+def test_preflight_returns_when_port_is_free():
+    """Free port → returns cleanly, no exit."""
+    port = _grab_free_port()
+    preflight_api_port(port)
+
+
+def test_preflight_exits_when_port_is_held():
+    """Port already bound by another listener → SystemExit with EX_TEMPFAIL.
+
+    SO_REUSEADDR makes simultaneous bind() calls on the same port succeed in
+    some kernels until one of them listen()s. We hold the port with listen()
+    so the preflight's probe bind reliably fails with EADDRINUSE, matching
+    the production failure mode (a previous Skulk's API server still
+    bound and listening).
+    """
+    held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        held.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        held.bind(("0.0.0.0", 0))
+        held.listen(1)
+        with pytest.raises(SystemExit) as exit_info:
+            preflight_api_port(_port_of(held))
+        assert exit_info.value.code == 75
+    finally:
+        held.close()

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -972,6 +972,35 @@ curl http://localhost:52415/v1/traces/cluster/<task_id>/stats
 curl -OJ http://localhost:52415/v1/traces/cluster/<task_id>/raw
 ```
 
+## Connectivity Endpoints
+
+### Tailscale status
+
+```
+GET /v1/connectivity/tailscale
+```
+
+Returns whether tailscaled is running on the **local** node and, if so, the node's Tailscale IP, hostname, DNS name, and tailnet. All fields except `running` are `null` when tailscaled is not installed or not running.
+
+**Response fields:**
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `running` | boolean | `true` when tailscaled reports `BackendState == "Running"` |
+| `selfIp` | string \| null | Node's Tailscale IPv4 address (100.x.x.x range) |
+| `hostname` | string \| null | Node hostname as registered in the tailnet |
+| `dnsName` | string \| null | Fully-qualified Tailscale MagicDNS name, e.g. `my-node.tailnet-abc.ts.net` |
+| `tailnet` | string \| null | Tailnet name derived from `dnsName` |
+| `version` | string \| null | Tailscale client version string |
+
+This endpoint always reflects the **node serving the request**, not a selected remote node. To check Tailscale status on a different cluster node, reach its API directly.
+
+Example:
+
+```bash
+curl http://localhost:52415/v1/connectivity/tailscale
+```
+
 ## Helpful Next Docs
 
 - [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md)

--- a/website/docs/release-notes/1.1.0.md
+++ b/website/docs/release-notes/1.1.0.md
@@ -1,0 +1,64 @@
+---
+title: Release Notes 1.1.0
+sidebar_position: 1
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+Release date: 2026-05-03
+
+## Highlights
+
+- **Autostart and crash recovery.** Skulk can now run as a supervised service on macOS (LaunchAgent) and Linux (systemd user unit). It starts at login/boot and restarts itself automatically if it crashes. One-shot installers handle the setup; no root required on either platform.
+- **Tailscale connectivity.** A new connectivity layer lets cluster nodes span multiple physical networks over Tailscale (or a self-hosted Headscale server). Each node detects its own Tailscale status at startup; the dashboard's Node tab shows Tailscale IP and DNS name; and a new API endpoint exposes connectivity status to monitoring tools.
+- **Operator panel.** A dedicated `/operator` route in the dashboard gives remote operators a mobile-first view of cluster health — memory, GPU, and temperature at a glance — with a tap-twice-to-confirm node restart button that doesn't require SSH.
+- **Remote dashboard fixes.** The chat view and copy affordances now work over plain HTTP (not just `localhost` or HTTPS), which matters when accessing Skulk over Tailscale.
+
+## Autostart and Crash Recovery
+
+`deployment/install/install-launchd.sh` (macOS) and `deployment/install/install-systemd.sh` (Linux) are one-shot scripts that register Skulk as a user-level service. Both supervisors:
+
+- Start Skulk at login (macOS) or boot (Linux, via `loginctl enable-linger`)
+- Restart on crash with backoff; stop after 5 crashes within 5 minutes to avoid a hot restart loop
+- Leave a clean exit (exit 0) alone — deliberate `skulk stop` stays stopped
+
+A pre-startup port preflight exits with `EX_TEMPFAIL` (75) when the API port is still held by a previous instance. The supervisor's backoff handles the brief race on restart; operators get a clear log line rather than a confusing mid-run bind error.
+
+See the [Run Skulk as a service](../run-skulk-as-a-service.md) guide for installation steps and day-to-day operations.
+
+## Tailscale Connectivity
+
+Add a `connectivity` section to `skulk.yaml` to enable multi-network clusters:
+
+```yaml
+connectivity:
+  tailscale:
+    enabled: true
+    bootstrap_peers:
+      - /ip4/100.101.102.103/tcp/52416   # other node
+```
+
+At startup, Skulk runs `tailscale status --json` and logs its Tailscale IP, hostname, and tailnet name. The Node tab in the Observability panel surfaces the same information. `GET /v1/connectivity/tailscale` exposes it to scripts and monitoring tools.
+
+See the [Tailscale guide](../tailscale.md) for full setup instructions, ACL guidance, and Headscale notes.
+
+## Operator Panel
+
+Open `/operator` in the dashboard (or tap "Operator" in the nav) for a layout optimized for phone-sized screens over Tailscale:
+
+- **Cluster summary bar** — total nodes, memory in use, average GPU utilization, and average temperature across the cluster
+- **Per-node cards** — role badge (master / worker), memory bar, GPU bar, temperature, and model placements
+- **Tap-twice restart** — tap "Restart" on a node card; a "Confirm?" prompt appears; tap again within 3 seconds to fire `POST /admin/restart`. Accidental taps do nothing.
+
+## Upgrade Guidance
+
+No breaking changes relative to 1.0.3. The new `connectivity.tailscale` config section is optional; omitting it leaves behaviour identical to 1.0.3.
+
+If you run Skulk as a manual `uv run skulk` process today, the service installer is additive — run it once and the existing process becomes supervised going forward.
+
+## Validation Snapshot
+
+- `uv run basedpyright` — 0 errors, 0 warnings, 0 notes
+- `uv run ruff check` — clean
+- `uv run pytest` — all pass
+- `cd dashboard-react && npm run build` — clean

--- a/website/docs/run-skulk-as-a-service.md
+++ b/website/docs/run-skulk-as-a-service.md
@@ -93,7 +93,7 @@ If it doesn't, jump to [Things that go wrong](#things-that-go-wrong).
 | What you want to do | macOS | Linux |
 | --- | --- | --- |
 | Check if it's running | `launchctl print gui/$(id -u)/foundation.foxlight.skulk \| grep "state ="` | `systemctl --user status skulk` |
-| Watch the logs live | `tail -f ~/.cache/skulk/logs/skulk.stderr.log` | `journalctl --user -u skulk -f` |
+| Watch the logs live | `tail -f ~/.skulk/logs/skulk.stderr.log` | `journalctl --user -u skulk -f` |
 | Restart it | `launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk` | `systemctl --user restart skulk` |
 | Stop it (stays stopped) | `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user stop skulk` |
 | Start it back up | `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user start skulk` |

--- a/website/docs/run-skulk-as-a-service.md
+++ b/website/docs/run-skulk-as-a-service.md
@@ -1,0 +1,221 @@
+---
+title: Run Skulk as a service
+description: Make Skulk start automatically when your computer turns on, and restart itself if it ever crashes.
+sidebar_label: Run as a service
+---
+
+# Run Skulk as a service
+
+Make Skulk start when your computer boots, and restart itself if it ever crashes. This is what you want for any always-on cluster node.
+
+## What you'll have when you're done
+
+- Skulk starts automatically — no more typing `uv run skulk` every time you reboot
+- If Skulk crashes, it comes back up on its own
+- You'll know exactly how to check it's running, see logs, restart it, and turn it off
+
+About 5 minutes per machine. No coding. No sudo for the standard install.
+
+## Before you start
+
+You need:
+
+1. **A working Skulk install.** You should already be able to run `uv run skulk` from your Skulk folder and have it boot cleanly. If you can't, do that first — the [Build and Runtime guide](./build-and-runtime.md) walks you through it.
+2. **`uv` on your PATH.** Check by running `which uv`. If you see a path, you're good. If it says "not found", install `uv` from [docs.astral.sh/uv](https://docs.astral.sh/uv/) and come back.
+3. **macOS** (any recent version) **or Linux** with systemd (Ubuntu, Debian, Fedora, Arch — anything modern).
+
+That's it.
+
+## Install — pick your platform
+
+### macOS
+
+Open Terminal, `cd` into your Skulk folder, then run:
+
+```bash
+deployment/install/install-launchd.sh
+```
+
+The script does everything for you. When it finishes (a few seconds), check it's running:
+
+```bash
+launchctl print gui/$(id -u)/foundation.foxlight.skulk | grep "state ="
+```
+
+You should see:
+
+```
+state = running
+```
+
+**That's it.** Skulk will start automatically the next time you log in, and will restart itself if it ever crashes.
+
+### Linux
+
+Open a terminal, `cd` into your Skulk folder, then run:
+
+```bash
+deployment/install/install-systemd.sh
+```
+
+The script does everything for you. When it finishes (a few seconds), check it's running:
+
+```bash
+systemctl --user status skulk
+```
+
+You should see a line that says:
+
+```
+Active: active (running)
+```
+
+**That's it.** Skulk will start automatically when the machine boots, and will restart itself if it ever crashes.
+
+:::tip Why does the Linux installer ask for your password sometimes?
+The installer enables "user lingering" so Skulk keeps running after you log out — that's what makes autostart work on a headless box. Lingering is normally root-only to enable, hence the password prompt. If you skip it, Skulk will only run while you're logged in.
+:::
+
+## Verify autostart actually works
+
+The real test is rebooting your machine.
+
+1. **Reboot.**
+2. Wait about 30 seconds after it comes back.
+3. Open `http://localhost:52415` in a browser. You should see the Skulk dashboard.
+
+If the dashboard loads after a reboot without you typing anything, autostart is working. You're done.
+
+If it doesn't, jump to [Things that go wrong](#things-that-go-wrong).
+
+## Day-to-day operations
+
+| What you want to do | macOS | Linux |
+| --- | --- | --- |
+| Check if it's running | `launchctl print gui/$(id -u)/foundation.foxlight.skulk \| grep "state ="` | `systemctl --user status skulk` |
+| Watch the logs live | `tail -f ~/.cache/skulk/logs/skulk.stderr.log` | `journalctl --user -u skulk -f` |
+| Restart it | `launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk` | `systemctl --user restart skulk` |
+| Stop it (stays stopped) | `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user stop skulk` |
+| Start it back up | `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user start skulk` |
+
+### Updating Skulk after `git pull`
+
+Pull the new code, rebuild the dashboard, then restart the service so it picks up the changes:
+
+```bash
+git pull
+cd dashboard-react && npm install && npm run build && cd ..
+
+# macOS:
+launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk
+# Linux:
+systemctl --user restart skulk
+```
+
+That's the whole update flow.
+
+## Things that go wrong
+
+### "I rebooted but Skulk didn't come back up"
+
+**On Linux**, this almost always means user lingering didn't get turned on. Linux user services normally stop the moment you log out — and rebooting counts as logging out. Fix:
+
+```bash
+sudo loginctl enable-linger $USER
+sudo reboot
+```
+
+After lingering is on, Skulk will come up on its own at boot.
+
+**On macOS**, LaunchAgents start when you log in, not at boot. If your Mac auto-logs-in at boot (System Settings → Users & Groups → Login Options → Automatic login), Skulk will start automatically. If you have to type a password to log in, Skulk waits for you to do that first.
+
+### "The status says `running` / `active` but the dashboard doesn't load"
+
+Wait 10–20 seconds — Skulk needs a moment to boot networking and load the dashboard.
+
+If the dashboard still doesn't load, check the logs (see the table above). Look for lines that say `ERROR` or `CRITICAL`. The most common causes:
+
+- **Another program is using port 52415.** Find it with `lsof -i :52415` and stop it (or change Skulk's port with `--api-port`).
+- **A typo in your `skulk.yaml`.** Skulk logs the parse error on startup — search the log for "config".
+- **You moved your Skulk folder after running the installer.** Re-run the installer; it'll update the path.
+
+### "It keeps crashing in a loop"
+
+Both macOS and Linux give up after 5 crashes within 5 minutes. This is on purpose — a broken config shouldn't hammer your machine forever. To get back to a working state:
+
+```bash
+# macOS — stop, fix the cause, then start again
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist
+# (fix whatever's broken)
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist
+
+# Linux — same idea
+systemctl --user stop skulk
+# (fix whatever's broken)
+systemctl --user reset-failed skulk
+systemctl --user start skulk
+```
+
+To figure out what's wrong, read the logs. Skulk almost always writes a `CRITICAL ...` line right before it dies, telling you exactly what went wrong.
+
+## Uninstall
+
+Removes the service so Skulk doesn't start automatically anymore. Doesn't touch your models, configs, or anything under `~/.skulk` — only the service definition is removed.
+
+### macOS
+
+```bash
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist
+rm ~/Library/LaunchAgents/foundation.foxlight.skulk.plist
+```
+
+### Linux
+
+```bash
+systemctl --user disable --now skulk
+rm ~/.config/systemd/user/skulk.service
+systemctl --user daemon-reload
+```
+
+## What survives a reboot
+
+You don't need to read this for normal use — Skulk handles reboots cleanly. Here for the curious.
+
+**Survives:**
+
+- Your downloaded models
+- Custom model cards you've added
+- Your `skulk.yaml` config
+- The cluster's event log (Skulk replays this on startup to figure out what was going on)
+
+**Doesn't survive (and doesn't need to):**
+
+- In-flight inference requests (the client gets a connection error and retries)
+- Currently-running model placements (the cluster re-elects and re-plans in seconds)
+- libp2p peer connections (everyone redials)
+
+## Power loss
+
+If a node loses power without warning:
+
+- Your filesystem (APFS on macOS, ext4 on Linux) protects the data on disk.
+- Skulk's event log is written so that a half-written entry from sudden power loss is detected and dropped on the next startup. Your model state and config are safe.
+- Any inference request that was running at the exact moment of power loss is lost. The client gets a connection error and retries.
+
+For nodes hosting valuable session state, a small UPS that gives the OS a few seconds to shut down cleanly is worth the money. For experimental or worker-only nodes, no UPS is fine — they recover by themselves.
+
+## Advanced: server-style install (Linux only)
+
+The standard install is "user-level" — Skulk runs as you, under your login, with lingering enabled. This is the right choice for almost everyone, **including headless servers**.
+
+You only need a system-level install if you have a strict "no user services" policy or your security team requires Skulk to run as a dedicated service user. Trade-off: no GPU/Metal access on Linux when running as a dedicated user, so this is only useful for CPU-only worker nodes.
+
+```bash
+sudo useradd --system --create-home --home-dir /var/lib/skulk --shell /bin/bash skulk
+# Clone Skulk into /var/lib/skulk/repo as the skulk user, then:
+sudo cp deployment/systemd/skulk.service /etc/systemd/system/skulk.service
+sudo sed -i "s|__SKULK_REPO__|/var/lib/skulk/repo|g" /etc/systemd/system/skulk.service
+sudo sed -i "/\[Service\]/a User=skulk\nGroup=skulk" /etc/systemd/system/skulk.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now skulk
+```

--- a/website/docs/tailscale.md
+++ b/website/docs/tailscale.md
@@ -1,0 +1,146 @@
+---
+title: Use Skulk over Tailscale
+description: Connect Skulk cluster nodes across the internet using Tailscale.
+sidebar_label: Tailscale
+---
+
+# Use Skulk over Tailscale
+
+By default, Skulk discovers cluster peers using mDNS, which only works on the same local network. Tailscale gives every node a stable `100.x.x.x` address that works from anywhere — at home, at a cloud provider, or behind a NAT — so you can build a cluster that spans physical locations.
+
+**What you get:**
+- Nodes on different networks join the same cluster
+- Encrypted peer-to-peer traffic between nodes (Tailscale handles it)
+- Works with [Headscale](https://headscale.net/) — same config, just join a different tailnet
+
+## Before you start
+
+On **every node** that will join the cluster:
+
+1. Install Tailscale: [tailscale.com/download](https://tailscale.com/download)
+2. Log in: `tailscale up`
+3. Confirm each machine has a `100.x.x.x` address: `tailscale ip -4`
+
+All nodes must be on the **same tailnet** (the same Tailscale account or Headscale server). Nodes on different tailnets cannot reach each other.
+
+## Quick setup
+
+Skulk nodes discover each other via **bootstrap peers** — a list of libp2p multiaddrs that each node dials at startup. For Tailscale, those multiaddrs use the `100.x.x.x` addresses.
+
+### 1. Find each node's Tailscale IP
+
+On each machine:
+
+```bash
+tailscale ip -4
+```
+
+Write down the IP for every node that should join the cluster.
+
+### 2. Edit `skulk.yaml`
+
+On **every node**, add a `connectivity` section listing the *other* nodes' Tailscale IPs. You only need to list peers — not yourself.
+
+```yaml
+connectivity:
+  tailscale:
+    enabled: true
+    bootstrap_peers:
+      - /ip4/100.101.102.103/tcp/52416   # Node B
+      - /ip4/100.101.102.104/tcp/52416   # Node C
+```
+
+Port `52416` is Skulk's default libp2p port. If you changed it with `--libp2p-port`, use that port instead.
+
+### 3. Restart Skulk
+
+```bash
+# If running manually:
+uv run skulk
+
+# If running as a service (macOS):
+launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk
+
+# If running as a service (Linux):
+systemctl --user restart skulk
+```
+
+That's it. Skulk reads the config, logs the Tailscale status, and dials the bootstrap peers over the Tailscale overlay.
+
+## Verify it's working
+
+**Check the startup logs** — look for the Tailscale line:
+
+```
+INFO  Tailscale: running | IP 100.101.102.103 | my-node.tailnet-abc.ts.net
+```
+
+If you see `Tailscale connectivity configured but tailscaled is not running`, tailscaled isn't up yet — run `tailscale status` and fix that first.
+
+**Check via the API:**
+
+```bash
+curl http://localhost:52415/v1/connectivity/tailscale | python3 -m json.tool
+```
+
+You should see something like:
+
+```json
+{
+  "running": true,
+  "self_ip": "100.101.102.103",
+  "hostname": "my-node",
+  "dns_name": "my-node.tailnet-abc.ts.net",
+  "tailnet": "tailnet-abc.ts.net",
+  "version": "1.66.1"
+}
+```
+
+**Check the dashboard** — open the Observability panel, pick a node, and look in the Runtime section. The Tailscale row shows your Tailscale IP and DNS name, or "not running" if tailscaled is down.
+
+**Check that peers connected** — open the dashboard cluster view. Once libp2p has dialed the bootstrap peers and gossipsub has propagated state, both nodes should appear.
+
+## Troubleshooting
+
+### `Tailscale: not running` in the logs
+
+tailscaled is installed but not running. Fix:
+
+```bash
+# macOS — start the Tailscale app or:
+sudo tailscaled &
+
+# Linux:
+sudo systemctl start tailscaled
+tailscale up
+```
+
+### Wrong IP — Tailscale IP doesn't appear in the multiaddr
+
+Run `tailscale ip -4` on that machine and update `skulk.yaml`. Tailscale IPs don't change unless you reinstall, but verify if anything looks off.
+
+### Nodes can't reach each other
+
+Check that Tailscale can ping between the machines:
+
+```bash
+ping 100.101.102.103
+```
+
+If ping fails, check your tailnet ACLs (Tailscale admin console → Access Controls). By default all nodes on the same tailnet can reach each other, but a custom ACL might block port 52416. Allow TCP on that port between Skulk nodes.
+
+### Only some nodes are visible
+
+Skulk peer discovery fans out from bootstrap peers via gossipsub. If Node A only lists Node B as a bootstrap peer, Node A learns about Node C indirectly once Node B connects to both. Give it 10–15 seconds after the last node restarts.
+
+## Headscale
+
+[Headscale](https://headscale.net/) is a self-hosted Tailscale control server. Skulk works with it identically — `tailscale status --json` reports the same structure regardless of whether the control plane is Tailscale's servers or a Headscale instance. No config changes needed.
+
+Join each node to your Headscale server:
+
+```bash
+tailscale up --login-server https://your-headscale-server.example.com
+```
+
+Then follow the same setup steps above.

--- a/website/docs/tailscale.md
+++ b/website/docs/tailscale.md
@@ -88,9 +88,9 @@ You should see something like:
 ```json
 {
   "running": true,
-  "self_ip": "100.101.102.103",
+  "selfIp": "100.101.102.103",
   "hostname": "my-node",
-  "dns_name": "my-node.tailnet-abc.ts.net",
+  "dnsName": "my-node.tailnet-abc.ts.net",
   "tailnet": "tailnet-abc.ts.net",
   "version": "1.66.1"
 }

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -22,6 +22,7 @@ const sidebars: SidebarsConfig = {
       items: [
         "api-guide",
         "build-and-runtime",
+        "run-skulk-as-a-service",
         "model-store",
         "kv-cache-backends",
         "tracing",

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -23,6 +23,7 @@ const sidebars: SidebarsConfig = {
         "api-guide",
         "build-and-runtime",
         "run-skulk-as-a-service",
+        "tailscale",
         "model-store",
         "kv-cache-backends",
         "tracing",

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -41,7 +41,7 @@ const sidebars: SidebarsConfig = {
         {
           type: "category",
           label: "Release Notes",
-          items: ["release-notes/1.0.3", "release-notes/1.0.2"],
+          items: ["release-notes/1.1.0", "release-notes/1.0.3", "release-notes/1.0.2"],
         },
         "architecture",
         "architecture-reference",


### PR DESCRIPTION
## Summary

- **Autostart on boot, restart on crash** for macOS (LaunchAgent) and Linux (systemd user unit).
- **Startup port preflight** that exits with `EX_TEMPFAIL=75` so the supervisor's backoff handles a port-still-held race on restart.
- **Tailscale connectivity layer** — detection, config section, API endpoint, dashboard status row, and user guide. Cluster nodes can now span multiple networks.
- **Operator panel** — a mobile-first `/operator` route in the dashboard for remote cluster control over Tailscale: node health at a glance, tap-twice node restart.
- **Remote dashboard fixes** — `crypto.randomUUID()` and `navigator.clipboard` replaced/shimmed so the dashboard works over plain HTTP (not just localhost/HTTPS).
- **TraceWaterfall cleanup** — removed the unwanted selected-bar highlight.

Phases 1–2 of the headless-resilience constellation tracked in #137. Phase 3 (operator panel) folded in.

## What's in here

| Path | Purpose |
| --- | --- |
| `deployment/systemd/skulk.service` | Linux user unit — `Restart=on-failure`, `RestartSec=10`, `StartLimitBurst`/`StartLimitIntervalSec` in `[Unit]`, `KillMode=mixed`, `LimitNOFILE=65536` |
| `deployment/launchd/foundation.foxlight.skulk.plist` | macOS LaunchAgent — conditional `KeepAlive`, login-shell `uv` wrapper |
| `deployment/install/install-systemd.sh` | One-shot Linux installer; enables `loginctl enable-linger` |
| `deployment/install/install-launchd.sh` | One-shot macOS installer; bootstraps into the gui domain; fixed log dir to `~/.skulk/logs` |
| `src/exo/startup_recovery.py` | `preflight_api_port` — exits 75 on `EADDRINUSE`, gated behind `spawn_api` flag |
| `src/exo/connectivity/tailscale.py` | `query_tailscale_status()` — subprocess `tailscale status --json` with timeout/fallback |
| `src/exo/store/config.py` | `TailscaleConnectivityConfig`, `ConnectivityConfig`, `connectivity` field on `ExoConfig` |
| `src/exo/api/main.py` | `GET /v1/connectivity/tailscale` endpoint (Connectivity tag) |
| `src/exo/main.py` | Startup Tailscale detection + logging |
| `dashboard-react/src/hooks/useTailscaleStatus.ts` | RTK Query hook for the tailscale status endpoint |
| `dashboard-react/src/components/observability/NodeTab.tsx` | Tailscale row in Runtime section |
| `dashboard-react/src/components/pages/OperatorPage.tsx` | Mobile-first operator panel: cluster stats, per-node health cards, tap-twice restart |
| `dashboard-react/src/store/endpoints/cluster.ts` | `restartNode` RTK mutation (`POST /admin/restart?node_id=`) |
| `dashboard-react/src/utils/clipboard.ts` | `copyToClipboard()` with Clipboard API + `execCommand` fallback for plain-HTTP contexts |
| `dashboard-react/src/components/pages/ChatView.tsx` | `uuid` package replaces `crypto.randomUUID()` |
| `dashboard-react/src/components/observability/TraceWaterfall.tsx` | Removed selected-bar visual highlight |
| `website/docs/tailscale.md` | Tailscale setup and troubleshooting guide |
| `website/docs/run-skulk-as-a-service.md` | Operator user guide; fixed macOS log path |
| `website/docs/api-guide.md` | Added `GET /v1/connectivity/tailscale` endpoint docs |

## Test plan

- [x] `uv run basedpyright` — 0 errors
- [x] `uv run ruff check` — clean
- [x] `uv run pytest` — all pass
- [x] `cd dashboard-react && npm run build` — clean
- [ ] Reviewers: walk through the service install guide on a fresh macOS or Linux box
- [ ] Reviewers: verify Tailscale status appears in Node tab when tailscaled is running
- [ ] Reviewers: open `/operator` on a phone over Tailscale and confirm restart flow

## Out of scope (remaining phases of #137)

- QR pairing — Phase 5
- Smart-switch webhook integration — Phase 6
- Power-cycle UI — Phase 7
- Native operator app reconsideration — Phase 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)