### PR TITLE
fix(mtp): repair Phase 1 MTP end-to-end on the 0.31.3 stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,24 @@ This project records release notes here and mirrors public-facing notes in
   full Vector + VictoriaLogs + Grafana stack: central-host install, per-node
   configuration, JSON schema, and troubleshooting.
 
+### Fixed
+
+- Phase 1 MTP speculative decoding repaired on the post-ladder stack (it had
+  never been validated end-to-end): the GDN softplus patch no longer probes
+  foreign lazy modules (transformers 5.10 resolved a `compute_g` probe into
+  an aria image-processing import requiring torchvision, crashing every GDN
+  runner at startup); tied-embedding models (Qwen3.5 small variants) locate
+  their output head via `embed_tokens.as_linear`; the MTP loop feeds the
+  trunk correctly-shaped token batches; rejects snapshot/restore SSM
+  (ArraysCache) state instead of zeroing it — the bug that degenerated
+  hybrid-model output; and `mtp.safetensors` sidecars resolve via a new
+  `build_sidecar_path` (sidecar repos have no `config.json`, so the model
+  resolver rejected them and MTP silently never engaged). Verified
+  end-to-end: greedy parity is byte-exact with MTP on vs off
+  (Qwen3.5-2B-4bit + the FoxlightAI bf16 sidecar). Draft acceptance is
+  currently 0% — the Phase 1 head intentionally omits the sidecar's
+  transformer block (Phase 2); tracked separately.
+
 ### Changed
 
 - Web framework migrated to starlette 1.x (1.2.1) / fastapi 0.136, unified

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -131,6 +131,28 @@ def resolve_model_in_path(model_id: ModelId) -> Path | None:
     return None
 
 
