### PR TITLE
feat: add MLX-only toggle to model browser, fix HF search

### DIFF
--- a/dashboard-react/src/components/models/ModelBrowser.tsx
+++ b/dashboard-react/src/components/models/ModelBrowser.tsx
@@ -36,7 +36,7 @@ export interface ModelBrowserProps {
   hfSearchResults?: HuggingFaceModel[];
   hfTrendingModels?: HuggingFaceModel[];
   hfIsSearching?: boolean;
-  onHfSearch?: (query: string) => void;
+  onHfSearch?: (query: string, mlxOnly?: boolean) => void;
   mlxOnly?: boolean;
   onToggleMlxOnly?: () => void;
 }
@@ -183,7 +183,13 @@ export function ModelBrowser({
               variant="outline"
               size="sm"
               $active={mlxOnly}
-              onClick={onToggleMlxOnly}
+              onClick={() => {
+                const nextMlxOnly = !mlxOnly;
+                onToggleMlxOnly();
+                if (picker.searchQuery.trim() && onHfSearch) {
+                  onHfSearch(picker.searchQuery, nextMlxOnly);
+                }
+              }}
             >
               MLX only
             </FilterBtn>

--- a/dashboard-react/src/components/models/ModelBrowser.tsx
+++ b/dashboard-react/src/components/models/ModelBrowser.tsx
@@ -37,6 +37,8 @@ export interface ModelBrowserProps {
   hfTrendingModels?: HuggingFaceModel[];
   hfIsSearching?: boolean;
   onHfSearch?: (query: string) => void;
+  mlxOnly?: boolean;
+  onToggleMlxOnly?: () => void;
 }
 
 /* ---------- layout ---------- */
@@ -127,6 +129,8 @@ export function ModelBrowser({
   hfTrendingModels,
   hfIsSearching,
   onHfSearch,
+  mlxOnly = false,
+  onToggleMlxOnly,
 }: ModelBrowserProps) {
   const picker = useModelPicker({
     models,
@@ -171,9 +175,19 @@ export function ModelBrowser({
               picker.setSearchQuery(q);
               if (isHf && onHfSearch) onHfSearch(q);
             }}
-            placeholder={isHf ? 'Search mlx-community models…' : 'Search models…'}
+            placeholder={isHf ? (mlxOnly ? 'Search mlx-community…' : 'Search all of HuggingFace…') : 'Search models…'}
             autoFocus
           />
+          {isHf && onToggleMlxOnly && (
+            <FilterBtn
+              variant="outline"
+              size="sm"
+              $active={mlxOnly}
+              onClick={onToggleMlxOnly}
+            >
+              MLX only
+            </FilterBtn>
+          )}
           {!isHf && (
             <FilterBtn
               variant="outline"

--- a/dashboard-react/src/components/pages/ModelSearchModal.tsx
+++ b/dashboard-react/src/components/pages/ModelSearchModal.tsx
@@ -179,6 +179,7 @@ export function ModelSearchModal({
 
   const handleToggleMlxOnly = useCallback(() => {
     setMlxOnly(prev => !prev);
+    setHfResults([]);
   }, []);
 
   const toggleFavorite = useCallback((groupId: string) => {

--- a/dashboard-react/src/components/pages/ModelSearchModal.tsx
+++ b/dashboard-react/src/components/pages/ModelSearchModal.tsx
@@ -71,6 +71,7 @@ export function ModelSearchModal({
   const [hfResults, setHfResults] = useState<HuggingFaceModel[]>([]);
   const [hfTrending, setHfTrending] = useState<HuggingFaceModel[]>([]);
   const [hfSearching, setHfSearching] = useState(false);
+  const [mlxOnly, setMlxOnly] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
@@ -106,17 +107,22 @@ export function ModelSearchModal({
         setModels(data.data ?? []);
       } catch { /* ignore */ }
     })();
-    // Fetch trending
+  }, [open]);
+
+  // Fetch trending whenever the modal opens or mlxOnly changes
+  useEffect(() => {
+    if (!open) return;
     (async () => {
       try {
-        const res = await fetch('/models/search?query=&limit=20');
+        const params = new URLSearchParams({ query: '', limit: '20', mlx_only: String(mlxOnly) });
+        const res = await fetch(`/models/search?${params}`);
         if (!res.ok) return;
         setHfTrending(await res.json());
       } catch { /* ignore */ }
     })();
-  }, [open]);
+  }, [open, mlxOnly]);
 
-  const handleHfSearch = useCallback((query: string) => {
+  const handleHfSearch = useCallback((query: string, mlxOnlyOverride?: boolean) => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (!query.trim()) {
       setHfResults([]);
@@ -124,14 +130,16 @@ export function ModelSearchModal({
       return;
     }
     setHfSearching(true);
+    const useMlxOnly = mlxOnlyOverride ?? mlxOnly;
     debounceRef.current = setTimeout(async () => {
       try {
-        const res = await fetch(`/models/search?query=${encodeURIComponent(query)}&limit=20`);
+        const params = new URLSearchParams({ query, limit: '20', mlx_only: String(useMlxOnly) });
+        const res = await fetch(`/models/search?${params}`);
         if (res.ok) setHfResults(await res.json());
       } catch { /* ignore */ }
       finally { setHfSearching(false); }
     }, 500);
-  }, []);
+  }, [mlxOnly]);
 
   const handleSelect = useCallback(async (modelId: string) => {
     try {
@@ -167,6 +175,10 @@ export function ModelSearchModal({
         }
       }
     } catch { /* ignore */ }
+  }, []);
+
+  const handleToggleMlxOnly = useCallback(() => {
+    setMlxOnly(prev => !prev);
   }, []);
 
   const toggleFavorite = useCallback((groupId: string) => {
@@ -216,6 +228,8 @@ export function ModelSearchModal({
             hfTrendingModels={hfTrending}
             hfIsSearching={hfSearching}
             onHfSearch={handleHfSearch}
+            mlxOnly={mlxOnly}
+            onToggleMlxOnly={handleToggleMlxOnly}
             mode="store-download"
           />
         </ModalBody>

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -712,8 +712,8 @@ class API:
             tags=["Models"],
             summary="Search Hugging Face for models",
             description=(
-                "Search for models to add or launch. Skulk prefers MLX-friendly results first, "
-                "then falls back to broader Hugging Face search results."
+                "Search for models to add or launch. Pass mlx_only=true to restrict results "
+                "to mlx-community; omit or pass false to search all of Hugging Face."
             ),
         )(self.search_models)
         self.app.post(
@@ -2728,9 +2728,9 @@ class API:
         )
 
     async def search_models(
-        self, query: str = "", limit: int = 20
+        self, query: str = "", limit: int = 20, mlx_only: bool = False
     ) -> list[HuggingFaceSearchResult]:
-        """Search HuggingFace Hub — tries mlx-community first, falls back to all of HuggingFace."""
+        """Search HuggingFace Hub. When mlx_only=True, restricts to mlx-community."""
         from huggingface_hub import ModelInfo, list_models
 
         def _to_results(models: Iterable[ModelInfo]) -> list[HuggingFaceSearchResult]:
@@ -2746,22 +2746,10 @@ class API:
                 for m in models
             ]
 
-        # Search mlx-community first
-        mlx_results = _to_results(
-            list_models(
-                search=query or None,
-                author="mlx-community",
-                sort="downloads",
-                limit=limit,
-            )
-        )
-        if mlx_results:
-            return mlx_results
-
-        # Fall back to searching all of HuggingFace
         return _to_results(
             list_models(
                 search=query or None,
+                author="mlx-community" if mlx_only else None,
                 sort="downloads",
                 limit=limit,
             )


### PR DESCRIPTION
## Summary

- **Root cause**: `search_models` only fell back to all of HuggingFace when mlx-community returned zero results — for any common query term, mlx-community returns something, making the broader HF search effectively unreachable
- **Fix**: replaced the broken fallback with an explicit `mlx_only` query parameter (default `false`, searches all of HuggingFace by default)
- **Toggle**: added an "MLX only" button in the HF search toolbar; highlights gold when active, updates the search placeholder, and re-fetches trending results when flipped

## Test plan

- [ ] Open model browser → HuggingFace tab, search for a model known to exist on HF but not in mlx-community — confirm it appears
- [ ] Enable "MLX only" toggle — confirm results restrict to mlx-community
- [ ] Disable toggle — confirm results return to full HF search
- [ ] Verify trending list re-fetches when toggle is flipped with no active search query
- [ ] Confirm `skulk-vindex doctor` / typecheck still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)