### PR TITLE
fix(mtp): finalize detokenizer before terminal yields (#180 item 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- MTP terminal responses (EOS / max-tokens break paths) now finalize the
+  detokenizer before yielding, matching the non-MTP path — sentencepiece-
+  backed tokenizers buffer partial byte sequences until finalize() and
+  could drop the last token's tail bytes (#180 item 4; latent for current
+  tiktoken-backed targets).
+
 ### Added
 
 - Sampled-decoding support for MTP speculative decoding (issue #180 item 1):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
-### Fixed
-
-- MTP terminal responses (EOS / max-tokens break paths) now finalize the
-  detokenizer before yielding, matching the non-MTP path — sentencepiece-
-  backed tokenizers buffer partial byte sequences until finalize() and
-  could drop the last token's tail bytes (#180 item 4; latent for current
-  tiktoken-backed targets).
-
 ### Added
 
 - Sampled-decoding support for MTP speculative decoding (issue #180 item 1):
@@ -76,6 +68,11 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- MTP terminal responses (EOS / max-tokens break paths) now finalize the
+  detokenizer exactly once before yielding, matching the non-MTP path —
+  sentencepiece-backed tokenizers buffer partial byte sequences until
+  finalize() and could drop the last token's tail bytes (#180 item 4;
+  latent for current tiktoken-backed targets).
 - MTP drafting consumed post-final-norm hidden states; the trunk accessor
   now returns pre-norm hiddens (what the heads were trained on) and folds
   the final norm into the head callable, keeping main-path logits

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1634,7 +1634,9 @@ def _stream_generate_with_mtp(
             )
         return
 
