### PR TITLE
fix: launch-smoke hardening — warmup tokenizer, dead-runner node-down, ENOSPC node-down

### DIFF
--- a/src/exo/utils/disk_event_log.py
+++ b/src/exo/utils/disk_event_log.py
@@ -164,6 +164,11 @@ class DiskEventLog:
             if not counted:
                 self._count += 1
             self._persistence_failed = True
+            # Dispose the dirty handle: buffered record bytes may be
+            # stranded and any later flush would raise again. All write
+            # and read paths are short-circuited by the flag from here.
+            with contextlib.suppress(Exception):
+                self._file.close()
             logger.critical(
                 "Event-log persistence failed and is now DISABLED for this "
                 f"session ({error}); the node continues with in-memory state "
@@ -231,6 +236,11 @@ class DiskEventLog:
 
     def read_range(self, start: int, end: int) -> Iterator[Event]:
         """Yield events from index start (inclusive) to end (exclusive)."""
+        if self._persistence_failed:
+            # Counting-only mode: the disk tail is incomplete and the file
+            # handle is closed — replay from this log is unavailable (the
+            # append-time CRITICAL log already told the operator).
+            return
         if start < 0 or end < 0:
             return
         start = max(start, self._base_idx)
@@ -262,7 +272,7 @@ class DiskEventLog:
 
     def read_all(self) -> Iterator[Event]:
         """Yield all events from the log one at a time."""
-        if self._count == 0:
+        if self._persistence_failed or self._count == 0:
             return
         self._file.flush()
         with open(self._active_path, "rb") as f:
@@ -277,6 +287,12 @@ class DiskEventLog:
 
     def close(self) -> None:
         """Close the file and rotate active file to compressed archive."""
+        if self._persistence_failed:
+            # The active file holds an incomplete tail; archiving it would
+            # preserve a corrupt log. Leave it for post-mortem inspection.
+            with contextlib.suppress(Exception):
+                self._file.close()
+            return
         if self._file.closed:
             return
         self._file.close()

--- a/src/exo/utils/disk_event_log.py
+++ b/src/exo/utils/disk_event_log.py
@@ -149,14 +149,20 @@ class DiskEventLog:
         if self._persistence_failed:
             self._count += 1
             return
+        counted = False
         try:
             packed = _serialize_event(event)
             self._file.write(len(packed).to_bytes(_HEADER_SIZE, byteorder="big"))
             self._file.write(packed)
             self._count += 1
+            counted = True
             self._write_metadata()
         except OSError as error:
-            self._count += 1
+            # The count must advance EXACTLY once per append: a failure in
+            # _write_metadata (the observed ENOSPC site) arrives here with
+            # the increment already done.
+            if not counted:
+                self._count += 1
             self._persistence_failed = True
             logger.critical(
                 "Event-log persistence failed and is now DISABLED for this "

--- a/src/exo/utils/disk_event_log.py
+++ b/src/exo/utils/disk_event_log.py
@@ -85,6 +85,9 @@ class DiskEventLog:
         self._offset_cache: OrderedDict[int, int] = OrderedDict()
         self._base_idx: int = 0
         self._count: int = 0
+        # Set on the first failed disk write (e.g. ENOSPC); the log then
+        # counts events without persisting so indices stay coherent.
+        self._persistence_failed: bool = False
 
         # Rotate stale active file from a previous session/crash
         if self._active_path.exists():
@@ -136,14 +139,39 @@ class DiskEventLog:
         self._cache_offset(target_idx, f.tell())
 
     def append(self, event: Event) -> None:
-        packed = _serialize_event(event)
-        self._file.write(len(packed).to_bytes(_HEADER_SIZE, byteorder="big"))
-        self._file.write(packed)
-        self._count += 1
-        self._write_metadata()
+        # Persistence failures (disk full being the canonical case) must
+        # NEVER take down the event processor: the in-memory state apply
+        # and the broadcast are the critical path, and event indices derive
+        # from len(self) — so the count keeps advancing even when the disk
+        # write fails, keeping follower replay indices coherent. The log
+        # degrades to in-memory-only with one CRITICAL line (launch E2E
+        # smoke 2026-06-05: ENOSPC in _write_metadata killed the node).
+        if self._persistence_failed:
+            self._count += 1
+            return
+        try:
+            packed = _serialize_event(event)
+            self._file.write(len(packed).to_bytes(_HEADER_SIZE, byteorder="big"))
+            self._file.write(packed)
+            self._count += 1
+            self._write_metadata()
+        except OSError as error:
+            self._count += 1
+            self._persistence_failed = True
+            logger.critical(
+                "Event-log persistence failed and is now DISABLED for this "
+                f"session ({error}); the node continues with in-memory state "
+                "only — follower replay from this node's disk log will be "
+                "unavailable. Free disk space and restart to restore "
+                "persistence."
+            )
 
     def compact(self, keep_from_idx: int) -> None:
         """Discard events before ``keep_from_idx`` while preserving absolute indices."""
+
+        if self._persistence_failed:
+            # Counting-only mode: there is no coherent disk tail to rebuild.
+            return
 
         absolute_end = len(self)
         keep_from_idx = max(keep_from_idx, self._base_idx)

--- a/src/exo/utils/tests/test_event_log.py
+++ b/src/exo/utils/tests/test_event_log.py
@@ -312,3 +312,23 @@ def test_persistence_failure_degrades_without_losing_indices(log_dir: Path):
     log.compact(2)
     assert len(log) == 3
     assert log.start_idx == 0
+
+
+def test_metadata_failure_counts_exactly_once(log_dir: Path):
+    """ENOSPC at the _write_metadata site (the observed crash) arrives with
+    the count already incremented — the handler must not increment again
+    (PR #209 review: double-count would corrupt follower replay indices)."""
+    log = DiskEventLog(log_dir)
+    log.append(TestEvent())
+    assert len(log) == 1
+
+    def _fail_metadata() -> None:
+        raise OSError(28, "No space left on device")
+
+    log._write_metadata = _fail_metadata
+
+    log.append(TestEvent())  # record write succeeds, metadata fails
+    assert len(log) == 2  # exactly once, not twice
+    assert log._persistence_failed
+    log.append(TestEvent())
+    assert len(log) == 3

--- a/src/exo/utils/tests/test_event_log.py
+++ b/src/exo/utils/tests/test_event_log.py
@@ -289,11 +289,13 @@ def test_persistence_failure_degrades_without_losing_indices(log_dir: Path):
     log._file.close()  # next write raises ValueError... use a stub instead
 
     class _FullDisk:
+        closed = False
+
         def write(self, _data: bytes) -> int:
             raise OSError(28, "No space left on device")
 
         def close(self) -> None:
-            pass
+            self.closed = True
 
         def flush(self) -> None:
             pass
@@ -312,6 +314,14 @@ def test_persistence_failure_degrades_without_losing_indices(log_dir: Path):
     log.compact(2)
     assert len(log) == 3
     assert log.start_idx == 0
+
+    # Reads return empty without touching the dead file — the master's
+    # replay caller only catches ValueError, so a flush-time OSError here
+    # would kill the node through the side door.
+    assert list(log.read_range(0, len(log))) == []
+    assert list(log.read_all()) == []
+
+    log.close()  # must not raise nor archive the dirty tail
 
 
 def test_metadata_failure_counts_exactly_once(log_dir: Path):
@@ -332,3 +342,4 @@ def test_metadata_failure_counts_exactly_once(log_dir: Path):
     assert log._persistence_failed
     log.append(TestEvent())
     assert len(log) == 3
+    log.close()

--- a/src/exo/utils/tests/test_event_log.py
+++ b/src/exo/utils/tests/test_event_log.py
@@ -1,3 +1,4 @@
+# pyright: reportPrivateUsage=false
 from pathlib import Path
 
 import pytest
@@ -274,3 +275,40 @@ def test_compact_keeps_active_log_when_retained_tail_is_corrupt(log_dir: Path):
     assert active_path.read_bytes() == corrupt_bytes
 
     log.close()
+
+
+def test_persistence_failure_degrades_without_losing_indices(log_dir: Path):
+    """ENOSPC (or any OSError) on append must not propagate — the canonical
+    failure killed a node during the 2026-06-05 launch E2E smoke. Indices
+    derive from len(log), so the count must keep advancing in the degraded
+    counting-only mode or follower replay indices would collide."""
+    log = DiskEventLog(log_dir)
+    log.append(TestEvent())
+    assert len(log) == 1
+
+    log._file.close()  # next write raises ValueError... use a stub instead
+
+    class _FullDisk:
+        def write(self, _data: bytes) -> int:
+            raise OSError(28, "No space left on device")
+
+        def close(self) -> None:
+            pass
+
+        def flush(self) -> None:
+            pass
+
+    log._file = _FullDisk()  # type: ignore[assignment]
+
+    log.append(TestEvent())  # must not raise
+    assert len(log) == 2
+    assert log._persistence_failed
+
+    # Subsequent appends count without touching the dead file.
+    log.append(TestEvent())
+    assert len(log) == 3
+
+    # Compaction is a no-op in counting-only mode (no coherent disk tail).
+    log.compact(2)
+    assert len(log) == 3
+    assert log.start_idx == 0

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -1228,7 +1228,7 @@ def fix_unmatched_think_end_tokens(
             "skipping unmatched think-end token fix"
         )
         return tokens
-    if not maybe_start_id or not maybe_end_id:
+    if maybe_start_id is None or maybe_end_id is None:
         return tokens
     think_start_id: int = maybe_start_id
     think_end_id: int = maybe_end_id

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -1214,10 +1214,24 @@ def fix_unmatched_think_end_tokens(
 ) -> mx.array:
     if not tokenizer.has_thinking:
         return tokens
-    assert tokenizer.think_start_id
-    assert tokenizer.think_end_id
-    think_start_id: int = tokenizer.think_start_id
-    think_end_id: int = tokenizer.think_end_id
+    try:
+        maybe_start_id: int | None = tokenizer.think_start_id
+        maybe_end_id: int | None = tokenizer.think_end_id
+    except ValueError:
+        # mlx-lm raises when a tokenizer's think marker is not a single
+        # token (observed: gemma-4-12B-it's unified tokenizer, launch E2E
+        # smoke 2026-06-05). The unmatched-end fix only makes sense for
+        # single-token markers — skip it rather than crash the runner
+        # during warmup of an otherwise healthy model.
+        logger.info(
+            "Thinking markers are multi-token for this tokenizer; "
+            "skipping unmatched think-end token fix"
+        )
+        return tokens
+    if not maybe_start_id or not maybe_end_id:
+        return tokens
+    think_start_id: int = maybe_start_id
+    think_end_id: int = maybe_end_id
     token_list: list[int] = cast(list[int], tokens.tolist())
     result: list[int] = []
     depth = 0

--- a/src/exo/worker/runner/runner_supervisor.py
+++ b/src/exo/worker/runner/runner_supervisor.py
@@ -439,10 +439,20 @@ class RunnerSupervisor:
     def _diagnostic_context(self) -> RunnerDiagnosticContext:
         """Build the stable runner context used by supervisor-authored entries."""
 
+        # A crashed-and-reaped runner's process object is CLOSED; reading
+        # .pid raises ValueError. Diagnostics must never take down the
+        # worker plan-step — cancelling a task on a dead runner is exactly
+        # when these entries matter most (launch E2E smoke 2026-06-05:
+        # warmup crash -> cancel -> closed-pid ValueError -> node down).
+        try:
+            runner_pid = self.runner_process.pid
+        except ValueError:
+            runner_pid = None
+
         return RunnerDiagnosticContext(
             node_id=str(self.bound_instance.bound_node_id),
             runner_id=str(self.bound_instance.bound_runner_id),
-            pid=self.runner_process.pid,
+            pid=runner_pid,
             instance_id=str(self.bound_instance.instance.instance_id),
             model_id=str(self.shard_metadata.model_card.model_id),
             rank=self.shard_metadata.device_rank,

--- a/src/exo/worker/tests/unittests/test_mlx/test_launch_smoke_hardening.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_launch_smoke_hardening.py
@@ -1,0 +1,85 @@
+# pyright: reportPrivateUsage=false, reportAny=false
+"""Regression tests for the two launch-E2E smoke crashes (2026-06-05).
+
+1. ``fix_unmatched_think_end_tokens`` crashed the runner during WARMUP when
+   a tokenizer's thinking markers are multi-token (mlx-lm's
+   ``think_start_id`` raises ValueError; observed on gemma-4-12B-it's
+   unified tokenizer).
+2. The runner crash then took down the WHOLE NODE: cancelling a task on the
+   dead runner built a diagnostic context that read ``.pid`` off a CLOSED
+   multiprocessing process object, and the ValueError propagated through
+   the worker plan-step.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from typing import cast
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+
+from exo.worker.engines.mlx.utils_mlx import fix_unmatched_think_end_tokens
+from exo.worker.runner.runner_supervisor import RunnerSupervisor
+
+
+class _MultiTokenThinkTokenizer:
+    """Tokenizer stub mirroring mlx-lm's behavior for multi-token markers."""
+
+    has_thinking = True
+
+    @property
+    def think_start_id(self) -> int:
+        raise ValueError("The start thinking sequence is more than 1 token")
+
+    @property
+    def think_end_id(self) -> int:
+        raise ValueError("The end thinking sequence is more than 1 token")
+
+
+class _SingleTokenThinkTokenizer:
+    has_thinking = True
+    think_start_id = 7
+    think_end_id = 9
+
+
+def test_multi_token_think_markers_skip_fix_instead_of_crashing() -> None:
+    tokens = mx.array([1, 2, 3])
+    out = fix_unmatched_think_end_tokens(
+        tokens, cast("object", _MultiTokenThinkTokenizer())  # type: ignore[arg-type]
+    )
+    assert out.tolist() == [1, 2, 3]
+
+
+def test_single_token_think_markers_still_fix_unmatched_end() -> None:
+    # An unmatched end marker gets a synthesized start inserted before it.
+    tokens = mx.array([1, 9, 2])
+    out = fix_unmatched_think_end_tokens(
+        tokens, cast("object", _SingleTokenThinkTokenizer())  # type: ignore[arg-type]
+    )
+    assert out.tolist() == [1, 7, 9, 2]
+
+
+def test_diagnostic_context_tolerates_closed_runner_process() -> None:
+    # A reaped runner's process object raises ValueError on .pid access;
+    # diagnostics must degrade to pid=None, not propagate.
+    process = mp.get_context("spawn").Process(target=int)
+    process.close()  # closed without ever starting — .pid now raises
+
+    supervisor = MagicMock(spec=RunnerSupervisor)
+    supervisor.runner_process = process
+    supervisor.bound_instance = MagicMock()
+    supervisor.bound_instance.bound_node_id = "node"
+    supervisor.bound_instance.bound_runner_id = "runner"
+    supervisor.bound_instance.instance.instance_id = "instance"
+    supervisor.shard_metadata = MagicMock()
+    supervisor.shard_metadata.model_card.model_id = "model"
+    supervisor.shard_metadata.device_rank = 0
+    supervisor.shard_metadata.world_size = 1
+    supervisor.shard_metadata.start_layer = 0
+    supervisor.shard_metadata.end_layer = 1
+    supervisor.shard_metadata.n_layers = 1
+
+    context = RunnerSupervisor._diagnostic_context(supervisor)
+    assert context.pid is None
+    assert context.runner_id == "runner"


### PR DESCRIPTION
## What

The launch runway's first production E2E smoke (gemma-4-12B-it via the real API) crashed the node in one request, through two stacked bugs:

1. **Warmup crash**: `fix_unmatched_think_end_tokens` calls mlx-lm's `think_start_id` unguarded — tokenizers with multi-token thinking markers (the 12B's unified tokenizer) raise `ValueError` there. The unmatched-end fix only makes sense for single-token markers; it now skips gracefully with a log line.
2. **Node down**: cancelling the task on the now-dead runner read `.pid` off a **closed** process object inside `_diagnostic_context`, and the `ValueError` propagated through the worker plan-step — the long-known unfiled "process object is closed" node-killer, finally pinned. Diagnostics degrade to `pid=None` (the field was already `int | None`).

Bug 2 is severity-critical for launch: *any* runner death became a node death.

## Tests

- 3 regression tests: multi-token markers skip the fix; single-token markers still get the unmatched-end repair; `_diagnostic_context` tolerates a closed process.
- 831 passed, 1 skipped; basedpyright 0 errors; ruff clean; nix fmt clean.

Found by launch-readiness P0 (E2E smoke matrix). The smoke resumes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)