### PR TITLE
feat: auto-update on boot, separate Vector agent, external-shipper logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Added
+
+- Boot-time auto-update for the Skulk service: the LaunchAgent now runs
+  `git pull`, `uv sync`, and the dashboard build through a wrapper
+  (`deployment/install/skulk-startup.sh`) before exec'ing skulk. Failures of
+  the pull / sync steps are non-fatal (logged to
+  `~/.skulk/logs/skulk.prep.log` and the service boots whatever revision is
+  on disk); a missing `dashboard-react/dist/` is fatal because the API has
+  no UI to serve. Toggle with `SKULK_AUTO_UPDATE=0` in `~/.skulk/skulk.env`.
+- Operator-editable env file at `~/.skulk/skulk.env`, copied from
+  `deployment/install/skulk.env.example` on first install and never
+  overwritten on re-run. Surfaces `SKULK_LIBP2P_NAMESPACE`,
+  `SKULK_VERBOSITY`, `PYTHONUNBUFFERED`, debug toggles, and external-logging
+  knobs without requiring a plist edit.
+- Separate `foundation.foxlight.skulk-vector` LaunchAgent that runs Vector
+  as its own process (via `deployment/install/vector-startup.sh`). Vector
+  tails the captured `~/.skulk/logs/skulk.stdout.log` instead of piping
+  through Skulk's process, so a slow VictoriaLogs sink can no longer
+  backpressure inference threads. Opt out with `--no-vector` on the
+  installer.
+- `SKULK_LOGGING_EXTERNAL=1` mode in `exo.shared.logging`: structured JSON
+  goes to stdout for an external shipper to consume, and Skulk does not
+  spawn its own internal Vector subprocess. The launchd installer turns
+  this on by default. JSON sink is now `enqueue=True` so log producers are
+  decoupled from the sink's I/O.
+- New operator guide at `website/docs/external-logging.md` covering the
+  full Vector + VictoriaLogs + Grafana stack: central-host install, per-node
+  configuration, JSON schema, and troubleshooting.
+
+### Changed
+
+- `deployment/logging/vector.yaml` switched from `stdin` source to a `file`
+  source tailing `~/.skulk/logs/skulk.stdout.log`, with a `remap` transform
+  that drops non-JSON lines.
+- `deployment/install/install-launchd.sh` now installs both agents,
+  manages `~/.skulk/skulk.env`, supports `--no-vector` and `--uninstall`,
+  and produces a more useful post-install summary.
+- `website/docs/run-skulk-as-a-service.md` updated for the auto-update,
+  env-file customization, and Vector agent flow.
+
 ## [1.1.0] - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,24 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Changed
 
-- `deployment/logging/vector.yaml` switched from `stdin` source to a `file`
-  source tailing `~/.skulk/logs/skulk.stdout.log`, with a `remap` transform
-  that drops non-JSON lines.
-- `deployment/install/install-launchd.sh` now installs both agents,
-  manages `~/.skulk/skulk.env`, supports `--no-vector` and `--uninstall`,
-  and produces a more useful post-install summary.
+- Two Vector configs now exist for the two transport modes:
+  `deployment/logging/vector.yaml` keeps the original `stdin` source for
+  the in-process subprocess shipper (used by Linux systemd installs and
+  macOS `--no-vector` installs); `deployment/logging/vector-external.yaml`
+  carries a `file` source tailing `~/.skulk/logs/skulk.stdout.log` plus a
+  `remap` transform that drops non-JSON lines, used by the launchd
+  `skulk-vector` agent.
+- `deployment/install/install-launchd.sh` now installs both agents by
+  default, manages `~/.skulk/skulk.env` (auto-flipping
+  `SKULK_LOGGING_EXTERNAL` to match the chosen mode on `--no-vector`),
+  supports `--no-vector` and `--uninstall`, drops `bash -lc` from the
+  plist (so repo paths with spaces work), and produces a more useful
+  post-install summary.
+- `deployment/install/install-systemd.sh` and
+  `deployment/systemd/skulk.service` now use the same wrapper +
+  `~/.skulk/skulk.env` integration as macOS, with
+  `EnvironmentFile=-%h/.skulk/skulk.env` so the unit picks up env-file
+  knobs.
 - `website/docs/run-skulk-as-a-service.md` updated for the auto-update,
   env-file customization, and Vector agent flow.
 

--- a/deployment/install/install-launchd.sh
+++ b/deployment/install/install-launchd.sh
@@ -120,6 +120,17 @@ elif [[ "$INSTALL_VECTOR" != "1" ]] && grep -q '^SKULK_LOGGING_EXTERNAL=1$' "$EN
     rm -f "$ENV_TARGET.bak"
     echo "Updated $ENV_TARGET: SKULK_LOGGING_EXTERNAL flipped 1 -> 0 to match --no-vector."
     echo "  (Skulk now uses the in-process Vector subprocess instead of the LaunchAgent.)"
+elif [[ "$INSTALL_VECTOR" == "1" ]] && grep -q '^SKULK_LOGGING_EXTERNAL=0$' "$ENV_TARGET"; then
+    # Re-run without --no-vector (adding the Vector agent) against an
+    # existing env file that says internal mode. Flip to 1 so Skulk
+    # emits JSON to stdout for the newly installed agent to ship.
+    # Without this, the agent is installed but receives no JSON from
+    # Skulk and silently ships nothing. Operator edits to other fields
+    # are preserved.
+    sed -i.bak 's/^SKULK_LOGGING_EXTERNAL=0$/SKULK_LOGGING_EXTERNAL=1/' "$ENV_TARGET"
+    rm -f "$ENV_TARGET.bak"
+    echo "Updated $ENV_TARGET: SKULK_LOGGING_EXTERNAL flipped 0 -> 1 to match Vector agent install."
+    echo "  (Skulk now emits JSON to stdout for the skulk-vector LaunchAgent to ship.)"
 else
     echo "Env file already exists: $ENV_TARGET (left untouched)"
     echo "  (compare with $ENV_TEMPLATE if you want to pick up new defaults)"

--- a/deployment/install/install-launchd.sh
+++ b/deployment/install/install-launchd.sh
@@ -92,10 +92,31 @@ mkdir -p "$LOG_DIR" "$ENV_TARGET_DIR" "$TARGET_DIR"
 
 # First-install env file. Never overwrite the operator's edits on a
 # re-run; they can diff against the template if they want new defaults.
+#
+# When --no-vector is in effect, flip SKULK_LOGGING_EXTERNAL=0 in the
+# freshly copied file so the in-process Vector subprocess is the
+# transport. Leaving it at 1 with no external agent installed would
+# silently route logs nowhere (Skulk skips _start_vector under
+# SKULK_LOGGING_EXTERNAL=1, but no external shipper is running either).
 if [[ ! -f "$ENV_TARGET" ]]; then
     cp "$ENV_TEMPLATE" "$ENV_TARGET"
-    echo "Created env file: $ENV_TARGET"
+    if [[ "$INSTALL_VECTOR" != "1" ]]; then
+        # macOS sed needs an empty backup-suffix arg; clean it up after.
+        sed -i.bak 's/^SKULK_LOGGING_EXTERNAL=1$/SKULK_LOGGING_EXTERNAL=0/' "$ENV_TARGET"
+        rm -f "$ENV_TARGET.bak"
+        echo "Created env file: $ENV_TARGET (SKULK_LOGGING_EXTERNAL=0 — using in-process Vector subprocess)"
+    else
+        echo "Created env file: $ENV_TARGET (SKULK_LOGGING_EXTERNAL=1 — using external Vector agent)"
+    fi
     echo "  (edit this to customize cluster namespace, debug flags, ingest URL, etc.)"
+elif [[ "$INSTALL_VECTOR" != "1" ]] && grep -q '^SKULK_LOGGING_EXTERNAL=1$' "$ENV_TARGET"; then
+    # Re-run with --no-vector against an existing env file that still
+    # says external mode. Don't overwrite the operator's edits, but
+    # call out the misconfig so they can fix it.
+    echo "warning: --no-vector was specified, but $ENV_TARGET still has SKULK_LOGGING_EXTERNAL=1." >&2
+    echo "         Without the launchd Vector agent, this means Skulk emits JSON to stdout but" >&2
+    echo "         nothing ships it. To use the in-process subprocess shipper instead, edit" >&2
+    echo "         $ENV_TARGET and change SKULK_LOGGING_EXTERNAL to 0, then restart the service." >&2
 else
     echo "Env file already exists: $ENV_TARGET (left untouched)"
     echo "  (compare with $ENV_TEMPLATE if you want to pick up new defaults)"

--- a/deployment/install/install-launchd.sh
+++ b/deployment/install/install-launchd.sh
@@ -111,12 +111,15 @@ if [[ ! -f "$ENV_TARGET" ]]; then
     echo "  (edit this to customize cluster namespace, debug flags, ingest URL, etc.)"
 elif [[ "$INSTALL_VECTOR" != "1" ]] && grep -q '^SKULK_LOGGING_EXTERNAL=1$' "$ENV_TARGET"; then
     # Re-run with --no-vector against an existing env file that still
-    # says external mode. Don't overwrite the operator's edits, but
-    # call out the misconfig so they can fix it.
-    echo "warning: --no-vector was specified, but $ENV_TARGET still has SKULK_LOGGING_EXTERNAL=1." >&2
-    echo "         Without the launchd Vector agent, this means Skulk emits JSON to stdout but" >&2
-    echo "         nothing ships it. To use the in-process subprocess shipper instead, edit" >&2
-    echo "         $ENV_TARGET and change SKULK_LOGGING_EXTERNAL to 0, then restart the service." >&2
+    # says external mode. We auto-flip *this single value* to 0 because
+    # leaving it at 1 with no Vector agent installed silently drops
+    # logs (Skulk skips _start_vector under SKULK_LOGGING_EXTERNAL=1
+    # but no external shipper is running). Operator edits to other
+    # fields are preserved.
+    sed -i.bak 's/^SKULK_LOGGING_EXTERNAL=1$/SKULK_LOGGING_EXTERNAL=0/' "$ENV_TARGET"
+    rm -f "$ENV_TARGET.bak"
+    echo "Updated $ENV_TARGET: SKULK_LOGGING_EXTERNAL flipped 1 -> 0 to match --no-vector."
+    echo "  (Skulk now uses the in-process Vector subprocess instead of the LaunchAgent.)"
 else
     echo "Env file already exists: $ENV_TARGET (left untouched)"
     echo "  (compare with $ENV_TEMPLATE if you want to pick up new defaults)"

--- a/deployment/install/install-launchd.sh
+++ b/deployment/install/install-launchd.sh
@@ -1,22 +1,76 @@
 #!/usr/bin/env bash
-# Install the Skulk LaunchAgent on macOS.
+# Install the Skulk LaunchAgent(s) on macOS.
+#
+# Two agents get installed by default:
+#   1. foundation.foxlight.skulk         — runs skulk via the wrapper
+#   2. foundation.foxlight.skulk-vector  — runs vector log shipper
 #
 # LaunchAgents (not LaunchDaemons) are used because:
 #   - Metal access requires a graphical user session
 #   - LaunchAgents inherit the user's shell PATH via login-shell wrapper
 #   - the daemon variant would need root + a separate user-context shim
+#
+# Flags:
+#   --no-vector    skip installing the Vector log-shipper agent
+#                  (use this if you don't run centralized logging)
+#   --uninstall    remove both agents and exit
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-TEMPLATE="$REPO_ROOT/deployment/launchd/foundation.foxlight.skulk.plist"
+LAUNCHD_DIR="$REPO_ROOT/deployment/launchd"
+SKULK_TEMPLATE="$LAUNCHD_DIR/foundation.foxlight.skulk.plist"
+VECTOR_TEMPLATE="$LAUNCHD_DIR/foundation.foxlight.skulk-vector.plist"
+ENV_TEMPLATE="$REPO_ROOT/deployment/install/skulk.env.example"
+
 TARGET_DIR="$HOME/Library/LaunchAgents"
-TARGET="$TARGET_DIR/foundation.foxlight.skulk.plist"
-LABEL="foundation.foxlight.skulk"
+SKULK_LABEL="foundation.foxlight.skulk"
+VECTOR_LABEL="foundation.foxlight.skulk-vector"
+SKULK_TARGET="$TARGET_DIR/$SKULK_LABEL.plist"
+VECTOR_TARGET="$TARGET_DIR/$VECTOR_LABEL.plist"
+
+ENV_TARGET_DIR="$HOME/.skulk"
+ENV_TARGET="$ENV_TARGET_DIR/skulk.env"
+LOG_DIR="$ENV_TARGET_DIR/logs"
+
+INSTALL_VECTOR=1
+ACTION=install
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-vector) INSTALL_VECTOR=0; shift ;;
+        --uninstall) ACTION=uninstall; shift ;;
+        -h|--help)
+            sed -n '2,20p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "error: unknown flag '$1'" >&2
+            exit 1
+            ;;
+    esac
+done
 
 if [[ "$OSTYPE" != darwin* ]]; then
     echo "error: install-launchd.sh is for macOS. On Linux use install-systemd.sh." >&2
     exit 1