-    detokenizer.finalize()
+    # No finalize here: this tail only runs after a `break`, and every break
+    # path yields a terminal response, which finalizes inside _response —
+    # finalization happens exactly once, structurally.
     acceptance_rate = accepted / attempted_drafts if attempted_drafts > 0 else 0.0
     logger.debug(
         f"MTP decode complete: {generated_count} tokens, "

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1345,7 +1345,16 @@ def _stream_generate_with_mtp(
         from_draft: bool,
         finish: str | None,
     ) -> MlxGenerationResponse:
-        """Build a response for *token_int* using the enclosing loop state."""
+        """Build a response for *token_int* using the enclosing loop state.
+
+        Terminal responses (``finish`` set) finalize the detokenizer first
+        so buffered partial byte/BPE sequences flush into the final segment
+        — sentencepiece-backed tokenizers buffer tail bytes until
+        ``finalize()`` (#180 item 4; tiktoken-backed targets flush eagerly,
+        so this is latent for current models).
+        """
+        if finish is not None:
+            detokenizer.finalize()
         return MlxGenerationResponse(
             text=detokenizer.last_segment,
             token=token_int,

--- a/src/exo/worker/engines/mlx/tests/test_drafters.py
+++ b/src/exo/worker/engines/mlx/tests/test_drafters.py
@@ -651,6 +651,7 @@ class TestStreamGenerateWithMTP:
         class _BufferingDetokenizer:
             def __init__(self) -> None:
                 self._finalized = False
+                self.finalize_calls = 0
 
             @property
             def last_segment(self) -> str:
@@ -664,6 +665,7 @@ class TestStreamGenerateWithMTP:
 
             def finalize(self) -> None:
                 self._finalized = True
+                self.finalize_calls += 1
 
         tokenizer.detokenizer = _BufferingDetokenizer()
         sampler = lambda lp: mx.argmax(lp, axis=-1)  # noqa: E731
@@ -688,6 +690,9 @@ class TestStreamGenerateWithMTP:
         assert terminal[-1].text == "tail", (
             "terminal response was built before detokenizer.finalize()"
         )
+        # Exactly once: the post-loop tail must not double-finalize after a
+        # break path already finalized via the terminal response.
+        assert tokenizer.detokenizer.finalize_calls == 1
 
     def test_reject_path_does_not_crash(self) -> None:
         outputs, _drafter, _cache = self._run(

--- a/src/exo/worker/engines/mlx/tests/test_drafters.py
+++ b/src/exo/worker/engines/mlx/tests/test_drafters.py
@@ -637,6 +637,58 @@ class TestStreamGenerateWithMTP:
         # Accept chains can yield 2 per pass so allow a small window.
         assert len(outputs) <= limit + 2
 
+    def test_terminal_response_carries_finalized_segment(self) -> None:
+        """Break-path terminal yields must finalize the detokenizer first —
+        sentencepiece-backed tokenizers buffer tail bytes until finalize()
+        (#180 item 4). The fake reveals its buffered tail only on finalize."""
+        from exo.worker.engines.mlx.generator.generate import _stream_generate_with_mtp
+
+        model, tokenizer, drafter, trunk_fn, head_fn, cache = _build_fake_stream_env(
+            main_token_ids=[5] * 20,
+            draft_token_id=5,
+        )
+
+        class _BufferingDetokenizer:
+            def __init__(self) -> None:
+                self._finalized = False
+
+            @property
+            def last_segment(self) -> str:
+                return "tail" if self._finalized else "hi"
+
+            def reset(self) -> None:
+                self._finalized = False
+
+            def add_token(self, token: int) -> None:
+                del token
+
+            def finalize(self) -> None:
+                self._finalized = True
+
+        tokenizer.detokenizer = _BufferingDetokenizer()
+        sampler = lambda lp: mx.argmax(lp, axis=-1)  # noqa: E731
+        outputs = list(
+            _stream_generate_with_mtp(
+                model=model,
+                tokenizer=tokenizer,
+                drafter=drafter,
+                trunk_fn=trunk_fn,
+                head_fn=head_fn,
+                prompt=mx.array([1, 2, 3]),
+                max_tokens=4,  # terminal via max_tokens break path
+                sampler=sampler,
+                logits_processors=[],
+                prompt_cache=cache,
+                kv_group_size=None,
+                kv_bits=None,
+            )
+        )
+        terminal = [o for o in outputs if o.finish_reason is not None]
+        assert terminal, "loop must yield a terminal response"
+        assert terminal[-1].text == "tail", (
+            "terminal response was built before detokenizer.finalize()"
+        )
+
     def test_reject_path_does_not_crash(self) -> None:
         outputs, _drafter, _cache = self._run(
             main_token_ids=[5, 3, 0],

--- a/src/exo/worker/engines/mlx/tests/test_drafters.py
+++ b/src/exo/worker/engines/mlx/tests/test_drafters.py
@@ -667,7 +667,8 @@ class TestStreamGenerateWithMTP:
                 self._finalized = True
                 self.finalize_calls += 1
 
-        tokenizer.detokenizer = _BufferingDetokenizer()
+        buffering_detokenizer = _BufferingDetokenizer()
+        tokenizer.detokenizer = buffering_detokenizer
         sampler = lambda lp: mx.argmax(lp, axis=-1)  # noqa: E731
         outputs = list(
             _stream_generate_with_mtp(
@@ -692,7 +693,7 @@ class TestStreamGenerateWithMTP:
         )
         # Exactly once: the post-loop tail must not double-finalize after a
         # break path already finalized via the terminal response.
-        assert tokenizer.detokenizer.finalize_calls == 1
+        assert buffering_detokenizer.finalize_calls == 1
 
     def test_reject_path_does_not_crash(self) -> None:
         outputs, _drafter, _cache = self._run(


### PR DESCRIPTION
## Summary

Last open single-node item of #180: MTP break paths (EOS / max-tokens) yielded terminal responses before `detokenizer.finalize()`, unlike the non-MTP path — on sentencepiece-backed tokenizers the buffered tail bytes of the final token would be dropped. Latent for current targets (tiktoken flushes eagerly), real for future sentencepiece models.

Fix is one place: the loop's `_response` helper finalizes whenever it builds a terminal response, covering every break path. Regression test uses a detokenizer that reveals its buffered tail only on `finalize()`.

## #180 status after this

| Item | Status |
|---|---|
| 1. Probability-ratio T>0 | ✅ #197 |
| 2. Temperature gating | ✅ superseded by #197 |
| 3. Accept-path RNG overconsumption | ✅ #193/#196 |
| 4. detokenizer.finalize() on break paths | ✅ **this PR** |
| 5. BatchGenerator MTP | runner force-routes MTP to SequentialGenerator (no silent drop); full batch+spec integration is future work |
| 6. Logits-processor bypass | ✅ guarded (#193-era); verify-side processing tracked in #195 |
| 7. Phase 2 transformer block | ✅ #193 |
| 8. Tied-embedding head fallback | ✅ #193 |

`basedpyright` 0 · `ruff` clean · 790 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)