### PR TITLE
feat(gemma4-mtp): Phase A — declare + pre-download the Gemma 4 assistant model

### DIFF
--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
@@ -25,6 +25,10 @@ tool_call_format = "gemma4"
 [runtime]
 prompt_renderer = "gemma4"
 output_parser = "gemma4"
+# Companion drafter for speculative decoding (Gemma 4 assistant pattern).
+# Pre-downloaded with the model; consumed once the gemma4_assistant
+# drafter (mlx-vlm >= 0.5.0) is wired in (Phase C).
+assistant_model_repo = "mlx-community/gemma-4-26B-A4B-it-assistant-bf16"
 # MLX_METAL_FAST_SYNCH wedges the GPU command queue on this model under the
 # ring backend with multimodal load: the runner thread enters TH_UNINT in
 # the AGX driver at pipeline_last_eval_output, transitively starves

--- a/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
@@ -24,6 +24,10 @@ tool_call_format = "gemma4"
 [runtime]
 prompt_renderer = "gemma4"
 output_parser = "gemma4"
+# Companion drafter for speculative decoding (Gemma 4 assistant pattern).
+# Pre-downloaded with the model; consumed once the gemma4_assistant
+# drafter (mlx-vlm >= 0.5.0) is wired in (Phase C).
+assistant_model_repo = "mlx-community/gemma-4-E4B-it-assistant-bf16"
 # Same FAST_SYNCH wedge as the 26b card — GPU command queue stalls in the
 # pipeline-parallel inference path, kernel watchdog panics the box. Disable
 # until the upstream MLX issue is fixed or a cheap inference-side fence

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -187,6 +187,39 @@ class ResumableShardDownloader(ShardDownloader):
                 skip_internet=self.offline,
             )
 