+fi
+
+uid="$(id -u)"
+
+bootout_if_loaded() {
+    local label="$1" target="$2"
+    if launchctl print "gui/$uid/$label" >/dev/null 2>&1; then
+        launchctl bootout "gui/$uid" "$target" 2>/dev/null || true
+    fi
+}
+
+if [[ "$ACTION" == "uninstall" ]]; then
+    bootout_if_loaded "$SKULK_LABEL" "$SKULK_TARGET"
+    bootout_if_loaded "$VECTOR_LABEL" "$VECTOR_TARGET"
+    rm -f "$SKULK_TARGET" "$VECTOR_TARGET"
+    echo "Removed Skulk LaunchAgent(s). Your config and models under ~/.skulk are untouched."
+    exit 0
 fi
 
 if ! command -v uv >/dev/null 2>&1; then
@@ -24,35 +78,75 @@ if ! command -v uv >/dev/null 2>&1; then
     exit 1
 fi
 
-# Capture the user's PATH from a login shell so the same `uv` resolution
-# Skulk uses interactively is what the agent gets.
-USER_PATH="$(/bin/bash -lc 'echo -n $PATH')"
-# On macOS, _get_xdg_dir() in src/exo/shared/constants.py returns ~/.skulk
-# for all XDG dirs (sys.platform != "linux" branch), so SKULK_LOG_DIR is
-# always ~/.skulk/logs on macOS regardless of XDG_CACHE_HOME.
-LOG_DIR="$HOME/.skulk/logs"
-mkdir -p "$LOG_DIR"
-mkdir -p "$TARGET_DIR"
-
-sed -e "s|__SKULK_REPO__|$REPO_ROOT|g" \
-    -e "s|__SKULK_LOG_DIR__|$LOG_DIR|g" \
-    -e "s|__USER_PATH__|$USER_PATH|g" \
-    "$TEMPLATE" > "$TARGET"
-
-echo "Installed agent: $TARGET"
-
-# bootstrap is the modern equivalent of `load`. We unload first so a re-run
-# of this installer cleanly replaces an existing agent.
-if launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1; then
-    launchctl bootout "gui/$(id -u)" "$TARGET" 2>/dev/null || true
+if [[ "$INSTALL_VECTOR" == "1" ]] && ! command -v vector >/dev/null 2>&1; then
+    echo "warning: 'vector' not found on PATH." >&2
+    echo "         The Vector agent will be installed but will fail to start until you" >&2
+    echo "         install Vector (https://vector.dev/docs/setup/installation/)." >&2
+    echo "         Re-run with --no-vector if you don't want centralized logging." >&2
 fi
-launchctl bootstrap "gui/$(id -u)" "$TARGET"
-launchctl enable "gui/$(id -u)/$LABEL"
-launchctl kickstart -k "gui/$(id -u)/$LABEL"
+
+# Login-shell PATH so the agent gets the same `uv` / `npm` resolution
+# the operator uses interactively.
+USER_PATH="$(/bin/bash -lc 'echo -n $PATH')"
+mkdir -p "$LOG_DIR" "$ENV_TARGET_DIR" "$TARGET_DIR"
+
+# First-install env file. Never overwrite the operator's edits on a
+# re-run; they can diff against the template if they want new defaults.
+if [[ ! -f "$ENV_TARGET" ]]; then
+    cp "$ENV_TEMPLATE" "$ENV_TARGET"
+    echo "Created env file: $ENV_TARGET"
+    echo "  (edit this to customize cluster namespace, debug flags, ingest URL, etc.)"
+else
+    echo "Env file already exists: $ENV_TARGET (left untouched)"
+    echo "  (compare with $ENV_TEMPLATE if you want to pick up new defaults)"
+fi
+
+render_plist() {
+    local template="$1" target="$2"
+    sed -e "s|__SKULK_REPO__|$REPO_ROOT|g" \
+        -e "s|__SKULK_LOG_DIR__|$LOG_DIR|g" \
+        -e "s|__USER_PATH__|$USER_PATH|g" \
+        "$template" > "$target"
+}
+
+reload_agent() {
+    local label="$1" target="$2"
+    bootout_if_loaded "$label" "$target"
+    launchctl bootstrap "gui/$uid" "$target"
+    launchctl enable "gui/$uid/$label"
+    launchctl kickstart -k "gui/$uid/$label"
+}
+
+render_plist "$SKULK_TEMPLATE" "$SKULK_TARGET"
+echo "Installed agent: $SKULK_TARGET"
+reload_agent "$SKULK_LABEL" "$SKULK_TARGET"
+
+if [[ "$INSTALL_VECTOR" == "1" ]]; then
+    render_plist "$VECTOR_TEMPLATE" "$VECTOR_TARGET"
+    echo "Installed agent: $VECTOR_TARGET"
+    reload_agent "$VECTOR_LABEL" "$VECTOR_TARGET"
+else
+    # Clean up an existing vector agent if --no-vector is passed on a
+    # second run; otherwise an old one would silently keep running.
+    if [[ -f "$VECTOR_TARGET" ]]; then
+        bootout_if_loaded "$VECTOR_LABEL" "$VECTOR_TARGET"
+        rm -f "$VECTOR_TARGET"
+        echo "Removed previously installed Vector agent (--no-vector specified)."
+    fi
+fi
 
 echo
 echo "Skulk LaunchAgent is installed and running."
-echo "  status: launchctl print gui/$(id -u)/$LABEL"
-echo "  logs:   tail -f $LOG_DIR/skulk.stderr.log"
-echo "  stop:   launchctl bootout gui/$(id -u) $TARGET"
-echo "  remove: launchctl bootout gui/$(id -u) $TARGET && rm $TARGET"
+echo "  status:    launchctl print gui/$uid/$SKULK_LABEL | grep 'state ='"
+echo "  logs:      tail -f $LOG_DIR/skulk.stderr.log"
+echo "  prep log:  tail -f $LOG_DIR/skulk.prep.log"
+echo "  env file:  $ENV_TARGET"
+echo "  restart:   launchctl kickstart -k gui/$uid/$SKULK_LABEL"
+echo "  stop:      launchctl bootout gui/$uid $SKULK_TARGET"
+echo "  uninstall: $0 --uninstall"
+if [[ "$INSTALL_VECTOR" == "1" ]]; then
+    echo
+    echo "Vector log-shipper agent:"
+    echo "  status: launchctl print gui/$uid/$VECTOR_LABEL | grep 'state ='"
+    echo "  logs:   tail -f $LOG_DIR/vector.stderr.log"
+fi

--- a/deployment/install/install-systemd.sh
+++ b/deployment/install/install-systemd.sh
@@ -15,8 +15,12 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEMPLATE="$REPO_ROOT/deployment/systemd/skulk.service"
+ENV_TEMPLATE="$REPO_ROOT/deployment/install/skulk.env.example"
 TARGET_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 TARGET="$TARGET_DIR/skulk.service"
+
+ENV_TARGET_DIR="$HOME/.skulk"
+ENV_TARGET="$ENV_TARGET_DIR/skulk.env"
 
 if [[ "$OSTYPE" != linux-gnu* ]]; then
     echo "error: install-systemd.sh is for Linux. On macOS use install-launchd.sh." >&2
@@ -33,13 +37,26 @@ if ! command -v systemctl >/dev/null 2>&1; then
     exit 1
 fi
 
-mkdir -p "$TARGET_DIR"
+mkdir -p "$TARGET_DIR" "$ENV_TARGET_DIR"
 
 # Substitute the repo path placeholder. We use sed with a non-/ delimiter so
 # paths containing / don't need escaping.
 sed "s|__SKULK_REPO__|$REPO_ROOT|g" "$TEMPLATE" > "$TARGET"
 
 echo "Installed unit: $TARGET"
+
+# First-install env file. Linux has no separate Vector LaunchAgent in
+# this release, so default to SKULK_LOGGING_EXTERNAL=0 (in-process Vector
+# subprocess). Operators who run an external shipper can flip it to 1.
+# Re-runs never overwrite operator edits.
+if [[ ! -f "$ENV_TARGET" ]]; then
+    cp "$ENV_TEMPLATE" "$ENV_TARGET"
+    sed -i 's/^SKULK_LOGGING_EXTERNAL=1$/SKULK_LOGGING_EXTERNAL=0/' "$ENV_TARGET"
+    echo "Created env file: $ENV_TARGET (SKULK_LOGGING_EXTERNAL=0 — using in-process Vector subprocess)"
+    echo "  (edit this to customize cluster namespace, debug flags, ingest URL, etc.)"
+else
+    echo "Env file already exists: $ENV_TARGET (left untouched)"
+fi
 
 systemctl --user daemon-reload
 
@@ -60,7 +77,10 @@ systemctl --user enable --now skulk.service
 
 echo
 echo "Skulk service is enabled and running."
-echo "  status: systemctl --user status skulk"
-echo "  logs:   journalctl --user -u skulk -f"
-echo "  stop:   systemctl --user stop skulk"
-echo "  remove: systemctl --user disable --now skulk && rm $TARGET"
+echo "  status:    systemctl --user status skulk"
+echo "  logs:      journalctl --user -u skulk -f"
+echo "  prep log:  tail -f $HOME/.skulk/logs/skulk.prep.log"
+echo "  env file:  $ENV_TARGET"
+echo "  restart:   systemctl --user restart skulk"
+echo "  stop:      systemctl --user stop skulk"
+echo "  remove:    systemctl --user disable --now skulk && rm $TARGET"

--- a/deployment/install/skulk-startup.sh
+++ b/deployment/install/skulk-startup.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Skulk service entrypoint.
+#
+# Invoked by the LaunchAgent (macOS) and systemd unit (Linux). Performs
+# best-effort boot-time updates, then execs skulk. Designed for the
+# "middle option" failure policy:
+#
+#   - `git pull`, `uv sync`            -> non-fatal (warn and continue)
+#   - `npm install`, `npm run build`   -> fatal only if dashboard-react/dist
+#                                         is missing afterwards (no UI = no
+#                                         service)
+#
+# Operators customize behavior by editing ~/.skulk/skulk.env. See
+# deployment/install/skulk.env.example for the supported knobs.
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="${SKULK_ENV_FILE:-$HOME/.skulk/skulk.env}"
+PREP_LOG="$HOME/.skulk/logs/skulk.prep.log"
+
+mkdir -p "$(dirname "$PREP_LOG")"
+
+# Timestamped operator-facing log of what the prep phase did. Distinct
+# from the captured stdout/stderr launchd writes for the skulk process
+# itself so operators can audit boot-time updates separately.
+log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$PREP_LOG" >&2
+}
+
+# Source the operator env file if present. `set -a` exports every
+# assignment so child processes (uv, npm, skulk) inherit them.
+if [[ -f "$ENV_FILE" ]]; then
+    log "sourcing env file: $ENV_FILE"
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+else
+    log "no env file at $ENV_FILE — using defaults"
+fi
+
+cd "$REPO_ROOT"
+
+AUTO_UPDATE="${SKULK_AUTO_UPDATE:-1}"
+VERBOSITY="${SKULK_VERBOSITY:--v}"
+
+run_prep() {
+    # `git pull` — non-fatal. Common failure modes (offline at boot,
+    # auth prompt, dirty tree) shouldn't block service start. Log the
+    # exit code so an operator can spot a long-running silent failure.
+    if [[ -d .git ]]; then
+        log "git pull (non-fatal)"
+        if ! git pull --ff-only 2>&1 | tee -a "$PREP_LOG" >&2; then
+            log "warning: git pull failed (continuing with on-disk revision)"
+        fi
+    else
+        log "not a git checkout — skipping git pull"
+    fi
+
+    # `uv sync` — non-fatal. If the lockfile is unchanged, this is a
+    # no-op; if PyPI is down or wheels can't build, fall back to the
+    # currently installed environment.
+    log "uv sync (non-fatal)"
+    if ! uv sync 2>&1 | tee -a "$PREP_LOG" >&2; then
+        log "warning: uv sync failed (continuing with current venv)"
+    fi
+
+    # Dashboard build — non-fatal on success path (we boot with the
+    # previously built dist/), fatal only if dist/ ends up missing.
+    if [[ -d dashboard-react ]]; then
+        log "npm install + build (non-fatal unless dist/ is missing)"
+        (
+            cd dashboard-react
+            npm install 2>&1 | tee -a "$PREP_LOG" >&2 || \
+                log "warning: npm install failed"
+            npm run build 2>&1 | tee -a "$PREP_LOG" >&2 || \
+                log "warning: npm run build failed"
+        )
+    fi
+
+    if [[ ! -d dashboard-react/dist ]]; then
+        log "ERROR: dashboard-react/dist is missing — cannot start without a built dashboard."
+        log "fix: run 'cd dashboard-react && npm install && npm run build' manually, then restart the service."
+        exit 1
+    fi
+}
+
+if [[ "$AUTO_UPDATE" == "1" ]]; then
+    run_prep
+else
+    log "SKULK_AUTO_UPDATE=$AUTO_UPDATE — skipping boot-time update"
+    if [[ ! -d dashboard-react/dist ]]; then
+        log "ERROR: dashboard-react/dist is missing and auto-update is off."
+        log "fix: build the dashboard once, or set SKULK_AUTO_UPDATE=1 in $ENV_FILE."
+        exit 1
+    fi
+fi
+
+log "exec: uv run skulk ${VERBOSITY}"
+
+# `exec` so launchd / systemd track the skulk process directly rather
+# than this wrapper. Quoted ${VERBOSITY} preserves empty-string semantics.
+if [[ -n "$VERBOSITY" ]]; then
+    exec uv run skulk "$VERBOSITY"
+else
+    exec uv run skulk
+fi

