### PR TITLE
fix(mtp): drafter buildability on distributed/MoE artifacts — slice alignment + per-expert stacking

### DIFF
--- a/resources/inference_model_cards/mlx-community--Qwen3.5-35B-A3B-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3.5-35B-A3B-4bit.toml
@@ -9,5 +9,13 @@ quantization = "4bit"
 base_model = "Qwen3.5 35B A3B"
 capabilities = ["text", "thinking", "thinking_toggle"]
 
+# NO MTP section — by measurement, not omission (2026-06-05, 3-node
+# pipeline, M4 fleet): the FoxlightAI/qwen3-5-35b-a3b-base-mtp sidecar
+# builds and drafts at 85% acceptance, but MTP measured 0.63x (35.6 ->
+# 22.3 tok/s). Fast MoEs are structurally MTP-hostile: each verify token
+# routes to its own experts (verify width is not free, unlike dense), and
+# a 28ms/step baseline magnifies fixed per-round overhead. Do not add a
+# sidecar here without re-measuring on materially different hardware.
+
 [storage_size]
 in_bytes = 20391405152

--- a/src/exo/worker/engines/mlx/drafters/introspection.py
+++ b/src/exo/worker/engines/mlx/drafters/introspection.py
@@ -111,16 +111,33 @@ def detect_quantization(model: object) -> tuple[int, int] | None:
     return None
 
 
+# How many candidate layer_idx values to probe when constructing a sibling
+# full-attention layer. Covers any plausible hybrid attention interval (the
+# known families use 4) with margin.
+_SIBLING_LAYER_IDX_PROBE_LIMIT = 16
+
+
 def build_sibling_attention_layer(model: object) -> nn.Module | None:
     """Construct an uninitialised sibling of the trunk's full-attention layer.
 
     MTP transformer blocks in Qwen3Next-descended families are architecturally
     one of the family's own decoder layers, so the most future-proof way to
     build one is to find a full-attention layer in the loaded trunk and
-    instantiate ``type(layer)(args, layer_idx=<same index>)``. New families
-    then work without new block code — and if a future family changes its
-    constructor signature, this returns ``None`` and the caller falls back to
-    running without MTP (loud log, no crash).
+    instantiate the family's own decoder-layer class. New families then work
+    without new block code — and if a future family changes its constructor
+    signature, this returns ``None`` and the caller falls back to running
+    without MTP (loud log, no crash).
+
+    Hybrid constructors derive the layer TYPE from ``layer_idx`` (e.g.
+    qwen3_5 full-attention iff ``(idx + 1) % full_attention_interval == 0``),
+    and under pipeline slicing the local position of a full-attention layer
+    no longer maps to a full-attention index in args terms — the 2B's
+    12-layer halves only worked because 12 is a multiple of the interval;
+    the 27B's 21-layer thirds are not, and the misaligned index silently
+    constructs a GDN sibling whose strict-load then fails (#201 Track 2a,
+    flagship run 2026-06-05). So instead of trusting the local index, probe
+    candidate indices until the constructed sibling actually carries
+    ``self_attn`` — self-validating against any family's indexing scheme.
     """
     trunk = get_trunk(model)
     args = get_model_args(model)
@@ -131,9 +148,16 @@ def build_sibling_attention_layer(model: object) -> nn.Module | None:
         # Full-attention layers carry `self_attn`; linear/SSM layers do not.
         if getattr(layer, "self_attn", None) is None:
             continue
-        try:
-            sibling = type(layer)(args, layer_idx=layer_idx)  # type: ignore[call-arg]
-        except TypeError:
-            return None
-        return cast(nn.Module, sibling)
+        # Pipeline wrappers proxy attribute access to the wrapped layer (so
+        # the self_attn scan sees them), but type(wrapper) is not the family
+        # decoder class — unwrap before constructing.
+        layer_source: object = getattr(layer, "original_layer", layer)
+        for candidate_idx in (layer_idx, *range(_SIBLING_LAYER_IDX_PROBE_LIMIT)):
+            try:
+                sibling = type(layer_source)(args, layer_idx=candidate_idx)  # type: ignore[call-arg]
+            except TypeError:
+                return None
+            if getattr(sibling, "self_attn", None) is not None:
+                return cast(nn.Module, sibling)
+        return None
     return None

--- a/src/exo/worker/engines/mlx/drafters/qwen_sidecar.py
+++ b/src/exo/worker/engines/mlx/drafters/qwen_sidecar.py
@@ -32,6 +32,7 @@ sidecar is rejected loudly at build time rather than silently mis-loaded.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Callable, Literal, Sequence, cast, final
 
 import mlx.core as mx
@@ -204,6 +205,53 @@ class QwenSidecarDrafter:
         return self._fc(combined)[None]
 
 