+def build_sidecar_path(model_id: ModelId, sidecar_filename: str) -> Path | None:
+    """Resolve a companion-artifact file (e.g. an ``mtp.safetensors`` sidecar).
+
+    Sidecar repos are not models: they ship a single weights file and no
+    ``config.json``, so ``build_model_path``'s model-completeness checks
+    reject their directories. Searches ``EXO_MODELS_PATH`` and then
+    ``EXO_MODELS_DIR`` for ``<org--repo>/<sidecar_filename>``.
+
+    Returns:
+        The path to the sidecar file, or ``None`` if it is not on disk.
+    """
+    import exo.shared.constants as _constants
+
+    normalized = model_id.normalize()
+    search_dirs = [*(_constants.EXO_MODELS_PATH or ()), EXO_MODELS_DIR]
+    for search_dir in search_dirs:
+        candidate = search_dir / normalized / sidecar_filename
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def build_model_path(model_id: ModelId) -> Path:
     """Resolve a local filesystem path for *model_id*.
 

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1221,6 +1221,10 @@ def _stream_generate_with_mtp(
     accepted = 0
     attempted_drafts = 0
     finish_reason = "length"
+    # Hybrid models (e.g. Qwen3.5 GDN) carry recurrent SSM state that cannot
+    # be trimmed positionally — and trim_cache without a snapshot ZEROES it.
+    # Rejects must restore a pre-verify snapshot instead.
+    mtp_has_ssm = has_non_kv_caches(prompt_cache)
 
     # cached_hidden: (hidden_size,) from a previous verify pass, or None (need main fwd)
     cached_hidden: mx.array | None = None
@@ -1324,10 +1328,16 @@ def _stream_generate_with_mtp(
 
         if draft_tok_int in eos_token_ids:
             # Draft would end sequence — do not verify, let next loop pick up EOS naturally
-            input_tokens = main_tok
+            # (sampler output is 0-d; the trunk needs (1, N) token ids — the
+            # 0.31.3 qwen3_5 rewrite unpacks (B, S, _) strictly and crashes
+            # on the 2-D hidden states the old module tolerated).
+            input_tokens = main_tok.reshape(-1)
             continue
 
         # ---- VERIFY PASS: process [main_tok, draft_tok] in one batched forward ----
+        # Snapshot recurrent (SSM) state first so a reject can restore it —
+        # the verify forward advances it by two positions irreversibly.
+        pre_verify_snapshot = snapshot_ssm_states(prompt_cache) if mtp_has_ssm else None
         verify_input = mx.array([main_tok_int, draft_tok_int])
         with mx.stream(generation_stream):
             v_h = trunk_fn(verify_input[None], cache=prompt_cache)  # (1, 2, H)
@@ -1407,11 +1417,21 @@ def _stream_generate_with_mtp(
 
             # Stash hidden state at draft_tok position for next MTP round.
             cached_hidden = v_h[0, 1, :]
-            input_tokens = next_main
+            input_tokens = next_main.reshape(-1)
         else:
             # ---- REJECT ----
-            # Trim the draft_tok position that was appended by the verify pass.
-            trim_cache(prompt_cache, 1)
+            if pre_verify_snapshot is not None:
+                # Hybrid model: drop BOTH verify positions from the KV caches
+                # and restore the SSM state to pre-verify; the next main
+                # forward replays [main_tok, target] so every cache lands
+                # consistently at ...main, target. (Trimming only the draft
+                # position would zero the recurrent state — see trim_cache.)
+                trim_cache(prompt_cache, 2, pre_verify_snapshot)
+                replay_tokens = [main_tok_int, target_int]
+            else:
+                # Pure-KV model: trim just the rejected draft position.
+                trim_cache(prompt_cache, 1)
+                replay_tokens = [target_int]
             # target_tok is the verifier's corrected token for the rejected position;
             # emit it before feeding it as input to the next forward.
             if target_int in eos_token_ids:
@@ -1465,7 +1485,7 @@ def _stream_generate_with_mtp(
                 finish_reason=None,
             )
 
-            input_tokens = target_tok
+            input_tokens = mx.array(replay_tokens)
             cached_hidden = None
 
     else:

--- a/src/exo/worker/engines/mlx/mtp.py
+++ b/src/exo/worker/engines/mlx/mtp.py
@@ -221,17 +221,36 @@ def _get_embed_fn(model: object) -> Callable[[mx.array], mx.array] | None:
     return None
 
 
+def _tied_head_fn(trunk: object | None) -> Callable[[mx.array], mx.array] | None:
+    """Output head for tied-embedding models: ``embed_tokens.as_linear``.
+
+    mlx-lm >= 0.31.3 qwen3_5 TextModel has no ``lm_head`` attribute when
+    ``tie_word_embeddings`` is set — its ``__call__`` projects through
+    ``self.model.embed_tokens.as_linear`` instead.
+    """
+    if trunk is None:
+        return None
+    embed: object | None = getattr(trunk, "embed_tokens", None)
+    as_linear: object | None = getattr(embed, "as_linear", None)
+    if as_linear is not None and callable(as_linear):
+        return cast(Callable[[mx.array], mx.array], as_linear)
+    return None
+
+
 def _get_head_fn(model: object) -> Callable[[mx.array], mx.array] | None:
-    """Extract lm_head callable from the main model."""
+    """Extract the lm_head callable (or tied-embedding equivalent)."""
     lm: object | None = getattr(model, "language_model", None)
     if lm is not None:
         head: object | None = getattr(lm, "lm_head", None)
         if head is not None and callable(head):
             return cast(Callable[[mx.array], mx.array], head)
+        tied = _tied_head_fn(getattr(lm, "model", None))
+        if tied is not None:
+            return tied
     top_head: object | None = getattr(model, "lm_head", None)
     if top_head is not None and callable(top_head):
         return cast(Callable[[mx.array], mx.array], top_head)
-    return None
+    return _tied_head_fn(getattr(model, "model", None))
 
 
 def _get_norm_fn(model: object) -> Callable[[mx.array], mx.array] | None:

--- a/src/exo/worker/engines/mlx/patches/high_precision_gdn_softplus.py
+++ b/src/exo/worker/engines/mlx/patches/high_precision_gdn_softplus.py
@@ -28,8 +28,18 @@ def patch_gdn_softplus() -> None:
 
     gated_delta.compute_g = _compute_g_f32
 
+    # Only mlx-lm/mlx-vlm model modules can hold a `from gated_delta import
+    # compute_g` copy. Probing arbitrary modules is dangerous: lazy-loading
+    # packages run imports on attribute access — transformers 5.10 resolves
+    # a top-level "compute_g" probe to an unrelated symbol in
+    # models.aria.image_processing_aria, whose import requires torchvision
+    # and crashed the runner at startup (ModuleNotFoundError escapes a
+    # getattr default, which only covers AttributeError).
     for mod in list(sys.modules.values()):
         if mod is gated_delta:
+            continue
+        module_name = getattr(mod, "__name__", "")
+        if not module_name.startswith(("mlx_lm", "mlx_vlm")):
             continue
         if getattr(mod, "compute_g", None) is compute_g:
             object.__setattr__(mod, "compute_g", _compute_g_f32)

--- a/src/exo/worker/engines/mlx/tests/test_mtp.py
+++ b/src/exo/worker/engines/mlx/tests/test_mtp.py
@@ -89,17 +89,20 @@ def _make_qwen35_weights(
 
 def _make_model(*, missing_head: bool = False, missing_embed: bool = False) -> MagicMock:
     """Return a fake model with Qwen3.5-style structure."""
-    embed = MagicMock()
+    # For missing_head, constrain the mock so it does not auto-create
+    # `as_linear` either — tied-embedding models are headed via
+    # embed_tokens.as_linear, so a truly headless model must lack both.
+    embed = MagicMock(spec=["__call__"]) if missing_head else MagicMock()
     embed.return_value = mx.zeros((1, HIDDEN))
 
     lm_head = MagicMock()
     lm_head.return_value = mx.zeros((1, 1, VOCAB))
 
-    trunk = MagicMock()
+    trunk = MagicMock(spec=["norm", "embed_tokens"])
     trunk.norm = MagicMock(side_effect=lambda x: x)
     trunk.embed_tokens = embed
 
-    lm = MagicMock()
+    lm = MagicMock(spec=["model", "lm_head"])
     lm.model = trunk
     lm.lm_head = None if missing_head else lm_head
 
@@ -500,3 +503,119 @@ class TestStreamGenerateWithMTP:
         )
         # After rejection we expect at least 1 token emitted
         assert len(outputs) >= 1
+
+
+class TestRejectPathSSMState:
+    def test_reject_restores_ssm_state(self) -> None:
+        """A reject must restore SSM (ArraysCache) state, not zero it.
+
+        Regression test: trim_cache without a snapshot sets ArraysCache
+        state to [None, ...], silently wiping the recurrent state of hybrid
+        models (Qwen3.5 GDN) on every rejected draft and degenerating the
+        output. The reject path must snapshot before the verify pass and
+        restore on reject.
+        """
+        from mlx_lm.models.cache import ArraysCache, KVCache
+
+        from exo.worker.engines.mlx.generator.generate import (
+            _stream_generate_with_mtp,
+        )
+
+        model, tokenizer, mtp_head, trunk_fn, head_fn, _fake_cache = (
+            _build_fake_stream_env(
+                main_token_ids=[5, 3, 0],
+                draft_token_id=7,  # head verifies 5/3 → draft 7 always rejected
+            )
+        )
+
+        ssm_cache = ArraysCache(size=1)
+        sentinel = mx.ones((1, 4))
+        ssm_cache.state = [sentinel]
+        # Seed the KV cache: in production it always holds prompt positions
+        # by the time the MTP loop runs, and trim on an empty KVCache throws.
+        kv_cache = KVCache()
+        _ = kv_cache.update_and_fetch(  # pyright: ignore[reportUnknownMemberType]
+            mx.zeros((1, 1, 8, 4)), mx.zeros((1, 1, 8, 4))
+        )
+        cache = [ssm_cache, kv_cache]
+
+        sampler = lambda lp: mx.argmax(lp, axis=-1)  # noqa: E731
+        outputs = list(
+            _stream_generate_with_mtp(
+                model=model,
+                tokenizer=tokenizer,
+                mtp_head=mtp_head,
+                trunk_fn=trunk_fn,
+                head_fn=head_fn,
+                prompt=mx.array([1, 2, 3]),
+                max_tokens=3,
+                sampler=sampler,
+                logits_processors=[],
+                prompt_cache=cache,
+                kv_group_size=None,
+                kv_bits=None,
+            )
+        )
+
+        assert len(outputs) >= 1
+        # The fake trunk never advances SSM state, so after snapshot+restore
+        # the sentinel must survive verbatim. The pre-fix code left this
+        # zeroed ([None]) after the first reject.
+        assert ssm_cache.state[0] is not None, "reject zeroed the SSM state"
+        assert mx.array_equal(ssm_cache.state[0], sentinel)
+
+
+class TestTiedEmbeddingsHead:
+    def test_head_located_via_as_linear(self) -> None:
+        """Tied-embedding models (mlx-lm >= 0.31.3 qwen3_5 TextModel) expose
+        no lm_head; the head is embed_tokens.as_linear."""
+
+        class _Embed:
+            def as_linear(self, x: mx.array) -> mx.array:
+                return x
+
+        class _Trunk:
+            embed_tokens = _Embed()
+
+        class _TextModel:
+            model = _Trunk()
+            # no lm_head attribute
+
+        class _Model:
+            language_model = _TextModel()
+
+        from exo.worker.engines.mlx.mtp import _get_head_fn
+
+        head = _get_head_fn(_Model())
+        assert head is not None
+        probe = mx.array([1.0])
+        assert mx.array_equal(head(probe), probe)
+
+
+class TestGdnPatchModuleSweep:
+    def test_sweep_skips_foreign_lazy_modules(self) -> None:
+        """patch_gdn_softplus must not probe non-mlx modules for compute_g.
+
+        Regression test: transformers 5.10's lazy top-level namespace
+        resolves a "compute_g" attribute probe by importing an unrelated
+        aria image-processing module that requires torchvision — crashing
+        the runner at startup. The sweep must only touch mlx_lm/mlx_vlm
+        modules.
+        """
+        import sys
+        import types
+
+        class _LazyBoobyTrap(types.ModuleType):
+            def __getattr__(self, name: str) -> object:
+                raise ModuleNotFoundError(f"booby trap tripped resolving {name!r}")
+
+        trap = _LazyBoobyTrap("fake_lazy_package")
+        sys.modules["fake_lazy_package"] = trap
+        try:
+            from exo.worker.engines.mlx.patches.high_precision_gdn_softplus import (
+                patch_gdn_softplus,
+            )
+
+            patch_gdn_softplus()  # raised ModuleNotFoundError before the fix
+        finally:
+            del sys.modules["fake_lazy_package"]

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -49,7 +49,7 @@ import mlx.nn as nn
 from mlx_lm.utils import load_model as _mlx_lm_load_model
 from pydantic import RootModel
 
-from exo.download.download_utils import build_model_path
+from exo.download.download_utils import build_model_path, build_sidecar_path
 from exo.shared.types.common import Host
 from exo.shared.types.memory import Memory
 from exo.shared.types.mlx import Model
@@ -694,18 +694,19 @@ def load_mlx_items(
     mtp_weights: dict[str, mx.array] | None = None
     runtime = bound_instance.bound_shard.model_card.runtime
     if runtime and runtime.mtp_sidecar_repo and runtime.mtp_heads:
-        try:
-            sidecar_path = build_model_path(ModelId(runtime.mtp_sidecar_repo))
-            mtp_safetensors = sidecar_path / "mtp.safetensors"
-            if mtp_safetensors.exists():
-                mtp_weights = cast("dict[str, mx.array]", mx.load(str(mtp_safetensors)))
-            else:
-                logger.warning(
-                    f"MTP sidecar declared but not found at {mtp_safetensors}; running without MTP"
-                )
-        except FileNotFoundError:
+        # Sidecar repos carry only mtp.safetensors (no config.json), so they
+        # must be resolved with the sidecar resolver — build_model_path's
+        # model-completeness check rejects their directories.
+        mtp_safetensors = build_sidecar_path(
+            ModelId(runtime.mtp_sidecar_repo), "mtp.safetensors"
+        )
+        if mtp_safetensors is not None:
+            mtp_weights = cast("dict[str, mx.array]", mx.load(str(mtp_safetensors)))
+            logger.info(f"MTP sidecar weights loaded from {mtp_safetensors}")
+        else:
             logger.warning(
-                f"MTP sidecar repo {runtime.mtp_sidecar_repo!r} not downloaded; running without MTP"
+                f"MTP sidecar repo {runtime.mtp_sidecar_repo!r} not downloaded; "
+                "running without MTP"
             )
 
     return cast(Model, model), tokenizer, vision_processor, mtp_weights


### PR DESCRIPTION
## Summary

Live end-to-end testing of Phase 1 MTP (Qwen3.5-2B-4bit + the SWP-published `FoxlightAI/qwen3-5-2b-base-mtp` bf16 sidecar) found it had **never actually run end-to-end** — five independent breaks, four exposed or caused by the version ladder:

| # | Break | Blast radius | Fix |
|---|---|---|---|
| 1 | GDN softplus patch probes `compute_g` on **all** of `sys.modules`; transformers 5.10's lazy namespace resolves the probe by importing aria image-processing → torchvision → crash | **Every GDN-model runner dies at startup** (MTP or not) | Sweep restricted to `mlx_lm`/`mlx_vlm` modules |
| 2 | mlx-lm 0.31.3 tied-embedding models have no `lm_head` (head = `embed_tokens.as_linear`) | MTP silently off for Qwen3.5 small variants | `_get_head_fn` mirrors upstream's tied path |
| 3 | MTP loop feeds 0-d sampler outputs to the trunk; rewritten qwen3_5 unpacks `(B, S, _)` strictly | Crash mid-generation | Inputs normalized to `(1, N)` |
| 4 | Rejects ran `trim_cache` without a snapshot, which **zeroes ArraysCache (SSM) state** | Degenerate output on hybrid models ("of the of the…") | Snapshot before verify; restore + trim 2 + replay `[main, target]` on reject (pure-KV models keep the cheap path) |
| 5 | Sidecar repos ship only `mtp.safetensors` (no `config.json`); `build_model_path` rejected them | MTP silently never engaged in the orchestrated runner | New `build_sidecar_path` companion-artifact resolver |

## Verified live

- ✅ **Sidecar auto-download**: declaring `runtime.mtp_sidecar_repo` on the card fetches `mtp.safetensors` automatically alongside the base model
- ✅ **Greedy parity byte-exact** MTP-on vs MTP-off (200-token probe)
- ✅ Full API path: `place_instance` → chat completion with "MTP speculative decoding enabled (D=1)" in the runner

## Known limitation (tracked separately)

Draft acceptance is **0%** — the Phase 1 head deliberately omits the sidecar's `mtp.layers.0` transformer block (deferred to Phase 2 per the in-code note), and the bf16-head × 4-bit-backbone precision interaction (mlx-lm #990 thread) may compound it. MTP is currently correct but provides no speedup. Follow-up issue to come.

## Tests

- SSM-restore regression test driving a real `ArraysCache` through the reject path (the fakes' trimmable caches are why this never failed before)
- Tied-embeddings head location
- Lazy-module booby-trap test for the patch sweep

Validation: basedpyright 0 errors, ruff clean, 743 fast tests, test_mtp 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)