### PR TITLE
feat: MTP sidecar download and loading infrastructure

### DIFF
--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -156,6 +156,37 @@ class ResumableShardDownloader(ShardDownloader):
                 skip_internet=self.offline,
             )
 
+        if (
+            not config_only
+            and not self.offline
+            and shard.model_card.runtime
+            and shard.model_card.runtime.mtp_sidecar_repo
+        ):
+            mtp_repo = shard.model_card.runtime.mtp_sidecar_repo
+            mtp_card = ModelCard(
+                model_id=ModelId(mtp_repo),
+                storage_size=Memory.from_bytes(0),
+                n_layers=1,
+                hidden_size=1,
+                supports_tensor=False,
+                tasks=[ModelTask.TextGeneration],
+            )
+            mtp_shard = PipelineShardMetadata(
+                model_card=mtp_card,
+                device_rank=0,
+                world_size=1,
+                start_layer=0,
+                end_layer=1,
+                n_layers=1,
+            )
+            await download_shard(
+                mtp_shard,
+                self.on_progress_wrapper,
+                max_parallel_downloads=self.max_parallel_downloads,
+                allow_patterns=["mtp.safetensors", "config.json"],
+                skip_internet=self.offline,
+            )
+
         return target_dir
 
     async def get_shard_download_status(

--- a/src/exo/download/tests/test_mtp_sidecar_download.py
+++ b/src/exo/download/tests/test_mtp_sidecar_download.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/src/exo/download/tests/test_mtp_sidecar_download.py
+++ b/src/exo/download/tests/test_mtp_sidecar_download.py
@@ -1,0 +1,187 @@
+"""Tests for MTP sidecar download in ResumableShardDownloader."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from exo.download.impl_shard_downloader import ResumableShardDownloader
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelTask,
+    RuntimeCapabilityCardConfig,
+)
+from exo.shared.types.common import ModelId
+from exo.shared.types.memory import Memory
+from exo.shared.types.worker.shards import PipelineShardMetadata
+
+
+def _make_card(
+    *,
+    mtp_sidecar_repo: str | None = None,
+    mtp_heads: bool | None = None,
+) -> ModelCard:
+    runtime = (
+        RuntimeCapabilityCardConfig(
+            mtp_sidecar_repo=mtp_sidecar_repo,
+            mtp_heads=mtp_heads,
+        )
+        if mtp_sidecar_repo is not None
+        else None
+    )
+    return ModelCard(
+        model_id=ModelId("test-org/test-model"),
+        storage_size=Memory.from_bytes(0),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        runtime=runtime,
+    )
+
+
+def _make_shard(card: ModelCard) -> PipelineShardMetadata:
+    return PipelineShardMetadata(
+        model_card=card,
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=1,
+        n_layers=1,
+    )
+
+
+@pytest.fixture
+def downloader() -> ResumableShardDownloader:
+    return ResumableShardDownloader(max_parallel_downloads=4, offline=False)
+
+
+class TestMtpSidecarDownload:
+    async def test_downloads_mtp_sidecar_when_configured(
+        self, downloader: ResumableShardDownloader, tmp_path: Path
+    ) -> None:
+        """When mtp_sidecar_repo is set, ensure_shard calls download_shard for the sidecar."""
+        card = _make_card(mtp_sidecar_repo="test-org/test-mtp", mtp_heads=True)
+        shard = _make_shard(card)
+
+        download_calls: list[dict[str, Any]] = []
+
+        async def fake_download_shard(
+            shard: Any,
+            on_progress: Any,
+            *,
+            max_parallel_downloads: int = 8,
+            allow_patterns: list[str] | None = None,
+            skip_internet: bool = False,
+            skip_download: bool = False,
+        ) -> tuple[Path, Any]:
+            download_calls.append(
+                {
+                    "model_id": str(shard.model_card.model_id),
+                    "allow_patterns": allow_patterns,
+                }
+            )
+            return tmp_path, MagicMock()
+
+        with patch(
+            "exo.download.impl_shard_downloader.download_shard",
+            side_effect=fake_download_shard,
+        ):
+            await downloader.ensure_shard(shard)
+
+        sidecar_calls = [c for c in download_calls if "mtp" in c["model_id"]]
+        assert len(sidecar_calls) == 1
+        assert sidecar_calls[0]["model_id"] == "test-org/test-mtp"
+        assert sidecar_calls[0]["allow_patterns"] == ["mtp.safetensors", "config.json"]
+
+    async def test_skips_mtp_download_when_not_configured(
+        self, downloader: ResumableShardDownloader, tmp_path: Path
+    ) -> None:
+        """When mtp_sidecar_repo is absent, no extra download_shard call is made."""
+        card = _make_card()
+        shard = _make_shard(card)
+
+        download_calls: list[dict[str, Any]] = []
+
+        async def fake_download_shard(
+            shard: Any,
+            on_progress: Any,
+            *,
+            max_parallel_downloads: int = 8,
+            allow_patterns: list[str] | None = None,
+            skip_internet: bool = False,
+            skip_download: bool = False,
+        ) -> tuple[Path, Any]:
+            download_calls.append({"model_id": str(shard.model_card.model_id)})
+            return tmp_path, MagicMock()
+
+        with patch(
+            "exo.download.impl_shard_downloader.download_shard",
+            side_effect=fake_download_shard,
+        ):
+            await downloader.ensure_shard(shard)
+
+        sidecar_calls = [c for c in download_calls if "mtp" in c["model_id"]]
+        assert len(sidecar_calls) == 0
+
+    async def test_skips_mtp_download_in_offline_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """When offline=True, the MTP sidecar download block is skipped."""
+        offline_downloader = ResumableShardDownloader(max_parallel_downloads=4, offline=True)
+        card = _make_card(mtp_sidecar_repo="test-org/test-mtp", mtp_heads=True)
+        shard = _make_shard(card)
+
+        download_calls: list[dict[str, Any]] = []
+
+        async def fake_download_shard(
+            shard: Any,
+            on_progress: Any,
+            *,
+            max_parallel_downloads: int = 8,
+            allow_patterns: list[str] | None = None,
+            skip_internet: bool = False,
+            skip_download: bool = False,
+        ) -> tuple[Path, Any]:
+            download_calls.append({"model_id": str(shard.model_card.model_id)})
+            return tmp_path, MagicMock()
+
+        with patch(
+            "exo.download.impl_shard_downloader.download_shard",
+            side_effect=fake_download_shard,
+        ):
+            await offline_downloader.ensure_shard(shard)
+
+        sidecar_calls = [c for c in download_calls if "mtp" in c["model_id"]]
+        assert len(sidecar_calls) == 0
+
+    async def test_skips_mtp_download_in_config_only_mode(
+        self, downloader: ResumableShardDownloader, tmp_path: Path
+    ) -> None:
+        """When config_only=True, the MTP sidecar download block is skipped."""
+        card = _make_card(mtp_sidecar_repo="test-org/test-mtp", mtp_heads=True)
+        shard = _make_shard(card)
+
+        download_calls: list[dict[str, Any]] = []
+
+        async def fake_download_shard(
+            shard: Any,
+            on_progress: Any,
+            *,
+            max_parallel_downloads: int = 8,
+            allow_patterns: list[str] | None = None,
+            skip_internet: bool = False,
+            skip_download: bool = False,
+        ) -> tuple[Path, Any]:
+            download_calls.append({"model_id": str(shard.model_card.model_id)})
+            return tmp_path, MagicMock()
+
+        with patch(
+            "exo.download.impl_shard_downloader.download_shard",
+            side_effect=fake_download_shard,
+        ):
+            await downloader.ensure_shard(shard, config_only=True)
+
+        sidecar_calls = [c for c in download_calls if "mtp" in c["model_id"]]
+        assert len(sidecar_calls) == 0

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -246,6 +246,26 @@ class RuntimeCapabilityCardConfig(CamelCaseModel):
     to ``True`` for models that have been measured to benefit and are
     known to be safe under the deployment's collective backend.
     """
+    mtp_heads: bool | None = None
+    """True when native MTP prediction heads are available via sidecar.
+
+    Set alongside ``mtp_sidecar_repo``. When false or absent, the runner
+    skips sidecar loading and uses standard autoregressive generation.
+    """
+    mtp_max_depth: int | None = None
+    """Maximum draft depth the MTP heads support.
+
+    Start at 1 for Apple Silicon. Deeper values can be evaluated via
+    profiling but are unlikely to amortize on Metal due to near-linear
+    verify-pass scaling.
+    """
+    mtp_sidecar_repo: str | None = None
+    """Hugging Face repo ID containing the published ``mtp.safetensors`` sidecar.
+
+    Example: ``"FoxlightAI/qwen3-5-7b-instruct-mtp-q4k"``
+    The sidecar is downloaded alongside the base model weights and loaded
+    into the runner for speculative decoding. Produced by SWP.
+    """
 
     @field_validator("prompt_renderer", mode="before")
     @classmethod

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -633,7 +633,7 @@ def load_mlx_items(
     group: Group | None,
     on_timeout: TimeoutCallback | None,
     on_layer_loaded: LayerLoadedCallback | None,
-) -> "tuple[Model, TokenizerWrapper, VisionProcessor | None]":
+) -> "tuple[Model, TokenizerWrapper, VisionProcessor | None, dict[str, mx.array] | None]":
     if group is None:
         logger.info(f"Single device used for {bound_instance.instance}")
         model_path = build_model_path(bound_instance.bound_shard.model_card.model_id)
