### PR TITLE
chore(deps): move mlx-lm fork to Foxlight-owned custody copy

### DIFF
--- a/docs/gemma4-assistant-plan.md
+++ b/docs/gemma4-assistant-plan.md
@@ -157,13 +157,15 @@ integrate**, not **implement**.
 ### Phase B — Adopt the upstream drafter via the mlx-vlm 0.5.0 bump (~1 day)
 
 > **Decision (current, matches [`gemma4-mtp-initiative.md`](./gemma4-mtp-initiative.md)
-> §decision-log): bump mlx-vlm to 0.5.0, do NOT vendor.** The §6a audit first
-> concluded "vendor" because the bump looked blocked by the mlx-lm fork stuck at
-> 0.31.2. That blocker is removed by *owning and reconciling* the fork onto
-> upstream ≥0.31.3 (initiative critical-path step 2). With that done, mlx-vlm
-> 0.5.0 installs cleanly and the drafter arrives as a **maintained dependency**
-> (plus APC / continuous-batching / dflash). Vendoring is retained below only as
-> the fallback if the bump proves problematic.
+> §decision-log): bump mlx-vlm to 0.5.0, do NOT vendor.** Reaching the bump
+> requires the **full version ladder** (§6a), not the fork alone: reconciling the
+> mlx-lm fork onto ≥0.31.3 is *necessary but not sufficient* — the bump also needs
+> `mlx` 0.31.1→0.31.2, the `transformers<5.4.0` cap lifted past 5.5, and the new
+> `llguidance` / `mlx-audio` deps. The fork was the gating blocker (it can't be
+> dropped); once the whole ladder lands, mlx-vlm 0.5.0 installs cleanly and the
+> drafter arrives as a **maintained dependency** (plus APC / continuous-batching /
+> dflash). Vendoring is retained below only as the fallback if the bump proves
+> problematic.
 
 **Preferred path — bump:** after the fork is reconciled (step 2) and the version
 ladder lands (step 3), mlx-vlm 0.5.0 brings
@@ -179,22 +181,28 @@ ladder lands (step 3), mlx-vlm 0.5.0 brings
   `from ....models.gemma4.language import DecoderLayer`) at Skulk's installed
   `mlx_vlm.models.gemma4` — confirmed present and structurally compatible (§6a).
 
-### Phase 6a — Dependency / vendoring audit (COMPLETE)
+### Phase 6a — Dependency audit (COMPLETE)
 
-**A straight bump to mlx-vlm 0.5.0 is blocked:**
+**The mlx-vlm 0.5.0 bump requires a version ladder — fork reconcile is necessary
+but not sufficient.** All of the following must land together; the fork is the
+gating item because it can't be dropped (it carries fixes not upstream):
 
-| Constraint | Skulk pins | 0.5.0 requires | Result |
+| Constraint | Skulk pins | 0.5.0 requires | Action |
 | ---------- | ---------- | -------------- | ------ |
-| `transformers` | `>=5.0.0,<5.4.0` | `>=5.5.0` | ❌ unsatisfiable |
-| `mlx` (darwin) | `==0.31.1` | `>=0.31.2` | ❌ conflict |
-| new deps | — | `llguidance`, `mlx-audio` | added surface |
-| gemma4 vision | Skulk's `_Gemma4DynamicVisionTower` wraps mlx-vlm vision internals | extensively changed in 0.5.0 | ❌ wrapper could break |
+| `mlx-lm` (fork) | fork @ d36e9b6 (0.31.2) | `>=0.31.3` | reconcile fork onto ≥0.31.3 (gating; step 2) |
+| `transformers` | `>=5.0.0,<5.4.0` | `>=5.5.0` | lift cap (audited safe — Skulk uses only stable `Auto*.from_pretrained`) |
+| `mlx` (darwin) | `==0.31.1` | `>=0.31.2` | bump one patch; re-verify macOS-26 Metal build |
+| new deps | — | `llguidance`, `mlx-audio` | accept (added surface) |
 