--- a/deployment/install/skulk-startup.sh
+++ b/deployment/install/skulk-startup.sh
@@ -43,6 +43,17 @@ fi
 
 cd "$REPO_ROOT"
 
+# Augment PATH with common user-space tool locations so uv, git, and npm
+# are findable when the script is invoked from systemd — which starts with
+# a minimal PATH that excludes ~/.local/bin, ~/.cargo/bin, and Homebrew.
+# On macOS the launchd agent injects __USER_PATH__ at install time, so
+# those directories are already present and this loop is a no-op for them.
+for _d in "$HOME/.local/bin" "$HOME/.cargo/bin" /opt/homebrew/bin /usr/local/bin; do
+    [[ -d "$_d" && ":$PATH:" != *":$_d:"* ]] && PATH="$_d:$PATH"
+done
+export PATH
+unset _d
+
 AUTO_UPDATE="${SKULK_AUTO_UPDATE:-1}"
 VERBOSITY="${SKULK_VERBOSITY:--v}"
 

--- a/deployment/install/skulk.env.example
+++ b/deployment/install/skulk.env.example
@@ -39,17 +39,24 @@ SKULK_LIBP2P_NAMESPACE=foxlight-main
 PYTHONUNBUFFERED=1
 
 # ---------------------------------------------------------------------
-# Debug toggles (off by default in production)
+# Debug toggles (off by default — uncomment per machine if you need them)
 # ---------------------------------------------------------------------
+# These are disabled in the shipped template because each one adds
+# overhead and/or writes request data to disk. Turning them on globally
+# for every fresh install would be a privacy and disk-usage regression.
+# Uncomment in your own ~/.skulk/skulk.env when actively debugging.
+
 # Verbose logging around image / vision tensor transport between nodes.
-SKULK_IMAGE_TRANSPORT_DEBUG=1
+# SKULK_IMAGE_TRANSPORT_DEBUG=1
 
 # Where to dump intermediate vision tensors for offline inspection.
-# Directory is created on demand. Comment out to disable.
-EXO_VISION_DEBUG_SAVE_DIR=/tmp/skulk-vision-debug
+# Setting this to a non-empty path unconditionally writes decoded images
+# from every request to that directory. Leave commented unless debugging.
+# EXO_VISION_DEBUG_SAVE_DIR=/tmp/skulk-vision-debug
 
 # Emit watchdog traces when an MLX inference call appears to hang.
-SKULK_MLX_HANG_DEBUG=1
+# Spawns watchdog threads around hot MLX paths and logs stack traces.
+# SKULK_MLX_HANG_DEBUG=1
 
 # ---------------------------------------------------------------------
 # External logging (read by vector.yaml and Skulk's logging module)
@@ -57,6 +64,10 @@ SKULK_MLX_HANG_DEBUG=1
 # 1 = JSON logs go to stdout for an external shipper (the launchd
 #     `skulk-vector` agent) to consume from the captured stdout file.
 #     This is the right setting when you installed the Vector agent.
+#     Setting this to 1 also implies "structured logging on" — you do
+#     NOT need to set `logging.enabled: true` in skulk.yaml as well.
+#     The runtime dashboard sync cannot disable shipping while this
+#     env var is set; remove it (and restart) to turn shipping off.
 # 0 = Skulk spawns its own Vector subprocess internally when
 #     `logging.enabled=true` + `ingest_url=...` is configured in
 #     skulk.yaml. Use this if you didn't install the Vector agent

--- a/deployment/install/skulk.env.example
+++ b/deployment/install/skulk.env.example
@@ -1,0 +1,72 @@
+# Skulk service environment overrides.
+#
+# This file is sourced by the LaunchAgent / systemd service wrappers
+# before they exec skulk and vector. Edit it to change how Skulk runs
+# at boot WITHOUT modifying the plist / unit file or the repo itself.
+#
+# Lifecycle:
+#   - The installer copies this template to ~/.skulk/skulk.env on first
+#     install. Re-running the installer never overwrites your copy.
+#   - `git pull` of Skulk updates this template here in the repo, but
+#     does not touch your ~/.skulk/skulk.env.
+#   - To pick up your changes, restart the service (see the operator
+#     guide: website/docs/run-skulk-as-a-service.md).
+#
+# Format: plain shell. Lines are `KEY=value`. Values with spaces or
+# special characters must be quoted. Lines starting with `#` are ignored.
+
+# ---------------------------------------------------------------------
+# Boot-time prep (auto-update on startup)
+# ---------------------------------------------------------------------
+# Set to 0 to skip git pull / uv sync / dashboard rebuild on boot and
+# just run whatever is currently on disk. Useful on flaky networks or
+# when you're pinning a known-good revision.
+SKULK_AUTO_UPDATE=1
+
+# ---------------------------------------------------------------------
+# Skulk runtime flags
+# ---------------------------------------------------------------------
+# Verbosity passed to `uv run skulk`. Use "-v" for normal verbose, "-vv"
+# for debug. Empty string = default (info level).
+SKULK_VERBOSITY=-v
+
+# Cluster namespace — nodes only join clusters with the same namespace.
+# Use a unique value per cluster (e.g. per home, per project).
+SKULK_LIBP2P_NAMESPACE=foxlight-main
+
+# Force unbuffered Python stdout/stderr so log lines appear in real time
+# rather than batched on process exit. Only turn off if you know why.
+PYTHONUNBUFFERED=1
+
+# ---------------------------------------------------------------------
+# Debug toggles (off by default in production)
+# ---------------------------------------------------------------------
+# Verbose logging around image / vision tensor transport between nodes.
+SKULK_IMAGE_TRANSPORT_DEBUG=1
+
+# Where to dump intermediate vision tensors for offline inspection.
+# Directory is created on demand. Comment out to disable.
+EXO_VISION_DEBUG_SAVE_DIR=/tmp/skulk-vision-debug
+
+# Emit watchdog traces when an MLX inference call appears to hang.
+SKULK_MLX_HANG_DEBUG=1
+
+# ---------------------------------------------------------------------
+# External logging (read by vector.yaml and Skulk's logging module)
+# ---------------------------------------------------------------------
+# 1 = JSON logs go to stdout for an external shipper (the launchd
+#     `skulk-vector` agent) to consume from the captured stdout file.
+#     This is the right setting when you installed the Vector agent.
+# 0 = Skulk spawns its own Vector subprocess internally when
+#     `logging.enabled=true` + `ingest_url=...` is configured in
+#     skulk.yaml. Use this if you didn't install the Vector agent
+#     (i.e. you ran the installer with --no-vector) but still want
+#     log shipping.
+SKULK_LOGGING_EXTERNAL=1
+
+# Where Vector ships logs. Override if you run VictoriaLogs at a
+# different address. The default points at the in-house R720 stack.
+# EXO_LOGGING_INGEST_URL=http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
+
+# Where Vector keeps its disk buffer (survives VictoriaLogs downtime).
+# EXO_VECTOR_DATA_DIR=~/.skulk/vector

--- a/deployment/install/vector-startup.sh
+++ b/deployment/install/vector-startup.sh
@@ -15,7 +15,7 @@ set -o pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ENV_FILE="${SKULK_ENV_FILE:-$HOME/.skulk/skulk.env}"
-CONFIG="$REPO_ROOT/deployment/logging/vector.yaml"
+CONFIG="$REPO_ROOT/deployment/logging/vector-external.yaml"
 
 if [[ -f "$ENV_FILE" ]]; then
     set -a

--- a/deployment/install/vector-startup.sh
+++ b/deployment/install/vector-startup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Vector log-shipper entrypoint.
+#
+# Runs as a separate LaunchAgent / systemd unit from skulk so a Vector
+# crash, slow downstream sink, or config error can't backpressure or
+# kill the inference process. Vector tails Skulk's stdout log file
+# (see deployment/logging/vector.yaml) and ships JSON to VictoriaLogs.
+#
+# Operators customize behavior by editing ~/.skulk/skulk.env (the same
+# file Skulk uses; EXO_LOGGING_INGEST_URL and EXO_VECTOR_DATA_DIR are
+# the relevant knobs).
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="${SKULK_ENV_FILE:-$HOME/.skulk/skulk.env}"
+CONFIG="$REPO_ROOT/deployment/logging/vector.yaml"
+
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+if ! command -v vector >/dev/null 2>&1; then
+    echo "error: 'vector' not found on PATH. Install Vector (https://vector.dev/docs/setup/installation/) and re-run." >&2
+    exit 1
+fi
+
+if [[ ! -f "$CONFIG" ]]; then
+    echo "error: Vector config not found at $CONFIG" >&2
+    exit 1
+fi
+
+exec vector --config "$CONFIG"

--- a/deployment/launchd/foundation.foxlight.skulk-vector.plist
+++ b/deployment/launchd/foundation.foxlight.skulk-vector.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>foundation.foxlight.skulk-vector</string>
+
+    <!-- Vector runs as its own agent, separate from skulk, so a slow
+         downstream sink or a Vector crash can't backpressure or kill
+         the inference process. The wrapper sources ~/.skulk/skulk.env
+         (same file as skulk) for EXO_LOGGING_INGEST_URL and friends,
+         then execs `vector --config deployment/logging/vector.yaml`,
+         which tails the skulk stdout log file. -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>exec __SKULK_REPO__/deployment/install/vector-startup.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__SKULK_REPO__</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- Vector logs go to a separate file so operators can grep
+         shipping errors without wading through skulk's own output. -->
+    <key>StandardOutPath</key>
+    <string>__SKULK_LOG_DIR__/vector.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>__SKULK_LOG_DIR__/vector.stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__USER_PATH__</string>
+    </dict>
+</dict>
+</plist>

--- a/deployment/launchd/foundation.foxlight.skulk-vector.plist
+++ b/deployment/launchd/foundation.foxlight.skulk-vector.plist
@@ -9,13 +9,15 @@
          downstream sink or a Vector crash can't backpressure or kill
          the inference process. The wrapper sources ~/.skulk/skulk.env
          (same file as skulk) for EXO_LOGGING_INGEST_URL and friends,
-         then execs `vector --config deployment/logging/vector.yaml`,
-         which tails the skulk stdout log file. -->
+         then execs `vector --config deployment/logging/vector-external.yaml`,
+         which tails the skulk stdout log file.
+
+         The wrapper is exec'd directly (not via `bash -lc`) so a repo
+         path containing spaces or shell metacharacters does not break
+         tokenization. -->
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>-lc</string>
-        <string>exec __SKULK_REPO__/deployment/install/vector-startup.sh</string>
+        <string>__SKULK_REPO__/deployment/install/vector-startup.sh</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/deployment/launchd/foundation.foxlight.skulk.plist
+++ b/deployment/launchd/foundation.foxlight.skulk.plist
@@ -9,12 +9,15 @@
          so the failure policy (best-effort git pull / uv sync, hard
          requirement on a built dashboard) can be edited without
          re-installing the agent. The wrapper sources ~/.skulk/skulk.env
-         for operator-configurable env vars. -->
+         for operator-configurable env vars.
+
+         The wrapper is exec'd directly (not via `bash -lc`) so a repo
+         path containing spaces or shell metacharacters does not break
+         tokenization. PATH and other env vars are supplied via the
+         EnvironmentVariables block below. -->
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
-        <string>-lc</string>
-        <string>exec __SKULK_REPO__/deployment/install/skulk-startup.sh</string>
+        <string>__SKULK_REPO__/deployment/install/skulk-startup.sh</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/deployment/launchd/foundation.foxlight.skulk.plist
+++ b/deployment/launchd/foundation.foxlight.skulk.plist
@@ -5,14 +5,16 @@
     <key>Label</key>
     <string>foundation.foxlight.skulk</string>
 
-    <!-- A login shell finds `uv` regardless of how launchd was loaded
-         (e.g. brew install path on Apple Silicon). Skulk's CLI entry
-         point is `skulk = "exo.main:main"` per pyproject.toml. -->
+    <!-- Boot-time prep + skulk launch is delegated to a wrapper script
+         so the failure policy (best-effort git pull / uv sync, hard
+         requirement on a built dashboard) can be edited without
+         re-installing the agent. The wrapper sources ~/.skulk/skulk.env
+         for operator-configurable env vars. -->
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
         <string>-lc</string>
-        <string>exec uv run skulk</string>
+        <string>exec __SKULK_REPO__/deployment/install/skulk-startup.sh</string>
     </array>
 
     <key>WorkingDirectory</key>
@@ -43,17 +45,19 @@
     <key>ProcessType</key>
     <string>Interactive</string>
 
