### PR TITLE
chore(deps): mlx-vlm 0.5.0 → 0.6.1 (Gemma 4 MTP Phase B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,14 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Changed
 
+- mlx-vlm 0.5.0 → 0.6.1 (Gemma 4 MTP initiative Phase B). 0.6.1 ships the
+  speculative-drafter catalog Phase C consumes (`gemma4_assistant`,
+  `gemma4_unified_assistant`, `gemma4_dflash` — plus upstream
+  `qwen3_5_mtp` and `deepseek_v4_mtp` drafters relevant to #194 and the
+  DeepSeek sidecar path). All Skulk touchpoints verified against 0.6.1
+  (prompt_utils, load_image_processor, dynamic `mlx_vlm.models.*` imports);
+  dependency floors were already satisfied by the #188/#190 ladder.
+
 - Web framework migrated to starlette 1.x (1.2.1) / fastapi 0.136, unified
   across darwin and linux. Test code uses `httpx2` for starlette's
   `TestClient` (the httpx-backed client is deprecated in 1.x); production

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "types-PyYAML>=6.0.12",
   # 0.6.1 bump is the next step (needs a vision-wrapper compat re-audit);
   # this starlette-1.x migration unblocks it.
-  "mlx-vlm==0.5.0; sys_platform == 'darwin'",
+  "mlx-vlm==0.6.1; sys_platform == 'darwin'",
   "transformers>=5.5.0,<6.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
   "zstandard>=0.23.0",
   "pyyaml>=6.0.2",
   "types-PyYAML>=6.0.12",
-  # 0.6.1 bump is the next step (needs a vision-wrapper compat re-audit);
-  # this starlette-1.x migration unblocks it.
+  # 0.6.1 ships the speculative-drafter catalog (gemma4_assistant et al.,
+  # Gemma 4 MTP Phase B); vision-wrapper touchpoints re-audited against it.
   "mlx-vlm==0.6.1; sys_platform == 'darwin'",
   "transformers>=5.5.0,<6.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -609,7 +609,7 @@ requires-dist = [
     { name = "mlx", extras = ["cpu"], marker = "sys_platform == 'linux'", specifier = "==0.30.6" },
     { name = "mlx-lm", git = "https://github.com/Foxlight-Foundation/mlx-lm?rev=e2f7ddcd31ec7d5214447a8d3206af0d2bff6e35" },
     { name = "mlx-optiq", extras = ["convert"], marker = "sys_platform == 'darwin'" },
-    { name = "mlx-vlm", marker = "sys_platform == 'darwin'", specifier = "==0.5.0" },
+    { name = "mlx-vlm", marker = "sys_platform == 'darwin'", specifier = "==0.6.1" },
     { name = "msgspec", specifier = ">=0.19.0" },
     { name = "openai-harmony", specifier = ">=0.0.8" },
     { name = "psutil", specifier = ">=7.0.0" },
@@ -1659,7 +1659,7 @@ convert = [
 
 [[package]]
 name = "mlx-vlm"
-version = "0.5.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datasets", marker = "sys_platform == 'darwin'" },
@@ -1673,13 +1673,14 @@ dependencies = [
     { name = "opencv-python", marker = "sys_platform == 'darwin'" },
     { name = "pillow", marker = "sys_platform == 'darwin'" },
     { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "starlette", marker = "sys_platform == 'darwin'" },
     { name = "tqdm", marker = "sys_platform == 'darwin'" },
     { name = "transformers", marker = "sys_platform == 'darwin'" },
     { name = "uvicorn", marker = "sys_platform == 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/a3/70dce014f6a72efd2cecc07b6a68fc11c0694fbe54ea553b2e00499c7b36/mlx_vlm-0.5.0.tar.gz", hash = "sha256:24563cd1b3a399fd941b2359100628306e2754db1b48780516d1283138258793", size = 1033154, upload-time = "2026-05-06T21:09:33.594Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/bc/5e6ecd5db33fa04e8b9b4939984c8966425c65c27ce94968a136dc4d0233/mlx_vlm-0.6.1.tar.gz", hash = "sha256:8ea7e1989f6ee462632b07d96d06c10ee77a545470236d2e9fb592df72f077be", size = 1315770, upload-time = "2026-06-03T17:27:01.65Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/66/fb955ccc442aa556e5e9d8836fb9041a7aadff5a88fa80c285e53dc19bf5/mlx_vlm-0.5.0-py3-none-any.whl", hash = "sha256:3351d6ccf609cbf57a4c8cd8308e9a1ce469883d8679d9968c6c6f77af016419", size = 1218132, upload-time = "2026-05-06T21:09:32.071Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/40/c72bb2e8a0d89b8c62981a2e85e689eb3788e6bdccaa96c23bd9c34b64f6/mlx_vlm-0.6.1-py3-none-any.whl", hash = "sha256:961a1539e35826a4b92f1f87929f1074c661c47d02f4c11eec8651cacef260b9", size = 1573590, upload-time = "2026-06-03T17:26:59.822Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase B of the Gemma 4 MTP initiative (foxlight-docs `gemma4-mtp`): bump mlx-vlm to **0.6.1**, the release that ships the speculative-drafter abstraction Phase C consumes.

## What 0.6.1 brings

The drafter catalog is richer than the initiative survey expected:
- `gemma4_assistant`, `gemma4_unified_assistant`, `gemma4_dflash` — the Phase C targets (`Gemma4AssistantDraftModel` import-verified)
- `qwen3_5_mtp` — upstream embedded-heads drafter, directly relevant to #194
- `deepseek_v4_mtp` — relevant to the DeepSeek sidecar Phase-2 gap
- `eagle3`, `ddtree`, `dflash` general machinery

## Validation

- Dependency floors (mlx ≥ 0.31.2, mlx-lm ≥ 0.31.3, transformers ≥ 5.5, starlette ≥ 1.0.1) all pre-satisfied by the #188/#190 ladder — resolution is clean
- Every Skulk `mlx_vlm` touchpoint verified importable and intact on 0.6.1: `prompt_utils.get_message_json`, `utils.load_image_processor`, dynamic `mlx_vlm.models.*` imports (vision.py), `mlx_vlm.models.gemma4`
- `basedpyright` 0 · `ruff` clean · full suite 787 passed

Phase C (consume the drafter behind the Skulk `Drafter` protocol) follows in its own PR — the phase-c-spec gets re-read against 0.6.1's abstraction first, since it was written for 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)