+        if (
+            not config_only
+            and not self.offline
+            and shard.model_card.runtime
+            and shard.model_card.runtime.assistant_model_repo
+        ):
+            assistant_repo = shard.model_card.runtime.assistant_model_repo
+            assistant_card = ModelCard(
+                model_id=ModelId(assistant_repo),
+                storage_size=Memory.from_bytes(0),
+                n_layers=1,
+                hidden_size=1,
+                supports_tensor=False,
+                tasks=[ModelTask.TextGeneration],
+            )
+            assistant_shard = PipelineShardMetadata(
+                model_card=assistant_card,
+                device_rank=0,
+                world_size=1,
+                start_layer=0,
+                end_layer=1,
+                n_layers=1,
+            )
+            # The assistant is a small full model (config + a single
+            # safetensors), so pull the weights and config alongside the target.
+            await download_shard(
+                assistant_shard,
+                self.on_progress_wrapper,
+                max_parallel_downloads=self.max_parallel_downloads,
+                allow_patterns=["*.safetensors", "config.json"],
+                skip_internet=self.offline,
+            )
+
         return target_dir
 
     async def get_shard_download_status(

--- a/src/exo/download/tests/test_assistant_model_download.py
+++ b/src/exo/download/tests/test_assistant_model_download.py
@@ -1,0 +1,130 @@
+"""Tests for Gemma 4 assistant-model download in ResumableShardDownloader."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from exo.download.impl_shard_downloader import ResumableShardDownloader
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelTask,
+    RuntimeCapabilityCardConfig,
+)
+from exo.shared.types.common import ModelId
+from exo.shared.types.memory import Memory
+from exo.shared.types.worker.shards import PipelineShardMetadata
+
+
+def _make_card(*, assistant_model_repo: str | None = None) -> ModelCard:
+    runtime = (
+        RuntimeCapabilityCardConfig(assistant_model_repo=assistant_model_repo)
+        if assistant_model_repo is not None
+        else None
+    )
+    return ModelCard(
+        model_id=ModelId("test-org/test-model"),
+        storage_size=Memory.from_bytes(0),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        runtime=runtime,
+    )
+
+
+def _make_shard(card: ModelCard) -> PipelineShardMetadata:
+    return PipelineShardMetadata(
+        model_card=card,
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=1,
+        n_layers=1,
+    )
+
+
+@pytest.fixture
+def downloader() -> ResumableShardDownloader:
+    return ResumableShardDownloader(max_parallel_downloads=4, offline=False)
+
+
+def _capture():
+    calls: list[dict[str, Any]] = []
+
+    async def fake_download_shard(
+        shard: Any,
+        on_progress: Any,
+        *,
+        max_parallel_downloads: int = 8,
+        allow_patterns: list[str] | None = None,
+        skip_internet: bool = False,
+        skip_download: bool = False,
+    ) -> tuple[Path, Any]:
+        calls.append(
+            {
+                "model_id": str(shard.model_card.model_id),
+                "allow_patterns": allow_patterns,
+            }
+        )
+        return Path("/tmp/x"), MagicMock()
+
+    return calls, fake_download_shard
+
+
+class TestAssistantModelDownload:
+    async def test_downloads_assistant_when_configured(
+        self, downloader: ResumableShardDownloader
+    ) -> None:
+        card = _make_card(assistant_model_repo="test-org/test-assistant")
+        shard = _make_shard(card)
+        calls, fake = _capture()
+
+        with patch(
+            "exo.download.impl_shard_downloader.download_shard", side_effect=fake
+        ):
+            await downloader.ensure_shard(shard)
+
+        assistant_calls = [c for c in calls if "assistant" in c["model_id"]]
+        assert len(assistant_calls) == 1
+        assert assistant_calls[0]["model_id"] == "test-org/test-assistant"
+        assert assistant_calls[0]["allow_patterns"] == ["*.safetensors", "config.json"]
+
+    async def test_skips_assistant_when_not_configured(
+        self, downloader: ResumableShardDownloader
+    ) -> None:
+        shard = _make_shard(_make_card())
+        calls, fake = _capture()
+
+        with patch(
+            "exo.download.impl_shard_downloader.download_shard", side_effect=fake
+        ):
+            await downloader.ensure_shard(shard)
+
+        assert [c for c in calls if "assistant" in c["model_id"]] == []
+
+    async def test_skips_assistant_in_offline_mode(self) -> None:
+        offline = ResumableShardDownloader(max_parallel_downloads=4, offline=True)
+        shard = _make_shard(_make_card(assistant_model_repo="test-org/test-assistant"))
+        calls, fake = _capture()
+
+        with patch(
+            "exo.download.impl_shard_downloader.download_shard", side_effect=fake
+        ):
+            await offline.ensure_shard(shard)
+
+        assert [c for c in calls if "assistant" in c["model_id"]] == []
+
+    async def test_skips_assistant_in_config_only_mode(
+        self, downloader: ResumableShardDownloader
+    ) -> None:
+        shard = _make_shard(_make_card(assistant_model_repo="test-org/test-assistant"))
+        calls, fake = _capture()
+
+        with patch(
+            "exo.download.impl_shard_downloader.download_shard", side_effect=fake
+        ):
+            await downloader.ensure_shard(shard, config_only=True)
+
+        assert [c for c in calls if "assistant" in c["model_id"]] == []

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -266,6 +266,21 @@ class RuntimeCapabilityCardConfig(CamelCaseModel):
     The sidecar is downloaded alongside the base model weights and loaded
     into the runner for speculative decoding. Produced by SWP.
     """
+    assistant_model_repo: str | None = None
+    """Hugging Face repo ID of a companion *assistant* (drafter) model.
+
+    Gemma 4 does speculative decoding differently from the Qwen3/DeepSeek
+    ``mtp.*`` heads: instead of embedded prediction heads, it pairs the target
+    with a separate small ``gemma4_assistant`` model (e.g.
+    ``"mlx-community/gemma-4-26B-A4B-it-assistant-bf16"``) that cross-attends
+    over the target's KV cache. When set, the assistant repo is downloaded
+    alongside the base model. Mutually exclusive with the ``mtp_*`` fields.
+
+    NOTE: consuming the assistant for speculative generation requires the
+    ``gemma4_assistant`` drafter from mlx-vlm >= 0.5.0 and is not yet wired into
+    the runner — declaring it here only pre-downloads it. See the Gemma 4 MTP
+    initiative in the foxlight-docs hub (Phase C).
+    """
 
     @field_validator("prompt_renderer", mode="before")
     @classmethod


### PR DESCRIPTION
First step toward Gemma 4 speculative decoding in Skulk. **Foundational plumbing only — safe to review/merge independently; no generation behavior changes.**

## What
- `RuntimeCapabilityCardConfig` gains `assistant_model_repo` — the companion drafter repo (Gemma 4's assistant pattern, parallel to the `mtp_*` sidecar fields).
- The shard downloader pre-downloads the assistant (config + `*.safetensors`) alongside the target when the card declares it, mirroring the MTP sidecar download block exactly.
- The two Gemma 4 cards now point at their bf16 assistants (`mlx-community/gemma-4-{26B-A4B,E4B}-it-assistant-bf16`).

## Scope (important)
This **declares and pre-downloads** the assistant only. **Loading + speculative generation is Phase C** — it requires the `gemma4_assistant` drafter from **mlx-vlm ≥ 0.5.0** (the version-ladder work: reconcile the mlx-lm fork onto ≥0.31.3, bump mlx/transformers/mlx-vlm). The field's consumer here is the downloader, so it's not a dead field; runtime consumption is intentionally deferred. Full plan + the reverse-engineered drafter mechanism are in the private `foxlight-docs` hub (`initiatives/gemma4-mtp/`).

## Tests / checks
- New `test_assistant_model_download.py` mirrors `test_mtp_sidecar_download.py` (downloads when configured w/ correct allow-patterns; skips when unconfigured / offline / config-only).
- `uv run ruff check` clean; download + model-card tests pass (8 + 30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)