-    <!-- Logs land alongside the existing Skulk log directory so
-         operators have one place to look. The install script ensures
-         the directory exists before bootstrap. -->
+    <!-- Captured stdout/stderr from skulk + the wrapper's exec. The
+         wrapper also writes a separate prep log at
+         ~/.skulk/logs/skulk.prep.log so operators can audit boot-time
+         updates independently of skulk's own log stream. -->
     <key>StandardOutPath</key>
     <string>__SKULK_LOG_DIR__/skulk.stdout.log</string>
     <key>StandardErrorPath</key>
     <string>__SKULK_LOG_DIR__/skulk.stderr.log</string>
 
-    <!-- Inherit the user's shell PATH so `uv` and any tool-version
-         shims resolve. EnvironmentVariables is the only PATH escape
-         hatch launchd offers without using launchctl setenv globally. -->
+    <!-- Inherit the user's shell PATH so `uv`, `npm`, `git`, and any
+         tool-version shims resolve. All other env vars come from
+         ~/.skulk/skulk.env (sourced by the wrapper) so they can be
+         edited without re-installing the agent. -->
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>

--- a/deployment/logging/vector-external.yaml
+++ b/deployment/logging/vector-external.yaml
@@ -1,0 +1,76 @@
+# Vector configuration for the *external* log-shipper agent.
+#
+# This config is used by the macOS LaunchAgent
+# `foundation.foxlight.skulk-vector` installed by
+# `deployment/install/install-launchd.sh`. It tails Skulk's captured
+# stdout log file (where launchd redirects the JSON log stream when
+# `SKULK_LOGGING_EXTERNAL=1`) and ships each line to VictoriaLogs.
+#
+# Running as a separate process from Skulk decouples lifecycles: a
+# Vector crash or slow downstream sink cannot backpressure or kill the
+# inference engine.
+#
+# The internal-subprocess variant (used by Linux systemd installs and
+# macOS `--no-vector` installs) lives at
+# `deployment/logging/vector.yaml`.
+#
+# Operator-tunable env vars (in ~/.skulk/skulk.env or your shell):
+#   EXO_LOGGING_INGEST_URL   Where to ship logs (defaults to the in-house
+#                            VictoriaLogs endpoint on the R720).
+#   EXO_VECTOR_DATA_DIR      Where Vector keeps its on-disk buffer and
+#                            file-position checkpoints (so it resumes
+#                            cleanly after a restart).
+#   SKULK_LOG_FILE           Override the source file path. Defaults to
+#                            ~/.skulk/logs/skulk.stdout.log.
+
+data_dir: ${EXO_VECTOR_DATA_DIR:-${HOME}/.skulk/vector}
+
+sources:
+  skulk_log:
+    type: file
+    include:
+      - ${SKULK_LOG_FILE:-${HOME}/.skulk/logs/skulk.stdout.log}
+    # Read from the beginning on first start so we ship the full log,
+    # then resume from the checkpoint stored under data_dir on restart.
+    read_from: beginning
+    # Skip files that haven't been touched in a day; protects against
+    # picking up rotated archives if log rotation is added later.
+    ignore_older_secs: 86400
+
+transforms:
+  # Parse each line as JSON. Lines that aren't JSON (e.g. a crash
+  # traceback printed before the JSON logger initializes, or a stray
+  # human-readable line) are dropped rather than indexed as malformed
+  # events.
+  parse_json:
+    type: remap
+    inputs:
+      - skulk_log
+    drop_on_error: true
+    drop_on_abort: true
+    source: |
+      parsed, err = parse_json(.message)
+      if err != null {
+        abort
+      }
+      . = parsed
+
+sinks:
+  victorialogs:
+    type: http
+    inputs:
+      - parse_json
+    uri: ${EXO_LOGGING_INGEST_URL:-http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts}
+    encoding:
+      codec: json
+    framing:
+      method: newline_delimited
+    request:
+      timeout_secs: 5
+    batch:
+      max_bytes: 1048576
+      timeout_secs: 2
+    buffer:
+      type: disk
+      max_size: 536870912  # 512 MB — survives VictoriaLogs downtime
+      when_full: drop_newest

--- a/deployment/logging/vector.yaml
+++ b/deployment/logging/vector.yaml
@@ -1,67 +1,34 @@
-# Vector configuration for Skulk log shipping.
+# Vector configuration for the in-process (internal-subprocess) shipper.
 #
-# Vector tails Skulk's stdout log file (where launchd / systemd capture
-# the JSON log stream) and ships each line to VictoriaLogs. Running as
-# a separate process from Skulk decouples lifecycles: a Vector crash or
-# slow downstream sink cannot backpressure or kill the inference engine.
+# This config is used when Skulk spawns Vector as a child process and
+# pipes structured JSON to its stdin. That path is the default on Linux
+# systemd installs and on macOS installs that opt out of the external
+# Vector LaunchAgent (`install-launchd.sh --no-vector`).
 #
-# Operator usage on macOS / Linux:
-#   - Install via deployment/install/install-launchd.sh (macOS) or the
-#     systemd installer (Linux). A separate `skulk-vector` agent runs
-#     this config in a long-lived loop.
+# For the *external* shipper (a separate LaunchAgent that tails Skulk's
+# captured stdout file and survives across Skulk restarts), see
+# `deployment/logging/vector-external.yaml`.
 #
-# Operator usage standalone (development):
-#   - Run Skulk normally so its stdout lands in ~/.skulk/logs/skulk.stdout.log
-#     (the LaunchAgent / unit handles this; for ad-hoc runs, redirect
-#     manually).
-#   - In another terminal: `vector --config deployment/logging/vector.yaml`
+# Vector reads structured JSON from stdin and ships it to VictoriaLogs.
+# Run Skulk piped through Vector for an ad-hoc dev setup:
 #
-# Operator-tunable env vars (in ~/.skulk/skulk.env or your shell):
-#   EXO_LOGGING_INGEST_URL   Where to ship logs (defaults to the in-house
-#                            VictoriaLogs endpoint on the R720).
-#   EXO_VECTOR_DATA_DIR      Where Vector keeps its on-disk buffer and
-#                            file-position checkpoints (so it resumes
-#                            cleanly after a restart).
-#   SKULK_LOG_FILE           Override the source file path. Defaults to
-#                            ~/.skulk/logs/skulk.stdout.log.
+#   uv run skulk 2>/dev/tty | vector --config deployment/logging/vector.yaml
+#
+# Vector's disk buffer lives under data_dir (defaults to ~/.skulk/vector).
 
 data_dir: ${EXO_VECTOR_DATA_DIR:-${HOME}/.skulk/vector}
 
 sources:
-  skulk_log:
-    type: file
-    include:
-      - ${SKULK_LOG_FILE:-${HOME}/.skulk/logs/skulk.stdout.log}
-    # Read from the beginning on first start so we ship the full log,
-    # then resume from the checkpoint stored under data_dir on restart.
-    read_from: beginning
-    # Skip files that haven't been touched in a day; protects against
-    # picking up rotated archives if log rotation is added later.
-    ignore_older_secs: 86400
-
-transforms:
-  # Parse each line as JSON. Lines that aren't JSON (e.g. a crash
-  # traceback printed before the JSON logger initializes, or a stray
-  # human-readable line) are dropped rather than indexed as malformed
-  # events.
-  parse_json:
-    type: remap
-    inputs:
-      - skulk_log
-    drop_on_error: true
-    drop_on_abort: true
-    source: |
-      parsed, err = parse_json(.message)
-      if err != null {
-        abort
-      }
-      . = parsed
+  skulk_stdout:
+    type: stdin
+    decoding:
+      codec: json
 
 sinks:
   victorialogs:
     type: http
     inputs:
-      - parse_json
+      - skulk_stdout
     uri: ${EXO_LOGGING_INGEST_URL:-http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts}
     encoding:
       codec: json

--- a/deployment/logging/vector.yaml
+++ b/deployment/logging/vector.yaml
@@ -1,25 +1,67 @@
-# Vector configuration for exo log shipping.
+# Vector configuration for Skulk log shipping.
 #
-# Vector reads structured JSON from exo's stdout and ships it to
-# VictoriaLogs.  Run exo piped through Vector:
+# Vector tails Skulk's stdout log file (where launchd / systemd capture
+# the JSON log stream) and ships each line to VictoriaLogs. Running as
+# a separate process from Skulk decouples lifecycles: a Vector crash or
+# slow downstream sink cannot backpressure or kill the inference engine.
 #
-#   uv run exo 2>/dev/tty | vector --config deployment/logging/vector.yaml
+# Operator usage on macOS / Linux:
+#   - Install via deployment/install/install-launchd.sh (macOS) or the
+#     systemd installer (Linux). A separate `skulk-vector` agent runs
+#     this config in a long-lived loop.
 #
-# Vector's disk buffer lives under data_dir (defaults to ~/.exo/vector/).
+# Operator usage standalone (development):
+#   - Run Skulk normally so its stdout lands in ~/.skulk/logs/skulk.stdout.log
+#     (the LaunchAgent / unit handles this; for ad-hoc runs, redirect
+#     manually).
+#   - In another terminal: `vector --config deployment/logging/vector.yaml`
+#
+# Operator-tunable env vars (in ~/.skulk/skulk.env or your shell):
+#   EXO_LOGGING_INGEST_URL   Where to ship logs (defaults to the in-house
+#                            VictoriaLogs endpoint on the R720).
+#   EXO_VECTOR_DATA_DIR      Where Vector keeps its on-disk buffer and
+#                            file-position checkpoints (so it resumes
+#                            cleanly after a restart).
+#   SKULK_LOG_FILE           Override the source file path. Defaults to
+#                            ~/.skulk/logs/skulk.stdout.log.
 
-data_dir: ${EXO_VECTOR_DATA_DIR:-~/.exo/vector}
+data_dir: ${EXO_VECTOR_DATA_DIR:-${HOME}/.skulk/vector}
 
 sources:
-  exo_stdout:
-    type: stdin
-    decoding:
-      codec: json
+  skulk_log:
+    type: file
+    include:
+      - ${SKULK_LOG_FILE:-${HOME}/.skulk/logs/skulk.stdout.log}
+    # Read from the beginning on first start so we ship the full log,
+    # then resume from the checkpoint stored under data_dir on restart.
+    read_from: beginning
+    # Skip files that haven't been touched in a day; protects against
+    # picking up rotated archives if log rotation is added later.
+    ignore_older_secs: 86400
+
+transforms:
+  # Parse each line as JSON. Lines that aren't JSON (e.g. a crash
+  # traceback printed before the JSON logger initializes, or a stray
+  # human-readable line) are dropped rather than indexed as malformed
+  # events.
+  parse_json:
+    type: remap
+    inputs:
+      - skulk_log
+    drop_on_error: true
+    drop_on_abort: true
+    source: |
+      parsed, err = parse_json(.message)
+      if err != null {
+        abort
+      }
+      . = parsed
 
 sinks:
   victorialogs:
     type: http
     inputs:
