### PR TITLE
fix(mtp): gate MTP to single-node operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- MTP is explicitly single-node for now: distributed placements (any group
+  size > 1) disengage speculation with a logged fallback. Pipeline sharding
+  was already excluded; tensor-parallel would mechanically run but
+  accept/reject decisions consume per-rank RNG and cross-rank lockstep is
+  unvalidated — a divergent decision would silently corrupt every rank's
+  cache. Distributed MTP (TP lockstep validation, then pipeline
+  draft/verify) is the next workstream.
 - MTP terminal responses (EOS / max-tokens break paths) now finalize the
   detokenizer exactly once before yielding, matching the non-MTP path —
   sentencepiece-backed tokenizers buffer partial byte sequences until

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -2579,7 +2579,7 @@ def mlx_generate(
     _drafter: Drafter | None = None
     _trunk_fn: Callable[..., mx.array] | None = None
     _head_fn: Callable[..., mx.array] | None = None
-    if mtp_weights is not None and group is not None:
+    if mtp_weights is not None and group is not None and group.size() > 1:
         # MTP is single-node only for now. Pipeline sharding needs the
         # distributed draft/verify design (#152 Phase 2: last-rank drafting,
         # K+1 pipeline verify, trim broadcast). Tensor-parallel would

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -2579,9 +2579,19 @@ def mlx_generate(
     _drafter: Drafter | None = None
     _trunk_fn: Callable[..., mx.array] | None = None
     _head_fn: Callable[..., mx.array] | None = None
-    if mtp_weights is not None and not (
-        group is not None and _has_pipeline_communication_layer(model)
-    ):
+    if mtp_weights is not None and group is not None:
+        # MTP is single-node only for now. Pipeline sharding needs the
+        # distributed draft/verify design (#152 Phase 2: last-rank drafting,
+        # K+1 pipeline verify, trim broadcast). Tensor-parallel would
+        # mechanically run today, but accept/reject and residual draws
+        # consume per-rank RNG — lockstep across ranks is unvalidated, and a
+        # divergent decision silently corrupts every rank's cache. Lift
+        # per-mode once TP lockstep is validated on real hardware.
+        logger.info(
+            "MTP speculative decoding is single-node only (group size "
+            f"{group.size()}); skipping MTP pending distributed support"
+        )
+    elif mtp_weights is not None:
         if logits_processors:
             # Accepted draft tokens are committed from RAW verifier logits —
             # logits processors (repetition penalty, bench EOS ban) are only

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -693,7 +693,13 @@ def load_mlx_items(
 
     mtp_weights: dict[str, mx.array] | None = None
     runtime = bound_instance.bound_shard.model_card.runtime
-    if runtime and runtime.mtp_sidecar_repo and runtime.mtp_heads:
+    if runtime and runtime.mtp_sidecar_repo and runtime.mtp_heads and (
+        group is None or group.size() <= 1
+    ):
+        # Distributed placements disengage MTP (single-node only pending
+        # distributed support, #201) — don't pay sidecar memory for
+        # speculation that will never run; on tight shard fits the eager
+        # load could even OOM.
         # Sidecar repos carry only mtp.safetensors (no config.json), so they
         # must be resolved with the sidecar resolver — build_model_path's
         # model-completeness check rejects their directories.
@@ -708,6 +714,12 @@ def load_mlx_items(
                 f"MTP sidecar repo {runtime.mtp_sidecar_repo!r} not downloaded; "
                 "running without MTP"
             )
+    elif runtime and runtime.mtp_sidecar_repo and runtime.mtp_heads:
+        logger.info(
+            "MTP sidecar declared but placement is distributed "
+            f"(group size {group.size() if group else 0}); skipping sidecar "
+            "load — MTP is single-node only pending #201"
+        )
 
     return cast(Model, model), tokenizer, vision_processor, mtp_weights
 


### PR DESCRIPTION
## Summary

Closes the one correctness-shaped hole left in the MTP series: **tensor-parallel placements slipped through the speculation gate** (only pipeline layers were excluded) and would attempt MTP across ranks unvalidated.

Post-#197 that is a live hazard, not a theoretical one: `ratio_accept` and `residual_sample` consume per-rank RNG. Cross-rank lockstep *probably* holds (identical logits from collectives, identically-seeded RNGs, data-dependent draw counts) — but "probably holds" is unvalidated, and a single divergent accept decision silently corrupts every rank's KV cache. Our cards ship `supports_tensor = true`, so a two-node user could hit this today.

Any `group` (size > 1) now disengages MTP with a logged fallback. Single-node behavior — everything measured and shipped this week — is unchanged.

## What lifts the guard

Distributed MTP is the next workstream, in order:
1. **TP lockstep validation** on real hardware (greedy first, then T=0.7 with explicit cross-rank divergence detection) → lift the guard for tensor-parallel
2. **Pipeline draft/verify design** (#152 Phase 2): last-rank drafting (final hiddens + lm_head live there; the sidecar block is small), K+1-token pipeline verify, accept/trim decision broadcast so each rank trims its own KV slice. Speculation is unusually valuable here — verify amortizes inter-node latency across K+1 committed tokens, exactly where the big sharded models hurt most.

`basedpyright` 0 · `ruff` clean · 790 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)