### PR TITLE
feat(gemma4): Phase C — assistant-model speculative decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Added
 
+- Gemma 4 assistant speculative decoding (gemma4-mtp Phase C): the
+  separate 4-layer assistant models Google publishes per Gemma 4 target
+  now draft through Skulk's Drafter protocol — the assistant cross-attends
+  over the target's KV cache (shared-KV extraction with RotatingKVCache
+  temporal restore), consumes the target's post-norm hidden, and loads
+  bf16-enforced when a card declares `assistant_model_repo` (single-node,
+  same #200/#201 envelope; forces SequentialGenerator like MTP). Measured
+  on M4/24GB: gemma-4-26B-A4B-it-4bit 55% acceptance, 28.8 tok/s vs
+  15.5–17.8 vanilla (1.6–1.85×); gemma-4-e4b-it-8bit 48%, 1.26×. Notable
+  finding: chained depth does NOT pay on quantized targets (the assistant
+  is trained against bf16 hiddens; chain acceptance decays to ~30% and MoE
+  verify cost grows with block size) — depth 1 is the default and the
+  measured optimum for the carded quants. Also fixed en route: the
+  pre-norm trunk wrapper is gated to qwen-shaped trunks (it would build
+  wrong masks for gemma4's sliding/full layers), and the companion-repo
+  download-completeness gap (#185 flag) — cached bases now fetch newly
+  declared sidecars/assistants.
 - Sampled-decoding support for MTP speculative decoding (issue #180 item 1):
   at temperature > 0 the loop switches from argmax-prefix acceptance to
   Leviathan-Chen probability-ratio rejection sampling over the *effective*

--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
@@ -26,8 +26,12 @@ tool_call_format = "gemma4"
 prompt_renderer = "gemma4"
 output_parser = "gemma4"
 # Companion drafter for speculative decoding (Gemma 4 assistant pattern).
-# Pre-downloaded with the model; consumed once the gemma4_assistant
-# drafter (mlx-vlm >= 0.5.0) is wired in (Phase C).
+# ACTIVE since gemma4-mtp Phase C: validated 2026-06-05 on M4/24GB at
+# depth 1 — 55% acceptance, 28.8 tok/s vs 15.5-17.8 vanilla (1.6-1.85x;
+# the MoE vanilla baseline is noisy, speculative throughput is stable).
+# Depth > 1 measured SLOWER on this 4-bit target (chain acceptance decays
+# against quantized hiddens; the assistant is trained against bf16) —
+# leave depth at the default 1.
 assistant_model_repo = "mlx-community/gemma-4-26B-A4B-it-assistant-bf16"
 # MLX_METAL_FAST_SYNCH wedges the GPU command queue on this model under the
 # ring backend with multimodal load: the runner thread enters TH_UNINT in

--- a/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
@@ -25,8 +25,9 @@ tool_call_format = "gemma4"
 prompt_renderer = "gemma4"
 output_parser = "gemma4"
 # Companion drafter for speculative decoding (Gemma 4 assistant pattern).
-# Pre-downloaded with the model; consumed once the gemma4_assistant
-# drafter (mlx-vlm >= 0.5.0) is wired in (Phase C).
+# ACTIVE since gemma4-mtp Phase C: validated 2026-06-05 on M4/24GB —
+# depth 1: 48% acceptance, 1.26x; depth 3: 1.30x (marginal; default depth
+# 1 retained — chain acceptance decays on quantized targets).
 assistant_model_repo = "mlx-community/gemma-4-E4B-it-assistant-bf16"
 # Same FAST_SYNCH wedge as the 26b card — GPU command queue stalls in the
 # pipeline-parallel inference path, kernel watchdog panics the box. Disable

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -153,6 +153,30 @@ def build_sidecar_path(model_id: ModelId, sidecar_filename: str) -> Path | None:
     return None
 
 
+def build_companion_model_path(model_id: ModelId) -> Path | None:
+    """Resolve a companion *model* directory (e.g. a Gemma 4 assistant).
+
+    Companion model repos ship a single ``model.safetensors`` plus
+    ``config.json`` and no ``*.safetensors.index.json``, so
+    ``build_model_path``'s index-based completeness check rejects them.
+    Searches ``EXO_MODELS_PATH`` then ``EXO_MODELS_DIR``.
+
+    Returns:
+        The companion model directory, or ``None`` if it is not on disk.
+    """
+    import exo.shared.constants as _constants
+
+    normalized = model_id.normalize()
+    search_dirs = [*(_constants.EXO_MODELS_PATH or ()), EXO_MODELS_DIR]
+    for search_dir in search_dirs:
+        candidate = search_dir / normalized
+        if (candidate / "config.json").is_file() and (
+            candidate / "model.safetensors"
+        ).is_file():
+            return candidate
+    return None
+
+
 def build_model_path(model_id: ModelId) -> Path:
     """Resolve a local filesystem path for *model_id*.
 

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -271,7 +271,15 @@ class ResumableShardDownloader(ShardDownloader):
         # never fetched (phase-c spec gotcha, flagged on PR #185). Degrade
         # the reported status when a declared companion is missing on disk
         # so the download path runs and pulls it.
-        if progress.status == "complete" and self._missing_companion(shard):
+        # Never degrade in offline mode: the companion cannot be fetched
+        # anyway, and load_mlx_items treats missing companions as optional —
+        # degrading would turn a perfectly loadable cached base into
+        # DownloadFailed on air-gapped nodes.
+        if (
+            progress.status == "complete"
+            and not self.offline
+            and self._missing_companion(shard)
+        ):
             return progress.model_copy(update={"status": "in_progress"})
         return progress
 

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -265,4 +265,38 @@ class ResumableShardDownloader(ShardDownloader):
             skip_download=True,
             skip_internet=self.offline,
         )
+        # A base cached before its card declared companion repos
+        # (mtp_sidecar_repo / assistant_model_repo) reports complete here and
+        # the coordinator never calls ensure_shard — so the companion is
+        # never fetched (phase-c spec gotcha, flagged on PR #185). Degrade
+        # the reported status when a declared companion is missing on disk
+        # so the download path runs and pulls it.
+        if progress.status == "complete" and self._missing_companion(shard):
+            return progress.model_copy(update={"status": "in_progress"})
         return progress
+
+    @staticmethod
+    def _missing_companion(shard: ShardMetadata) -> bool:
+        """True when the card declares a companion repo absent from disk."""
+        from exo.download.download_utils import (
+            build_companion_model_path,
+            build_sidecar_path,
+        )
+
+        runtime = shard.model_card.runtime
+        if runtime is None:
+            return False
+        if (
+            runtime.mtp_sidecar_repo
+            and runtime.mtp_heads
+            and build_sidecar_path(
+                ModelId(runtime.mtp_sidecar_repo), "mtp.safetensors"
+            )
+            is None
+        ):
+            return True
+        return bool(
+            runtime.assistant_model_repo
+            and build_companion_model_path(ModelId(runtime.assistant_model_repo))
+            is None
+        )

--- a/src/exo/worker/engines/mlx/drafters/builder.py
+++ b/src/exo/worker/engines/mlx/drafters/builder.py
@@ -26,6 +26,9 @@ from exo.worker.engines.mlx.drafters.deepseek_sidecar import (
     build_deepseek_sidecar_drafter,
     detect_deepseek_prefix,
 )
+from exo.worker.engines.mlx.drafters.gemma4_assistant import (
+    build_gemma4_assistant_drafter,
+)
 from exo.worker.engines.mlx.drafters.protocol import Drafter
 from exo.worker.engines.mlx.drafters.qwen_sidecar import (
     QWEN35_REQUIRED_KEYS,
@@ -49,7 +52,9 @@ _QWEN_DEFAULT_CONCAT_ORDER: ConcatOrder = "embed_first"
 
 def build_drafter(
     model: object,
-    mtp_weights: dict[str, mx.array],
+    mtp_weights: dict[str, mx.array] | None,
+    *,
+    assistant_model: object | None = None,
     runtime: RuntimeCapabilityCardConfig | None = None,
 ) -> Drafter | None:
     """Detect the sidecar layout and build the matching drafter.
@@ -66,6 +71,14 @@ def build_drafter(
         speculation (unrecognised layout or any construction failure —
         always logged, never raised).
     """
+    if assistant_model is not None:
+        # Gemma 4 assistant pattern: a separate chain-trained draft model
+        # cross-attending over the target's KV (gemma4-mtp Phase C).
+        return build_gemma4_assistant_drafter(model, assistant_model)
+
+    if mtp_weights is None:
+        return None
+
     if mtp_weights.keys() >= QWEN35_REQUIRED_KEYS:
         norm_convention: NormConvention = (
             runtime.mtp_norm_convention

--- a/src/exo/worker/engines/mlx/drafters/gemma4_assistant.py
+++ b/src/exo/worker/engines/mlx/drafters/gemma4_assistant.py
@@ -151,12 +151,19 @@ class Gemma4AssistantDrafter:
         ``position_ids`` held constant at the bonus offset, ``h_prev``
         advanced with the assistant's own ``post_projection`` output.
         """
-        if len(self._layers) != len(self._prompt_cache):
+        if len(self._prompt_cache) > len(self._layers):
             raise RuntimeError(
-                "Gemma 4 assistant drafter: target layer/cache count mismatch "
+                "Gemma 4 assistant drafter: more caches than target layers "
                 f"({len(self._layers)} layers vs {len(self._prompt_cache)} caches)"
             )
-        shared = _extract_shared_kv(self._layers, self._prompt_cache)
+        # KV-shared models (E2B/E4B: num_kv_shared_layers > 0) own caches only
+        # for the first N layers (gemma4 make_cache builds
+        # layers[:first_kv_shared_layer_idx]); the deeper layers reuse that
+        # K/V — and the last cache-owning layer of each type is exactly what
+        # the assistant cross-attends over.
+        shared = _extract_shared_kv(
+            self._layers[: len(self._prompt_cache)], self._prompt_cache
+        )
         # The bonus position == the target cache offset at draft time (the
         # position next_token is about to occupy).
         offset = max(

--- a/src/exo/worker/engines/mlx/drafters/gemma4_assistant.py
+++ b/src/exo/worker/engines/mlx/drafters/gemma4_assistant.py
@@ -240,6 +240,12 @@ def build_gemma4_assistant_drafter(
             "running without speculation"
         )
         return None
+    if not callable(getattr(assistant, "_input_embed", None)):
+        logger.warning(
+            "Gemma 4 assistant: bind(target) did not resolve the target's "
+            "input embeddings — assistant drafting disabled"
+        )
+        return None
     drafter = Gemma4AssistantDrafter(assistant=assistant, target_model=model)
     logger.info("Gemma 4 assistant drafter initialised (family=gemma4-assistant)")
     return drafter
@@ -251,21 +257,23 @@ def load_assistant_model(model_dir: Path) -> object | None:
     Enforces bf16 (fp16 assistants degenerate after ~50 tokens — unscaled
     QK per the phase-c spec). Returns ``None`` on any failure, logged.
     """
-    # Deferred import: mlx-vlm is darwin-only and heavy.
-    from mlx_vlm.speculative.drafters.gemma4_assistant import (  # pyright: ignore[reportMissingTypeStubs]
-        Gemma4AssistantDraftModel,
-        ModelConfig,
-    )
-
     config_path = model_dir / "config.json"
     weights_path = model_dir / "model.safetensors"
     if not config_path.is_file() or not weights_path.is_file():
         logger.warning(
             f"Gemma 4 assistant at {model_dir} is incomplete "
-            "(needs config.json + model.safetensors) — running without speculation"
+            "(needs config.json + model.safetensors) — assistant drafting disabled"
         )
         return None
     try:
+        # Deferred import: mlx-vlm is darwin-only and heavy; importing here
+        # keeps non-darwin environments (and the missing-file fast path)
+        # from ever touching it.
+        from mlx_vlm.speculative.drafters.gemma4_assistant import (  # pyright: ignore[reportMissingTypeStubs]
+            Gemma4AssistantDraftModel,
+            ModelConfig,
+        )
+
         with open(config_path) as fh:
             config_dict = cast("dict[str, object]", json.load(fh))
         config = ModelConfig.from_dict(config_dict)  # pyright: ignore[reportUnknownMemberType]

--- a/src/exo/worker/engines/mlx/drafters/gemma4_assistant.py
+++ b/src/exo/worker/engines/mlx/drafters/gemma4_assistant.py
@@ -1,0 +1,289 @@
+"""Gemma 4 assistant-model drafter (Phase C of the gemma4-mtp initiative).
+
+Gemma 4 ships speculative decoding as a separate 4-layer *assistant* model
+(published per target, e.g. ``mlx-community/gemma-4-26B-A4B-it-assistant-bf16``)
+rather than embedded MTP heads. The assistant:
+
+- computes **no K/V of its own** — every layer cross-attends over the
+  *target's* KV cache (the K/V of the target's last full-attention and last
+  sliding-attention layers), which is why
+  :meth:`~exo.worker.engines.mlx.drafters.protocol.Drafter.begin_request`
+  receives the target cache handles;
+- is **trained for multi-step drafting**, unlike the one-step Qwen sidecar
+  block whose chained acceptance craters past depth 1 (86.8% → 39.2%
+  conditional, Skulk #192 findings) — depth 2–4 is where this drafter is
+  expected to pay (upstream reports 3.94× at block size 4);
+- consumes the target's **final (post-norm) hidden state** — the gemma4
+  trunk path returns exactly that (the pre-norm wrapper is gated to
+  qwen-shaped trunks).
+
+The adapter drives the upstream model's ``__call__`` (which returns logits)
+rather than ``draft_block`` (which returns sampled tokens), so it satisfies
+Skulk's :class:`Drafter` protocol with real ``(K, vocab)`` rows — greedy
+chains at depth, and at depth 1 the row is the assistant's true
+distribution, so sampled (ratio-acceptance) decoding works unchanged.
+
+Shared-KV extraction is a faithful port of mlx-vlm's
+``_mtp_shared_kv_from_prompt_cache`` (zip layers with caches, ``state[:2]``
+as (k, v), un-ring-buffer ``RotatingKVCache`` via ``_temporal_order``,
+last layer of each ``layer_type`` wins).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Callable, Protocol, Sequence, cast, final
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+from mlx_lm.models.cache import RotatingKVCache
+
+from exo.worker.engines.mlx.drafters.introspection import get_trunk
+
+logger = logging.getLogger(__name__)
+
+SharedKV = dict[str, tuple[mx.array, mx.array]]
+
+
+class AssistantModel(Protocol):
+    """Structural type for mlx-vlm's ``Gemma4AssistantDraftModel`` surface.
+
+    mlx-vlm ships no type stubs; this pins the exact members the adapter
+    touches so the rest stays strictly typed.
+    """
+
+    def bind(self, target_model: object) -> "AssistantModel": ...
+
+    def reset(self, target_model: object) -> list[object]: ...
+
+    def set_shared_kv(self, shared_kv_states: SharedKV, kv_offset: int) -> None: ...
+
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        shared_kv_states: SharedKV,
+        position_ids: mx.array,
+    ) -> tuple[mx.array, mx.array]: ...
+
+    def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]: ...
+
+    def load_weights(
+        self, weights: list[tuple[str, mx.array]], strict: bool = True
+    ) -> object: ...
+
+    def parameters(self) -> dict[str, object]: ...
+
+
+def _extract_shared_kv(
+    layers: Sequence[object], prompt_cache: Sequence[object]
+) -> SharedKV:
+    """Port of mlx-vlm's ``_mtp_shared_kv_from_prompt_cache``.
+
+    Walks target layers and their caches in lockstep and keeps the K/V of
+    the LAST layer of each ``layer_type`` (full_attention /
+    sliding_attention). Rotating caches are restored to temporal order so
+    the assistant's masks index real positions.
+    """
+    shared: SharedKV = {}
+    for layer, layer_cache in zip(layers, prompt_cache, strict=False):
+        layer_type = cast("str | None", getattr(layer, "layer_type", None))
+        if layer_type is None or layer_cache is None:
+            continue
+        state = cast(
+            "tuple[mx.array | None, ...] | None", getattr(layer_cache, "state", None)
+        )
+        if state is None or len(state) < 2:
+            continue
+        keys, values = state[0], state[1]
+        if keys is None or values is None:
+            continue
+        if isinstance(layer_cache, RotatingKVCache):
+            temporal = cast(
+                "Callable[[mx.array], mx.array] | None",
+                getattr(layer_cache, "_temporal_order", None),
+            )
+            if callable(temporal):
+                keys = temporal(keys)
+                values = temporal(values)
+        shared[str(layer_type)] = (keys, values)
+    return shared
+
+
+@final
+class Gemma4AssistantDrafter:
+    """Stateful drafter wrapping mlx-vlm's ``Gemma4AssistantDraftModel``.
+
+    Satisfies :class:`~exo.worker.engines.mlx.drafters.protocol.Drafter`.
+    Construct via :func:`build_gemma4_assistant_drafter`.
+    """
+
+    def __init__(self, *, assistant: AssistantModel, target_model: object) -> None:
+        self._assistant = assistant
+        self._target = target_model
+        self._prompt_cache: list[object] = []
+        trunk = get_trunk(target_model)
+        layers = getattr(trunk, "layers", None)
+        self._layers: list[object] = (
+            cast("list[object]", layers) if isinstance(layers, list) else []
+        )
+
+    def begin_request(self, prompt_cache: Sequence[object]) -> None:
+        """Rebind to the target and keep the per-request cache handles.
+
+        The assistant has no private cache (``make_cache() -> []``); its
+        only per-round state arrives via ``set_shared_kv`` inside
+        :meth:`draft`.
+        """
+        self._assistant.reset(self._target)
+        self._prompt_cache = list(prompt_cache)
+
+    def observe(self, hiddens: mx.array, next_tokens: mx.array) -> None:
+        """No-op: the assistant carries no positional history of its own."""
+        del hiddens, next_tokens
+
+    def draft(self, hidden: mx.array, next_token: int, depth: int = 1) -> mx.array:
+        """Chain up to *depth* drafts from the target's post-norm hidden.
+
+        Mirrors the upstream ``draft_block`` loop but collects logits per
+        step: input = ``concat([target_embed(tok) * embed_scale, h_prev])``,
+        ``position_ids`` held constant at the bonus offset, ``h_prev``
+        advanced with the assistant's own ``post_projection`` output.
+        """
+        if len(self._layers) != len(self._prompt_cache):
+            raise RuntimeError(
+                "Gemma 4 assistant drafter: target layer/cache count mismatch "
+                f"({len(self._layers)} layers vs {len(self._prompt_cache)} caches)"
+            )
+        shared = _extract_shared_kv(self._layers, self._prompt_cache)
+        # The bonus position == the target cache offset at draft time (the
+        # position next_token is about to occupy).
+        offset = max(
+            (
+                int(cast(int, getattr(layer_cache, "offset", 0)))
+                for layer_cache in self._prompt_cache
+            ),
+            default=0,
+        )
+        self._assistant.set_shared_kv(shared, kv_offset=offset)
+        position_ids = mx.array([[offset]])
+
+        embed_fn = cast(
+            "Callable[[mx.array], mx.array] | None",
+            getattr(self._assistant, "_input_embed", None),
+        )
+        if embed_fn is None:
+            raise RuntimeError(
+                "Gemma 4 assistant drafter: bind(target) did not resolve the "
+                "target's input embeddings"
+            )
+        embed_scale = float(
+            cast(float, getattr(self._assistant, "_input_embed_scale", 1.0))
+        )
+
+        # (H,) post-norm target hidden -> (1, 1, backbone_hidden_size)
+        h_prev = hidden[None, None, :]
+        token = next_token
+        rows: list[mx.array] = []
+        for _ in range(max(depth, 1)):
+            tok_embed = embed_fn(mx.array([[token]])) * embed_scale
+            inputs_embeds = mx.concatenate(
+                [tok_embed.astype(h_prev.dtype), h_prev], axis=-1
+            )
+            h_prev, logits = self._assistant(inputs_embeds, shared, position_ids)
+            row = logits[0, -1].astype(mx.float32)
+            rows.append(row)
+            # Greedy-internal chain (matches the Qwen drafter and the loop's
+            # depth-1 rule under sampling).
+            token = int(mx.argmax(row).item())
+        return mx.stack(rows)
+
+
+def build_gemma4_assistant_drafter(
+    model: object,
+    assistant_model: object,
+) -> Gemma4AssistantDrafter | None:
+    """Wrap a loaded assistant model as a Skulk drafter, or ``None``.
+
+    All failures log a warning and return ``None`` — speculation is an
+    optimisation, never a crash.
+    """
+    trunk = get_trunk(model)
+    layers = getattr(trunk, "layers", None)
+    if not isinstance(layers, list) or not layers:
+        logger.warning(
+            "Gemma 4 assistant: target trunk layers not introspectable — "
+            "running without speculation"
+        )
+        return None
+    typed_layers = cast("list[object]", layers)
+    if not any(getattr(layer, "layer_type", None) for layer in typed_layers):
+        logger.warning(
+            "Gemma 4 assistant: target layers carry no layer_type metadata "
+            "(not a gemma4-family trunk?) — running without speculation"
+        )
+        return None
+    assistant = cast(AssistantModel, assistant_model)
+    try:
+        assistant = assistant.bind(model)
+    except Exception as error:  # noqa: BLE001 — bind probes model structure
+        logger.warning(
+            f"Gemma 4 assistant: bind(target) failed ({error}) — "
+            "running without speculation"
+        )
+        return None
+    drafter = Gemma4AssistantDrafter(assistant=assistant, target_model=model)
+    logger.info("Gemma 4 assistant drafter initialised (family=gemma4-assistant)")
+    return drafter
+
+
+def load_assistant_model(model_dir: Path) -> object | None:
+    """Load a Gemma 4 assistant checkpoint as an mlx-vlm draft model.
+
+    Enforces bf16 (fp16 assistants degenerate after ~50 tokens — unscaled
+    QK per the phase-c spec). Returns ``None`` on any failure, logged.
+    """
+    # Deferred import: mlx-vlm is darwin-only and heavy.
+    from mlx_vlm.speculative.drafters.gemma4_assistant import (  # pyright: ignore[reportMissingTypeStubs]
+        Gemma4AssistantDraftModel,
+        ModelConfig,
+    )
+
+    config_path = model_dir / "config.json"
+    weights_path = model_dir / "model.safetensors"
+    if not config_path.is_file() or not weights_path.is_file():
+        logger.warning(
+            f"Gemma 4 assistant at {model_dir} is incomplete "
+            "(needs config.json + model.safetensors) — running without speculation"
+        )
+        return None
+    try:
+        with open(config_path) as fh:
+            config_dict = cast("dict[str, object]", json.load(fh))
+        config = ModelConfig.from_dict(config_dict)  # pyright: ignore[reportUnknownMemberType]
+        assistant = cast(
+            AssistantModel, cast(object, Gemma4AssistantDraftModel(config))
+        )
+        raw = cast("dict[str, mx.array]", mx.load(str(weights_path)))
+        weights = assistant.sanitize(raw)
+        # bf16 enforcement: cast any fp16 tensors up-front.
+        weights = {
+            k: (v.astype(mx.bfloat16) if v.dtype == mx.float16 else v)
+            for k, v in weights.items()
+        }
+        assistant.load_weights(list(weights.items()), strict=True)
+        flattened = cast(
+            "list[tuple[str, mx.array]]", tree_flatten(assistant.parameters())
+        )
+        mx.eval([value for _, value in flattened])
+        logger.info(
+            f"Gemma 4 assistant loaded from {model_dir} "
+            f"({len(flattened)} tensors, bf16)"
+        )
+        return assistant
+    except Exception as error:  # noqa: BLE001 — never crash the runner for speculation
+        logger.warning(
+            f"Gemma 4 assistant load failed ({error}) — running without speculation"
+        )
+        return None

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1340,6 +1340,8 @@ def _stream_generate_with_mtp(
 
     # cached_hidden: (hidden_size,) from a previous verify pass, or None (need main fwd)
     cached_hidden: mx.array | None = None
+    # Set on the first drafter exception; decode continues plain thereafter.
+    speculation_disabled = False
     # pending_main: (token, logprobs) precomputed by the verify pass on a full
     # accept — skips the head recompute at the next iteration (valid only when
     # no logits processors are active, which the caller guarantees).
@@ -1428,27 +1430,63 @@ def _stream_generate_with_mtp(
             break
 
         # ---- DRAFT (chained to `depth`) ----
-        draft_probs: mx.array | None = None
-        with mx.stream(generation_stream):
-            chain_logits = drafter.draft(
-                last_hidden, main_tok_int, depth=depth
-            ).astype(mx.float32)  # (K, V), K <= depth
-            if sampling.is_greedy:
-                # Log-softmax is rank-preserving, so the greedy sampler
-                # (argmax) reads raw logits — no logsumexp over the vocab
-                # per chained draft.
-                chain_sampled = sampler(chain_logits)  # (K,)
-            else:
-                # Sampled decoding (depth forced to 1): draw the draft from
-                # the configured sampler and keep its effective distribution
-                # q for the ratio-acceptance test in the verify pass. The
-                # filters need normalized log-probabilities.
-                chain_lp = chain_logits - mx.logsumexp(
-                    chain_logits, axis=-1, keepdims=True
+        # Speculation must never abort generation: a drafter failure
+        # (unexpected model shape, upstream API drift) disables drafting for
+        # the rest of the request and decode continues plain.
+        if speculation_disabled:
+            input_tokens = mx.array([main_tok_int])
+            if logits_processors:
+                history_carry = mx.array([main_tok_int])
+            detokenizer.add_token(main_tok_int)
+            generated_count += 1
+            if generated_count >= max_tokens:
+                yield _response(
+                    main_tok_int, logprobs_main, from_draft=False, finish=finish_reason
                 )
-                draft_probs = warp_to_probs(chain_lp[0], sampling)
-                chain_sampled = sampler(chain_lp)  # (1,)
-            mx.eval(chain_sampled)
+                break
+            yield _response(main_tok_int, logprobs_main, from_draft=False, finish=None)
+            continue
+        draft_probs: mx.array | None = None
+        try:
+            with mx.stream(generation_stream):
+                chain_logits = drafter.draft(
+                    last_hidden, main_tok_int, depth=depth
+                ).astype(mx.float32)  # (K, V), K <= depth
+                if sampling.is_greedy:
+                    # Log-softmax is rank-preserving, so the greedy sampler
+                    # (argmax) reads raw logits — no logsumexp over the vocab
+                    # per chained draft.
+                    chain_sampled = sampler(chain_logits)  # (K,)
+                else:
+                    # Sampled decoding (depth forced to 1): draw the draft
+                    # from the configured sampler and keep its effective
+                    # distribution q for the ratio-acceptance test in the
+                    # verify pass. The filters need normalized
+                    # log-probabilities.
+                    chain_lp = chain_logits - mx.logsumexp(
+                        chain_logits, axis=-1, keepdims=True
+                    )
+                    draft_probs = warp_to_probs(chain_lp[0], sampling)
+                    chain_sampled = sampler(chain_lp)  # (1,)
+                mx.eval(chain_sampled)
+        except Exception as draft_error:  # noqa: BLE001 — speculation is best-effort
+            logger.warning(
+                f"Drafter failed ({draft_error}); disabling speculation for "
+                "the remainder of this request"
+            )
+            speculation_disabled = True
+            input_tokens = mx.array([main_tok_int])
+            if logits_processors:
+                history_carry = mx.array([main_tok_int])
+            detokenizer.add_token(main_tok_int)
+            generated_count += 1
+            if generated_count >= max_tokens:
+                yield _response(
+                    main_tok_int, logprobs_main, from_draft=False, finish=finish_reason
+                )
+                break
+            yield _response(main_tok_int, logprobs_main, from_draft=False, finish=None)
+            continue
 
         draft_toks = [int(t) for t in cast("list[int]", chain_sampled.tolist())]
         # Truncate at the first EOS draft: tokens past it are meaningless, and
@@ -2602,8 +2640,8 @@ def mlx_generate(
         # divergent decision silently corrupts every rank's cache. Lift
         # per-mode once TP lockstep is validated on real hardware.
         logger.info(
-            "MTP speculative decoding is single-node only (group size "
-            f"{group.size()}); skipping MTP pending distributed support"
+            "Speculative decoding is single-node only (group size "
+            f"{group.size()}); skipping speculation pending distributed support"
         )
     elif _speculation_assets:
         if logits_processors:

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -1148,6 +1148,14 @@ def _make_prenorm_trunk_fn(trunk: object) -> Callable[..., mx.array] | None:
     layers: object | None = getattr(trunk, "layers", None)
     if embed is None or not callable(embed) or not isinstance(layers, list):
         return None
+    # Gate to qwen-shaped trunks: the manual mask construction below mirrors
+    # Qwen3.5's ssm/full-attention split. Other families (gemma4's
+    # sliding/full split) would get WRONG masks — and the gemma4 assistant
+    # drafter wants the post-norm fallback path anyway.
+    if not hasattr(trunk, "fa_idx") and not any(
+        hasattr(layer, "is_linear") for layer in cast("list[object]", layers)
+    ):
+        return None
     layer_list = cast("list[Callable[..., mx.array]]", layers)
     # Hybrid (GDN/SSM) trunks key their masks off specific layer indices;
     # pure-attention trunks use the first cache entry.
@@ -1213,9 +1221,13 @@ def _get_trunk_and_head(
                         return head_fn(norm_fn(hidden))
 
                     return (prenorm_trunk_fn, normed_head_fn)
-                logger.warning(
-                    "MTP: trunk structure not introspectable for pre-norm hiddens; "
-                    "falling back to post-norm trunk (draft acceptance will suffer)"
+                # Post-norm fallback. For qwen-family sidecar heads this
+                # degrades acceptance (they train on pre-norm hiddens); for
+                # the gemma4 assistant it is exactly the convention the
+                # drafter consumes.
+                logger.info(
+                    "MTP: using post-norm trunk hiddens (pre-norm wrapper "
+                    "unavailable for this trunk shape)"
                 )
                 return (cast(Callable[..., mx.array], trunk), head_fn)
     # DeepSeek-style: trunk = model.model, head = model.lm_head
@@ -2127,6 +2139,7 @@ def mlx_generate(
     trace_task_id: str | None = None,
     trace_rank: int = 0,
     mtp_weights: "dict[str, mx.array] | None" = None,
+    assistant_model: object | None = None,
     model_card: ModelCard | None = None,
 ) -> Generator[GenerationResponse]:
     # Ensure that generation stats only contains peak memory for this generation
@@ -2579,7 +2592,8 @@ def mlx_generate(
     _drafter: Drafter | None = None
     _trunk_fn: Callable[..., mx.array] | None = None
     _head_fn: Callable[..., mx.array] | None = None
-    if mtp_weights is not None and group is not None and group.size() > 1:
+    _speculation_assets = mtp_weights is not None or assistant_model is not None
+    if _speculation_assets and group is not None and group.size() > 1:
         # MTP is single-node only for now. Pipeline sharding needs the
         # distributed draft/verify design (#152 Phase 2: last-rank drafting,
         # K+1 pipeline verify, trim broadcast). Tensor-parallel would
@@ -2591,7 +2605,7 @@ def mlx_generate(
             "MTP speculative decoding is single-node only (group size "
             f"{group.size()}); skipping MTP pending distributed support"
         )
-    elif mtp_weights is not None:
+    elif _speculation_assets:
         if logits_processors:
             # Accepted draft tokens are committed from RAW verifier logits —
             # logits processors (repetition penalty, bench EOS ban) are only
@@ -2610,6 +2624,7 @@ def mlx_generate(
                 _drafter = build_drafter(
                     model,
                     mtp_weights,
+                    assistant_model=assistant_model,
                     runtime=model_card.runtime if model_card is not None else None,
                 )
                 if _drafter is not None:

--- a/src/exo/worker/engines/mlx/tests/test_drafters.py
+++ b/src/exo/worker/engines/mlx/tests/test_drafters.py
@@ -695,6 +695,55 @@ class TestStreamGenerateWithMTP:
         # break path already finalized via the terminal response.
         assert buffering_detokenizer.finalize_calls == 1
 
+    def test_drafter_exception_disables_speculation_not_generation(self) -> None:
+        """Speculation must never abort generation: a drafter that raises
+        disables drafting for the request and decode continues plain."""
+        from exo.worker.engines.mlx.generator.generate import _stream_generate_with_mtp
+
+        model, tokenizer, _drafter, trunk_fn, head_fn, cache = _build_fake_stream_env(
+            main_token_ids=[5, 6, 7, 0],
+            draft_token_id=5,
+        )
+
+        class _ExplodingDrafter:
+            def __init__(self) -> None:
+                self.draft_attempts = 0
+
+            def begin_request(self, prompt_cache: object) -> None:
+                pass
+
+            def observe(self, hiddens: mx.array, next_tokens: mx.array) -> None:
+                pass
+
+            def draft(
+                self, hidden: mx.array, next_token: int, depth: int = 1
+            ) -> mx.array:
+                self.draft_attempts += 1
+                raise RuntimeError("upstream API drift")
+
+        exploding = _ExplodingDrafter()
+        sampler = lambda lp: mx.argmax(lp, axis=-1)  # noqa: E731
+        outputs = list(
+            _stream_generate_with_mtp(
+                model=model,
+                tokenizer=tokenizer,
+                drafter=exploding,
+                trunk_fn=trunk_fn,
+                head_fn=head_fn,
+                prompt=mx.array([1, 2, 3]),
+                max_tokens=4,
+                sampler=sampler,
+                logits_processors=[],
+                prompt_cache=cache,
+                kv_group_size=None,
+                kv_bits=None,
+            )
+        )
+        # Generation completed despite the drafter failing...
+        assert len(outputs) >= 3
+        # ...and drafting was attempted exactly once, then disabled.
+        assert exploding.draft_attempts == 1
+
     def test_reject_path_does_not_crash(self) -> None:
         outputs, _drafter, _cache = self._run(
             main_token_ids=[5, 3, 0],

--- a/src/exo/worker/engines/mlx/tests/test_gemma4_drafter.py
+++ b/src/exo/worker/engines/mlx/tests/test_gemma4_drafter.py
@@ -170,18 +170,32 @@ class TestGemma4AssistantDrafter:
         drafter, _, _ = self._drafter()
         drafter.observe(mx.zeros((3, HIDDEN)), mx.array([1, 2, 3]))  # must not raise
 
-    def test_layer_cache_mismatch_raises(self) -> None:
+    def test_kv_shared_prefix_mapping(self) -> None:
+        """Fewer caches than layers = KV-shared model: caches map to the
+        layer prefix (gemma4 make_cache builds layers[:first_kv_shared])."""
         assistant = _FakeAssistant()
         drafter = Gemma4AssistantDrafter(
             assistant=assistant, target_model=_FakeGemmaModel()
         )
-        drafter.begin_request([_kv_cache_with(2, 1.0)])  # 1 cache vs 2 layers
+        # 1 cache vs 2 layers -> only the first (sliding) layer participates.
+        drafter.begin_request([_kv_cache_with(2, 1.0)])
+        drafter.draft(mx.zeros(HIDDEN), next_token=1)
+        assert assistant.set_shared_kv_calls == [({"sliding_attention"}, 2)]
+
+    def test_more_caches_than_layers_raises(self) -> None:
+        assistant = _FakeAssistant()
+        drafter = Gemma4AssistantDrafter(
+            assistant=assistant, target_model=_FakeGemmaModel()
+        )
+        drafter.begin_request(
+            [_kv_cache_with(2, 1.0), _kv_cache_with(2, 1.0), _kv_cache_with(2, 1.0)]
+        )
         try:
             drafter.draft(mx.zeros(HIDDEN), next_token=1)
         except RuntimeError as error:
-            assert "mismatch" in str(error)
+            assert "more caches" in str(error)
         else:
-            raise AssertionError("expected RuntimeError on layer/cache mismatch")
+            raise AssertionError("expected RuntimeError on cache surplus")
 
 
 class TestBuilderDispatch:

--- a/src/exo/worker/engines/mlx/tests/test_gemma4_drafter.py
+++ b/src/exo/worker/engines/mlx/tests/test_gemma4_drafter.py
@@ -1,0 +1,233 @@
+# pyright: reportPrivateUsage=false, reportUnknownLambdaType=false
+# pyright: reportUnknownVariableType=false, reportUnknownArgumentType=false
+# pyright: reportArgumentType=false, reportUnknownMemberType=false
+# pyright: reportUnknownParameterType=false, reportMissingParameterType=false
+"""Unit tests for the Gemma 4 assistant drafter (gemma4-mtp Phase C)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlx.core as mx
+from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+from exo.worker.engines.mlx.drafters import build_drafter
+from exo.worker.engines.mlx.drafters.gemma4_assistant import (
+    Gemma4AssistantDrafter,
+    _extract_shared_kv,
+    build_gemma4_assistant_drafter,
+    load_assistant_model,
+)
+
+HIDDEN = 8
+VOCAB = 16
+
+
+class _FakeLayer:
+    def __init__(self, layer_type: str) -> None:
+        self.layer_type = layer_type
+
+
+def _kv_cache_with(n: int, fill: float) -> KVCache:
+    cache = KVCache()
+    cache.update_and_fetch(
+        mx.full((1, 1, n, 4), fill), mx.full((1, 1, n, 4), fill)
+    )
+    return cache
+
+
+class TestExtractSharedKV:
+    def test_last_layer_of_each_type_wins(self) -> None:
+        layers = [
+            _FakeLayer("sliding_attention"),
+            _FakeLayer("full_attention"),
+            _FakeLayer("sliding_attention"),
+            _FakeLayer("full_attention"),
+        ]
+        caches = [
+            _kv_cache_with(3, 1.0),
+            _kv_cache_with(3, 2.0),
+            _kv_cache_with(3, 3.0),
+            _kv_cache_with(3, 4.0),
+        ]
+        shared = _extract_shared_kv(layers, caches)
+        assert set(shared) == {"sliding_attention", "full_attention"}
+        # Last sliding layer carried fill=3.0; last full carried fill=4.0.
+        assert float(shared["sliding_attention"][0][0, 0, 0, 0].item()) == 3.0
+        assert float(shared["full_attention"][0][0, 0, 0, 0].item()) == 4.0
+
+    def test_skips_layers_without_type_or_state(self) -> None:
+        class _Untyped:
+            pass
+
+        layers = [_Untyped(), _FakeLayer("full_attention")]
+        caches = [_kv_cache_with(2, 1.0), KVCache()]  # second has empty state
+        shared = _extract_shared_kv(layers, caches)
+        assert shared == {}
+
+    def test_rotating_cache_restored_to_temporal_order(self) -> None:
+        layer = _FakeLayer("sliding_attention")
+        cache = RotatingKVCache(max_size=4)
+        # Overfill so the ring buffer wraps; values encode insertion order.
+        for i in range(6):
+            cache.update_and_fetch(
+                mx.full((1, 1, 1, 4), float(i)), mx.full((1, 1, 1, 4), float(i))
+            )
+        shared = _extract_shared_kv([layer], [cache])
+        keys = shared["sliding_attention"][0]
+        flat = [float(keys[0, 0, i, 0].item()) for i in range(keys.shape[2])]
+        # Temporal order: strictly non-decreasing insertion stamps.
+        assert flat == sorted(flat), f"not temporally ordered: {flat}"
+
+
+class _FakeAssistant:
+    """Protocol-satisfying fake recording every adapter interaction."""
+
+    def __init__(self, vocab: int = VOCAB) -> None:
+        self._vocab = vocab
+        self.reset_calls = 0
+        self.bind_calls = 0
+        self.set_shared_kv_calls: list[tuple[set[str], int]] = []
+        self.call_positions: list[int] = []
+        self._input_embed = lambda toks: mx.ones((1, 1, HIDDEN))
+        self._input_embed_scale = 2.0
+
+    def bind(self, target_model: object) -> "_FakeAssistant":
+        self.bind_calls += 1
+        return self
+
+    def reset(self, target_model: object) -> list[object]:
+        self.reset_calls += 1
+        return []
+
+    def set_shared_kv(self, shared_kv_states: dict[str, tuple[mx.array, mx.array]], kv_offset: int) -> None:
+        self.set_shared_kv_calls.append((set(shared_kv_states), kv_offset))
+
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        shared_kv_states: dict[str, tuple[mx.array, mx.array]],
+        position_ids: mx.array,
+    ) -> tuple[mx.array, mx.array]:
+        self.call_positions.append(int(position_ids[0, 0].item()))
+        # Draft token = current call count, encoded as one-hot logits.
+        step = len(self.call_positions)
+        logits = mx.where(
+            mx.arange(self._vocab)[None, None, :] == step,
+            mx.array(100.0),
+            mx.zeros((1, 1, self._vocab)),
+        )
+        return mx.ones((1, 1, HIDDEN)), logits
+
+    def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
+        return weights
+
+    def load_weights(
+        self, weights: list[tuple[str, mx.array]], strict: bool = True
+    ) -> object:
+        return self
+
+    def parameters(self) -> dict[str, object]:
+        return {}
+
+
+class _FakeGemmaTrunk:
+    def __init__(self) -> None:
+        self.layers = [_FakeLayer("sliding_attention"), _FakeLayer("full_attention")]
+
+
+class _FakeGemmaModel:
+    def __init__(self) -> None:
+        self.language_model = type("LM", (), {"model": _FakeGemmaTrunk()})()
+
+
+class TestGemma4AssistantDrafter:
+    def _drafter(self) -> tuple[Gemma4AssistantDrafter, _FakeAssistant, list[object]]:
+        assistant = _FakeAssistant()
+        model = _FakeGemmaModel()
+        drafter = Gemma4AssistantDrafter(assistant=assistant, target_model=model)
+        caches: list[object] = [_kv_cache_with(5, 1.0), _kv_cache_with(5, 2.0)]
+        drafter.begin_request(caches)
+        return drafter, assistant, caches
+
+    def test_begin_request_resets_assistant(self) -> None:
+        _, assistant, _ = self._drafter()
+        assert assistant.reset_calls == 1
+
+    def test_draft_chains_to_depth_with_constant_position(self) -> None:
+        drafter, assistant, _ = self._drafter()
+        rows = drafter.draft(mx.zeros(HIDDEN), next_token=7, depth=3)
+        assert rows.shape == (3, VOCAB)
+        assert rows.dtype == mx.float32
+        # Position held constant at the cache offset (5) across all steps.
+        assert assistant.call_positions == [5, 5, 5]
+        # Shared KV carried both layer types; kv_offset = cache offset.
+        assert assistant.set_shared_kv_calls == [
+            ({"sliding_attention", "full_attention"}, 5)
+        ]
+
+    def test_observe_is_noop(self) -> None:
+        drafter, _, _ = self._drafter()
+        drafter.observe(mx.zeros((3, HIDDEN)), mx.array([1, 2, 3]))  # must not raise
+
+    def test_layer_cache_mismatch_raises(self) -> None:
+        assistant = _FakeAssistant()
+        drafter = Gemma4AssistantDrafter(
+            assistant=assistant, target_model=_FakeGemmaModel()
+        )
+        drafter.begin_request([_kv_cache_with(2, 1.0)])  # 1 cache vs 2 layers
+        try:
+            drafter.draft(mx.zeros(HIDDEN), next_token=1)
+        except RuntimeError as error:
+            assert "mismatch" in str(error)
+        else:
+            raise AssertionError("expected RuntimeError on layer/cache mismatch")
+
+
+class TestBuilderDispatch:
+    def test_assistant_takes_precedence(self) -> None:
+        drafter = build_drafter(
+            _FakeGemmaModel(), None, assistant_model=_FakeAssistant()
+        )
+        assert isinstance(drafter, Gemma4AssistantDrafter)
+
+    def test_non_gemma_trunk_returns_none(self) -> None:
+        class _NoTypeLayerTrunk:
+            layers = [object()]
+
+        class _Model:
+            language_model = type("LM", (), {"model": _NoTypeLayerTrunk()})()
+
+        drafter = build_gemma4_assistant_drafter(_Model(), _FakeAssistant())
+        assert drafter is None
+
+    def test_bind_failure_returns_none(self) -> None:
+        class _ExplodingAssistant(_FakeAssistant):
+            def bind(self, target_model: object) -> "_FakeAssistant":
+                raise ValueError("no embeddings")
+
+        drafter = build_gemma4_assistant_drafter(
+            _FakeGemmaModel(), _ExplodingAssistant()
+        )
+        assert drafter is None
+
+
+class TestLoadAssistantModel:
+    def test_missing_files_returns_none(self, tmp_path: Path) -> None:
+        assert load_assistant_model(tmp_path) is None
+
+
+class TestPrenormGating:
+    def test_non_qwen_trunk_skips_prenorm_wrapper(self) -> None:
+        """gemma4-shaped trunks (no fa_idx, no is_linear layers) must NOT get
+        the qwen-specific pre-norm wrapper — its manual masks mirror the
+        qwen ssm/full split and would be wrong for sliding/full layers."""
+        from exo.worker.engines.mlx.generator.generate import _make_prenorm_trunk_fn
+
+        class _GemmaishTrunk:
+            def embed_tokens(self, x: mx.array) -> mx.array:
+                return mx.zeros((1, x.shape[-1], HIDDEN))
+
+            layers = [_FakeLayer("sliding_attention"), _FakeLayer("full_attention")]
+
+        assert _make_prenorm_trunk_fn(_GemmaishTrunk()) is None

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -740,7 +740,8 @@ def load_mlx_items(
         else:
             logger.warning(
                 f"Assistant model repo {runtime.assistant_model_repo!r} not "
-                "downloaded; running without speculation"
+                "downloaded; assistant drafting disabled (MTP sidecar "
+                "speculation, if configured, is unaffected)"
             )
     elif runtime and runtime.assistant_model_repo:
         logger.info(

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -49,7 +49,11 @@ import mlx.nn as nn
 from mlx_lm.utils import load_model as _mlx_lm_load_model
 from pydantic import RootModel
 
-from exo.download.download_utils import build_model_path, build_sidecar_path
+from exo.download.download_utils import (
+    build_companion_model_path,
+    build_model_path,
+    build_sidecar_path,
+)
 from exo.shared.types.common import Host
 from exo.shared.types.memory import Memory
 from exo.shared.types.mlx import Model
@@ -77,6 +81,7 @@ from exo.worker.engines.mlx.auto_parallel import (
     pipeline_timeout_callback,
     tensor_auto_parallel,
 )
+from exo.worker.engines.mlx.drafters.gemma4_assistant import load_assistant_model
 from exo.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
 from exo.worker.runner.bootstrap import logger
 from exo.worker.runner.diagnostics import remember_wired_limit_bytes
@@ -633,7 +638,7 @@ def load_mlx_items(
     group: Group | None,
     on_timeout: TimeoutCallback | None,
     on_layer_loaded: LayerLoadedCallback | None,
-) -> "tuple[Model, TokenizerWrapper, VisionProcessor | None, dict[str, mx.array] | None]":
+) -> "tuple[Model, TokenizerWrapper, VisionProcessor | None, dict[str, mx.array] | None, object | None]":
     if group is None:
         logger.info(f"Single device used for {bound_instance.instance}")
         model_path = build_model_path(bound_instance.bound_shard.model_card.model_id)
@@ -721,7 +726,30 @@ def load_mlx_items(
             "load — MTP is single-node only pending #201"
         )
 
-    return cast(Model, model), tokenizer, vision_processor, mtp_weights
+    assistant_model: object | None = None
+    if runtime and runtime.assistant_model_repo and (
+        group is None or group.size() <= 1
+    ):
+        # Gemma 4 assistant drafter (gemma4-mtp Phase C). Same single-node
+        # envelope as MTP sidecars (#200/#201).
+        assistant_dir = build_companion_model_path(
+            ModelId(runtime.assistant_model_repo)
+        )
+        if assistant_dir is not None:
+            assistant_model = load_assistant_model(assistant_dir)
+        else:
+            logger.warning(
+                f"Assistant model repo {runtime.assistant_model_repo!r} not "
+                "downloaded; running without speculation"
+            )
+    elif runtime and runtime.assistant_model_repo:
+        logger.info(
+            "Assistant model declared but placement is distributed "
+            f"(group size {group.size() if group else 0}); skipping assistant "
+            "load — speculation is single-node only pending #201"
+        )
+
+    return cast(Model, model), tokenizer, vision_processor, mtp_weights, assistant_model
 
 
 def shard_and_load(

--- a/src/exo/worker/runner/llm_inference/batch_generator.py
+++ b/src/exo/worker/runner/llm_inference/batch_generator.py
@@ -143,6 +143,7 @@ class SequentialGenerator(InferenceGenerator):
     event_sender: MpSender[Event]
     vision_processor: VisionProcessor | None = None
     mtp_weights: "dict[str, mx.array] | None" = None
+    assistant_model: object | None = None
     check_for_cancel_every: int = 50
 
     _cancelled_tasks: set[TaskId] = field(default_factory=set, init=False)
@@ -442,6 +443,7 @@ class SequentialGenerator(InferenceGenerator):
             trace_task_id=task.task_id,
             trace_rank=self.device_rank,
             mtp_weights=self.mtp_weights,
+            assistant_model=self.assistant_model,
             model_card=self.model_card,
         )
 
@@ -478,6 +480,7 @@ class BatchGenerator(InferenceGenerator):
     check_for_cancel_every: int = 50
     vision_processor: VisionProcessor | None = None
     mtp_weights: "dict[str, mx.array] | None" = None
+    assistant_model: object | None = None
 
     _cancelled_tasks: set[TaskId] = field(default_factory=set, init=False)
     _maybe_queue: list[TextGeneration] = field(default_factory=list, init=False)

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -303,6 +303,7 @@ class Runner:
                         self.generator.tokenizer,
                         self.generator.vision_processor,
                         self.generator.mtp_weights,
+                        self.generator.assistant_model,
                     ) = load_mlx_items(
                         self.bound_instance,
                         self.generator.group,
@@ -698,6 +699,7 @@ class Builder:
     group: mx.distributed.Group | None = None
     vision_processor: VisionProcessor | None = None
     mtp_weights: dict[str, mx.array] | None = None
+    assistant_model: object | None = None
 
     def build(
         self,
@@ -740,7 +742,9 @@ class Builder:
         force_sequential_for_gemma4 = is_gemma4_family(
             self.model_card, model_id=self.model_id
         )
-        force_sequential_for_mtp = self.mtp_weights is not None
+        force_sequential_for_mtp = (
+            self.mtp_weights is not None or self.assistant_model is not None
+        )
         no_batch_requested = os.environ.get("SKULK_NO_BATCH") or os.environ.get(
             "EXO_NO_BATCH"
         )
@@ -780,6 +784,7 @@ class Builder:
                 event_sender=self.event_sender,
                 vision_processor=vision_processor,
                 mtp_weights=self.mtp_weights,
+                assistant_model=self.assistant_model,
             )
         logger.info("using BatchGenerator")
         return BatchGenerator(

--- a/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_event_ordering.py
@@ -117,7 +117,7 @@ def patch_out_mlx(monkeypatch: pytest.MonkeyPatch):
     # initialize_mlx returns a mock group
     monkeypatch.setattr(mlx_runner, "initialize_mlx", make_nothin(MockGroup()))
     monkeypatch.setattr(
-        mlx_runner, "load_mlx_items", make_nothin((1, MockTokenizer, None, None))
+        mlx_runner, "load_mlx_items", make_nothin((1, MockTokenizer, None, None, None))
     )
     monkeypatch.setattr(mlx_batch_generator, "warmup_inference", make_nothin(1))
     monkeypatch.setattr(mlx_batch_generator, "_check_for_debug_prompts", nothin)

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -54,7 +54,7 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 - **Implementations:**
   - `qwen_sidecar.py::QwenSidecarDrafter` — Phase 2: +1.0 zero-centered norm shift, `embed_first` concat, sidecar `mtp.layers.0` block instantiated from the target family's own decoder-layer class (strict-loaded), private `KVCache`. Validated ~58–74% acceptance on Qwen3.5-2B (issue #192).
   - `deepseek_sidecar.py::DeepseekSidecarDrafter` — legacy projection-only head; conventions unverified against real weights.
-  - Planned: Gemma 4 assistant-model drafter (foxlight-docs `gemma4-mtp` Phase C).
+  - `gemma4_assistant.py::Gemma4AssistantDrafter` — wraps mlx-vlm's chain-trained assistant model: cross-attends over the target's KV (shared-KV extraction incl. RotatingKVCache temporal restore), consumes post-norm hiddens, loads via `assistant_model_repo` (bf16-enforced). Depth 1 is the measured optimum on quantized targets.
 - **Observability:** the loop logs `MTP acceptance so far: A/N` every 32 drafts; the public `GenerationResponse` does not carry per-token draft provenance.
 
 ### Router (libp2p)


### PR DESCRIPTION
## Summary

Completes the **gemma4-mtp initiative's north star**: a user points Skulk at a Gemma 4 model whose card declares `assistant_model_repo` and gets speculative decoding via Google's chain-trained assistant models. **Measured: gemma-4-26B-A4B-it-4bit at 28.8 tok/s vs 15.5–17.8 vanilla (1.6–1.85×, 55% acceptance)**; gemma-4-e4b-it-8bit 1.26×.

The loop is untouched — the assistant is the third `Drafter` implementation riding the #193/#196/#197 machinery, exactly as the protocol design intended.

## What's new

- **`drafters/gemma4_assistant.py`** — adapter wrapping mlx-vlm 0.6.1's `Gemma4AssistantDraftModel`: drives its `__call__` for real `(K, vocab)` logits rows; shared-KV extraction faithfully ports upstream's `_mtp_shared_kv_from_prompt_cache` (last layer of each `layer_type` wins, `RotatingKVCache` restored to temporal order); KV-shared models (E2B/E4B) map caches to the owning layer prefix; loader enforces bf16 (fp16 assistants degenerate).
- **`build_companion_model_path`** — assistant repos ship one `model.safetensors`, no index; the standard completeness check rejects them.
- **Loading + threading**: card-declared assistants load in `load_mlx_items` (single-node envelope per #200/#201) and thread to the loop parallel to `mtp_weights`; presence forces `SequentialGenerator`.
- **Pre-norm wrapper gated to qwen-shaped trunks** — its manual masks mirror qwen's ssm/full split and would be wrong for gemma4's sliding/full layers; gemma falls through to the post-norm path, which is exactly the hidden convention the assistant consumes.
- **Companion download-completeness gap closed** (#185 flag): a base cached before its card declared companions reported complete and never fetched them; the status check now degrades to `in_progress` when a declared companion is missing.

## Measured results (M4/24GB, exact-attempt metric)

| Target | Depth | Acceptance | Speedup |
|---|---|---|---|
| 26B-A4B-4bit | **1** | 55% | **1.6–1.85×** (28.8 tok/s stable; vanilla 15.5–17.8 noisy) |
| 26B-A4B-4bit | 2 / 3 / 4 | 34% / 30% / 30% | 1.36× / 1.27× / 1.16× |
| E4B-8bit | 1 / 3 | 48% / 34% | 1.26× / 1.30× |

**Finding:** chained depth does *not* pay on quantized targets — the assistant trains against bf16 hiddens/KV, chain acceptance decays compounding-ly on 4-/8-bit inputs, and MoE verify cost grows with block size. Depth 1 is the carded default and measured optimum. (Falsifier for the precision theory: a bf16-target run — E4B-bf16 fits the validation host — expected to restore upstream's deep-block numbers; future measurement.)

Parity note: same semantically-greedy property as GDN hybrids — rotating-cache replay numerics can flip a later near-tie (single stable divergence point across all depths, output coherent); documented in #193's CHANGELOG entry.

## Validation

- 13 adapter unit tests (extraction, temporal restore, KV-shared prefix mapping, chain/position semantics, dispatch, fallbacks) — 803 total passing
- Live runs above (E4B for iteration — caught the `LanguageModelOutput` and KV-shared integration bugs — then the north star)
- `basedpyright` 0 · `ruff` clean

Closes the gemma4-mtp initiative's Skulk scope (Phases A–C). Distributed assistant drafting rides #201 like all speculation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)