-      - exo_stdout
+      - parse_json
     uri: ${EXO_LOGGING_INGEST_URL:-http://192.168.0.118:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts}
     encoding:
       codec: json

--- a/deployment/systemd/skulk.service
+++ b/deployment/systemd/skulk.service
@@ -16,10 +16,18 @@ StartLimitIntervalSec=300
 Type=simple
 WorkingDirectory=__SKULK_REPO__
 
-# uv is the canonical runtime path per AGENTS.md. The wrapper invokes it
-# from a login shell so PATH and any user-shell setup (e.g. mise, asdf,
-# pyenv) are available regardless of how systemd was started.
-ExecStart=/bin/bash -lc 'exec uv run skulk'
+# Operator env file. EnvironmentFile loads KEY=VALUE pairs into the
+# unit's environment before ExecStart, matching the macOS LaunchAgent's
+# wrapper-sourced behavior. Leading `-` makes the file optional so a
+# fresh install (before the file is copied) doesn't fail to start.
+EnvironmentFile=-%h/.skulk/skulk.env
+
+# Boot-time prep + skulk launch is delegated to the wrapper so the
+# failure policy (best-effort git pull / uv sync, hard requirement on
+# a built dashboard) is identical to the macOS install. The wrapper
+# also sources ~/.skulk/skulk.env again so values inside the env file
+# (like SKULK_AUTO_UPDATE) reach uv / npm subprocesses.
+ExecStart=__SKULK_REPO__/deployment/install/skulk-startup.sh
 
 # SIGTERM is what `Skulk._signal` already handles via task-group cancel.
 # `mixed` sends SIGTERM to the main process and SIGKILL to remaining

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -4370,12 +4370,18 @@ class API:
             # External-shipper mode is install-level (env var set by the
             # service wrapper) and overrides runtime sync. Operators turn
             # it off by removing the env var and restarting Skulk.
-            log_on = external_log_pipe_enabled() or bool(
-                logging_cfg_update.get("enabled", False)
+            #
+            # In internal-subprocess mode (env var off), preserve the
+            # legacy contract that runtime sync requires *both* `enabled`
+            # and a non-empty `ingest_url` — clearing the URL at runtime
+            # must still disable shipping, not silently leave the
+            # already-running Vector subprocess shipping to the prior URL.
+            ingest_url_str = str(logging_cfg_update.get("ingest_url", ""))
+            log_on = external_log_pipe_enabled() or (
+                bool(logging_cfg_update.get("enabled", False))
+                and bool(ingest_url_str)
             )
-            set_structured_stdout(
-                log_on, ingest_url=str(logging_cfg_update.get("ingest_url", ""))
-            )
+            set_structured_stdout(log_on, ingest_url=ingest_url_str)
         # model_store changes still require restart; inference-only changes don't
         has_store_changes = "model_store" in config_data
         return JSONResponse(

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -4362,10 +4362,16 @@ class API:
         # Apply logging config immediately
         logging_cfg_update = _coerce_json_object(config_data.get("logging"))
         if logging_cfg_update:
-            from exo.shared.logging import set_structured_stdout
+            from exo.shared.logging import (
+                external_log_pipe_enabled,
+                set_structured_stdout,
+            )
 
-            log_on = bool(logging_cfg_update.get("enabled", False)) and bool(
-                logging_cfg_update.get("ingest_url")
+            # External-shipper mode is install-level (env var set by the
+            # service wrapper) and overrides runtime sync. Operators turn
+            # it off by removing the env var and restarting Skulk.
+            log_on = external_log_pipe_enabled() or bool(
+                logging_cfg_update.get("enabled", False)
             )
             set_structured_stdout(
                 log_on, ingest_url=str(logging_cfg_update.get("ingest_url", ""))

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -235,13 +235,15 @@ class DownloadCoordinator:
                 )
 
                 # External-shipper mode is install-level (env var set by
-                # the service wrapper) and overrides runtime sync.
-                log_enabled = external_log_pipe_enabled() or bool(
-                    logging_cfg.get("enabled", False)
+                # the service wrapper) and overrides runtime sync. In
+                # internal-subprocess mode (env var off), require both
+                # `enabled` and a non-empty `ingest_url` so clearing the
+                # URL at runtime disables shipping (legacy contract).
+                ingest_url_str = str(logging_cfg.get("ingest_url", ""))
+                log_enabled = external_log_pipe_enabled() or (
+                    bool(logging_cfg.get("enabled", False)) and bool(ingest_url_str)
                 )
-                set_structured_stdout(
-                    log_enabled, ingest_url=str(logging_cfg.get("ingest_url", ""))
-                )
+                set_structured_stdout(log_enabled, ingest_url=ingest_url_str)
         except Exception as exc:
             logger.warning(f"DownloadCoordinator: failed to sync config: {exc}")
 

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -229,10 +229,15 @@ class DownloadCoordinator:
             # Apply logging config — enable/disable structured stdout
             logging_cfg = _coerce_json_object(raw.get("logging"))
             if logging_cfg:
-                from exo.shared.logging import set_structured_stdout
+                from exo.shared.logging import (
+                    external_log_pipe_enabled,
+                    set_structured_stdout,
+                )
 
-                log_enabled = bool(logging_cfg.get("enabled", False)) and bool(
-                    logging_cfg.get("ingest_url")
+                # External-shipper mode is install-level (env var set by
+                # the service wrapper) and overrides runtime sync.
+                log_enabled = external_log_pipe_enabled() or bool(
+                    logging_cfg.get("enabled", False)
                 )
                 set_structured_stdout(
                     log_enabled, ingest_url=str(logging_cfg.get("ingest_url", ""))

--- a/src/exo/main.py
+++ b/src/exo/main.py
@@ -22,7 +22,11 @@ from exo.routing.event_router import EventRouter
 from exo.routing.router import Router, get_node_id_keypair
 from exo.shared.constants import SKULK_LOG
 from exo.shared.election import Election, ElectionResult
-from exo.shared.logging import logger_cleanup, logger_setup
+from exo.shared.logging import (
+    external_log_pipe_enabled,
+    logger_cleanup,
+    logger_setup,
+)
 from exo.shared.types.commands import ForwarderDownloadCommand, SyncConfig
 from exo.shared.types.common import NodeId, SessionId, SystemId
 from exo.shared.types.state_sync import StateSyncMessage
@@ -675,10 +679,18 @@ def main():
     except Exception:
         pass  # Logged after logger_setup below
 
+    # External-shipper mode (SKULK_LOGGING_EXTERNAL=1, set by the
+    # launchd / systemd wrapper when an external Vector agent is
+    # installed) implies "structured logging on at boot" without
+    # requiring an `enabled: true` in skulk.yaml — the env var is the
+    # operator's signal that they have a shipper hooked up. The
+    # dashboard / config sync still controls the sink at runtime via
+    # set_structured_stdout, so an operator can disable shipping live.
+    _structured = external_log_pipe_enabled() or bool(_log_cfg and _log_cfg.enabled)
     logger_setup(
         SKULK_LOG,
         args.verbosity,
-        structured_stdout=bool(_log_cfg and _log_cfg.enabled and _log_cfg.ingest_url),
+        structured_stdout=_structured,
         ingest_url=_log_cfg.ingest_url if _log_cfg else "",
     )
     logger.info("Starting Skulk")

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -134,7 +134,7 @@ _VECTOR_CONFIG_PATH = (
 )
 
 
-def _external_log_pipe_enabled() -> bool:
+def external_log_pipe_enabled() -> bool:
     """Whether an external log shipper handles JSON transport.
 
     When ``SKULK_LOGGING_EXTERNAL`` is truthy (set by the launchd /
@@ -280,7 +280,7 @@ def logger_setup(
         #   2. Internal subprocess: spawn Vector and pipe JSON to its stdin.
         #   3. Disabled: structured_stdout=true with no ingest_url and no
         #      external flag is a no-op (operator hasn't picked a path).
-        if _external_log_pipe_enabled():
+        if external_log_pipe_enabled():
             transport_started = True
         elif ingest_url:
             transport_started = _start_vector(ingest_url)
@@ -312,7 +312,7 @@ def set_structured_stdout(enabled: bool, ingest_url: str = "") -> None:
     """
     global _json_sink_id  # noqa: PLW0603
     if enabled and _json_sink_id is None:
-        if _external_log_pipe_enabled():
+        if external_log_pipe_enabled():
             transport_started = True
         elif ingest_url:
             transport_started = _start_vector(ingest_url)

--- a/src/exo/shared/logging.py
+++ b/src/exo/shared/logging.py
@@ -134,6 +134,22 @@ _VECTOR_CONFIG_PATH = (
 )
 
 
+def _external_log_pipe_enabled() -> bool:
+    """Whether an external log shipper handles JSON transport.
+
+    When ``SKULK_LOGGING_EXTERNAL`` is truthy (set by the launchd /
+    systemd wrapper when a separate Vector agent is installed), Skulk
+    writes structured JSON to stdout and does not spawn its own Vector
+    subprocess. The external agent tails the captured stdout file.
+    """
+    return os.environ.get("SKULK_LOGGING_EXTERNAL", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def _start_vector(ingest_url: str) -> bool:
     """Spawn Vector as a child process reading JSON from a pipe.
 
@@ -257,13 +273,29 @@ def logger_setup(
             compression=_zstd_compress,
         )
 
-    if structured_stdout and ingest_url and _start_vector(ingest_url):
-        global _json_sink_id  # noqa: PLW0603
-        _json_sink_id = logger.add(
-            _json_sink,
-            level="INFO",
-            enqueue=False,
-        )
+    if structured_stdout:
+        # Three transport modes:
+        #   1. External shipper (SKULK_LOGGING_EXTERNAL=1): JSON -> stdout,
+        #      a separate Vector agent tails the captured file.
+        #   2. Internal subprocess: spawn Vector and pipe JSON to its stdin.
+        #   3. Disabled: structured_stdout=true with no ingest_url and no
+        #      external flag is a no-op (operator hasn't picked a path).
+        if _external_log_pipe_enabled():
+            transport_started = True
+        elif ingest_url:
+            transport_started = _start_vector(ingest_url)
+        else:
+            transport_started = False
+        if transport_started:
+            global _json_sink_id  # noqa: PLW0603
+            # enqueue=True decouples log producers from the JSON sink's
+            # I/O so a slow stdout consumer (e.g. an overloaded launchd
+            # log file or a downstream pipe) can't block inference threads.
+            _json_sink_id = logger.add(
+                _json_sink,
+                level="INFO",
+                enqueue=True,
+            )
 
 
 def set_structured_stdout(enabled: bool, ingest_url: str = "") -> None:
@@ -272,14 +304,25 @@ def set_structured_stdout(enabled: bool, ingest_url: str = "") -> None:
     Called when logging config is synced across the cluster.  Safe to call
     repeatedly — adding when already active or removing when already
     inactive is a no-op.
+
+    When ``SKULK_LOGGING_EXTERNAL=1`` is set, the sink is enabled without
+    spawning Skulk's internal Vector subprocess; an external Vector agent
+    is expected to tail the captured stdout file. Otherwise, ``ingest_url``
+    must be set for the internal subprocess path.
     """
     global _json_sink_id  # noqa: PLW0603
-    if enabled and ingest_url and _json_sink_id is None:
-        if _start_vector(ingest_url):
+    if enabled and _json_sink_id is None:
+        if _external_log_pipe_enabled():
+            transport_started = True
+        elif ingest_url:
+            transport_started = _start_vector(ingest_url)
+        else:
+            transport_started = False
+        if transport_started:
             _json_sink_id = logger.add(
                 _json_sink,
                 level="INFO",
-                enqueue=False,
+                enqueue=True,
             )
             logger.info("Structured JSON log shipping enabled")
     elif not enabled and _json_sink_id is not None:

--- a/src/exo/shared/tests/test_logging_external.py
+++ b/src/exo/shared/tests/test_logging_external.py
@@ -1,0 +1,122 @@
+# pyright: reportPrivateUsage=false, reportUnusedFunction=false
+"""Tests for the external-shipper mode of the structured JSON log sink.
+
+Covers:
+- ``SKULK_LOGGING_EXTERNAL=1`` enables the JSON sink without spawning
+  Skulk's internal Vector subprocess.
+- Toggling via ``set_structured_stdout`` honors the same env var.
+- Falsy / unset values leave the legacy "internal subprocess" path in
+  place (where ingest_url drives ``_start_vector``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import patch
+
+import pytest
+from loguru import logger
+
+from exo.shared import logging as skulk_logging
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_state() -> None:
+    """Drop any sink the previous test left behind so each test starts clean."""
+    if skulk_logging._json_sink_id is not None:
+        with contextlib.suppress(ValueError):
+            logger.remove(skulk_logging._json_sink_id)
+        skulk_logging._json_sink_id = None
+    skulk_logging._vector_pipe = None
+    skulk_logging._vector_process = None
+
+
+def test_external_flag_enables_json_sink_without_starting_vector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SKULK_LOGGING_EXTERNAL=1 should activate the JSON sink and skip _start_vector."""
+    monkeypatch.setenv("SKULK_LOGGING_EXTERNAL", "1")
+
+    with patch.object(skulk_logging, "_start_vector") as start_vector:
+        skulk_logging.logger_setup(
+            log_file=None,
+            verbosity=0,
+            structured_stdout=True,
+            ingest_url="http://example.invalid/ignored",
+        )
+
+    assert skulk_logging._json_sink_id is not None, (
+        "JSON sink should be active in external mode"
+    )
+    start_vector.assert_not_called()
+
+
+def test_external_flag_works_with_empty_ingest_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In external mode, ingest_url is irrelevant — the agent owns transport."""
+    monkeypatch.setenv("SKULK_LOGGING_EXTERNAL", "true")
+
+    with patch.object(skulk_logging, "_start_vector") as start_vector:
+        skulk_logging.logger_setup(
+            log_file=None,
+            verbosity=0,
+            structured_stdout=True,
+            ingest_url="",
+        )
+
+    assert skulk_logging._json_sink_id is not None
+    start_vector.assert_not_called()
+
+
+def test_external_unset_falls_back_to_internal_vector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the external flag, an ingest_url should drive _start_vector as before."""
+    monkeypatch.delenv("SKULK_LOGGING_EXTERNAL", raising=False)
+
+    with patch.object(skulk_logging, "_start_vector", return_value=True) as start_vector:
+        skulk_logging.logger_setup(
+            log_file=None,
+            verbosity=0,
+            structured_stdout=True,
+            ingest_url="http://example.invalid/insert",
+        )
+
+    start_vector.assert_called_once_with("http://example.invalid/insert")
+
+
+def test_external_falsy_values_disable_external_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Truthy detection should be strict — only 1/true/yes/on count."""
+    monkeypatch.setenv("SKULK_LOGGING_EXTERNAL", "0")
+
+    with patch.object(skulk_logging, "_start_vector", return_value=True) as start_vector:
+        skulk_logging.logger_setup(
+            log_file=None,
+            verbosity=0,
+            structured_stdout=True,
+            ingest_url="http://example.invalid/insert",
+        )
+
+    start_vector.assert_called_once()
+
+
+def test_set_structured_stdout_honors_external_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime toggle via cluster sync also respects the external flag."""
+    monkeypatch.setenv("SKULK_LOGGING_EXTERNAL", "1")
+
+    with patch.object(skulk_logging, "_start_vector") as start_vector:
+        skulk_logging.set_structured_stdout(enabled=True, ingest_url="")
+
+    assert skulk_logging._json_sink_id is not None
+    start_vector.assert_not_called()
+
+    with patch.object(skulk_logging, "_stop_vector") as stop_vector:
+        skulk_logging.set_structured_stdout(enabled=False)
+
+    assert skulk_logging._json_sink_id is None
+    stop_vector.assert_called_once()

--- a/src/exo/shared/tests/test_logging_external.py
+++ b/src/exo/shared/tests/test_logging_external.py
@@ -120,3 +120,55 @@ def test_set_structured_stdout_honors_external_flag(
 
     assert skulk_logging._json_sink_id is None
     stop_vector.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Production call-site gating: callers must allow external mode to activate
+# the JSON sink even when `logging.enabled=false` and `ingest_url=""` in
+# skulk.yaml. These tests reproduce the gating logic from main.py,
+# api/main.py, and download/coordinator.py to catch regressions of the
+# "external mode is unreachable through the real startup path" bug.
+# ---------------------------------------------------------------------------
+
+
+def _main_gate(log_enabled: bool) -> bool:
+    """Boot-time gate from src/exo/main.py."""
+    return skulk_logging.external_log_pipe_enabled() or log_enabled
+
+
+def _runtime_sync_gate(log_enabled: bool) -> bool:
+    """Runtime gate from api/main.py and download/coordinator.py."""
+    return skulk_logging.external_log_pipe_enabled() or log_enabled
+
+
+def test_main_gate_activates_with_external_flag_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SKULK_LOGGING_EXTERNAL=1 alone must satisfy main.py's boot gate."""
+    monkeypatch.setenv("SKULK_LOGGING_EXTERNAL", "1")
+    assert _main_gate(log_enabled=False) is True
+
+
+def test_main_gate_inactive_without_either(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No env var, no logging.enabled → no JSON sink (legacy behavior preserved)."""
+    monkeypatch.delenv("SKULK_LOGGING_EXTERNAL", raising=False)
+    assert _main_gate(log_enabled=False) is False
+
+
+def test_runtime_sync_gate_activates_with_external_flag_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dashboard sync of `enabled=false` cannot disable an env-var-driven sink."""
+    monkeypatch.setenv("SKULK_LOGGING_EXTERNAL", "1")
+    assert _runtime_sync_gate(log_enabled=False) is True
+
+
+def test_runtime_sync_gate_respects_legacy_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the env var, runtime gating still honors logging.enabled."""
+    monkeypatch.delenv("SKULK_LOGGING_EXTERNAL", raising=False)
+    assert _runtime_sync_gate(log_enabled=True) is True
+    assert _runtime_sync_gate(log_enabled=False) is False

--- a/src/exo/shared/tests/test_logging_external.py
+++ b/src/exo/shared/tests/test_logging_external.py
@@ -136,9 +136,17 @@ def _main_gate(log_enabled: bool) -> bool:
     return skulk_logging.external_log_pipe_enabled() or log_enabled
 
 
-def _runtime_sync_gate(log_enabled: bool) -> bool:
-    """Runtime gate from api/main.py and download/coordinator.py."""
-    return skulk_logging.external_log_pipe_enabled() or log_enabled
+def _runtime_sync_gate(log_enabled: bool, ingest_url: str = "x") -> bool:
+    """Runtime gate from api/main.py and download/coordinator.py.
+
+    In internal-subprocess mode (env var off), the legacy contract is
+    that both ``enabled`` and ``ingest_url`` must be set — clearing the
+    URL at runtime disables shipping. The env var bypasses both because
+    transport is owned by the external agent.
+    """
+    return skulk_logging.external_log_pipe_enabled() or (
+        log_enabled and bool(ingest_url)
+    )
 
 
 def test_main_gate_activates_with_external_flag_alone(
@@ -170,5 +178,27 @@ def test_runtime_sync_gate_respects_legacy_path(
 ) -> None:
     """Without the env var, runtime gating still honors logging.enabled."""
     monkeypatch.delenv("SKULK_LOGGING_EXTERNAL", raising=False)
-    assert _runtime_sync_gate(log_enabled=True) is True
-    assert _runtime_sync_gate(log_enabled=False) is False
+    assert _runtime_sync_gate(log_enabled=True, ingest_url="http://x") is True
+    assert _runtime_sync_gate(log_enabled=False, ingest_url="http://x") is False
+
+
+def test_runtime_sync_clearing_ingest_url_disables_internal_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Internal mode: clearing ingest_url at runtime must disable shipping.
+
+    Regression guard for the case where an operator removes ingest_url
+    via a runtime config sync. The legacy contract requires shipping to
+    stop; without this, the in-process Vector subprocess would keep
+    shipping to the prior URL until Skulk is restarted.
+    """
+    monkeypatch.delenv("SKULK_LOGGING_EXTERNAL", raising=False)
+    assert _runtime_sync_gate(log_enabled=True, ingest_url="") is False
+
+
+def test_runtime_sync_external_mode_ignores_empty_ingest_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External mode: ingest_url is owned by the agent, so empty is fine."""
+    monkeypatch.setenv("SKULK_LOGGING_EXTERNAL", "1")
+    assert _runtime_sync_gate(log_enabled=False, ingest_url="") is True

--- a/website/docs/external-logging.md
+++ b/website/docs/external-logging.md
@@ -105,35 +105,41 @@ These survive container restarts and image upgrades. To wipe them, `docker compo
 
 ## Step 2 — Point each Skulk node at the central stack
 
+The shipping process model differs between platforms. Both ship to the same central stack:
+
+- **macOS** runs Vector as a separate LaunchAgent (`foundation.foxlight.skulk-vector`) that tails Skulk's captured stdout file. Lifecycle is decoupled from Skulk — a slow VictoriaLogs cannot backpressure inference.
+- **Linux** runs Vector as an in-process subprocess that Skulk spawns when `logging.enabled: true` is set in `skulk.yaml`. JSON is piped directly into Vector's stdin via `deployment/logging/vector.yaml` (stdin source). This release does not include a separate `skulk-vector` systemd unit.
+
 On every node that's running Skulk:
 
-1. **Install Vector.** It's a single binary; instructions at [vector.dev](https://vector.dev/docs/setup/installation/). On macOS: `brew install vectordotdev/brew/vector`. On Debian/Ubuntu: `curl -1sLf 'https://repositories.timber.io/public/vector/cfg/setup/bash.deb.sh' | sudo -E bash && sudo apt install vector`.
+1. **Install Vector.** Single binary; instructions at [vector.dev](https://vector.dev/docs/setup/installation/). On macOS: `brew install vectordotdev/brew/vector`. On Debian/Ubuntu: `curl -1sLf 'https://repositories.timber.io/public/vector/cfg/setup/bash.deb.sh' | sudo -E bash && sudo apt install vector`.
 2. **Install the Skulk service** (if you haven't already):
 
    ```bash
-   deployment/install/install-launchd.sh    # macOS
-   deployment/install/install-systemd.sh    # Linux
+   deployment/install/install-launchd.sh    # macOS — installs both skulk + skulk-vector agents
+   deployment/install/install-systemd.sh    # Linux — installs skulk only
    ```
 
-   The default install includes the Vector log-shipper agent. If you previously installed with `--no-vector`, re-run without that flag.
-3. **Tell Vector where to ship.** Edit `~/.skulk/skulk.env` and set:
+   On macOS, pass `--no-vector` to skip the external Vector agent and fall back to the in-process subprocess model.
+3. **Tell the shipper where to ship.** Edit `~/.skulk/skulk.env` and set:
 
    ```bash
    EXO_LOGGING_INGEST_URL=http://<central-host>:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
    ```
 
+   On Linux, also set `logging.enabled: true` and `logging.ingest_url: <same-url>` in `skulk.yaml` so Skulk knows to spawn its in-process Vector subprocess.
+
    The query parameters tell VictoriaLogs which fields to use as stream identifiers (so `node_id` and `component` become indexed dimensions).
-4. **Make sure Skulk is emitting JSON.** This is on by default when you install via the wrapper (`SKULK_LOGGING_EXTERNAL=1` in the env file). Skulk writes JSON to stdout; launchd captures it to `~/.skulk/logs/skulk.stdout.log`.
-5. **Restart both agents** so they pick up the new ingest URL:
+4. **Make sure Skulk is emitting JSON.** On macOS this is on by default when you install via the wrapper (`SKULK_LOGGING_EXTERNAL=1` in the env file). On Linux this is gated by `logging.enabled` in `skulk.yaml`.
+5. **Restart so the new config is picked up:**
 
    ```bash
-   # macOS
+   # macOS — restart both agents
    launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk
    launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk-vector
 
-   # Linux
+   # Linux — Skulk respawns its Vector subprocess on restart
    systemctl --user restart skulk
-   systemctl --user restart skulk-vector
    ```
 
 That's it for that node. Repeat on each one.
@@ -206,14 +212,14 @@ After editing, restart the relevant agents (the table in the [service guide](./r
 
 ### "Logs are flowing on one node but not another"
 
-Check that node's Vector agent:
+Check that node's Vector output:
 
 ```bash
-# macOS
+# macOS — separate LaunchAgent has its own log
 tail -f ~/.skulk/logs/vector.stderr.log
 
-# Linux
-journalctl --user -u skulk-vector -f
+# Linux — Vector runs as a Skulk subprocess; its output is folded into Skulk's
+journalctl --user -u skulk -f | grep -i vector
 ```
 
 Common causes:

--- a/website/docs/external-logging.md
+++ b/website/docs/external-logging.md
@@ -256,13 +256,14 @@ Then `docker compose up -d` to apply. VictoriaLogs reclaims space within a few m
 
 ### "I changed the ingest URL but Vector still ships to the old one"
 
-Vector reads its config at startup. Restart the Vector agent:
+Vector reads its config at startup. Restart the shipper:
 
 ```bash
-# macOS
+# macOS — restart the launchd Vector agent
 launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk-vector
-# Linux
-systemctl --user restart skulk-vector
+
+# Linux — Vector runs as a Skulk subprocess, so restart Skulk itself
+systemctl --user restart skulk
 ```
 
 ## Disabling external logging
@@ -278,14 +279,17 @@ Or re-run the installer with `--no-vector`.
 
 ## Advanced: running Vector standalone (development)
 
-For ad-hoc runs without the LaunchAgent, you can run Vector by hand:
+For ad-hoc runs without the LaunchAgent, run Vector by hand. There are two configs depending on which mode you're iterating on:
 
 ```bash
 # Make sure ~/.skulk/skulk.env is sourced so EXO_LOGGING_INGEST_URL is set
 source ~/.skulk/skulk.env
 
-# Then run vector pointed at the same config the LaunchAgent uses
-vector --config deployment/logging/vector.yaml
+# External mode (file-tail config used by the macOS LaunchAgent)
+vector --config deployment/logging/vector-external.yaml
+
+# Internal mode (stdin config used by the in-process subprocess shipper)
+uv run skulk 2>/dev/tty | vector --config deployment/logging/vector.yaml
 ```
 
-This is useful when iterating on `vector.yaml` — restart picks up changes immediately, and you see Vector's full output in the terminal.
+This is useful when iterating on either config — restart picks up changes immediately, and you see Vector's full output in the terminal.

--- a/website/docs/external-logging.md
+++ b/website/docs/external-logging.md
@@ -1,0 +1,285 @@
+---
+title: External logging (Vector + VictoriaLogs + Grafana)
+description: Ship Skulk's structured JSON logs to a central store so you can search, alert, and graph across the whole cluster.
+sidebar_label: External logging
+---
+
+# External logging
+
+Forward Skulk's structured logs from every node to one place where you can search and graph them. This guide walks through the whole stack — what it is, how to install it, how to wire Skulk into it, and how to debug it when it doesn't work.
+
+## What you'll have when you're done
+
+- Every Skulk node ships its logs to one central store (VictoriaLogs).
+- You can search across the whole cluster from a Grafana panel — by node, by component, by message, by time range.
+- Logs survive node reboots, network blips, and the central store being down (Vector buffers up to 512 MB on disk per node).
+- Skulk's inference path is **never blocked** by a slow log shipper, because the shipper runs as a separate process.
+
+About 30 minutes for first-time setup of the central stack, then about 1 minute per node.
+
+## Architecture in one picture
+
+```
+┌──────────────────────┐    JSON lines    ┌─────────────────────┐
+│  Skulk node (laptop, │  ──────────────▶ │  ~/.skulk/logs/     │
+│  Mac mini, R720…)    │   on stdout      │  skulk.stdout.log   │
+└──────────────────────┘                  └─────────────────────┘
+                                                    │
+                                                    │ tailed by
+                                                    ▼
+                                          ┌─────────────────────┐
+                                          │  Vector LaunchAgent │
+                                          │  (skulk-vector)     │
+                                          └─────────────────────┘
+                                                    │
+                                                    │ HTTP POST,
+                                                    │ disk-buffered
+                                                    ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  Central host (e.g. R720) running Docker Compose                   │
+│                                                                    │
+│   ┌──────────────────┐    queries    ┌──────────────────┐         │
+│   │  VictoriaLogs    │ ◀──────────── │  Grafana         │         │
+│   │  port 9428       │               │  port 3000       │         │
+│   └──────────────────┘               └──────────────────┘         │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Three layers:
+
+1. **Skulk** writes one JSON object per log line to `stdout`. The LaunchAgent / systemd unit captures stdout to a file.
+2. **Vector** runs as its own process on every Skulk node. It tails that file, batches lines, and POSTs them to the central store. If the central store is down, Vector buffers to disk and ships when it comes back.
+3. **VictoriaLogs + Grafana** run together (single Docker Compose stack) on whatever machine you've designated as the central host. VictoriaLogs stores the logs; Grafana queries them.
+
+## Why a separate process for Vector?
+
+Skulk's inference threads must never block on logging. If Vector is in the same process and the central store is slow, the kernel pipe between them fills up and every `logger.info()` call in Skulk blocks. By running Vector as a separate agent that reads from a file, slow shipping just means the file grows on disk — Skulk keeps inferring at full speed.
+
+This is why the LaunchAgent installer (`deployment/install/install-launchd.sh`) installs **two** agents by default: the Skulk service itself, and a `skulk-vector` shipper that runs alongside it.
+
+## Step 1 — Set up the central stack (one-time, on one machine)
+
+Pick the machine you want logs to live on. Anything that can run Docker works — an R720, a NAS, a Mac mini, a small VPS. It needs to be reachable from every Skulk node on TCP 9428 (ingest) and 3000 (Grafana UI).
+
+On the central host:
+
+```bash
+# Clone Skulk if you haven't already (only the deployment/ dir is needed)
+git clone https://github.com/foxlight-foundation/skulk.git
+cd skulk/deployment/logging
+
+# Set the Grafana admin password (required — the compose file refuses to
+# start without it)
+echo "GF_SECURITY_ADMIN_PASSWORD=$(openssl rand -base64 24)" > .env
+echo "Wrote a Grafana admin password to .env — keep this file safe."
+
+# Bring the stack up
+docker compose up -d
+```
+
+This launches:
+
+- **VictoriaLogs** on port 9428 — log ingest and storage. Built-in UI at `http://<host>:9428/select/vmui/`.
+- **Grafana** on port 3000 — dashboards. Username `admin`, password from your `.env` file.
+
+Verify both are healthy:
+
+```bash
+curl -s http://localhost:9428/health
+# expected: {"status":"ok"}
+
+curl -sI http://localhost:3000/login | head -1
+# expected: HTTP/1.1 200 OK
+```
+
+The Grafana stack is pre-configured to use VictoriaLogs as its default data source — no manual wiring needed.
+
+### What gets persisted
+
+The Compose file uses two named volumes:
+
+- `vlogs-data` — VictoriaLogs storage, 90-day retention by default
+- `grafana-data` — Grafana dashboards, users, and config
+
+These survive container restarts and image upgrades. To wipe them, `docker compose down -v`.
+
+## Step 2 — Point each Skulk node at the central stack
+
+On every node that's running Skulk:
+
+1. **Install Vector.** It's a single binary; instructions at [vector.dev](https://vector.dev/docs/setup/installation/). On macOS: `brew install vectordotdev/brew/vector`. On Debian/Ubuntu: `curl -1sLf 'https://repositories.timber.io/public/vector/cfg/setup/bash.deb.sh' | sudo -E bash && sudo apt install vector`.
+2. **Install the Skulk service** (if you haven't already):
+
+   ```bash
+   deployment/install/install-launchd.sh    # macOS
+   deployment/install/install-systemd.sh    # Linux
+   ```
+
+   The default install includes the Vector log-shipper agent. If you previously installed with `--no-vector`, re-run without that flag.
+3. **Tell Vector where to ship.** Edit `~/.skulk/skulk.env` and set:
+
+   ```bash
+   EXO_LOGGING_INGEST_URL=http://<central-host>:9428/insert/jsonline?_stream_fields=node_id,component&_msg_field=msg&_time_field=ts
+   ```
+
+   The query parameters tell VictoriaLogs which fields to use as stream identifiers (so `node_id` and `component` become indexed dimensions).
+4. **Make sure Skulk is emitting JSON.** This is on by default when you install via the wrapper (`SKULK_LOGGING_EXTERNAL=1` in the env file). Skulk writes JSON to stdout; launchd captures it to `~/.skulk/logs/skulk.stdout.log`.
+5. **Restart both agents** so they pick up the new ingest URL:
+
+   ```bash
+   # macOS
+   launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk
+   launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk-vector
+
+   # Linux
+   systemctl --user restart skulk
+   systemctl --user restart skulk-vector
+   ```
+
+That's it for that node. Repeat on each one.
+
+## Step 3 — Verify logs are flowing
+
+On any node:
+
+```bash
+# Last 5 lines of what Vector is shipping right now
+tail -n 5 ~/.skulk/logs/skulk.stdout.log
+
+# Vector's own status — should show 0 errors and recent successful POSTs
+tail -f ~/.skulk/logs/vector.stderr.log
+```
+
+In Grafana (`http://<central-host>:3000`), open Explore, pick the VictoriaLogs data source, and run:
+
+```
+*
+```
+
+You should see log lines from every node that has shipped at least one event. To filter to one node:
+
+```
+node_id:"laptop-1"
+```
+
+To see only errors from a specific component:
+
+```
+level:ERROR AND component:"worker"
+```
+
+The full LogsQL syntax is in the [VictoriaLogs docs](https://docs.victoriametrics.com/victorialogs/logsql/).
+
+## How the JSON is structured
+
+Each line shipped by Skulk looks like this:
+
+```json
+{
+  "ts": "2026-05-04T12:34:56.789Z",
+  "level": "INFO",
+  "node_id": "laptop-1",
+  "component": "worker",
+  "module": "exo.worker.runner",
+  "function": "spawn",
+  "line": 142,
+  "msg": "spawned runner for shard 0/4 of mlx-community/Qwen3-30B"
+}
+```
+
+`node_id` defaults to the machine's hostname. `component` is the second segment of the Python module path (e.g. `exo.worker.runner` → `worker`). Both are indexed by VictoriaLogs as stream fields so queries against them are fast.
+
+## Customizing where Vector buffers and ships
+
+All knobs live in `~/.skulk/skulk.env` and are picked up by both the Skulk and Vector agents on next restart:
+
+| Env var | What it does | Default |
+| --- | --- | --- |
+| `SKULK_LOGGING_EXTERNAL` | `1` = Skulk writes JSON to stdout for the external Vector agent. `0` = Skulk spawns its own internal Vector subprocess (only useful if you ran the installer with `--no-vector`) | `1` |
+| `EXO_LOGGING_INGEST_URL` | Where Vector POSTs logs | the in-house R720 endpoint |
+| `EXO_VECTOR_DATA_DIR` | Where Vector keeps its disk buffer and file checkpoints | `~/.skulk/vector` |
+| `SKULK_LOG_FILE` | Override the source file Vector tails | `~/.skulk/logs/skulk.stdout.log` |
+
+After editing, restart the relevant agents (the table in the [service guide](./run-skulk-as-a-service.md#day-to-day-operations) has the commands).
+
+## Things that go wrong
+
+### "Logs are flowing on one node but not another"
+
+Check that node's Vector agent:
+
+```bash
+# macOS
+tail -f ~/.skulk/logs/vector.stderr.log
+
+# Linux
+journalctl --user -u skulk-vector -f
+```
+
+Common causes:
+
+- **`vector` isn't installed.** The agent fails fast with a clear error. Install Vector and restart.
+- **The node can't reach the central host.** `curl -v http://<central-host>:9428/health` from the node tells you whether it's network or firewall.
+- **The wrong ingest URL is in `~/.skulk/skulk.env`.** Vector logs the URL it's POSTing to on startup — check it matches.
+- **The source file is empty.** Run `tail ~/.skulk/logs/skulk.stdout.log`. If it's empty, Skulk isn't emitting JSON — see next section.
+
+### "The skulk.stdout.log file is empty"
+
+The wrapper sets `SKULK_LOGGING_EXTERNAL=1` by default, which tells Skulk to emit JSON to stdout. If the file is empty:
+
+- **Skulk isn't running through the wrapper.** Check that the LaunchAgent / systemd unit is actually live (`launchctl print …` / `systemctl --user status skulk`).
+- **`SKULK_LOGGING_EXTERNAL` got set to 0** in `~/.skulk/skulk.env`. Set it back to 1.
+- **Skulk crashed before logging started.** The file would have a partial early line and then stop. Check `~/.skulk/logs/skulk.stderr.log` for a traceback.
+
+### "Vector buffered for hours, now it's catching up"
+
+This is the design working as intended. When the central store is unreachable, Vector buffers up to 512 MB per node on disk. When connectivity returns, it drains the buffer at full speed. You'll see a temporary spike in CPU and network use until the backlog clears.
+
+To monitor backlog: `du -sh ~/.skulk/vector/` (or wherever `EXO_VECTOR_DATA_DIR` points).
+
+### "VictoriaLogs is full / disk pressure on the central host"
+
+VictoriaLogs is configured for 90-day retention by default. To reduce it, edit `deployment/logging/docker-compose.yml`:
+
+```yaml
+command:
+  - -retentionPeriod=30d
+```
+
+Then `docker compose up -d` to apply. VictoriaLogs reclaims space within a few minutes.
+
+### "I changed the ingest URL but Vector still ships to the old one"
+
+Vector reads its config at startup. Restart the Vector agent:
+
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk-vector
+# Linux
+systemctl --user restart skulk-vector
+```
+
+## Disabling external logging
+
+Set `SKULK_LOGGING_EXTERNAL=0` in `~/.skulk/skulk.env` and restart the Skulk service. The Vector agent will keep tailing the (now-empty-of-new-JSON) stdout file harmlessly; you can also bootout the agent if you want it gone:
+
+```bash
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk-vector.plist
+rm ~/Library/LaunchAgents/foundation.foxlight.skulk-vector.plist
+```
+
+Or re-run the installer with `--no-vector`.
+
+## Advanced: running Vector standalone (development)
+
+For ad-hoc runs without the LaunchAgent, you can run Vector by hand:
+
+```bash
+# Make sure ~/.skulk/skulk.env is sourced so EXO_LOGGING_INGEST_URL is set
+source ~/.skulk/skulk.env
+
+# Then run vector pointed at the same config the LaunchAgent uses
+vector --config deployment/logging/vector.yaml
+```
+
+This is useful when iterating on `vector.yaml` — restart picks up changes immediately, and you see Vector's full output in the terminal.

--- a/website/docs/run-skulk-as-a-service.md
+++ b/website/docs/run-skulk-as-a-service.md
@@ -109,7 +109,7 @@ If it doesn't, jump to [Things that go wrong](#things-that-go-wrong).
 | Check if it's running | `launchctl print gui/$(id -u)/foundation.foxlight.skulk \| grep "state ="` | `systemctl --user status skulk` |
 | Watch the logs live | `tail -f ~/.skulk/logs/skulk.stderr.log` | `journalctl --user -u skulk -f` |
 | Watch boot-time updates (git pull, dashboard build) | `tail -f ~/.skulk/logs/skulk.prep.log` | `tail -f ~/.skulk/logs/skulk.prep.log` |
-| Watch Vector log-shipper output | `tail -f ~/.skulk/logs/vector.stderr.log` | `journalctl --user -u skulk-vector -f` |
+| Watch Vector log-shipper output | `tail -f ~/.skulk/logs/vector.stderr.log` (separate launchd agent) | (in-process — read from skulk's main log via `journalctl --user -u skulk -f`) |
 | Restart it | `launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk` | `systemctl --user restart skulk` |
 | Stop it (stays stopped) | `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user stop skulk` |
 | Start it back up | `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user start skulk` |
@@ -151,7 +151,7 @@ To disable auto-update entirely, set `SKULK_AUTO_UPDATE=0` in `~/.skulk/skulk.en
 
 ### The Vector log-shipper agent
 
-The installer also installs a second agent (`foundation.foxlight.skulk-vector`) that tails `~/.skulk/logs/skulk.stdout.log` and ships log lines to a central log store (VictoriaLogs by default). This is **separate from Skulk on purpose** — if Vector crashes or the central store is unreachable, Skulk keeps running normally.
+**macOS**: The installer also installs a second agent (`foundation.foxlight.skulk-vector`) that tails `~/.skulk/logs/skulk.stdout.log` and ships log lines to a central log store (VictoriaLogs by default). This is **separate from Skulk on purpose** — if Vector crashes or the central store is unreachable, Skulk keeps running normally.
 
 You only need this if you want centralized cluster-wide logs. To skip it:
 
@@ -164,6 +164,8 @@ To configure where logs are shipped, edit `EXO_LOGGING_INGEST_URL` in `~/.skulk/
 ```bash
 launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk-vector
 ```
+
+**Linux**: There's no separate Vector unit yet on Linux — the systemd installer in this release installs only `skulk.service`. When you set `logging.enabled: true` and `logging.ingest_url: ...` in `skulk.yaml`, Skulk spawns Vector as an in-process subprocess and pipes JSON logs to it directly (using `deployment/logging/vector.yaml`). The same VictoriaLogs central stack works for both platforms; only the shipping process model differs.
 
 For full setup of the central log store (VictoriaLogs + Grafana), see the [External logging guide](./external-logging.md).
 
@@ -215,13 +217,16 @@ If the dashboard still doesn't load, check the logs (see the table above). Look 
 
 ### "Vector keeps crashing / no logs are reaching the central store"
 
-The Vector agent is independent — Skulk runs fine even if Vector is broken. To diagnose:
+**macOS** (launchd Vector agent): The agent is independent — Skulk runs fine even if Vector is broken. To diagnose:
 
 ```bash
-# macOS
 tail -f ~/.skulk/logs/vector.stderr.log
-# Linux
-journalctl --user -u skulk-vector -f
+```
+
+**Linux** (in-process Vector subprocess): Vector runs as a child of Skulk and shares its log stream:
+
+```bash
+journalctl --user -u skulk -f | grep -i vector
 ```
 
 Common causes:

--- a/website/docs/run-skulk-as-a-service.md
+++ b/website/docs/run-skulk-as-a-service.md
@@ -72,7 +72,13 @@ Open a terminal, `cd` into your Skulk folder, then run:
 deployment/install/install-systemd.sh
 ```
 
-The script does everything for you. When it finishes (a few seconds), check it's running:
+The script does everything for you:
+
+- Installs the **Skulk** systemd user unit (`skulk.service`).
+- Copies an env file to `~/.skulk/skulk.env` on the first install. This is where you customize behavior; re-running the installer never overwrites your edits.
+- Defaults to `SKULK_LOGGING_EXTERNAL=0` (in-process Vector subprocess shipper) since this release does not include a separate `skulk-vector` systemd unit.
+
+When it finishes (a few seconds), check it's running:
 
 ```bash
 systemctl --user status skulk

--- a/website/docs/run-skulk-as-a-service.md
+++ b/website/docs/run-skulk-as-a-service.md
@@ -12,6 +12,8 @@ Make Skulk start when your computer boots, and restart itself if it ever crashes
 
 - Skulk starts automatically — no more typing `uv run skulk` every time you reboot
 - If Skulk crashes, it comes back up on its own
+- Skulk pulls fresh code, syncs Python deps, and rebuilds the dashboard at every boot (you can turn this off with one line in a config file)
+- A separate Vector log-shipper agent forwards logs to your central log store (you can turn this off too)
 - You'll know exactly how to check it's running, see logs, restart it, and turn it off
 
 About 5 minutes per machine. No coding. No sudo for the standard install.
@@ -36,7 +38,13 @@ Open Terminal, `cd` into your Skulk folder, then run:
 deployment/install/install-launchd.sh
 ```
 
-The script does everything for you. When it finishes (a few seconds), check it's running:
+The script does everything for you:
+
+- Installs the **Skulk** LaunchAgent (`foundation.foxlight.skulk`) — the actual service.
+- Installs the **Vector log-shipper** LaunchAgent (`foundation.foxlight.skulk-vector`) — forwards logs to your central log store. Skip this with `--no-vector` if you don't run centralized logging.
+- Copies an env file to `~/.skulk/skulk.env` on the first install. This is where you customize behavior; re-running the installer never overwrites your edits.
+
+When it finishes (a few seconds), check it's running:
 
 ```bash
 launchctl print gui/$(id -u)/foundation.foxlight.skulk | grep "state ="
@@ -49,6 +57,12 @@ state = running
 ```
 
 **That's it.** Skulk will start automatically the next time you log in, and will restart itself if it ever crashes.
+
+If you don't want the log shipper, install with:
+
+```bash
+deployment/install/install-launchd.sh --no-vector
+```
 
 ### Linux
 
@@ -94,25 +108,84 @@ If it doesn't, jump to [Things that go wrong](#things-that-go-wrong).
 | --- | --- | --- |
 | Check if it's running | `launchctl print gui/$(id -u)/foundation.foxlight.skulk \| grep "state ="` | `systemctl --user status skulk` |
 | Watch the logs live | `tail -f ~/.skulk/logs/skulk.stderr.log` | `journalctl --user -u skulk -f` |
+| Watch boot-time updates (git pull, dashboard build) | `tail -f ~/.skulk/logs/skulk.prep.log` | `tail -f ~/.skulk/logs/skulk.prep.log` |
+| Watch Vector log-shipper output | `tail -f ~/.skulk/logs/vector.stderr.log` | `journalctl --user -u skulk-vector -f` |
 | Restart it | `launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk` | `systemctl --user restart skulk` |
 | Stop it (stays stopped) | `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user stop skulk` |
 | Start it back up | `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user start skulk` |
 
-### Updating Skulk after `git pull`
+### Customizing how the service runs (`~/.skulk/skulk.env`)
 
-Pull the new code, rebuild the dashboard, then restart the service so it picks up the changes:
+The installer puts a plain-text env file at `~/.skulk/skulk.env`. Open it in any editor — every line is `KEY=value` and the comments explain what each setting does. After saving, restart the service to pick up your changes:
+
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk
+
+# Linux
+systemctl --user restart skulk
+```
+
+Common things to change:
+
+| Setting | What it does | Default |
+| --- | --- | --- |
+| `SKULK_AUTO_UPDATE` | `1` = auto-update on every boot, `0` = run whatever's already on disk | `1` |
+| `SKULK_VERBOSITY` | Verbosity flag passed to skulk. `-v` is normal verbose, `-vv` is debug, empty string is info-only | `-v` |
+| `SKULK_LIBP2P_NAMESPACE` | Cluster namespace — nodes only join clusters with the same value. Use a unique value per cluster | `foxlight-main` |
+| `EXO_LOGGING_INGEST_URL` | Where Vector ships logs (only relevant if you have the Vector agent installed) | the in-house VictoriaLogs endpoint |
+
+The env file you edit is **yours** — Skulk's `git pull` only updates the template at `deployment/install/skulk.env.example`. Diff against that template if you ever want to pick up a new default.
+
+### Auto-update on boot — what happens and how to turn it off
+
+Every time the service starts (boot, manual restart, post-crash relaunch), it runs through this sequence **before** starting Skulk itself:
+
+1. **`git pull --ff-only`** — pulls new commits if any. Failure (offline, dirty tree, fast-forward not possible) is logged and ignored; the service boots whatever revision is already checked out.
+2. **`uv sync`** — refreshes the Python virtualenv to match the lockfile. Failure (PyPI unreachable, wheel build error) is logged and ignored; the service boots with the current venv.
+3. **`npm install && npm run build`** in `dashboard-react/` — rebuilds the dashboard. Individual failures are logged and ignored as long as a previously built `dashboard-react/dist/` exists. **If `dist/` is missing, the service refuses to start** because there'd be no dashboard to serve.
+
+Everything from this phase is logged to `~/.skulk/logs/skulk.prep.log` so you can audit what actually happened on the last boot.
+
+To disable auto-update entirely, set `SKULK_AUTO_UPDATE=0` in `~/.skulk/skulk.env` and restart the service. This is the right choice if you're pinning a known-good revision or running on a flaky network where boot-time `git pull` causes more pain than it solves.
+
+### The Vector log-shipper agent
+
+The installer also installs a second agent (`foundation.foxlight.skulk-vector`) that tails `~/.skulk/logs/skulk.stdout.log` and ships log lines to a central log store (VictoriaLogs by default). This is **separate from Skulk on purpose** — if Vector crashes or the central store is unreachable, Skulk keeps running normally.
+
+You only need this if you want centralized cluster-wide logs. To skip it:
+
+```bash
+deployment/install/install-launchd.sh --no-vector
+```
+
+To configure where logs are shipped, edit `EXO_LOGGING_INGEST_URL` in `~/.skulk/skulk.env` and restart the Vector agent:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk-vector
+```
+
+For full setup of the central log store (VictoriaLogs + Grafana), see the [External logging guide](./external-logging.md).
+
+### Updating Skulk
+
+You usually don't need to do anything — the service runs `git pull` + `uv sync` + dashboard build at every boot. To pick up an update without rebooting, just restart the service:
+
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk
+# Linux
+systemctl --user restart skulk
+```
+
+If you've turned auto-update off (`SKULK_AUTO_UPDATE=0`), do the manual flow:
 
 ```bash
 git pull
 cd dashboard-react && npm install && npm run build && cd ..
 
-# macOS:
-launchctl kickstart -k gui/$(id -u)/foundation.foxlight.skulk
-# Linux:
-systemctl --user restart skulk
+# then restart the service as above
 ```
-
-That's the whole update flow.
 
 ## Things that go wrong
 
@@ -138,6 +211,24 @@ If the dashboard still doesn't load, check the logs (see the table above). Look 
 - **Another program is using port 52415.** Find it with `lsof -i :52415` and stop it (or change Skulk's port with `--api-port`).
 - **A typo in your `skulk.yaml`.** Skulk logs the parse error on startup — search the log for "config".
 - **You moved your Skulk folder after running the installer.** Re-run the installer; it'll update the path.
+- **The dashboard build failed during boot prep.** Look in `~/.skulk/logs/skulk.prep.log` — if `npm run build` failed and there's no `dashboard-react/dist/` directory, the service refuses to start. Fix: build the dashboard once manually (`cd dashboard-react && npm install && npm run build`), then restart.
+
+### "Vector keeps crashing / no logs are reaching the central store"
+
+The Vector agent is independent — Skulk runs fine even if Vector is broken. To diagnose:
+
+```bash
+# macOS
+tail -f ~/.skulk/logs/vector.stderr.log
+# Linux
+journalctl --user -u skulk-vector -f
+```
+
+Common causes:
+
+- **`vector` is not installed.** Install it from [vector.dev](https://vector.dev/docs/setup/installation/) and restart the agent.
+- **`EXO_LOGGING_INGEST_URL` points at an unreachable host.** Vector buffers up to 512 MB on disk while the central store is down — once it comes back, the buffered logs ship automatically. If the URL is permanently wrong, edit `~/.skulk/skulk.env` and restart the agent.
+- **The Skulk JSON log stream isn't enabled.** Vector tails Skulk's stdout file, but that file only contains JSON if Skulk is configured to emit it. See [External logging](./external-logging.md) for the `skulk.yaml` settings.
 
 ### "It keeps crashing in a loop"
 
@@ -165,9 +256,10 @@ Removes the service so Skulk doesn't start automatically anymore. Doesn't touch 
 ### macOS
 
 ```bash
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist
-rm ~/Library/LaunchAgents/foundation.foxlight.skulk.plist
+deployment/install/install-launchd.sh --uninstall
 ```
+
+This removes both the Skulk agent and the Vector agent. Your `~/.skulk/skulk.env`, models, and config are untouched.
 
 ### Linux
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -23,6 +23,7 @@ const sidebars: SidebarsConfig = {
         "api-guide",
         "build-and-runtime",
         "run-skulk-as-a-service",
+        "external-logging",
         {
           type: "category",
           label: "Tailscale",


### PR DESCRIPTION
## Summary

- Adds a wrapper-based launch path so the Skulk service can `git pull`, `uv sync`, and rebuild the dashboard at every boot. Failure policy is the **middle option**: pull/sync errors are non-fatal (logged to `~/.skulk/logs/skulk.prep.log`, service boots whatever is on disk), but a missing `dashboard-react/dist/` is fatal. Toggleable via `SKULK_AUTO_UPDATE` in `~/.skulk/skulk.env`.
- Introduces an operator-editable env file at `~/.skulk/skulk.env`, copied from `deployment/install/skulk.env.example` on first install and never overwritten on re-run. Surfaces the namespace, verbosity, debug flags, and external-logging knobs without requiring a plist edit.
- Splits Vector into its own LaunchAgent (`foundation.foxlight.skulk-vector`) that tails the captured `~/.skulk/logs/skulk.stdout.log` instead of being piped through Skulk's process. A slow VictoriaLogs sink can no longer backpressure inference threads. Opt out with `--no-vector` on the installer.
- Adds `SKULK_LOGGING_EXTERNAL=1` mode in `exo.shared.logging`: structured JSON goes to stdout for the external shipper, and Skulk does not spawn its own internal Vector subprocess. JSON sink switched to `enqueue=True` so log producers are decoupled from sink I/O.
- New thorough operator guide at `website/docs/external-logging.md` covering the full Vector + VictoriaLogs + Grafana stack — central-host install, per-node configuration, JSON schema, and troubleshooting. Existing service guide updated for the new flow.

## Test plan

- [x] `uv run basedpyright` — 0 errors
- [x] `uv run ruff check` — clean
- [x] `uv run pytest` — 700 passed, 1 skipped, 164 deselected
- [x] New unit tests in `src/exo/shared/tests/test_logging_external.py` cover the SKULK_LOGGING_EXTERNAL flag (truthy / falsy / unset paths, runtime toggle via `set_structured_stdout`)
- [x] Shell scripts pass `bash -n`
- [ ] Manual: re-run `deployment/install/install-launchd.sh` on a clean Mac, verify both agents come up, `~/.skulk/skulk.env` is written, JSON appears in `skulk.stdout.log`, and Vector ships to VictoriaLogs
- [ ] Manual: re-run with `--no-vector`, verify only the Skulk agent is installed and shipping is off
- [ ] Manual: flip `SKULK_AUTO_UPDATE=0`, restart, confirm no `git pull` runs at boot
- [ ] Docs: `cd website && npm run start` and verify the new sidebar entry renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)