+_PER_EXPERT_KEY = re.compile(
+    r"^(.*)\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
+)
+
+
+def _stack_per_expert_block_weights(
+    pairs: list[tuple[str, mx.array]],
+) -> list[tuple[str, mx.array]]:
+    """Normalize raw per-expert MoE keys to mlx-lm's stacked switch layout.
+
+    SWP sidecars preserve the checkpoint's original per-expert keys
+    (``mlp.experts.<n>.{gate,up,down}_proj.weight``), but mlx-lm decoder
+    layers hold stacked ``SwitchGLU`` tensors
+    (``mlp.switch_mlp.<proj>.weight``, shape ``(num_experts, out, in)``) —
+    the conversion normally happens in the family ``sanitize()``, which the
+    sidecar strict-load path never runs. Dense sidecars pass through
+    untouched.
+    """
+    stacked_groups: dict[tuple[str, str], dict[int, mx.array]] = {}
+    passthrough: list[tuple[str, mx.array]] = []
+    for key, value in pairs:
+        match = _PER_EXPERT_KEY.match(key)
+        if match is None:
+            passthrough.append((key, value))
+            continue
+        group_key = (match.group(1), match.group(3))
+        stacked_groups.setdefault(group_key, {})[int(match.group(2))] = value
+    for (prefix, projection), by_expert in stacked_groups.items():
+        expert_count = len(by_expert)
+        if sorted(by_expert) != list(range(expert_count)):
+            # A gap means a truncated/corrupt sidecar — let the strict load
+            # fail loudly on the missing stacked key rather than stacking
+            # a silently wrong tensor.
+            passthrough.extend(
+                (f"{prefix}.experts.{idx}.{projection}.weight", tensor)
+                for idx, tensor in by_expert.items()
+            )
+            continue
+        passthrough.append(
+            (
+                f"{prefix}.switch_mlp.{projection}.weight",
+                mx.stack([by_expert[idx] for idx in range(expert_count)]),
+            )
+        )
+    return passthrough
+
+
 def build_qwen_sidecar_drafter(
     model: object,
     weights: dict[str, mx.array],
@@ -252,14 +300,16 @@ def build_qwen_sidecar_drafter(
         )
         return None
 
-    block_pairs = [
-        (
-            key.removeprefix(QWEN35_BLOCK_PREFIX),
-            norm_weight(key) if "norm" in key else value,
-        )
-        for key, value in weights.items()
-        if key.startswith(QWEN35_BLOCK_PREFIX)
-    ]
+    block_pairs = _stack_per_expert_block_weights(
+        [
+            (
+                key.removeprefix(QWEN35_BLOCK_PREFIX),
+                norm_weight(key) if "norm" in key else value,
+            )
+            for key, value in weights.items()
+            if key.startswith(QWEN35_BLOCK_PREFIX)
+        ]
+    )
     if not block_pairs:
         logger.warning(
             "MTP: sidecar has no mtp.layers.0.* transformer block — the "

--- a/src/exo/worker/engines/mlx/tests/test_drafters.py
+++ b/src/exo/worker/engines/mlx/tests/test_drafters.py
@@ -1196,6 +1196,72 @@ class TestDeferredReplay:
 
 
 # ---------------------------------------------------------------------------
+# Sibling-layer construction under pipeline slicing
+# ---------------------------------------------------------------------------
+
+
+def _hybrid_args() -> qwen3_5.TextModelArgs:
+    """Toy hybrid args: full attention every 4th layer (like real Qwen3.5)."""
+    return qwen3_5.TextModelArgs(  # pyright: ignore[reportCallIssue]
+        model_type="qwen3_5",
+        hidden_size=HIDDEN,
+        intermediate_size=2 * HIDDEN,
+        num_hidden_layers=8,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        vocab_size=VOCAB,
+        full_attention_interval=4,
+        tie_word_embeddings=True,
+    )
+
+
+class TestSiblingLayerSliceAlignment:
+    """Hybrid constructors derive layer TYPE from layer_idx; a pipeline
+    slice whose offset is not a multiple of the attention interval makes the
+    local index of a full-attention layer map to a LINEAR position — the
+    naive ``type(layer)(args, layer_idx=<local>)`` silently builds a GDN
+    sibling and the strict-load fails (#201 Track 2a flagship run). The
+    builder must self-validate that the constructed sibling carries
+    ``self_attn``.
+    """
+
+    def test_aligned_slice_builds_attention_sibling(self) -> None:
+        from exo.worker.engines.mlx.drafters.introspection import (
+            build_sibling_attention_layer,
+        )
+
+        class _Model:
+            def __init__(self) -> None:
+                self.language_model = qwen3_5.TextModel(_hybrid_args())
+
+        sibling = build_sibling_attention_layer(_Model())
+        assert sibling is not None
+        assert getattr(sibling, "self_attn", None) is not None
+
+    def test_misaligned_slice_builds_attention_sibling(self) -> None:
+        # Simulate a pipeline shard: slice the trunk so the first
+        # full-attention layer (global 3) lands at local index 1 — a linear
+        # position in args terms. The 27B's 21-layer thirds hit exactly
+        # this; the 2B's 12-layer halves dodged it (12 % 4 == 0).
+        from exo.worker.engines.mlx.drafters.introspection import (
+            build_sibling_attention_layer,
+        )
+
+        class _Model:
+            def __init__(self) -> None:
+                self.language_model = qwen3_5.TextModel(_hybrid_args())
+
+        model = _Model()
+        trunk = model.language_model.model
+        trunk.layers = trunk.layers[2:]  # offset 2: 2 % 4 != 0
+
+        sibling = build_sibling_attention_layer(model)
+        assert sibling is not None
+        assert getattr(sibling, "self_attn", None) is not None
+
+
+# ---------------------------------------------------------------------------
 # Quantize-on-load — sidecar matches the target's precision
 # ---------------------------------------------------------------------------
 

--- a/src/exo/worker/engines/mlx/tests/test_drafters.py
+++ b/src/exo/worker/engines/mlx/tests/test_drafters.py
@@ -1196,6 +1196,69 @@ class TestDeferredReplay:
 
 
 # ---------------------------------------------------------------------------
+# Per-expert MoE sidecar key stacking
+# ---------------------------------------------------------------------------
+
+
+class TestPerExpertStacking:
+    """SWP sidecars for MoE backbones preserve raw per-expert keys
+    (``mlp.experts.N.*``); mlx-lm decoder layers hold stacked SwitchGLU
+    tensors. The builder must normalize on load (found on the 35B-A3B
+    sidecar; the family sanitize that normally does this never runs on the
+    sidecar strict-load path)."""
+
+    def test_stacks_per_expert_keys(self) -> None:
+        from exo.worker.engines.mlx.drafters.qwen_sidecar import (
+            _stack_per_expert_block_weights,
+        )
+
+        pairs = [
+            ("input_layernorm.weight", mx.ones(4)),
+            ("mlp.experts.1.gate_proj.weight", mx.full((8, 4), 1.0)),
+            ("mlp.experts.0.gate_proj.weight", mx.full((8, 4), 0.0)),
+            ("mlp.experts.0.down_proj.weight", mx.full((4, 8), 0.0)),
+            ("mlp.experts.1.down_proj.weight", mx.full((4, 8), 1.0)),
+            ("mlp.gate.weight", mx.zeros((2, 4))),
+        ]
+        out = dict(_stack_per_expert_block_weights(pairs))
+        assert "mlp.switch_mlp.gate_proj.weight" in out
+        gate = out["mlp.switch_mlp.gate_proj.weight"]
+        # (num_experts, out, in), expert order by index regardless of input
+        # order.
+        assert gate.shape == (2, 8, 4)
+        assert mx.allclose(gate[0], mx.zeros((8, 4)))
+        assert mx.allclose(gate[1], mx.ones((8, 4)))
+        assert out["mlp.switch_mlp.down_proj.weight"].shape == (2, 4, 8)
+        # Router and norms pass through untouched.
+        assert "mlp.gate.weight" in out
+        assert "input_layernorm.weight" in out
+        assert not any("experts." in k for k in out)
+
+    def test_dense_pairs_pass_through(self) -> None:
+        from exo.worker.engines.mlx.drafters.qwen_sidecar import (
+            _stack_per_expert_block_weights,
+        )
+
+        pairs = [("self_attn.q_proj.weight", mx.zeros((4, 4)))]
+        assert _stack_per_expert_block_weights(pairs) == pairs
+
+    def test_expert_gap_left_unstacked_for_loud_failure(self) -> None:
+        from exo.worker.engines.mlx.drafters.qwen_sidecar import (
+            _stack_per_expert_block_weights,
+        )
+
+        pairs = [
+            ("mlp.experts.0.gate_proj.weight", mx.zeros((8, 4))),
+            ("mlp.experts.2.gate_proj.weight", mx.ones((8, 4))),  # 1 missing
+        ]
+        out = dict(_stack_per_expert_block_weights(pairs))
+        # Truncated sidecar: keys stay per-expert so the strict load fails
+        # on the missing stacked key instead of stacking a wrong tensor.
+        assert "mlp.switch_mlp.gate_proj.weight" not in out
+        assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
 # Sibling-layer construction under pipeline slicing
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Found on the first 27B 3-node flagship run (#201 Track 2a follow-through): `build_sibling_attention_layer` passed the **local** enumerate index as `layer_idx`, but hybrid constructors derive the layer *type* from that index. Slices whose offset isn't a multiple of `full_attention_interval` silently constructed a **GDN** sibling → attention strict-load failed → drafter `None`. The 2B's 12-layer halves dodged it by coincidence (12 % 4 == 0); the 27B's 21-layer thirds hit it on ranks 1 and 2.

Production behavior without this fix: the #206 agreement collective disables speculation cluster-wide (safe, no wedge) — so this is a *speculation availability* fix for pipeline hybrids, not a correctness fix. (The probe that found it bypasses the collective, which is how it surfaced as a wedge + Metal timeout on the abandoned peers.)

## Fix

Self-validating construction: probe candidate `layer_idx` values until the constructed sibling actually carries `self_attn` — robust to any family's indexing scheme, no per-family knowledge added. Also unwraps Pipeline layer wrappers before constructing (`type(wrapper)` isn't the family class), covering slices whose only full-attention layer is first/last.

## Tests

- New `TestSiblingLayerSliceAlignment`: hybrid toy model (interval 4), aligned + misaligned slices.
- 822 passed, 1 skipped; basedpyright 0 errors; ruff clean; nix fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)