@@ -691,7 +691,19 @@ def load_mlx_items(
     else:
         vision_processor = None
 
-    return cast(Model, model), tokenizer, vision_processor
+    mtp_weights: dict[str, mx.array] | None = None
+    runtime = bound_instance.bound_shard.model_card.runtime
+    if runtime and runtime.mtp_sidecar_repo and runtime.mtp_heads:
+        sidecar_path = build_model_path(ModelId(runtime.mtp_sidecar_repo))
+        mtp_safetensors = sidecar_path / "mtp.safetensors"
+        if mtp_safetensors.exists():
+            mtp_weights = cast("dict[str, mx.array]", mx.load(str(mtp_safetensors)))
+        else:
+            logger.warning(
+                f"MTP sidecar declared but not found at {mtp_safetensors}; running without MTP"
+            )
+
+    return cast(Model, model), tokenizer, vision_processor, mtp_weights
 
 
 def shard_and_load(

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -694,13 +694,18 @@ def load_mlx_items(
     mtp_weights: dict[str, mx.array] | None = None
     runtime = bound_instance.bound_shard.model_card.runtime
     if runtime and runtime.mtp_sidecar_repo and runtime.mtp_heads:
-        sidecar_path = build_model_path(ModelId(runtime.mtp_sidecar_repo))
-        mtp_safetensors = sidecar_path / "mtp.safetensors"
-        if mtp_safetensors.exists():
-            mtp_weights = cast("dict[str, mx.array]", mx.load(str(mtp_safetensors)))
-        else:
+        try:
+            sidecar_path = build_model_path(ModelId(runtime.mtp_sidecar_repo))
+            mtp_safetensors = sidecar_path / "mtp.safetensors"
+            if mtp_safetensors.exists():
+                mtp_weights = cast("dict[str, mx.array]", mx.load(str(mtp_safetensors)))
+            else:
+                logger.warning(
+                    f"MTP sidecar declared but not found at {mtp_safetensors}; running without MTP"
+                )
+        except FileNotFoundError:
             logger.warning(
-                f"MTP sidecar declared but not found at {mtp_safetensors}; running without MTP"
+                f"MTP sidecar repo {runtime.mtp_sidecar_repo!r} not downloaded; running without MTP"
             )
 
     return cast(Model, model), tokenizer, vision_processor, mtp_weights

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -142,6 +142,7 @@ class SequentialGenerator(InferenceGenerator):
     cancel_receiver: MpReceiver[TaskId]
     event_sender: MpSender[Event]
     vision_processor: VisionProcessor | None = None
+    mtp_weights: "dict[str, mx.array] | None" = None
     check_for_cancel_every: int = 50
 
     _cancelled_tasks: set[TaskId] = field(default_factory=set, init=False)
@@ -474,6 +475,7 @@ class BatchGenerator(InferenceGenerator):
     event_sender: MpSender[Event]
     check_for_cancel_every: int = 50
     vision_processor: VisionProcessor | None = None
+    mtp_weights: "dict[str, mx.array] | None" = None
 
     _cancelled_tasks: set[TaskId] = field(default_factory=set, init=False)
     _maybe_queue: list[TextGeneration] = field(default_factory=list, init=False)

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -302,6 +302,7 @@ class Runner:
                         self.generator.inference_model,
                         self.generator.tokenizer,
                         self.generator.vision_processor,
+                        self.generator.mtp_weights,
                     ) = load_mlx_items(
                         self.bound_instance,
                         self.generator.group,
@@ -696,6 +697,7 @@ class Builder:
     tokenizer: TokenizerWrapper | None = None
     group: mx.distributed.Group | None = None
     vision_processor: VisionProcessor | None = None
+    mtp_weights: dict[str, mx.array] | None = None
 
     def build(
         self,
@@ -773,6 +775,7 @@ class Builder:
                 cancel_receiver=self.cancel_receiver,
                 event_sender=self.event_sender,
                 vision_processor=vision_processor,
+                mtp_weights=self.mtp_weights,
             )
         logger.info("using BatchGenerator")
         return BatchGenerator(
@@ -787,4 +790,5 @@ class Builder:
             cancel_receiver=self.cancel_receiver,
             event_sender=self.event_sender,
             vision_processor=vision_processor,
+            mtp_weights=self.mtp_weights,
         )

--- a/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
@@ -117,7 +117,7 @@ def patch_out_mlx(monkeypatch: pytest.MonkeyPatch):
     # initialize_mlx returns a mock group
     monkeypatch.setattr(mlx_runner, "initialize_mlx", make_nothin(MockGroup()))
     monkeypatch.setattr(
-        mlx_runner, "load_mlx_items", make_nothin((1, MockTokenizer, None))
+        mlx_runner, "load_mlx_items", make_nothin((1, MockTokenizer, None, None))
     )
     monkeypatch.setattr(mlx_batch_generator, "warmup_inference", make_nothin(1))
     monkeypatch.setattr(mlx_batch_generator, "_check_for_debug_prompts", nothin)

--- a/website/docs/model-cards.md
+++ b/website/docs/model-cards.md
@@ -148,6 +148,53 @@ Declares runtime integration preferences:
   - prompt renderer to use, such as `tokenizer`, `gemma4`, or `dsml`
 - `output_parser`
   - output parser to use, such as `generic`, `gemma4`, `gpt_oss`, or `deepseek_v32`
+- `metal_fast_synch`
+  - per-model override for the MLX `MLX_METAL_FAST_SYNCH` flag; set to `false` for models that deadlock under FAST_SYNCH on the ring backend
+- `mtp_heads`
+  - set to `true` when the model has native MTP prediction heads available via sidecar; required alongside `mtp_sidecar_repo` to enable speculative decoding
+- `mtp_max_depth`
+  - maximum draft depth the MTP heads support; start at `1` for Apple Silicon (deeper values rarely amortize on Metal due to near-linear verify-pass scaling)
+- `mtp_sidecar_repo`
+  - Hugging Face repo ID containing the published `mtp.safetensors` sidecar (e.g. `"FoxlightAI/qwen3-5-7b-instruct-mtp-q4k"`); produced by SWP from the original BF16 checkpoint
+
+## MTP Speculative Decoding
+
+Some models include native multi-token prediction (MTP) heads baked into their checkpoint weights. Skulk uses these heads for speculative decoding: the MTP heads draft candidate tokens cheaply, a full forward pass verifies them, and accepted tokens are emitted in bulk — substantially increasing throughput with no accuracy loss.
+
+### Why a sidecar
+
+Standard quantization pipelines — including mlx-lm's `sanitize()` — strip `mtp.*` tensor keys at conversion time. The MLX-quantized checkpoint you download from Hugging Face typically does not contain MTP weights.
+
+SWP (Skulk Weights Publisher) solves this by re-extracting the `mtp.*` tensors from the original BF16 checkpoint, quantizing only those tensors, and publishing the result as `mtp.safetensors` to a dedicated sidecar repo on Hugging Face. This is the same pattern Skulk uses for vision encoder weights.
+
+### How it works
+
+When a model card declares `mtp_heads = true` and `mtp_sidecar_repo`, Skulk:
+
+1. Downloads `mtp.safetensors` from the sidecar repo alongside the base model weights.
+2. Loads the sidecar at model load time and makes the weights available to the runner.
+3. Uses the MTP heads during generation for speculative decoding (requires runner support — see issue #152).
+
+If the sidecar is declared but the file is not found locally, Skulk logs a warning and continues with standard autoregressive generation.
+
+### Models with native MTP heads
+
+- Qwen3.5 variants (7B, 14B, 32B, 72B)
+- Qwen3.6 variants
+- DeepSeek V3 / R1
+
+Gemma 4 does **not** use native MTP heads — it uses an external drafter model for speculative decoding, which is a separate feature.
+
+### Adding MTP to a card
+
+```toml
+[runtime]
+mtp_heads = true
+mtp_max_depth = 1
+mtp_sidecar_repo = "FoxlightAI/qwen3-5-7b-instruct-mtp-q4k"
+```
+
+The sidecar repo must be published by SWP before adding these fields. See the [SWP documentation](https://foxlight-foundation.github.io/skulk-weights-publisher/) for how sidecars are produced and published.
 
 ## Declarative vs Resolved
 


### PR DESCRIPTION
## Summary

Prerequisite plumbing for native MTP speculative decoding (closes #177). The draft/verify loop itself is #152 — this PR gets the weights loaded and wired through to the generator so #152 has something to work with.

- `RuntimeCapabilityCardConfig` gains `mtp_heads`, `mtp_max_depth`, and `mtp_sidecar_repo` fields
- `ResumableShardDownloader.ensure_shard` downloads `mtp.safetensors` from the declared sidecar repo, mirroring the existing vision sidecar pattern; skipped in offline and config-only mode
- `load_mlx_items` loads the sidecar at model load time, warns gracefully when declared but not found, and returns it as the 4th tuple element
- `Builder`, `SequentialGenerator`, and `BatchGenerator` carry `mtp_weights: dict[str, mx.array] | None` through the load pipeline — unused until #152
- `model-cards.md` documents the three new `[runtime]` fields, which models have native MTP heads, and the sidecar pattern

No user-visible behavior changes. Existing behaviour is unchanged when `mtp_heads` is absent or false.

## Test plan

- [x] 4 new tests in `test_mtp_sidecar_download.py`: sidecar downloaded when configured, skipped when not configured, skipped in offline mode, skipped in config-only mode
- [x] `test_event_ordering.py` mock updated to 4-tuple — all existing runner tests pass
- [x] 243 unit tests pass, 0 failures
- [x] `basedpyright` clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)