-So bumping would force a transformers + mlx upgrade and risk Skulk's existing
-Gemma 4 *vision* wrapper — high cost for unrelated reasons.
+**Gemma 4 vision wrapper — audited, NOT a blocker.** An earlier draft worried
+that Skulk's `_Gemma4DynamicVisionTower` (which wraps mlx-vlm's gemma4 vision
+internals) might break on 0.5.0. The audit resolved this: every attribute the
+wrapper touches — `patch_embedder`, `encoder`, `pooler`, `std_bias`, `std_scale`,
+and the call signatures — is unchanged between 0.4.4 and 0.5.0. The wrapper needs
+no changes. (This matches the initiative tracker's decision log.)
 
-**The drafter, by contrast, vendors cleanly.** Verified imports of the
-`gemma4_assistant` drafter (v0.5.0):
+**If the bump is undesirable, the drafter vendors cleanly** (the fallback path
+in Phase B). Verified imports of the `gemma4_assistant` drafter (v0.5.0):
 
 - `gemma4_assistant.py`: `mlx.core`, `mlx.nn`, `mlx.nn.RMSNorm`,
   `.config`, `.masked_embedder`, `.masks`, and
@@ -244,9 +252,12 @@ match makes this low-probability.
 ## 7. Risks / open questions
 
 - ~~mlx-vlm 0.5.0 bump blast radius.~~ RESOLVED — audit complete (§6a). The
-  bump's only real blocker was the mlx-lm fork pinned at 0.31.2; **owning and
-  reconciling that fork onto ≥0.31.3 (critical-path step 2) unblocks the bump**,
-  which is the chosen path. Vendoring is the documented fallback only.
+  mlx-lm fork (pinned at 0.31.2) was the **gating** blocker, but unblocking the
+  bump also requires the rest of the version ladder: `mlx` 0.31.2, the
+  `transformers` cap lifted past 5.5, and the new `llguidance` / `mlx-audio`
+  deps. Reconciling the fork is necessary but not sufficient. The gemma4 vision
+  wrapper was audited as safe (unchanged in 0.5.0). Vendoring is the documented
+  fallback only.
 - **KV-cache exposure refactor** is the riskiest change — it touches the hot
   generation loop. Gate it behind the existing MTP single-node guard so the
   default path is untouched.

--- a/docs/gemma4-assistant-plan.md
+++ b/docs/gemma4-assistant-plan.md
@@ -1,0 +1,293 @@
+# Plan: Gemma 4 Assistant (Speculative Decoding) Support in Skulk
+
+> Status: PROPOSED — research complete, no code written yet.
+> Companion work in SWP (catalog + GUI) is already merged on `feature/ui-v1`.
+> Last updated after confirming upstream mlx-vlm already implements the drafter.
+
+---
+
+## 1. Context
+
+Gemma 4 uses a fundamentally different speculative-decoding mechanism than the
+Qwen3 / DeepSeek models Skulk supports today. Those embed projection-only
+`mtp.*` heads inside the checkpoint; SWP extracts them to an `mtp.safetensors`
+sidecar and Skulk's `MTPHead` (Phase 1) consumes them.
+
+Gemma 4 instead pairs each model with a **separate 4-layer transformer drafter**,
+published by Google as `{model}-assistant`. It is NOT a projection head, so
+Skulk's existing Phase-1 MTP path cannot consume it directly.
+
+---
+
+## 2. The assistant models (verified on HF)
+
+All four exist, each a single `model.safetensors` + `config.json`,
+`model_type: gemma4_assistant`, `dtype: bfloat16`:
+
+| Target (bf16)                          | Assistant (bf16)                                | LM head           |
+| -------------------------------------- | ----------------------------------------------- | ----------------- |
+| `mlx-community/gemma-4-E2B-it-bf16`     | `mlx-community/gemma-4-E2B-it-assistant-bf16`     | centroid (sparse) |
+| `mlx-community/gemma-4-E4B-it-bf16`     | `mlx-community/gemma-4-E4B-it-assistant-bf16`     | centroid (sparse) |
+| `mlx-community/gemma-4-26B-A4B-it-bf16` | `mlx-community/gemma-4-26B-A4B-it-assistant-bf16` | tied dense        |
+| `mlx-community/gemma-4-31B-it-bf16`     | `mlx-community/gemma-4-31B-it-assistant-bf16`     | tied dense        |
+
+(Google's originals live at `google/gemma-4-*-it-assistant`; the
+`mlx-community/*-bf16` conversions are the MLX-ready ones.)
+
+### Architecture (from the real `config.json`)
+
+- `architectures: ["Gemma4AssistantForCausalLM"]`, `dtype: bfloat16`
+- `backbone_hidden_size: 2816` (the target's hidden dim, consumed as input)
+- `text_config`: 4 layers, `hidden_size: 1024`,
+  `layer_types: [sliding, sliding, sliding, full]`,
+  `head_dim: 256` / `global_head_dim: 512`, `attention_k_eq_v: true`
+- **`num_kv_shared_layers: 4` over 4 layers** — every layer is KV-shared. The
+  drafter computes NO K/V of its own; it attends over the *target model's* KV
+  cache (last full-attention layer + last sliding-attention layer). Its only
+  recurrent state is the target's last hidden, projected via `post_projection`.
+- Drafter input each step:
+  `concat([target_embed(last_token), last_hidden], dim=-1)` shape
+  `[B, 1, 2 * backbone_hidden_size]`, projected to drafter hidden by
+  `pre_projection`.
+- Queries RoPE-rotated at the bonus token's absolute position, held constant
+  across draft steps within a block.
+- E2B/E4B use a **centroid-routed sparse softmax** LM head: score 2048 clusters,
+  materialise top-K (32) clusters (~4096 of 262144 tokens), scatter back into a
+  full-vocab tensor. 26B/31B use a tied dense head.
+
+---
+
+## 3. KEY FINDING — upstream mlx-vlm already implements this
+
+`Blaizzy/mlx-vlm` **v0.5.0** (released 2026-05-06) ships a complete, tested MLX
+port of the Gemma 4 assistant drafter under `mlx_vlm/speculative/`:
+
+```
+mlx_vlm/speculative/
+├── common.py              # shared draft/verify utilities
+├── dflash.py
+├── ddtree.py
+├── eagle3.py              # (also has EAGLE3 drafters)
+├── mtp.py
+├── utils.py
+└── drafters/
+    ├── __init__.py        # load_drafter(), auto-discovery by model_type
+    ├── eagle3/
+    ├── qwen3_5_mtp/
+    └── gemma4_assistant/
+        ├── config.py            # Gemma4AssistantConfig (HF-compatible)
+        ├── gemma4_assistant.py  # Gemma4AssistantDraftModel:
+        │                        #   forward, bind, set_shared_kv,
+        │                        #   draft_block, sanitize
+        ├── masked_embedder.py   # centroid sparse LM head (E2B/E4B)
+        ├── masks.py             # bidirectional full/SWA masks
+        └── parity_check.py      # fake-target smoke test
+```
+
+- Auto-discovered by `model_type == "gemma4_assistant"`.
+- Reference CLI:
+  `python -m mlx_vlm.generate --model <target-bf16> --draft-model <assistant-bf16>
+   --draft-kind mtp --draft-block-size 4 --temp 0`.
+- `--draft-block-size` = `num_assistant_tokens` (first token is the accepted
+  bonus, so it drafts `block_size - 1` candidates/round).
+- Claims byte-identical greedy output vs the target at temp 0.
+
+**Skulk is pinned to `mlx-vlm==0.4.4`** (`pyproject.toml`), whose installed wheel
+has no `speculative/` module. So the drafter code exists upstream but is not yet
+available to Skulk.
+
+This collapses the original "Phase B greenfield drafter" risk: the hard math
+(KV-shared attention, sparse centroid head, masks, RoPE-at-bonus-position) is
+already written and parity-checked upstream. The Skulk job becomes **adopt +
+integrate**, not **implement**.
+
+---
+
+## 4. Skulk today — what exists to build on
+
+(Exact paths from codebase exploration.)
+
+- **MTP framework (projection-only, Phase 1):**
+  - `src/exo/worker/engines/mlx/mtp.py` — `MTPHead` (DeepSeek + Qwen3.5 layouts).
+  - `src/exo/worker/engines/mlx/generator/generate.py:1167`
+    `_stream_generate_with_mtp` — draft → batched verify → accept/reject →
+    cache-trim. Single-node, greedy (temp 0.0) only.
+  - `src/exo/worker/runner/llm_inference/runner.py:743` — `force_sequential_for_mtp`.
+- **Sidecar loading:** `src/exo/worker/engines/mlx/utils_mlx.py:694` — downloads
+  `mtp_sidecar_repo`, loads `mtp.safetensors` via `mx.load`.
+- **Model-card runtime config:** `src/exo/shared/models/model_cards.py:232`
+  `RuntimeCapabilityCardConfig` — `mtp_heads`, `mtp_sidecar_repo`, `mtp_max_depth`.
+- **Gemma 4 base inference (works):** loaded via mlx-vlm
+  (`utils_mlx.py:508 load_model`, mlx-vlm fallback). `mlx_vlm/models/gemma4/
+  language.py` already implements KV-shared attention (`is_kv_shared_layer`
+  reads `cache.state`), QK-norm, sliding/full layer types — the exact primitives
+  the drafter depends on.
+- **Gemma 4 detection:** `src/exo/shared/models/capabilities.py:82`
+  `is_gemma4_family`.
+- **No `gemma4_assistant`** in the installed mlx-vlm 0.4.4.
+
+---
+
+## 5. The gap, precisely
+
+1. **Get the upstream drafter into Skulk.** Either bump `mlx-vlm` 0.4.4 → 0.5.0,
+   or vendor `mlx_vlm/speculative/drafters/gemma4_assistant/` (+ its `masks.py`,
+   `masked_embedder.py`, `common.py` deps).
+2. **Drive the drafter from Skulk's own generation loop.** Skulk does NOT use
+   mlx-vlm's generate loop — it has its own distributed `generate.py` with the
+   Phase-1 accept/reject machinery. The drafter must be wired into that loop,
+   feeding it the target's per-layer KV cache + last hidden each step (the one
+   genuinely new data flow — today the cache only flows INTO the model).
+3. **Model-card + catalog field agreement.** Add `assistant_model_repo` to the
+   runtime config; SWP already emits `assistant_model_repo` on catalog entries.
+
+---
+
+## 6. Proposed approach
+
+### Phase A — Model-card + loader plumbing (low risk, ~0.5 day)
+- Add `assistant_model_repo: str | None` to `RuntimeCapabilityCardConfig`
+  (`model_cards.py`), mutually exclusive with `mtp_sidecar_repo`.
+- In `utils_mlx.py::load_mlx_items` (~694): when set, `build_model_path` +
+  download the assistant alongside the target, load it, keep the handle on the
+  bound instance next to the target model.
+- Author Gemma 4 model cards pointing at the `mlx-community/*-assistant-bf16`
+  repos. Reuse the SWP field name verbatim.
+
+### Phase B — Vendor the upstream drafter (DECIDED: vendor, not bump; ~1 day)
+
+**Decision: vendor, do not bump.** The 0.4.4→0.5.0 audit (see §6a) shows a
+straight bump is blocked by dependency conflicts, while the drafter itself is
+nearly self-contained and vendors cleanly.
+
+- Copy these 0.5.0 files into `src/exo/worker/engines/mlx/drafters/gemma4_assistant/`
+  with a provenance header (upstream path + commit/tag `v0.5.0`):
+  - `gemma4_assistant.py` — `Gemma4AssistantDraftModel`
+  - `config.py` — `Gemma4AssistantConfig`
+  - `masked_embedder.py` — sparse centroid head (E2B/E4B)
+  - `masks.py` — drafter masks
+  - `__init__.py`
+- Repoint the two relative imports
+  (`from ....models.gemma4.config import TextConfig`,
+  `from ....models.gemma4.language import DecoderLayer`) at Skulk's installed
+  `mlx_vlm.models.gemma4` (0.4.4) — confirmed present and structurally
+  compatible (see §6a).
+- Wrap behind a `Drafter` protocol with `draft_block(...)`, alongside the
+  existing `MTPHead`. The sparse centroid head (E2B/E4B) comes along for free.
+
+### Phase 6a — Dependency / vendoring audit (COMPLETE)
+
+**A straight bump to mlx-vlm 0.5.0 is blocked:**
+
+| Constraint | Skulk pins | 0.5.0 requires | Result |
+| ---------- | ---------- | -------------- | ------ |
+| `transformers` | `>=5.0.0,<5.4.0` | `>=5.5.0` | ❌ unsatisfiable |
+| `mlx` (darwin) | `==0.31.1` | `>=0.31.2` | ❌ conflict |
+| new deps | — | `llguidance`, `mlx-audio` | added surface |
+| gemma4 vision | Skulk's `_Gemma4DynamicVisionTower` wraps mlx-vlm vision internals | extensively changed in 0.5.0 | ❌ wrapper could break |
+
+So bumping would force a transformers + mlx upgrade and risk Skulk's existing
+Gemma 4 *vision* wrapper — high cost for unrelated reasons.
+
+**The drafter, by contrast, vendors cleanly.** Verified imports of the
+`gemma4_assistant` drafter (v0.5.0):
+
+- `gemma4_assistant.py`: `mlx.core`, `mlx.nn`, `mlx.nn.RMSNorm`,
+  `.config`, `.masked_embedder`, `.masks`, and
+  `....models.gemma4.config.TextConfig` + `....models.gemma4.language.DecoderLayer`
+- `config.py`: no imports (pure config)
+- `masked_embedder.py`: `mlx.core`, `mlx.nn`
+- `masks.py`: `mlx.core` + `mlx_lm.models.cache.dynamic_roll`
+
+Every external symbol is already available in Skulk's installed environment:
+- `mlx_lm.models.cache.dynamic_roll` — ✅ present (Skulk's mlx-lm 0.31.2).
+- `mlx_vlm.models.gemma4.config.TextConfig` + `.language.DecoderLayer` — ✅
+  present in installed 0.4.4, including the `is_kv_shared_layer` /
+  `num_kv_shared_layers` shared-KV machinery the drafter relies on; class layout
+  matches 0.5.0 closely (`DecoderLayer` ~line 244/246, `Attention` shared-KV
+  block near-identical).
+- No `transformers`, no `mlx-vlm` internals beyond `gemma4` config/layer, no new
+  third-party deps.
+
+**Residual verification (do during Phase B):** diff the 0.4.4 vs 0.5.0
+`gemma4/language.py` `DecoderLayer`/`Attention` bodies to confirm the drafter
+doesn't depend on a 0.5.0-only tweak. If a small delta exists, vendor the
+0.5.0 `DecoderLayer`/`TextConfig` too (still pure MLX, no dep changes). Structural
+match makes this low-probability.
+
+### Phase C — Generation integration (the real engineering, ~2 days)
+- Generalize `_stream_generate_with_mtp` into a drafter-agnostic loop: keep the
+  accept/reject + cache-trim machinery; swap the single `MTPHead.draft()` call
+  for the `Drafter` protocol (impls: `MTPHead`, `Gemma4AssistantDrafter`).
+- Implement the new data flow: expose the target's per-layer KV cache + the
+  chosen-layer hidden state to the drafter each step; call `set_shared_kv` /
+  `draft_block` per the upstream API.
+- Support block drafting (`draft_block_size > 1`) — upstream drafts several
+  tokens/round, vs Phase-1's D=1. Verify Skulk's batched-verify + cache-trim
+  handles a block, not just a single draft token.
+- Keep single-node + greedy (temp 0) for v1 — same envelope as Phase-1 MTP.
+
+### Phase D — Validation + docs (~1 day)
+- Unit tests mirroring `tests/test_mtp.py` for the drafter path (accept/reject,
+  block trim, bf16 dtype preservation, sparse-head argmax parity).
+- Port/adapt upstream `parity_check.py` as a smoke test.
+- End-to-end: `gemma-4-26B-A4B-it-bf16` + assistant, confirm greedy output is
+  identical to no-drafter and measure tokens/s speedup.
+- Update Skulk architecture docs + model-card reference with the assistant path.
+
+---
+
+## 7. Risks / open questions
+
+- ~~mlx-vlm 0.5.0 bump blast radius.~~ RESOLVED — audit complete (§6a). Bump is
+  blocked by transformers/mlx pin conflicts; **vendoring the drafter is the
+  chosen path** and is clean (only external dep is `dynamic_roll`, already
+  present).
+- **KV-cache exposure refactor** is the riskiest change — it touches the hot
+  generation loop. Gate it behind the existing MTP single-node guard so the
+  default path is untouched.
+- **Block drafting vs Phase-1 D=1.** Skulk's current verify/trim assumes one
+  draft token; the assistant drafts a block. Confirm the batched verify
+  generalizes.
+- **MoE target (`26B-A4B`)** KV-share layer indexing must line up with the MoE
+  layer layout, not just the dense `31B`. Validate both.
+- **Distributed/pipeline mode** stays out of scope for v1 (Phase-1 MTP is
+  single-node too).
+
+---
+
+## 8. Effort estimate (revised down after upstream finding)
+
+| Phase | Work | Est. |
+| ----- | ---- | ---- |
+| A | Model-card + loader plumbing | ~0.5 day |
+| B | Vendor drafter (audit done — clean) | ~1 day |
+| C | Generation-loop integration + KV exposure | ~2 days |
+| D | Tests + parity + docs | ~1 day |
+
+**Total ~4–5 days** for a single-node, greedy v1 (was ~1 week when Phase B was
+assumed greenfield). Phase C — exposing the target's KV cache to the drafter in
+Skulk's generation loop — is now unambiguously the critical path.
+
+---
+
+## 9. Recommendation
+
+1. Land **Phase A** first — cheap, unblocks model cards, makes SWP↔Skulk field
+   names agree.
+2. Before Phase B, **audit the mlx-vlm 0.4.4 → 0.5.0 delta** to choose bump vs
+   vendor. This is the single most important de-risking step.
+3. Phase C is the genuine engineering; everything the drafter needs
+   mathematically already exists upstream and is parity-checked, so the focus is
+   wiring it into Skulk's loop, not reimplementing model math.
+
+## 10. References
+
+- Upstream drafter: `Blaizzy/mlx-vlm` v0.5.0,
+  `mlx_vlm/speculative/drafters/gemma4_assistant/`.
+- Google docs: ai.google.dev/gemma/docs/mtp/mtp.
+- HF assistants: `google/gemma-4-{E2B,E4B,26B-A4B,31B}-it-assistant`;
+  MLX bf16: `mlx-community/gemma-4-*-it-assistant-bf16`.
+- Skulk integration points: see §4 for exact file:line anchors.
+- SWP companion work: `skulk-weights-publisher` `feature/ui-v1`
+  (`assistant_model_repo` catalog field + GUI "Register in Catalog").

--- a/docs/gemma4-assistant-plan.md
+++ b/docs/gemma4-assistant-plan.md
@@ -154,26 +154,30 @@ integrate**, not **implement**.
 - Author Gemma 4 model cards pointing at the `mlx-community/*-assistant-bf16`
   repos. Reuse the SWP field name verbatim.
 
-### Phase B — Vendor the upstream drafter (DECIDED: vendor, not bump; ~1 day)
+### Phase B — Adopt the upstream drafter via the mlx-vlm 0.5.0 bump (~1 day)
 
-**Decision: vendor, do not bump.** The 0.4.4→0.5.0 audit (see §6a) shows a
-straight bump is blocked by dependency conflicts, while the drafter itself is
-nearly self-contained and vendors cleanly.
+> **Decision (current, matches [`gemma4-mtp-initiative.md`](./gemma4-mtp-initiative.md)
+> §decision-log): bump mlx-vlm to 0.5.0, do NOT vendor.** The §6a audit first
+> concluded "vendor" because the bump looked blocked by the mlx-lm fork stuck at
+> 0.31.2. That blocker is removed by *owning and reconciling* the fork onto
+> upstream ≥0.31.3 (initiative critical-path step 2). With that done, mlx-vlm
+> 0.5.0 installs cleanly and the drafter arrives as a **maintained dependency**
+> (plus APC / continuous-batching / dflash). Vendoring is retained below only as
+> the fallback if the bump proves problematic.
 
+**Preferred path — bump:** after the fork is reconciled (step 2) and the version
+ladder lands (step 3), mlx-vlm 0.5.0 brings
+`mlx_vlm/speculative/drafters/gemma4_assistant/` directly. Wrap it behind a
+`Drafter` protocol with `draft_block(...)`, alongside the existing `MTPHead`.
+
+**Fallback path — vendor** (only if the bump is blocked for unforeseen reasons):
 - Copy these 0.5.0 files into `src/exo/worker/engines/mlx/drafters/gemma4_assistant/`
   with a provenance header (upstream path + commit/tag `v0.5.0`):
-  - `gemma4_assistant.py` — `Gemma4AssistantDraftModel`
-  - `config.py` — `Gemma4AssistantConfig`
-  - `masked_embedder.py` — sparse centroid head (E2B/E4B)
-  - `masks.py` — drafter masks
-  - `__init__.py`
+  `gemma4_assistant.py`, `config.py`, `masked_embedder.py`, `masks.py`, `__init__.py`.
 - Repoint the two relative imports
   (`from ....models.gemma4.config import TextConfig`,
   `from ....models.gemma4.language import DecoderLayer`) at Skulk's installed
-  `mlx_vlm.models.gemma4` (0.4.4) — confirmed present and structurally
-  compatible (see §6a).
-- Wrap behind a `Drafter` protocol with `draft_block(...)`, alongside the
-  existing `MTPHead`. The sparse centroid head (E2B/E4B) comes along for free.
+  `mlx_vlm.models.gemma4` — confirmed present and structurally compatible (§6a).
 
 ### Phase 6a — Dependency / vendoring audit (COMPLETE)
 
@@ -239,10 +243,10 @@ match makes this low-probability.
 
 ## 7. Risks / open questions
 
-- ~~mlx-vlm 0.5.0 bump blast radius.~~ RESOLVED — audit complete (§6a). Bump is
-  blocked by transformers/mlx pin conflicts; **vendoring the drafter is the
-  chosen path** and is clean (only external dep is `dynamic_roll`, already
-  present).
+- ~~mlx-vlm 0.5.0 bump blast radius.~~ RESOLVED — audit complete (§6a). The
+  bump's only real blocker was the mlx-lm fork pinned at 0.31.2; **owning and
+  reconciling that fork onto ≥0.31.3 (critical-path step 2) unblocks the bump**,
+  which is the chosen path. Vendoring is the documented fallback only.
 - **KV-cache exposure refactor** is the riskiest change — it touches the hot
   generation loop. Gate it behind the existing MTP single-node guard so the
   default path is untouched.
@@ -261,7 +265,7 @@ match makes this low-probability.
 | Phase | Work | Est. |
 | ----- | ---- | ---- |
 | A | Model-card + loader plumbing | ~0.5 day |
-| B | Vendor drafter (audit done — clean) | ~1 day |
+| B | Adopt drafter via mlx-vlm 0.5.0 bump (fork reconciled first) | ~1 day |
 | C | Generation-loop integration + KV exposure | ~2 days |
 | D | Tests + parity + docs | ~1 day |
 
@@ -275,8 +279,9 @@ Skulk's generation loop — is now unambiguously the critical path.
 
 1. Land **Phase A** first — cheap, unblocks model cards, makes SWP↔Skulk field
    names agree.
-2. Before Phase B, **audit the mlx-vlm 0.4.4 → 0.5.0 delta** to choose bump vs
-   vendor. This is the single most important de-risking step.
+2. **Reconcile the mlx-lm fork onto ≥0.31.3** (critical-path step 2) — this is
+   what unblocks the mlx-vlm 0.5.0 bump that delivers the drafter. The audit
+   (§6a) confirmed the bump is otherwise clean. Vendoring stays as fallback only.
 3. Phase C is the genuine engineering; everything the drafter needs
    mathematically already exists upstream and is parity-checked, so the focus is
    wiring it into Skulk's loop, not reimplementing model math.

--- a/docs/gemma4-mtp-initiative.md
+++ b/docs/gemma4-mtp-initiative.md
@@ -1,0 +1,130 @@
+# Initiative: Gemma 4 MTP Speculative Decoding
+
+> **Master tracker.** Source of truth for the whole effort across SWP + Skulk +
+> the mlx-lm fork. Start here to re-orient. Implementation detail lives in
+> [`gemma4-assistant-plan.md`](./gemma4-assistant-plan.md).
+> Last updated: 2026-05-31.
+
+---
+
+## North star
+
+A user points Skulk at a Gemma 4 model and gets **speculative decoding via the
+Gemma 4 assistant drafter** — faster tokens, identical greedy output. SWP
+catalogs the pairing; Skulk consumes it.
+
+---
+
+## Why this is non-trivial (the one-paragraph briefing)
+
+Gemma 4 does MTP differently from Qwen3/DeepSeek. Those embed `mtp.*` heads in
+the checkpoint (Skulk's existing Phase-1 MTP handles them). Gemma 4 ships a
+**separate 4-layer assistant model** that attends over the *target's* KV cache.
+The drafter already exists, maintained, in **mlx-vlm 0.5.0** — so the clean path
+is to bump to it. But Skulk pins **mlx-vlm 0.4.4**, and bumping is gated by a
+**custom mlx-lm fork** that carries fixes we can't lose. Untangling that fork —
+owning it, then reconciling it onto a newer base — is the critical path.
+
+---
+
+## Status dashboard
+
+| Workstream | State | Notes |
+|---|---|---|
+| **SWP — catalog + GUI** | ✅ DONE | `assistant_model_repo` detection, GUI "Register in Catalog", docs. Branch `feature/ui-v1`. 119 py + 45 ui tests green. |
+| **mlx-lm fork — custody** | ✅ DONE | Owned at `Foxlight-Foundation/mlx-lm`, pinned by rev `d36e9b6`. Branch `chore/mlx-lm-custody-foxlight` (committed, not pushed). |
+| **mlx-lm fork — reconcile onto ≥0.31.3** | ⬜ NEXT | Forward-port the fixes; functionally verify each survives. |
+| **Version ladder (mlx, mlx-vlm, transformers)** | ⬜ TODO | Bump mlx 0.31.1→0.31.2, mlx-vlm 0.4.4→0.5.0, lift transformers cap. |
+| **Skulk — consume the drafter** | ⬜ TODO | Model-card `assistant_model_repo`, loader, wire drafter into the generation loop (expose target KV cache). |
+| **Validate end-to-end** | ⬜ TODO | Greedy parity + speedup on gemma-4-26B-A4B + assistant. |
+
+---
+
+## Decision log (with rationale)
+
+1. **Bump mlx-vlm, don't vendor the drafter.** The drafter is maintained upstream
+   in mlx-vlm 0.5.0; vendoring means owning code that drifts. Bumping gets it as a
+   maintained dep + APC/continuous-batching/dflash for free. *(Earlier I leaned
+   vendor based on overstated blockers — corrected after the dependency audit.)*
+
+2. **The transformers `<5.4.0` cap is soft.** Undocumented snapshot; mlx-vlm 0.4.4
+   itself only needs ≥5.1.0; Skulk uses only stable `Auto*.from_pretrained` APIs;
+   no 5.4→5.9 breaking change touches them. Liftable with a 3-area test.
+
+3. **The mlx-vlm 0.5.0 bump does NOT break Skulk's Gemma 4 vision wrapper.**
+   Audited — every internal `_Gemma4DynamicVisionTower` touches is unchanged in
+   0.5.0. (I had flagged this as a risk; it isn't.)
+
+4. **The real gate is the mlx-lm fork**, stuck at version 0.31.2 < the 0.31.3
+   mlx-vlm 0.5.0 requires — and it can't be dropped (carries non-upstream fixes
+   Skulk depends on).
+
+5. **Own the fork; do not upstream.** (Per Tupp: upstreaming isn't viable; reconcile
+   our own fork instead.) Forked `ml-explore/mlx-lm` → `Foxlight-Foundation/mlx-lm`
+   (upstream lineage preserved), snapshotted the consumed commits in.
+
+6. **Custody-first, by exact rev, before any version move.** Pin the precise
+   consumed commit `d36e9b6` (not the branch — its tip moved on and needs a newer
+   mlx). Pure ownership change, zero behavior delta. Reconciliation is a separate,
+   tested step. This is the "don't lose the fixes / don't regress" discipline.
+
+7. **EXO does not depend on this fork.** Upstream EXO uses stock `mlx-lm` (it forks
+   *core mlx* instead, which Skulk deliberately does not use). So owning/reconciling
+   our mlx-lm fork won't desync from EXO.
+
+---
+
+## The fixes we must never lose (carried in `d36e9b6`)
+
+Verified present in `Foxlight-Foundation/mlx-lm`:
+- **float32 logprobs** — cast before log_softmax; without it logprobs quantize and
+  break sampling parity (Skulk exposes `top_logprobs`).
+- **DeepSeek-V3.2 lightning-indexer batch fix** — masks padded positions; without
+  it batched DSV3.2 attention corrupts.
+- **ArraysCache leak fix** — `mx.depends(...)` keeps Metal caches in-graph; without
+  it GPU memory leaks on long runs.
+- **GDN precision**, **left_padding eval** — supporting precision/correctness.
+
+Each must be **functionally** re-verified (the actual call survives, not just a
+clean merge) when reconciling onto a newer base.
+
+---
+
+## Critical path (ordered)
+
+- [x] **0. SWP catalog/GUI support** — done (`feature/ui-v1`).
+- [x] **1. Own the mlx-lm fork (custody, rev-pinned)** — done
+      (`chore/mlx-lm-custody-foxlight`, `Foxlight-Foundation/mlx-lm`).
+- [ ] **2. Reconcile the fork onto upstream ≥0.31.3** — cherry-pick/forward-port
+      the fixes; functionally verify each; bump fork `_version.py` past 0.31.3.
+- [ ] **3. Version ladder** — mlx 0.31.1→0.31.2 (re-verify macOS-26 Metal build),
+      lift transformers cap, mlx-vlm 0.4.4→0.5.0; `uv lock`; smoke-test.
+- [ ] **4. Skulk consumes the drafter** — model-card `assistant_model_repo`,
+      loader plumbing, wire `Gemma4AssistantDraftModel` into the generation loop
+      (expose target per-layer KV cache + last hidden each step).
+- [ ] **5. Validate** — greedy parity vs no-drafter + tokens/s speedup on
+      gemma-4-26B-A4B-it + its assistant.
+
+---
+
+## Key references
+
+- **Fork (ours):** `github.com/Foxlight-Foundation/mlx-lm` — branch
+  `foxlight/fix-arrayscache-leak`, tag `foxlight-consumed-d36e9b6`, consumed rev
+  `d36e9b661e55a5fc0f77fb6f17ea643aa2dc87aa`.
+- **Upstream drafter:** `Blaizzy/mlx-vlm` v0.5.0,
+  `mlx_vlm/speculative/drafters/gemma4_assistant/`.
+- **Assistant weights:** `mlx-community/gemma-4-{E2B,E4B,26B-A4B,31B}-it-assistant-bf16`.
+- **SWP companion:** `skulk-weights-publisher` `feature/ui-v1` (`assistant_model_repo`).
+- **Skulk integration anchors + architecture detail:** `gemma4-assistant-plan.md`.
+
+---
+
+## Open questions
+
+- Reconcile base: upstream `0.31.3` tag vs current `main` (further ahead). Pick the
+  lowest base that satisfies mlx-vlm 0.5.0 and still builds with our target mlx.
+- Does mlx 0.31.2 build on macOS 26 Metal SDK under our setup? (mlx-lm fork patches
+  touch Metal kernel paths — re-verify.)
+- Block drafting (`draft_block_size > 1`) vs Skulk's current D=1 verify/trim — does
+  the existing accept/reject machinery generalize to a block?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,15 @@ exo_pyo3_bindings = { workspace = true }
 # build on macOS 26 Metal SDK. The fork's only change is a DSB memory barrier for
 # Thunderbolt RDMA GPU coherence, which we don't need (exo uses libp2p, not RDMA).
 # mlx = { git = "https://github.com/rltakashige/mlx-jaccl-fix-small-recv.git", branch = "address-rdma-gpu-locks", marker = "sys_platform == 'darwin'" }
-mlx-lm = { git = "https://github.com/rltakashige/mlx-lm", branch = "leo/fix-arrayscache-leak" }
+# Foxlight-owned custody copy of rltakashige/mlx-lm @ leo/fix-arrayscache-leak.
+# Pinned by exact rev to the commit Skulk has always consumed (d36e9b6) — a
+# byte-identical, behavior-frozen custody cutover (tag: foxlight-consumed-d36e9b6).
+# Carries fixes not in upstream mlx-lm: float32 logprobs, DeepSeek-V3.2
+# lightning-indexer batch fix, ArraysCache leak, GDN precision, left_padding eval.
+# NOTE: the branch tip moved past this commit and requires a newer mlx than our
+# pinned 0.31.1 — do NOT track the branch. Reconcile onto upstream >=0.31.3 as a
+# separate, tested step before bumping mlx / mlx-vlm. See docs/gemma4-assistant-plan.md.
+mlx-lm = { git = "https://github.com/Foxlight-Foundation/mlx-lm", rev = "d36e9b661e55a5fc0f77fb6f17ea643aa2dc87aa" }
 # Uncomment to use local mlx/mlx-lm development versions:
 # mlx = { path = "/Users/Shared/mlx", editable=true }
 # mlx-lm = { path = "/Users/Shared/mlx-lm", editable=true }

--- a/uv.lock
+++ b/uv.lock
@@ -612,7 +612,7 @@ requires-dist = [
     { name = "mflux", specifier = ">=0.16.9" },
     { name = "mlx", marker = "sys_platform == 'darwin'", specifier = "==0.31.1" },
     { name = "mlx", extras = ["cpu"], marker = "sys_platform == 'linux'", specifier = "==0.30.6" },
-    { name = "mlx-lm", git = "https://github.com/rltakashige/mlx-lm?branch=leo%2Ffix-arrayscache-leak" },
+    { name = "mlx-lm", git = "https://github.com/Foxlight-Foundation/mlx-lm?rev=d36e9b661e55a5fc0f77fb6f17ea643aa2dc87aa" },
     { name = "mlx-optiq", extras = ["convert"], marker = "sys_platform == 'darwin'" },
     { name = "mlx-vlm", specifier = "==0.4.4" },
     { name = "msgspec", specifier = ">=0.19.0" },
@@ -1555,7 +1555,7 @@ wheels = [
 [[package]]
 name = "mlx-lm"
 version = "0.31.2"
-source = { git = "https://github.com/rltakashige/mlx-lm?branch=leo%2Ffix-arrayscache-leak#d36e9b661e55a5fc0f77fb6f17ea643aa2dc87aa" }
+source = { git = "https://github.com/Foxlight-Foundation/mlx-lm?rev=d36e9b661e55a5fc0f77fb6f17ea643aa2dc87aa#d36e9b661e55a5fc0f77fb6f17ea643aa2dc87aa" }
 dependencies = [
     { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mlx", version = "0.31.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },


### PR DESCRIPTION
## What

Repoint `mlx-lm` from the third-party fork `rltakashige/mlx-lm` to our own **`Foxlight-Foundation/mlx-lm`**, pinned by exact rev (`d36e9b6`) to the commit Skulk has always consumed. Byte-identical, behavior-frozen — no other dependency moves.

Also adds two docs: a master initiative tracker and the implementation plan for Gemma 4 MTP.

## Why

The dependency previously hung on a stranger's personal branch (could be force-pushed or deleted). The consumed commit carries fixes **not in upstream mlx-lm** that we cannot lose:
- float32 logprobs (sampling parity)
- DeepSeek-V3.2 lightning-indexer batch fix
- ArraysCache leak fix
- GDN precision, left_padding eval

Owning the fork preserves them and is the prerequisite for later reconciling onto upstream ≥0.31.3 (needed for mlx-vlm 0.5.0 + Gemma 4 MTP) without dropping the fixes.

## Safety

- Pinned **by rev, not branch**: the upstream branch tip moved past `d36e9b6` and now needs a newer mlx than our pinned `0.31.1` — tracking the branch would break resolution. Exact commit tagged `foxlight-consumed-d36e9b6`.
- `uv lock` re-resolves to the identical SHA; `mlx`/`mlx-vlm`/`transformers` unchanged.
- `uv sync` + `import mlx_lm` verified.

## Not in scope (tracked in docs/gemma4-mtp-initiative.md)

Reconciling the fork onto ≥0.31.3, the version ladder, and Skulk's drafter consumption are separate, tested steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)