### PR TITLE
fix(mtp): companion repos on every download path; warmup deadline; loud speculation diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Speculative decoding now engages for models that were already on
+  disk.** Three of the model-store downloader's four resolution paths
+  (already-staged fast path, store staging, direct-from-store) returned
+  the base model without fetching the card's companion repos (MTP
+  sidecar / assistant model / vision weights) — a staged model would
+  load and silently run without speculation (observed in the launch
+  smoke). Every `ensure_shard` resolution now also ensures companions
+  through the same store-first path (so sidecars are served from the
+  store when present), companion fetch failures log loudly without
+  failing the base load, and the previously triplicated companion
+  construction in the HF downloader is shared via
+  `companion_download_specs`.
+- **A wedged warmup no longer silently disables a node.** A faulted
+  Metal eval can park warmup forever at 0% CPU (uninterruptible from
+  Python); the runner then sat in `RunnerWarmingUp` indefinitely while
+  every API request queued and timed out with no surfaced error. Warmup
+  now runs under a hard deadline (default 300s,
+  `SKULK_WARMUP_DEADLINE_SECONDS`): on overrun the runner logs a
+  CRITICAL diagnosis (including the reboot-if-GPU-wedged guidance) and
+  exits, the supervisor reports `RunnerFailed`, and the node keeps
+  dispatching.
+- **Disabled speculation is no longer near-silent.** Requests carrying
+  logits processors (typically a `repetition_penalty` — some client
+  libraries send one by default) fall back to plain decode; that
+  fallback now logs a WARNING naming the cause and the fix instead of
+  an easy-to-miss INFO line. The gemma 4 E-series pipeline rejection
+  also explains itself in operator terms (place on a single node)
+  instead of internals-speak.
+
 - **Multi-node placement is now reliable and placement failures are
   visible.** Four compounding issues fixed in the placement path:
   (1) memory admission is per node instead of summed across the cycle —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ This project records release notes here and mirrors public-facing notes in
   load and silently run without speculation (observed in the launch
   smoke). Every `ensure_shard` resolution now also ensures companions
   through the same store-first path (so sidecars are served from the
-  store when present), companion fetch failures log loudly without
-  failing the base load, and the previously triplicated companion
+  store when present), optional-companion fetch failures (MTP
+  sidecar / assistant) log loudly without failing the base load, while
+  split vision weights stay load-bearing, and the previously triplicated companion
   construction in the HF downloader is shared via
   `companion_download_specs`.
 - **A wedged warmup no longer silently disables a node.** A faulted

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -14,6 +14,7 @@ from exo.download.download_utils import (
     RepoDownloadProgress,
     delete_model,
     map_repo_download_progress_to_download_progress_data,
+    model_companions_present_on_disk,
     resolve_model_in_path,
 )
 from exo.download.shard_downloader import ShardDownloader
@@ -366,8 +367,23 @@ class DownloadCoordinator:
                 )
                 return
 
-        # Check EXO_MODELS_PATH for pre-downloaded models
+        # Check EXO_MODELS_PATH for pre-downloaded models. A base model on
+        # disk does NOT make the download complete when the card declares a
+        # companion (MTP sidecar / assistant) that is missing — treating it
+        # as complete here bypassed ensure_shard entirely and loaded staged
+        # models with speculative decoding silently unavailable (codex
+        # review on the launch-smoke fix). Fall through to the download
+        # path instead so the companion gets fetched.
         found_path = resolve_model_in_path(model_id)
+        if found_path is not None and not model_companions_present_on_disk(
+            shard.model_card
+        ):
+            logger.info(
+                f"DownloadCoordinator: {model_id} base model is on disk at "
+                f"{found_path} but a declared companion repo is missing — "
+                "running the download path to fetch it"
+            )
+            found_path = None
         if found_path is not None:
             logger.info(
                 f"DownloadCoordinator: Model {model_id} found in EXO_MODELS_PATH at {found_path}"
@@ -630,6 +646,13 @@ class DownloadCoordinator:
                     ):
                         continue
                     found = resolve_model_in_path(mid)
+                    if found is not None and not model_companions_present_on_disk(
+                        card
+                    ):
+                        # Same companion gate as _start_download: a staged
+                        # base missing its sidecar/assistant must not be
+                        # advertised as complete.
+                        continue
                     if found is not None:
                         logger.info(
                             f"DownloadCoordinator: EXO_MODELS_PATH hit: {mid} -> {found}"

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -375,14 +375,14 @@ class DownloadCoordinator:
         # review on the launch-smoke fix). Fall through to the download
         # path instead so the companion gets fetched.
         found_path = resolve_model_in_path(model_id)
-        # In offline mode the companion can never be fetched, and the
-        # runner treats a missing companion as run-without-speculation —
-        # hiding a loadable base behind a doomed download would only
-        # produce DownloadFailed for a usable model.
-        if (
-            found_path is not None
-            and not self.offline
-            and not model_companions_present_on_disk(shard.model_card)
+        # In offline mode optional companions can never be fetched and the
+        # runner degrades to run-without-speculation, so only load-bearing
+        # companions (split vision weights) block the shortcut there —
+        # hiding a loadable base behind a doomed download would produce
+        # DownloadFailed for a usable model, but advertising a vision model
+        # without its weights would hand out a broken one.
+        if found_path is not None and not model_companions_present_on_disk(
+            shard.model_card, required_only=self.offline
         ):
             logger.info(
                 f"DownloadCoordinator: {model_id} base model is on disk at "
@@ -652,15 +652,14 @@ class DownloadCoordinator:
                     ):
                         continue
                     found = resolve_model_in_path(mid)
-                    if (
-                        found is not None
-                        and not self.offline
-                        and not model_companions_present_on_disk(card)
+                    if found is not None and not model_companions_present_on_disk(
+                        card, required_only=self.offline
                     ):
                         # Same companion gate as _start_download: a staged
-                        # base missing its sidecar/assistant must not be
-                        # advertised as complete (offline nodes excepted —
-                        # the companion can never arrive there).
+                        # base missing a companion must not be advertised
+                        # as complete (offline nodes check only the
+                        # load-bearing vision weights — optional companions
+                        # can never arrive there).
                         continue
                     if found is not None:
                         logger.info(

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -375,8 +375,14 @@ class DownloadCoordinator:
         # review on the launch-smoke fix). Fall through to the download
         # path instead so the companion gets fetched.
         found_path = resolve_model_in_path(model_id)
-        if found_path is not None and not model_companions_present_on_disk(
-            shard.model_card
+        # In offline mode the companion can never be fetched, and the
+        # runner treats a missing companion as run-without-speculation —
+        # hiding a loadable base behind a doomed download would only
+        # produce DownloadFailed for a usable model.
+        if (
+            found_path is not None
+            and not self.offline
+            and not model_companions_present_on_disk(shard.model_card)
         ):
             logger.info(
                 f"DownloadCoordinator: {model_id} base model is on disk at "
@@ -646,12 +652,15 @@ class DownloadCoordinator:
                     ):
                         continue
                     found = resolve_model_in_path(mid)
-                    if found is not None and not model_companions_present_on_disk(
-                        card
+                    if (
+                        found is not None
+                        and not self.offline
+                        and not model_companions_present_on_disk(card)
                     ):
                         # Same companion gate as _start_download: a staged
                         # base missing its sidecar/assistant must not be
-                        # advertised as complete.
+                        # advertised as complete (offline nodes excepted —
+                        # the companion can never arrive there).
                         continue
                     if found is not None:
                         logger.info(

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -251,8 +251,15 @@ def companion_download_specs(
     return specs
 
 
-def model_companions_present_on_disk(model_card: ModelCard) -> bool:
+def model_companions_present_on_disk(
+    model_card: ModelCard, required_only: bool = False
+) -> bool:
     """True when every *checkable* companion the card declares is on disk.
+
+    ``required_only`` restricts the check to load-bearing companions (split
+    vision weights) — used in offline mode, where optional companions can
+    never arrive (run-without-speculation is fine) but a vision model
+    without its weights is broken and must not be advertised complete.
 
     Used to decide whether an already-on-disk base model can be treated as
     download-complete: a staged base with a missing MTP sidecar or assistant
@@ -270,11 +277,24 @@ def model_companions_present_on_disk(model_card: ModelCard) -> bool:
         model_card.model_id
     ):
         vision_repo = ModelId(model_card.vision.weights_repo)
-        if (
-            resolve_model_in_path(vision_repo) is None
-            and build_companion_model_path(vision_repo) is None
-        ):
+        # Probe BOTH search roots: EXO_MODELS_PATH (staging/store) and
+        # EXO_MODELS_DIR (where download_shard writes) — a vision repo
+        # downloaded via HF lives only in the latter, and missing it here
+        # would degrade the cached base to in_progress forever.
+        import exo.shared.constants as _constants
+
+        vision_present = build_companion_model_path(vision_repo) is not None
+        if not vision_present:
+            normalized = vision_repo.normalize()
+            for search_dir in [*(_constants.EXO_MODELS_PATH or ()), EXO_MODELS_DIR]:
+                candidate = search_dir / normalized
+                if candidate.is_dir() and is_model_directory_complete(candidate):
+                    vision_present = True
+                    break
+        if not vision_present:
             return False
+    if required_only:
+        return True
     runtime = model_card.runtime
     if runtime is None:
         return True

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -31,7 +31,7 @@ from exo.download.huggingface_utils import (
     get_hf_token,
 )
 from exo.shared.constants import EXO_MODELS_DIR
-from exo.shared.models.model_cards import ModelTask
+from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.common import ModelId
 from exo.shared.types.memory import Memory
 from exo.shared.types.worker.downloads import (
@@ -41,7 +41,7 @@ from exo.shared.types.worker.downloads import (
     RepoDownloadProgress,
     RepoFileDownloadProgress,
 )
-from exo.shared.types.worker.shards import ShardMetadata
+from exo.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
 
 
 class HuggingFaceAuthenticationError(Exception):
@@ -175,6 +175,64 @@ def build_companion_model_path(model_id: ModelId) -> Path | None:
         ).is_file():
             return candidate
     return None
+
+
+def companion_download_specs(
+    model_card: ModelCard,
+) -> list[tuple[PipelineShardMetadata, list[str]]]:
+    """Build download shards for every companion repo a model card declares.
+
+    Companions are the artifacts a model needs beyond its own repo: a
+    separate vision-weights repo, an MTP sidecar (``mtp_sidecar_repo``), or
+    a speculative-decoding assistant model (``assistant_model_repo``).
+    Every downloader path that resolves a base model MUST also ensure its
+    companions — a base model present on disk without its companion is the
+    "model loads, speculative decoding silently unavailable" failure mode
+    (launch smoke, 2026-06-06).
+
+    Returns ``(shard, allow_patterns)`` pairs; the shards carry bare model
+    cards (no ``runtime``/``vision`` sections), so recursively ensuring a
+    companion never yields further companions.
+    """
+    def _bare_shard(repo: str) -> PipelineShardMetadata:
+        return PipelineShardMetadata(
+            model_card=ModelCard(
+                model_id=ModelId(repo),
+                storage_size=Memory.from_bytes(0),
+                n_layers=1,
+                hidden_size=1,
+                supports_tensor=False,
+                tasks=[ModelTask.TextGeneration],
+            ),
+            device_rank=0,
+            world_size=1,
+            start_layer=0,
+            end_layer=1,
+            n_layers=1,
+        )
+
+    specs: list[tuple[PipelineShardMetadata, list[str]]] = []
+    if model_card.vision and model_card.vision.weights_repo != str(
+        model_card.model_id
+    ):
+        specs.append(
+            (_bare_shard(model_card.vision.weights_repo), ["*.safetensors", "config.json"])
+        )
+    runtime = model_card.runtime
+    if runtime and runtime.mtp_sidecar_repo:
+        specs.append(
+            (_bare_shard(runtime.mtp_sidecar_repo), ["mtp.safetensors", "config.json"])
+        )
+    if runtime and runtime.assistant_model_repo:
+        # The assistant is a small full model (config + a single
+        # safetensors), so pull the weights and config alongside the target.
+        specs.append(
+            (
+                _bare_shard(runtime.assistant_model_repo),
+                ["*.safetensors", "config.json"],
+            )
+        )
+    return specs
 
 
 def build_model_path(model_id: ModelId) -> Path:

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -235,6 +235,35 @@ def companion_download_specs(
     return specs
 
 
+def model_companions_present_on_disk(model_card: ModelCard) -> bool:
+    """True when every *checkable* companion the card declares is on disk.
+
+    Used to decide whether an already-on-disk base model can be treated as
+    download-complete: a staged base with a missing MTP sidecar or assistant
+    must NOT short-circuit the download path, or the model loads with
+    speculative decoding silently unavailable (launch smoke, 2026-06-06).
+
+    Split vision repos are intentionally NOT checked here: there is no
+    reliable on-disk completeness probe for an arbitrary multi-file vision
+    repo, and a false "missing" from this function would make the
+    coordinator re-run the download path forever.
+    """
+    runtime = model_card.runtime
+    if runtime is None:
+        return True
+    if (
+        runtime.mtp_sidecar_repo
+        and runtime.mtp_heads
+        and build_sidecar_path(ModelId(runtime.mtp_sidecar_repo), "mtp.safetensors")
+        is None
+    ):
+        return False
+    return not (
+        runtime.assistant_model_repo
+        and build_companion_model_path(ModelId(runtime.assistant_model_repo)) is None
+    )
+
+
 def build_model_path(model_id: ModelId) -> Path:
     """Resolve a local filesystem path for *model_id*.
 

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -219,7 +219,10 @@ def companion_download_specs(
             (_bare_shard(model_card.vision.weights_repo), ["*.safetensors", "config.json"])
         )
     runtime = model_card.runtime
-    if runtime and runtime.mtp_sidecar_repo:
+    # The runner only loads the sidecar when mtp_heads is also set (see
+    # load_mlx_items); downloading one the runner will never load wastes
+    # bandwidth and produces misleading speculation warnings.
+    if runtime and runtime.mtp_sidecar_repo and runtime.mtp_heads:
         specs.append(
             (_bare_shard(runtime.mtp_sidecar_repo), ["mtp.safetensors", "config.json"])
         )
@@ -243,11 +246,22 @@ def model_companions_present_on_disk(model_card: ModelCard) -> bool:
     must NOT short-circuit the download path, or the model loads with
     speculative decoding silently unavailable (launch smoke, 2026-06-06).
 
-    Split vision repos are intentionally NOT checked here: there is no
-    reliable on-disk completeness probe for an arbitrary multi-file vision
-    repo, and a false "missing" from this function would make the
-    coordinator re-run the download path forever.
+    Split vision repos are probed with BOTH layout checks (the index-based
+    model-directory completeness used for bases, and the single-file
+    companion layout): a repo matching neither would cost one no-op verify
+    pass through the download path per session — the coordinator marks the
+    model complete after ensure_shard returns, so the gate cannot loop
+    within a session.
     """
+    if model_card.vision and model_card.vision.weights_repo != str(
+        model_card.model_id
+    ):
+        vision_repo = ModelId(model_card.vision.weights_repo)
+        if (
+            resolve_model_in_path(vision_repo) is None
+            and build_companion_model_path(vision_repo) is None
+        ):
+            return False
     runtime = model_card.runtime
     if runtime is None:
         return True

--- a/src/exo/download/download_utils.py
+++ b/src/exo/download/download_utils.py
@@ -179,7 +179,7 @@ def build_companion_model_path(model_id: ModelId) -> Path | None:
 
 def companion_download_specs(
     model_card: ModelCard,
-) -> list[tuple[PipelineShardMetadata, list[str]]]:
+) -> list[tuple[PipelineShardMetadata, list[str], bool]]:
     """Build download shards for every companion repo a model card declares.
 
     Companions are the artifacts a model needs beyond its own repo: a
@@ -190,9 +190,13 @@ def companion_download_specs(
     "model loads, speculative decoding silently unavailable" failure mode
     (launch smoke, 2026-06-06).
 
-    Returns ``(shard, allow_patterns)`` pairs; the shards carry bare model
-    cards (no ``runtime``/``vision`` sections), so recursively ensuring a
-    companion never yields further companions.
+    Returns ``(shard, allow_patterns, required)`` triples; the shards carry
+    bare model cards (no ``runtime``/``vision`` sections), so recursively
+    ensuring a companion never yields further companions. ``required``
+    distinguishes criticality: split vision weights are load-bearing (a
+    vision model without them is broken — fetch failures must fail the
+    base), while MTP sidecars and assistants degrade gracefully to
+    run-without-speculation (best-effort).
     """
     def _bare_shard(repo: str) -> PipelineShardMetadata:
         return PipelineShardMetadata(
@@ -211,12 +215,16 @@ def companion_download_specs(
             n_layers=1,
         )
 
-    specs: list[tuple[PipelineShardMetadata, list[str]]] = []
+    specs: list[tuple[PipelineShardMetadata, list[str], bool]] = []
     if model_card.vision and model_card.vision.weights_repo != str(
         model_card.model_id
     ):
         specs.append(
-            (_bare_shard(model_card.vision.weights_repo), ["*.safetensors", "config.json"])
+            (
+                _bare_shard(model_card.vision.weights_repo),
+                ["*.safetensors", "config.json"],
+                True,
+            )
         )
     runtime = model_card.runtime
     # The runner only loads the sidecar when mtp_heads is also set (see
@@ -224,7 +232,11 @@ def companion_download_specs(
     # bandwidth and produces misleading speculation warnings.
     if runtime and runtime.mtp_sidecar_repo and runtime.mtp_heads:
         specs.append(
-            (_bare_shard(runtime.mtp_sidecar_repo), ["mtp.safetensors", "config.json"])
+            (
+                _bare_shard(runtime.mtp_sidecar_repo),
+                ["mtp.safetensors", "config.json"],
+                False,
+            )
         )
     if runtime and runtime.assistant_model_repo:
         # The assistant is a small full model (config + a single
@@ -233,6 +245,7 @@ def companion_download_specs(
             (
                 _bare_shard(runtime.assistant_model_repo),
                 ["*.safetensors", "config.json"],
+                False,
             )
         )
     return specs

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -220,21 +220,23 @@ class ResumableShardDownloader(ShardDownloader):
         # never fetched (phase-c spec gotcha, flagged on PR #185). Degrade
         # the reported status when a declared companion is missing on disk
         # so the download path runs and pulls it.
-        # Never degrade in offline mode: the companion cannot be fetched
-        # anyway, and load_mlx_items treats missing companions as optional —
-        # degrading would turn a perfectly loadable cached base into
-        # DownloadFailed on air-gapped nodes.
-        if (
-            progress.status == "complete"
-            and not self.offline
-            and self._missing_companion(shard)
+        # Offline mode degrades only for LOAD-BEARING companions (split
+        # vision weights): optional companions can never be fetched there
+        # and load_mlx_items degrades to run-without-speculation, so
+        # degrading for them would turn a perfectly loadable cached base
+        # into DownloadFailed on air-gapped nodes — but a vision model
+        # without its weights is broken and must not report complete.
+        if progress.status == "complete" and self._missing_companion(
+            shard, required_only=self.offline
         ):
             return progress.model_copy(update={"status": "in_progress"})
         return progress
 
     @staticmethod
-    def _missing_companion(shard: ShardMetadata) -> bool:
+    def _missing_companion(shard: ShardMetadata, required_only: bool = False) -> bool:
         """True when the card declares a companion repo absent from disk."""
         from exo.download.download_utils import model_companions_present_on_disk
 
-        return not model_companions_present_on_disk(shard.model_card)
+        return not model_companions_present_on_disk(
+            shard.model_card, required_only=required_only
+        )

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -121,22 +121,34 @@ class ResumableShardDownloader(ShardDownloader):
         # the moment it fires, and the planner dispatches model loads off
         # that state — so it must mean "everything the model needs is
         # here", not "the base is here and the sidecar is on its way".
-        # Companions are best-effort: the runtime treats a missing
-        # sidecar/assistant/vision repo as "run without that feature",
-        # so a transient fetch failure must not turn a loadable base
-        # model into a download error. Failures log loudly instead.
+        # Criticality differs per companion: split vision weights are
+        # load-bearing (their failure fails the base — a vision model
+        # without them is broken), while MTP sidecars and assistants are
+        # best-effort (the runtime degrades to run-without-speculation;
+        # failures log loudly instead).
         if not config_only and not self.offline:
             for companion_shard, allow, required in companion_download_specs(
                 shard.model_card
             ):
                 try:
-                    await download_shard(
+                    _, companion_progress = await download_shard(
                         companion_shard,
                         self.on_progress_wrapper,
                         max_parallel_downloads=self.max_parallel_downloads,
                         allow_patterns=allow,
                         skip_internet=self.offline,
                     )
+                    # download_shard converts repo-level fetch failures
+                    # (e.g. FileNotFoundError on the file list) into a
+                    # not_started result instead of raising — a required
+                    # companion must not slip through that hole.
+                    if required and companion_progress.status != "complete":
+                        raise RuntimeError(
+                            f"Required companion repo "
+                            f"{companion_shard.model_card.model_id} did not "
+                            f"download (status="
+                            f"{companion_progress.status!r})"
+                        )
                 except Exception as error:
                     if required:
                         # Split vision weights are load-bearing: a vision

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -126,7 +126,9 @@ class ResumableShardDownloader(ShardDownloader):
         # so a transient fetch failure must not turn a loadable base
         # model into a download error. Failures log loudly instead.
         if not config_only and not self.offline:
-            for companion_shard, allow in companion_download_specs(shard.model_card):
+            for companion_shard, allow, required in companion_download_specs(
+                shard.model_card
+            ):
                 try:
                     await download_shard(
                         companion_shard,
@@ -136,11 +138,15 @@ class ResumableShardDownloader(ShardDownloader):
                         skip_internet=self.offline,
                     )
                 except Exception as error:
+                    if required:
+                        # Split vision weights are load-bearing: a vision
+                        # model without them is broken, not degraded.
+                        raise
                     logger.warning(
                         f"Companion repo {companion_shard.model_card.model_id} "
                         f"for {shard.model_card.model_id} could not be fetched "
-                        f"({error}); speculative decoding / vision features "
-                        "that depend on it will be unavailable on this node."
+                        f"({error}); speculative decoding that depends on it "
+                        "will be unavailable on this node."
                     )
 
         target_dir, _ = await download_shard(

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -125,14 +125,26 @@ class ResumableShardDownloader(ShardDownloader):
         )
 
         if not config_only and not self.offline:
+            # Companions are best-effort: the runtime treats a missing
+            # sidecar/assistant/vision repo as "run without that feature",
+            # so a transient fetch failure must not turn a loadable base
+            # model into a download error. Failures log loudly instead.
             for companion_shard, allow in companion_download_specs(shard.model_card):
-                await download_shard(
-                    companion_shard,
-                    self.on_progress_wrapper,
-                    max_parallel_downloads=self.max_parallel_downloads,
-                    allow_patterns=allow,
-                    skip_internet=self.offline,
-                )
+                try:
+                    await download_shard(
+                        companion_shard,
+                        self.on_progress_wrapper,
+                        max_parallel_downloads=self.max_parallel_downloads,
+                        allow_patterns=allow,
+                        skip_internet=self.offline,
+                    )
+                except Exception as error:
+                    logger.warning(
+                        f"Companion repo {companion_shard.model_card.model_id} "
+                        f"for {shard.model_card.model_id} could not be fetched "
+                        f"({error}); speculative decoding / vision features "
+                        "that depend on it will be unavailable on this node."
+                    )
 
         return target_dir
 
@@ -200,25 +212,6 @@ class ResumableShardDownloader(ShardDownloader):
     @staticmethod
     def _missing_companion(shard: ShardMetadata) -> bool:
         """True when the card declares a companion repo absent from disk."""
-        from exo.download.download_utils import (
-            build_companion_model_path,
-            build_sidecar_path,
-        )
+        from exo.download.download_utils import model_companions_present_on_disk
 
-        runtime = shard.model_card.runtime
-        if runtime is None:
-            return False
-        if (
-            runtime.mtp_sidecar_repo
-            and runtime.mtp_heads
-            and build_sidecar_path(
-                ModelId(runtime.mtp_sidecar_repo), "mtp.safetensors"
-            )
-            is None
-        ):
-            return True
-        return bool(
-            runtime.assistant_model_repo
-            and build_companion_model_path(ModelId(runtime.assistant_model_repo))
-            is None
-        )
+        return not model_companions_present_on_disk(shard.model_card)

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -8,16 +8,15 @@ from loguru import logger
 
 from exo.download.download_utils import (
     RepoDownloadProgress,
+    companion_download_specs,
     download_shard,
 )
 from exo.download.shard_downloader import ShardDownloader
 from exo.shared.models.model_cards import (
     ModelCard,
     ModelId,
-    ModelTask,
     get_model_cards,
 )
-from exo.shared.types.memory import Memory
 from exo.shared.types.worker.shards import (
     PipelineShardMetadata,
     ShardMetadata,
@@ -125,100 +124,15 @@ class ResumableShardDownloader(ShardDownloader):
             skip_internet=self.offline,
         )
 
-        if (
-            not config_only
-            and not self.offline
-            and shard.model_card.vision
-            and shard.model_card.vision.weights_repo != str(shard.model_card.model_id)
-        ):
-            vision_repo = shard.model_card.vision.weights_repo
-            vision_card = ModelCard(
-                model_id=ModelId(vision_repo),
-                storage_size=Memory.from_bytes(0),
-                n_layers=1,
-                hidden_size=1,
-                supports_tensor=False,
-                tasks=[ModelTask.TextGeneration],
-            )
-            vision_shard = PipelineShardMetadata(
-                model_card=vision_card,
-                device_rank=0,
-                world_size=1,
-                start_layer=0,
-                end_layer=1,
-                n_layers=1,
-            )
-            await download_shard(
-                vision_shard,
-                self.on_progress_wrapper,
-                max_parallel_downloads=self.max_parallel_downloads,
-                allow_patterns=["*.safetensors", "config.json"],
-                skip_internet=self.offline,
-            )
-
-        if (
-            not config_only
-            and not self.offline
-            and shard.model_card.runtime
-            and shard.model_card.runtime.mtp_sidecar_repo
-        ):
-            mtp_repo = shard.model_card.runtime.mtp_sidecar_repo
-            mtp_card = ModelCard(
-                model_id=ModelId(mtp_repo),
-                storage_size=Memory.from_bytes(0),
-                n_layers=1,
-                hidden_size=1,
-                supports_tensor=False,
-                tasks=[ModelTask.TextGeneration],
-            )
-            mtp_shard = PipelineShardMetadata(
-                model_card=mtp_card,
-                device_rank=0,
-                world_size=1,
-                start_layer=0,
-                end_layer=1,
-                n_layers=1,
-            )
-            await download_shard(
-                mtp_shard,
-                self.on_progress_wrapper,
-                max_parallel_downloads=self.max_parallel_downloads,
-                allow_patterns=["mtp.safetensors", "config.json"],
-                skip_internet=self.offline,
-            )
-
-        if (
-            not config_only
-            and not self.offline
-            and shard.model_card.runtime
-            and shard.model_card.runtime.assistant_model_repo
-        ):
-            assistant_repo = shard.model_card.runtime.assistant_model_repo
-            assistant_card = ModelCard(
-                model_id=ModelId(assistant_repo),
-                storage_size=Memory.from_bytes(0),
-                n_layers=1,
-                hidden_size=1,
-                supports_tensor=False,
-                tasks=[ModelTask.TextGeneration],
-            )
-            assistant_shard = PipelineShardMetadata(
-                model_card=assistant_card,
-                device_rank=0,
-                world_size=1,
-                start_layer=0,
-                end_layer=1,
-                n_layers=1,
-            )
-            # The assistant is a small full model (config + a single
-            # safetensors), so pull the weights and config alongside the target.
-            await download_shard(
-                assistant_shard,
-                self.on_progress_wrapper,
-                max_parallel_downloads=self.max_parallel_downloads,
-                allow_patterns=["*.safetensors", "config.json"],
-                skip_internet=self.offline,
-            )
+        if not config_only and not self.offline:
+            for companion_shard, allow in companion_download_specs(shard.model_card):
+                await download_shard(
+                    companion_shard,
+                    self.on_progress_wrapper,
+                    max_parallel_downloads=self.max_parallel_downloads,
+                    allow_patterns=allow,
+                    skip_internet=self.offline,
+                )
 
         return target_dir
 

--- a/src/exo/download/impl_shard_downloader.py
+++ b/src/exo/download/impl_shard_downloader.py
@@ -116,19 +116,16 @@ class ResumableShardDownloader(ShardDownloader):
     ) -> Path:
         allow_patterns = ["config.json"] if config_only else None
 
-        target_dir, _ = await download_shard(
-            shard,
-            self.on_progress_wrapper,
-            max_parallel_downloads=self.max_parallel_downloads,
-            allow_patterns=allow_patterns,
-            skip_internet=self.offline,
-        )
-
+        # Companions download BEFORE the base on purpose: the base repo's
+        # "complete" progress event becomes cluster-visible download state
+        # the moment it fires, and the planner dispatches model loads off
+        # that state — so it must mean "everything the model needs is
+        # here", not "the base is here and the sidecar is on its way".
+        # Companions are best-effort: the runtime treats a missing
+        # sidecar/assistant/vision repo as "run without that feature",
+        # so a transient fetch failure must not turn a loadable base
+        # model into a download error. Failures log loudly instead.
         if not config_only and not self.offline:
-            # Companions are best-effort: the runtime treats a missing
-            # sidecar/assistant/vision repo as "run without that feature",
-            # so a transient fetch failure must not turn a loadable base
-            # model into a download error. Failures log loudly instead.
             for companion_shard, allow in companion_download_specs(shard.model_card):
                 try:
                     await download_shard(
@@ -145,6 +142,14 @@ class ResumableShardDownloader(ShardDownloader):
                         f"({error}); speculative decoding / vision features "
                         "that depend on it will be unavailable on this node."
                     )
+
+        target_dir, _ = await download_shard(
+            shard,
+            self.on_progress_wrapper,
+            max_parallel_downloads=self.max_parallel_downloads,
+            allow_patterns=allow_patterns,
+            skip_internet=self.offline,
+        )
 
         return target_dir
 

--- a/src/exo/download/tests/test_companions_present.py
+++ b/src/exo/download/tests/test_companions_present.py
@@ -88,3 +88,50 @@ def test_sidecar_without_mtp_heads_is_not_required(models_dir: Path) -> None:
         RuntimeCapabilityCardConfig(mtp_heads=False, mtp_sidecar_repo=_SIDECAR_REPO)
     )
     assert model_companions_present_on_disk(card)
+
+
+def test_split_vision_repo_missing_blocks_completion(models_dir: Path) -> None:
+    """A vision card with a separate weights repo absent from disk must not
+    let the base short-circuit as complete (codex round 2 on #213)."""
+    from exo.shared.models.model_cards import VisionCardConfig
+
+    card = ModelCard(
+        model_id=ModelId("test-org/test-base"),
+        storage_size=Memory.from_bytes(0),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        vision=VisionCardConfig(
+            image_token_id=1,
+            model_type="test",
+            weights_repo="test-org/test-base-vision",
+        ),
+    )
+    assert not model_companions_present_on_disk(card)
+
+    # Present via the single-file companion layout -> complete.
+    vision_dir = models_dir / "test-org--test-base-vision"
+    vision_dir.mkdir(parents=True)
+    (vision_dir / "config.json").write_text("{}")
+    (vision_dir / "model.safetensors").write_bytes(b"fake")
+    assert model_companions_present_on_disk(card)
+
+
+def test_same_repo_vision_is_not_a_companion(models_dir: Path) -> None:
+    from exo.shared.models.model_cards import VisionCardConfig
+
+    card = ModelCard(
+        model_id=ModelId("test-org/test-base"),
+        storage_size=Memory.from_bytes(0),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        vision=VisionCardConfig(
+            image_token_id=1,
+            model_type="test",
+            weights_repo="test-org/test-base",
+        ),
+    )
+    assert model_companions_present_on_disk(card)

--- a/src/exo/download/tests/test_companions_present.py
+++ b/src/exo/download/tests/test_companions_present.py
@@ -135,3 +135,74 @@ def test_same_repo_vision_is_not_a_companion(models_dir: Path) -> None:
         ),
     )
     assert model_companions_present_on_disk(card)
+
+
+def test_required_only_checks_vision_but_not_speculation(models_dir: Path) -> None:
+    """Offline mode: optional companions never block (they can't arrive),
+    but missing split-vision weights still do — a vision model without
+    them is broken, not degraded."""
+    from exo.shared.models.model_cards import VisionCardConfig
+
+    card = ModelCard(
+        model_id=ModelId("test-org/test-base"),
+        storage_size=Memory.from_bytes(0),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        vision=VisionCardConfig(
+            image_token_id=1,
+            model_type="test",
+            weights_repo="test-org/test-base-vision",
+        ),
+        runtime=RuntimeCapabilityCardConfig(
+            mtp_heads=True, mtp_sidecar_repo=_SIDECAR_REPO
+        ),
+    )
+    # Vision missing: blocked in both modes.
+    assert not model_companions_present_on_disk(card, required_only=True)
+    assert not model_companions_present_on_disk(card)
+
+    vision_dir = models_dir / "test-org--test-base-vision"
+    vision_dir.mkdir(parents=True)
+    (vision_dir / "config.json").write_text("{}")
+    (vision_dir / "model.safetensors").write_bytes(b"fake")
+
+    # Vision present, sidecar missing: required-only passes, full check blocks.
+    assert model_companions_present_on_disk(card, required_only=True)
+    assert not model_companions_present_on_disk(card)
+
+
+def test_vision_repo_found_in_models_dir(
+    models_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A vision repo downloaded via HF lives in EXO_MODELS_DIR, not on the
+    EXO_MODELS_PATH search path — the probe must find it there too, or
+    cached bases degrade to in_progress forever (Copilot round 7)."""
+    import exo.shared.constants as constants_module
+    from exo.shared.models.model_cards import VisionCardConfig
+
+    hf_dir = tmp_path / "hf_models"
+    hf_dir.mkdir()
+    monkeypatch.setattr(constants_module, "EXO_MODELS_PATH", ())
+    monkeypatch.setattr(download_utils_module, "EXO_MODELS_DIR", hf_dir)
+
+    vision_dir = hf_dir / "test-org--test-base-vision"
+    vision_dir.mkdir(parents=True)
+    (vision_dir / "config.json").write_text("{}")
+    (vision_dir / "model.safetensors").write_bytes(b"fake")
+
+    card = ModelCard(
+        model_id=ModelId("test-org/test-base"),
+        storage_size=Memory.from_bytes(0),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        vision=VisionCardConfig(
+            image_token_id=1,
+            model_type="test",
+            weights_repo="test-org/test-base-vision",
+        ),
+    )
+    assert model_companions_present_on_disk(card)

--- a/src/exo/download/tests/test_companions_present.py
+++ b/src/exo/download/tests/test_companions_present.py
@@ -1,0 +1,90 @@
+# pyright: reportPrivateUsage=false
+"""Tests for the on-disk companion presence check.
+
+This predicate gates the DownloadCoordinator's resolve-in-path shortcut: a
+base model already on disk must NOT be reported download-complete when the
+card declares an MTP sidecar or assistant that is missing — that shortcut
+bypassed ensure_shard entirely and loaded staged models with speculative
+decoding silently unavailable (codex review on #213).
+"""
+
+from pathlib import Path
+
+import pytest
+
+import exo.download.download_utils as download_utils_module
+import exo.shared.constants as constants_module
+from exo.download.download_utils import model_companions_present_on_disk
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelTask,
+    RuntimeCapabilityCardConfig,
+)
+from exo.shared.types.common import ModelId
+from exo.shared.types.memory import Memory
+
+_SIDECAR_REPO = "FoxlightAI/test-9b-mtp"
+_ASSISTANT_REPO = "mlx-community/test-12b-assistant-bf16"
+
+
+def _card(runtime: RuntimeCapabilityCardConfig | None) -> ModelCard:
+    return ModelCard(
+        model_id=ModelId("test-org/test-base"),
+        storage_size=Memory.from_bytes(0),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        runtime=runtime,
+    )
+
+
+@pytest.fixture
+def models_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(constants_module, "EXO_MODELS_PATH", (tmp_path,))
+    monkeypatch.setattr(download_utils_module, "EXO_MODELS_DIR", tmp_path)
+    return tmp_path
+
+
+def test_bare_card_has_no_missing_companions(models_dir: Path) -> None:
+    assert model_companions_present_on_disk(_card(None))
+
+
+def test_declared_sidecar_missing_on_disk(models_dir: Path) -> None:
+    card = _card(
+        RuntimeCapabilityCardConfig(mtp_heads=True, mtp_sidecar_repo=_SIDECAR_REPO)
+    )
+    assert not model_companions_present_on_disk(card)
+
+
+def test_declared_sidecar_present_on_disk(models_dir: Path) -> None:
+    sidecar_dir = models_dir / "FoxlightAI--test-9b-mtp"
+    sidecar_dir.mkdir(parents=True)
+    (sidecar_dir / "mtp.safetensors").write_bytes(b"fake")
+    card = _card(
+        RuntimeCapabilityCardConfig(mtp_heads=True, mtp_sidecar_repo=_SIDECAR_REPO)
+    )
+    assert model_companions_present_on_disk(card)
+
+
+def test_declared_assistant_missing_on_disk(models_dir: Path) -> None:
+    card = _card(RuntimeCapabilityCardConfig(assistant_model_repo=_ASSISTANT_REPO))
+    assert not model_companions_present_on_disk(card)
+
+
+def test_declared_assistant_present_on_disk(models_dir: Path) -> None:
+    assistant_dir = models_dir / "mlx-community--test-12b-assistant-bf16"
+    assistant_dir.mkdir(parents=True)
+    (assistant_dir / "config.json").write_text("{}")
+    (assistant_dir / "model.safetensors").write_bytes(b"fake")
+    card = _card(RuntimeCapabilityCardConfig(assistant_model_repo=_ASSISTANT_REPO))
+    assert model_companions_present_on_disk(card)
+
+
+def test_sidecar_without_mtp_heads_is_not_required(models_dir: Path) -> None:
+    """A sidecar repo declared without mtp_heads is never loaded by the
+    runner, so its absence must not block the path shortcut."""
+    card = _card(
+        RuntimeCapabilityCardConfig(mtp_heads=False, mtp_sidecar_repo=_SIDECAR_REPO)
+    )
+    assert model_companions_present_on_disk(card)

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -131,7 +131,7 @@ def _staged_directory_looks_complete(directory: Path) -> bool:
     """
     from exo.download.download_utils import is_model_directory_complete
 
-    if any(directory.glob("*.partial")):
+    if any(directory.rglob("*.partial")):
         return False
     if is_model_directory_complete(directory):
         return True

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -79,7 +79,7 @@ import aiofiles.os as aios
 import aiohttp
 from loguru import logger
 
-from exo.download.download_utils import create_http_session
+from exo.download.download_utils import companion_download_specs, create_http_session
 from exo.download.shard_downloader import ShardDownloader
 from exo.shared.types.memory import Memory
 from exo.shared.types.worker.downloads import RepoDownloadProgress
@@ -744,7 +744,53 @@ class ModelStoreDownloader(ShardDownloader):
     async def ensure_shard(
         self, shard: ShardMetadata, config_only: bool = False
     ) -> Path:
-        """Ensure the shard is available locally, staging from the store if needed.
+        """Ensure the shard AND its companion repos are available locally.
+
+        Resolves the base model via :meth:`_ensure_base_shard` (store-first
+        with optional HF fallback), then ensures every companion repo the
+        card declares (vision weights, MTP sidecar, assistant model) through
+        the same store-first path. Before this wrapper existed, three of the
+        four base-resolution paths returned without fetching companions — a
+        staged base model would load and run with speculative decoding
+        silently unavailable (launch smoke, 2026-06-06).
+
+        Companion failures are logged loudly but never fail the base load:
+        the runner treats missing companions as "run without speculation",
+        and a missing sidecar should not turn a loadable model into a
+        download error.
+        """
+        path = await self._ensure_base_shard(shard, config_only)
+        if not config_only:
+            await self._ensure_companion_shards(shard)
+        return path
+
+    async def _ensure_companion_shards(self, shard: ShardMetadata) -> None:
+        """Ensure every companion repo declared by the shard's model card.
+
+        Recurses through :meth:`ensure_shard` so companions get the same
+        store-first resolution as base models (already staged → skip; in
+        store → stage; missing → store-host HF fetch / inner fallback).
+        Companion cards are bare, so the recursion terminates after one
+        level.
+        """
+        for companion_shard, _allow_patterns in companion_download_specs(
+            shard.model_card
+        ):
+            companion_id = companion_shard.model_card.model_id
+            try:
+                await self.ensure_shard(companion_shard)
+            except Exception as error:
+                logger.warning(
+                    f"ModelStoreDownloader: companion repo {companion_id} for "
+                    f"{shard.model_card.model_id} could not be fetched "
+                    f"({error}); speculative decoding / vision features that "
+                    "depend on it will be unavailable on this node."
+                )
+
+    async def _ensure_base_shard(
+        self, shard: ShardMetadata, config_only: bool = False
+    ) -> Path:
+        """Ensure the base model is available locally, staging from the store if needed.
 
         Resolution order:
 

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -120,6 +120,28 @@ def _make_store_url(host: str, port: int, path: str) -> str:
     return f"http://{host}:{port}{path}"
 
 
+def _staged_directory_looks_complete(directory: Path) -> bool:
+    """Heuristic completeness check for a staged directory.
+
+    Accepts the three repo layouts the store serves: a full model repo
+    (index-based completeness, same probe the downloader uses), a
+    single-file companion model (config.json + model.safetensors), or an
+    MTP sidecar (mtp.safetensors). A directory with leftover ``.partial``
+    files is never complete.
+    """
+    from exo.download.download_utils import is_model_directory_complete
+
+    if any(directory.glob("*.partial")):
+        return False
+    if is_model_directory_complete(directory):
+        return True
+    if (directory / "config.json").is_file() and (
+        directory / "model.safetensors"
+    ).is_file():
+        return True
+    return (directory / "mtp.safetensors").is_file()
+
+
 @final
 class StoreHealthInfo:
     """Parsed response from ``GET /health`` on the store server.
@@ -838,11 +860,16 @@ class ModelStoreDownloader(ShardDownloader):
                     return direct_path
             return await self._inner.ensure_shard(shard, config_only)
 
-        # Fast path: if the model is already staged locally, skip the
-        # HTTP availability probe.  This keeps inference working when the store
-        # server is temporarily unreachable and avoids an unnecessary round-trip.
+        # Fast path: if the model is already staged locally AND the staged
+        # directory looks complete, skip the HTTP availability probe. This
+        # keeps inference working when the store server is temporarily
+        # unreachable and avoids an unnecessary round-trip. An interrupted
+        # staging leaves a partial directory (e.g. just config.json or a
+        # .partial file) — trusting any non-empty dir here would hand MLX a
+        # broken model, so incomplete dirs fall through to re-staging
+        # (which resumes partial files via HTTP Range).
         dest_path = _staging_dir(self._staging_config.node_cache_path, model_id)
-        if dest_path.exists() and any(dest_path.iterdir()):
+        if dest_path.exists() and _staged_directory_looks_complete(dest_path):
             logger.info(
                 f"ModelStoreDownloader: {model_id} already staged at {dest_path} — skipping availability probe"
             )

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -780,18 +780,22 @@ class ModelStoreDownloader(ShardDownloader):
         Companion cards are bare, so the recursion terminates after one
         level.
         """
-        for companion_shard, _allow_patterns in companion_download_specs(
+        for companion_shard, _allow_patterns, required in companion_download_specs(
             shard.model_card
         ):
             companion_id = companion_shard.model_card.model_id
             try:
                 await self.ensure_shard(companion_shard)
             except Exception as error:
+                if required:
+                    # Split vision weights are load-bearing: a vision model
+                    # without them is broken, not degraded.
+                    raise
                 logger.warning(
                     f"ModelStoreDownloader: companion repo {companion_id} for "
                     f"{shard.model_card.model_id} could not be fetched "
-                    f"({error}); speculative decoding / vision features that "
-                    "depend on it will be unavailable on this node."
+                    f"({error}); speculative decoding that depends on it "
+                    "will be unavailable on this node."
                 )
 
     async def _ensure_base_shard(

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -853,7 +853,9 @@ class ModelStoreDownloader(ShardDownloader):
                 direct_path = self._store_client.local_store_path / _sanitize_model_id(
                     model_id
                 )
-                if direct_path.exists() and any(direct_path.iterdir()):
+                if direct_path.exists() and _staged_directory_looks_complete(
+                    direct_path
+                ):
                     logger.info(
                         f"ModelStoreDownloader: staging disabled — loading {model_id} directly from store at {direct_path}"
                     )

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -754,10 +754,11 @@ class ModelStoreDownloader(ShardDownloader):
         staged base model would load and run with speculative decoding
         silently unavailable (launch smoke, 2026-06-06).
 
-        Companion failures are logged loudly but never fail the base load:
-        the runner treats missing companions as "run without speculation",
-        and a missing sidecar should not turn a loadable model into a
-        download error.
+        Companion criticality differs: split vision weights are
+        load-bearing, so their fetch failures fail the base load (a vision
+        model without them is broken). MTP sidecars and assistants are
+        best-effort — the runner degrades to run-without-speculation, so
+        their failures log loudly without failing a loadable base model.
         """
         path = await self._ensure_base_shard(shard, config_only)
         if not config_only:

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -762,6 +762,13 @@ class ModelStoreDownloader(ShardDownloader):
         path = await self._ensure_base_shard(shard, config_only)
         if not config_only:
             await self._ensure_companion_shards(shard)
+        # Terminal progress is emitted HERE, after companions: the
+        # "complete" status becomes cluster-visible DownloadCompleted state
+        # the moment it fires, and the planner dispatches LoadModel off
+        # that state — emitting it from the base-resolution paths let a
+        # runner load while a companion was still staging and run without
+        # speculation (codex review on #213).
+        await self._emit_progress(shard, status="complete")
         return path
 
     async def _ensure_companion_shards(self, shard: ShardMetadata) -> None:
@@ -823,7 +830,6 @@ class ModelStoreDownloader(ShardDownloader):
                     logger.info(
                         f"ModelStoreDownloader: staging disabled — loading {model_id} directly from store at {direct_path}"
                     )
-                    await self._emit_progress(shard, status="complete")
                     return direct_path
             return await self._inner.ensure_shard(shard, config_only)
 
@@ -835,7 +841,6 @@ class ModelStoreDownloader(ShardDownloader):
             logger.info(
                 f"ModelStoreDownloader: {model_id} already staged at {dest_path} — skipping availability probe"
             )
-            await self._emit_progress(shard, status="complete")
             return dest_path
 
         available = await self._store_client.is_model_available(model_id)
@@ -855,7 +860,6 @@ class ModelStoreDownloader(ShardDownloader):
                         total_bytes=total,
                     ),
                 )
-                await self._emit_progress(shard, status="complete")
                 return path
             except ModelNotInStoreError:
                 # Store index was stale — the file was reported present but
@@ -896,7 +900,6 @@ class ModelStoreDownloader(ShardDownloader):
                     total_bytes=total,
                 ),
             )
-            await self._emit_progress(shard, status="complete")
             return path
 
         raise ModelNotInStoreError(

--- a/src/exo/store/tests/test_model_store_companions.py
+++ b/src/exo/store/tests/test_model_store_companions.py
@@ -130,6 +130,7 @@ async def test_already_staged_base_still_ensures_companion(tmp_path: Path) -> No
     """
     base_dir = tmp_path / "mlx-community--Qwen-test-9B-4bit"
     base_dir.mkdir(parents=True)
+    (base_dir / "config.json").write_text("{}")
     (base_dir / "model.safetensors").write_bytes(b"fake-weights")
 
     store = _RecordingStoreClient(available={_SIDECAR_REPO})
@@ -162,6 +163,7 @@ async def test_companion_failure_does_not_fail_base_load(tmp_path: Path) -> None
     """
     base_dir = tmp_path / "mlx-community--Qwen-test-9B-4bit"
     base_dir.mkdir(parents=True)
+    (base_dir / "config.json").write_text("{}")
     (base_dir / "model.safetensors").write_bytes(b"fake-weights")
 
     # Sidecar is reported available but staging it always fails, and the
@@ -197,6 +199,7 @@ async def test_terminal_progress_waits_for_companions(tmp_path: Path) -> None:
     run without speculation (codex review, #213)."""
     base_dir = tmp_path / "mlx-community--Qwen-test-9B-4bit"
     base_dir.mkdir(parents=True)
+    (base_dir / "config.json").write_text("{}")
     (base_dir / "model.safetensors").write_bytes(b"fake-weights")
 
     store = _RecordingStoreClient(available={_SIDECAR_REPO})
@@ -229,3 +232,20 @@ async def test_terminal_progress_waits_for_companions(tmp_path: Path) -> None:
     assert sidecar_staged < base_complete, (
         f"base completed before its sidecar staged: {ordering}"
     )
+
+
+@pytest.mark.anyio
+async def test_partial_staged_dir_is_restaged(tmp_path: Path) -> None:
+    """An interrupted staging (partial file present) must not satisfy the
+    fast path — the model gets re-staged (resume via Range) instead of
+    being handed to MLX broken (codex round 6 on #213)."""
+    base_dir = tmp_path / "mlx-community--Qwen-test-9B-4bit"
+    base_dir.mkdir(parents=True)
+    (base_dir / "model.safetensors.partial").write_bytes(b"half")
+
+    store = _RecordingStoreClient(available={_BASE_MODEL, _SIDECAR_REPO})
+    downloader = _downloader(store, tmp_path)
+
+    await downloader.ensure_shard(_shard_with_sidecar())
+
+    assert _BASE_MODEL in store.staged

--- a/src/exo/store/tests/test_model_store_companions.py
+++ b/src/exo/store/tests/test_model_store_companions.py
@@ -1,0 +1,189 @@
+# pyright: reportAny=false
+"""Companion-repo handling in ModelStoreDownloader.
+
+The launch smoke (2026-06-06) found that three of the store downloader's
+four base-resolution paths returned without fetching the card's companion
+repos (MTP sidecar / assistant model / vision weights) — a staged base
+model would load and silently run without speculative decoding. These
+tests pin the fixed contract: every ``ensure_shard`` resolution also
+ensures the declared companions, and a companion failure never fails the
+base load.
+"""
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from exo.download.download_utils import RepoDownloadProgress
+from exo.download.shard_downloader import ShardDownloader
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelTask,
+    RuntimeCapabilityCardConfig,
+)
+from exo.shared.types.common import ModelId
+from exo.shared.types.memory import Memory
+from exo.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
+from exo.store.config import StagingNodeConfig
+from exo.store.model_store_client import ModelStoreClient, ModelStoreDownloader
+
+_BASE_MODEL = "mlx-community/Qwen-test-9B-4bit"
+_SIDECAR_REPO = "FoxlightAI/qwen-test-9b-mtp"
+
+
+class _UnusedInnerDownloader(ShardDownloader):
+    """Inner downloader that must not be reached in store-served tests."""
+
+    async def ensure_shard(
+        self, shard: ShardMetadata, config_only: bool = False
+    ) -> Path:
+        raise AssertionError(
+            f"inner downloader should not be used (model {shard.model_card.model_id})"
+        )
+
+    def on_progress(
+        self,
+        callback: Callable[[ShardMetadata, RepoDownloadProgress], Awaitable[None]],
+    ) -> None:
+        pass
+
+    async def get_shard_download_status(
+        self,
+    ) -> AsyncIterator[tuple[Path, RepoDownloadProgress]]:
+        if False:
+            yield (Path("/unused"), cast(RepoDownloadProgress, object()))
+
+    async def get_shard_download_status_for_shard(
+        self, shard: ShardMetadata
+    ) -> RepoDownloadProgress:
+        raise AssertionError("status queries are not used in this test")
+
+
+class _RecordingStoreClient:
+    """Store client stub that records availability probes and staging calls."""
+
+    def __init__(self, available: set[str], fail_staging: set[str] | None = None):
+        self.available = available
+        self.fail_staging = fail_staging or set()
+        self.staged: list[str] = []
+
+    async def is_model_available(self, model_id: str) -> bool:
+        return model_id in self.available
+
+    async def stage_shard(
+        self,
+        model_id: str,
+        dest_path: Path,
+        on_progress: Callable[[int, int], Awaitable[None]] | None = None,
+    ) -> Path:
+        if model_id in self.fail_staging:
+            raise RuntimeError(f"simulated staging failure for {model_id}")
+        self.staged.append(model_id)
+        dest_path.mkdir(parents=True, exist_ok=True)
+        (dest_path / "weights.safetensors").write_bytes(b"fake")
+        return dest_path
+
+
+def _shard_with_sidecar() -> PipelineShardMetadata:
+    return PipelineShardMetadata(
+        model_card=ModelCard(
+            model_id=ModelId(_BASE_MODEL),
+            storage_size=Memory.from_bytes(4),
+            n_layers=2,
+            hidden_size=8,
+            supports_tensor=False,
+            tasks=[ModelTask.TextGeneration],
+            runtime=RuntimeCapabilityCardConfig(
+                mtp_heads=True,
+                mtp_sidecar_repo=_SIDECAR_REPO,
+            ),
+        ),
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=2,
+        n_layers=2,
+    )
+
+
+def _downloader(
+    store_client: _RecordingStoreClient, staging_root: Path
+) -> ModelStoreDownloader:
+    return ModelStoreDownloader(
+        inner=_UnusedInnerDownloader(),
+        store_client=cast(ModelStoreClient, cast(object, store_client)),
+        staging_config=StagingNodeConfig(
+            enabled=True,
+            node_cache_path=str(staging_root),
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_already_staged_base_still_ensures_companion(tmp_path: Path) -> None:
+    """The fast path (base already staged) must still fetch the sidecar.
+
+    This is the exact kite1 failure: base weights present in staging, fast
+    path returns, sidecar never fetched, MTP silently disabled.
+    """
+    base_dir = tmp_path / "mlx-community--Qwen-test-9B-4bit"
+    base_dir.mkdir(parents=True)
+    (base_dir / "model.safetensors").write_bytes(b"fake-weights")
+
+    store = _RecordingStoreClient(available={_SIDECAR_REPO})
+    downloader = _downloader(store, tmp_path)
+
+    path = await downloader.ensure_shard(_shard_with_sidecar())
+
+    assert path == base_dir
+    assert store.staged == [_SIDECAR_REPO]
+    assert (tmp_path / "FoxlightAI--qwen-test-9b-mtp").is_dir()
+
+
+@pytest.mark.anyio
+async def test_store_staged_base_also_stages_companion(tmp_path: Path) -> None:
+    """Staging the base from the store must stage the sidecar alongside it."""
+    store = _RecordingStoreClient(available={_BASE_MODEL, _SIDECAR_REPO})
+    downloader = _downloader(store, tmp_path)
+
+    await downloader.ensure_shard(_shard_with_sidecar())
+
+    assert store.staged == [_BASE_MODEL, _SIDECAR_REPO]
+
+
+@pytest.mark.anyio
+async def test_companion_failure_does_not_fail_base_load(tmp_path: Path) -> None:
+    """A sidecar that cannot be fetched logs loudly but the base still loads.
+
+    The runner treats a missing companion as "run without speculation"; a
+    fetch failure must not turn a loadable model into a download error.
+    """
+    base_dir = tmp_path / "mlx-community--Qwen-test-9B-4bit"
+    base_dir.mkdir(parents=True)
+    (base_dir / "model.safetensors").write_bytes(b"fake-weights")
+
+    # Sidecar is reported available but staging it always fails, and the
+    # inner downloader (HF fallback) raises if reached — the base load must
+    # survive both.
+    store = _RecordingStoreClient(
+        available={_SIDECAR_REPO}, fail_staging={_SIDECAR_REPO}
+    )
+    downloader = _downloader(store, tmp_path)
+
+    path = await downloader.ensure_shard(_shard_with_sidecar())
+
+    assert path == base_dir
+    assert store.staged == []
+
+
+@pytest.mark.anyio
+async def test_companion_recursion_terminates_on_bare_cards(tmp_path: Path) -> None:
+    """Companion shards carry bare cards, so ensuring them must not recurse."""
+    store = _RecordingStoreClient(available={_BASE_MODEL, _SIDECAR_REPO})
+    downloader = _downloader(store, tmp_path)
+
+    await downloader.ensure_shard(_shard_with_sidecar())
+    # One staging call per repo — no repeated/looping companion fetches.
+    assert store.staged.count(_SIDECAR_REPO) == 1

--- a/src/exo/store/tests/test_model_store_companions.py
+++ b/src/exo/store/tests/test_model_store_companions.py
@@ -187,3 +187,45 @@ async def test_companion_recursion_terminates_on_bare_cards(tmp_path: Path) -> N
     await downloader.ensure_shard(_shard_with_sidecar())
     # One staging call per repo — no repeated/looping companion fetches.
     assert store.staged.count(_SIDECAR_REPO) == 1
+
+
+@pytest.mark.anyio
+async def test_terminal_progress_waits_for_companions(tmp_path: Path) -> None:
+    """The base's "complete" progress becomes cluster-visible download state
+    that gates model loads — it must not fire until companions are ensured,
+    or a runner can load while the sidecar is still staging and silently
+    run without speculation (codex review, #213)."""
+    base_dir = tmp_path / "mlx-community--Qwen-test-9B-4bit"
+    base_dir.mkdir(parents=True)
+    (base_dir / "model.safetensors").write_bytes(b"fake-weights")
+
+    store = _RecordingStoreClient(available={_SIDECAR_REPO})
+    downloader = _downloader(store, tmp_path)
+
+    ordering: list[str] = []
+
+    async def _on_progress(shard: ShardMetadata, progress: object) -> None:
+        status = getattr(progress, "status", "?")
+        if status == "complete":
+            ordering.append(f"complete:{shard.model_card.model_id}")
+
+    original_stage = store.stage_shard
+
+    async def _recording_stage(
+        model_id: str,
+        dest_path: Path,
+        on_progress: Callable[[int, int], Awaitable[None]] | None = None,
+    ) -> Path:
+        ordering.append(f"staged:{model_id}")
+        return await original_stage(model_id, dest_path, on_progress=on_progress)
+
+    store.stage_shard = _recording_stage
+    downloader.on_progress(_on_progress)
+
+    await downloader.ensure_shard(_shard_with_sidecar())
+
+    base_complete = ordering.index(f"complete:{_BASE_MODEL}")
+    sidecar_staged = ordering.index(f"staged:{_SIDECAR_REPO}")
+    assert sidecar_staged < base_complete, (
+        f"base completed before its sidecar staged: {ordering}"
+    )

--- a/src/exo/worker/engines/mlx/auto_parallel.py
+++ b/src/exo/worker/engines/mlx/auto_parallel.py
@@ -734,9 +734,13 @@ def pipeline_auto_parallel(
             # enough to never need sharding; fail loud rather than compute
             # silently wrong attention.
             raise ValueError(
-                "gemma4 pipeline slice cuts a KV-sharing edge "
-                f"(slice [{start_layer}, {end_layer}) consumes K/V from an "
-                "earlier rank); KV-shared models are not pipeline-shardable"
+                "This model shares KV caches across layers (gemma 4 "
+                "E-series) and cannot be split across nodes: the pipeline "
+                f"slice [{start_layer}, {end_layer}) would consume K/V "
+                "produced on an earlier rank, which the pipeline does not "
+                "carry — attention would be silently wrong. Place this "
+                "model on a single node instead (KV-shared models are "
+                "small enough to fit)."
             )
         inner_model_instance.previous_kvs = [
             prev_idx - start_layer for prev_idx in sliced_prev

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -2808,9 +2808,13 @@ def mlx_generate(
             # token could slip through via an accepted draft. Until the
             # verify pass applies processors, MTP and processors are
             # mutually exclusive.
-            logger.info(
-                "MTP speculative decoding is incompatible with logits "
-                f"processors ({len(logits_processors)} active); skipping MTP"
+            logger.warning(
+                "Speculative decoding DISABLED for this request: "
+                f"{len(logits_processors)} logits processor(s) are active — "
+                "typically a repetition_penalty in the request (some client "
+                "libraries send one by default). Generation falls back to "
+                "plain decode; drop repetition_penalty/penalty parameters "
+                "from the request to keep speculative decoding engaged."
             )
         else:
             trunk_head = _get_trunk_and_head(model)

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -124,8 +124,10 @@ def resolve_warmup_deadline_seconds() -> float:
         except ValueError:
             pass
         logger.warning(
-            f"Ignoring invalid SKULK_WARMUP_DEADLINE_SECONDS value {raw!r}; "
-            f"using default {WARMUP_DEADLINE_SECONDS_DEFAULT:.0f}s"
+            "Ignoring invalid warmup-deadline override "
+            f"(SKULK_WARMUP_DEADLINE_SECONDS / EXO_WARMUP_DEADLINE_SECONDS) "
+            f"value {raw!r}; using default "
+            f"{WARMUP_DEADLINE_SECONDS_DEFAULT:.0f}s"
         )
     return WARMUP_DEADLINE_SECONDS_DEFAULT
 

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -1,9 +1,11 @@
+import contextlib
 import gc
 import os
 import resource
 import signal
 import threading
 import time
+from collections.abc import Callable, Iterator
 
 import loguru
 
@@ -94,6 +96,90 @@ def resolve_metal_fast_synch(card_runtime: RuntimeCapabilityCardConfig | None) -
     if _card_declares_speculative_decoding(card_runtime):
         return False
     return FAST_SYNCH_CLUSTER_DEFAULT
+
+
+WARMUP_DEADLINE_SECONDS_DEFAULT: float = 300.0
+"""How long a runner may spend in warmup before it is declared wedged.
+
+Healthy warmups finish in seconds (kernel compile + a 1-token generation);
+five minutes is far beyond any legitimate cold start while still bounding
+the failure. The canonical wedge (launch smoke, 2026-06-05): a Metal fault
+leaves ``mx.eval`` parked in ``IOSurfaceSharedEvent`` forever at 0% CPU —
+uninterruptible from Python — and the runner sits in ``RunnerWarmingUp``
+silently blocking ALL task dispatch on the node. Override with
+``SKULK_WARMUP_DEADLINE_SECONDS``.
+"""
+
+
+def resolve_warmup_deadline_seconds() -> float:
+    """Resolve the warmup deadline, honoring the operator env override."""
+    raw = preferred_env_value(
+        "SKULK_WARMUP_DEADLINE_SECONDS", "EXO_WARMUP_DEADLINE_SECONDS"
+    )
+    if raw is not None:
+        try:
+            parsed = float(raw)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+        logger.warning(
+            f"Ignoring invalid SKULK_WARMUP_DEADLINE_SECONDS value {raw!r}; "
+            f"using default {WARMUP_DEADLINE_SECONDS_DEFAULT:.0f}s"
+        )
+    return WARMUP_DEADLINE_SECONDS_DEFAULT
+
+
+@contextlib.contextmanager
+def deadline_watchdog(
+    seconds: float,
+    description: str,
+    on_timeout: Callable[[], None] | None = None,
+) -> Iterator[None]:
+    """Hard deadline for a block that may wedge uninterruptibly.
+
+    A wedged Metal eval blocks inside the driver at 0% CPU and cannot be
+    interrupted by signals or async timeouts — the only reliable escape is
+    process exit (the supervisor observes the death and reports
+    ``RunnerFailed``; Metal memory is reclaimed on exit). A daemon thread
+    waits out the deadline and, if the block has not finished, logs a
+    CRITICAL diagnosis and terminates the process via ``os._exit``.
+
+    Args:
+        seconds: Deadline for the wrapped block.
+        description: Human-readable name of the operation (appears in the
+            CRITICAL log line).
+        on_timeout: Test seam — replaces the default log-and-``os._exit``
+            action when provided.
+    """
+    finished = threading.Event()
+
+    def _default_timeout_action() -> None:
+        logger.critical(
+            f"{description} exceeded its {seconds:.0f}s deadline — the GPU "
+            "may be wedged (a faulted Metal eval blocks forever at 0% CPU). "
+            "Terminating this runner so the node can keep dispatching. If "
+            "runners keep dying here, test the GPU with a small matmul; if "
+            "that hangs too, the machine needs a reboot to reset the Metal "
+            "device queue."
+        )
+        _release_metal_resources()
+        os._exit(1)
+
+    action = on_timeout if on_timeout is not None else _default_timeout_action
+
+    def _watch() -> None:
+        if not finished.wait(seconds):
+            action()
+
+    watcher = threading.Thread(
+        target=_watch, name="runner-deadline-watchdog", daemon=True
+    )
+    watcher.start()
+    try:
+        yield
+    finally:
+        finished.set()
 
 
 def _release_metal_resources() -> None:

--- a/src/exo/worker/runner/bootstrap.py
+++ b/src/exo/worker/runner/bootstrap.py
@@ -165,7 +165,11 @@ def deadline_watchdog(
             "that hangs too, the machine needs a reboot to reset the Metal "
             "device queue."
         )
-        _release_metal_resources()
+        # Deliberately NO _release_metal_resources() here: mx.clear_cache()
+        # would touch the very Metal device this watchdog assumes is wedged
+        # and could block before the exit. Process exit reclaims all Metal
+        # allocations on its own (verified across every crash class,
+        # 2026-06-05).
         os._exit(1)
 
     action = on_timeout if on_timeout is not None else _default_timeout_action

--- a/src/exo/worker/runner/llm_inference/runner.py
+++ b/src/exo/worker/runner/llm_inference/runner.py
@@ -70,7 +70,11 @@ from exo.worker.engines.mlx.utils_mlx import (
     load_mlx_items,
 )
 from exo.worker.engines.mlx.vision import VisionProcessor
-from exo.worker.runner.bootstrap import logger
+from exo.worker.runner.bootstrap import (
+    deadline_watchdog,
+    logger,
+    resolve_warmup_deadline_seconds,
+)
 from exo.worker.runner.diagnostics import record_runner_phase, runner_phase
 from exo.worker.runner.llm_inference.batch_generator import (
     BatchGenerator,
@@ -347,12 +351,24 @@ class Runner:
                         "or set it to 0 to restore synthetic warmup)"
                     )
                 else:
-                    with runner_phase(
-                        "warmup",
-                        detail="warmup_generator",
-                        task_id=task.task_id,
-                        attrs={"group_size": group_size},
-                        include_memory=True,
+                    # A wedged warmup (faulted Metal eval parked forever at
+                    # 0% CPU) used to leave the runner in RunnerWarmingUp
+                    # indefinitely, silently blocking ALL dispatch on the
+                    # node. The watchdog hard-exits the runner instead; the
+                    # supervisor reports RunnerFailed and the node keeps
+                    # working.
+                    with (
+                        deadline_watchdog(
+                            resolve_warmup_deadline_seconds(),
+                            f"Warmup of {self.model_id}",
+                        ),
+                        runner_phase(
+                            "warmup",
+                            detail="warmup_generator",
+                            task_id=task.task_id,
+                            attrs={"group_size": group_size},
+                            include_memory=True,
+                        ),
                     ):
                         warmup_generator.warmup()
 

--- a/src/exo/worker/tests/unittests/test_runner/test_warmup_deadline.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_warmup_deadline.py
@@ -9,7 +9,6 @@ which cannot run inside pytest).
 """
 
 import threading
-import time
 
 import pytest
 
@@ -33,9 +32,9 @@ def test_watchdog_does_not_fire_when_block_completes() -> None:
     with deadline_watchdog(0.2, "test block", on_timeout=fired.set):
         pass  # completes immediately
 
-    # Give the watchdog thread ample time to (incorrectly) fire.
-    time.sleep(0.4)
-    assert not fired.is_set(), "watchdog fired after the block completed"
+    # Wait past the deadline; the event staying unset proves the watchdog
+    # was disarmed (waiting on the event returns early only if it fires).
+    assert not fired.wait(0.4), "watchdog fired after the block completed"
 
 
 def test_watchdog_does_not_fire_on_exception_exit() -> None:
@@ -48,8 +47,7 @@ def test_watchdog_does_not_fire_on_exception_exit() -> None:
     ):
         raise RuntimeError("boom")
 
-    time.sleep(0.4)
-    assert not fired.is_set(), "watchdog fired after exceptional exit"
+    assert not fired.wait(0.4), "watchdog fired after exceptional exit"
 
 
 def test_resolver_returns_default_without_env(

--- a/src/exo/worker/tests/unittests/test_runner/test_warmup_deadline.py
+++ b/src/exo/worker/tests/unittests/test_runner/test_warmup_deadline.py
@@ -1,0 +1,75 @@
+"""Tests for the warmup deadline watchdog.
+
+A wedged Metal eval parks the runner at 0% CPU forever and previously left
+it in ``RunnerWarmingUp`` indefinitely — silently blocking all dispatch on
+the node (launch smoke, 2026-06-05). The watchdog bounds that failure by
+hard-exiting the runner; these tests exercise the timing contract through
+the ``on_timeout`` test seam (the production action is log + ``os._exit``,
+which cannot run inside pytest).
+"""
+
+import threading
+import time
+
+import pytest
+
+from exo.worker.runner.bootstrap import (
+    WARMUP_DEADLINE_SECONDS_DEFAULT,
+    deadline_watchdog,
+    resolve_warmup_deadline_seconds,
+)
+
+
+def test_watchdog_fires_when_block_overruns() -> None:
+    fired = threading.Event()
+
+    with deadline_watchdog(0.05, "test block", on_timeout=fired.set):
+        assert fired.wait(timeout=2.0), "watchdog did not fire on overrun"
+
+
+def test_watchdog_does_not_fire_when_block_completes() -> None:
+    fired = threading.Event()
+
+    with deadline_watchdog(0.2, "test block", on_timeout=fired.set):
+        pass  # completes immediately
+
+    # Give the watchdog thread ample time to (incorrectly) fire.
+    time.sleep(0.4)
+    assert not fired.is_set(), "watchdog fired after the block completed"
+
+
+def test_watchdog_does_not_fire_on_exception_exit() -> None:
+    """Leaving the block via an exception still disarms the watchdog."""
+    fired = threading.Event()
+
+    with (
+        pytest.raises(RuntimeError),
+        deadline_watchdog(0.2, "test block", on_timeout=fired.set),
+    ):
+        raise RuntimeError("boom")
+
+    time.sleep(0.4)
+    assert not fired.is_set(), "watchdog fired after exceptional exit"
+
+
+def test_resolver_returns_default_without_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SKULK_WARMUP_DEADLINE_SECONDS", raising=False)
+    monkeypatch.delenv("EXO_WARMUP_DEADLINE_SECONDS", raising=False)
+    assert resolve_warmup_deadline_seconds() == WARMUP_DEADLINE_SECONDS_DEFAULT
+
+
+def test_resolver_honors_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SKULK_WARMUP_DEADLINE_SECONDS", "42.5")
+    assert resolve_warmup_deadline_seconds() == 42.5
+
+
+@pytest.mark.parametrize("value", ["abc", "-5", "0"])
+def test_resolver_rejects_invalid_env(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Garbage or non-positive overrides fall back to the default rather
+    than disabling the watchdog or arming it with a nonsense deadline."""
+    monkeypatch.setenv("SKULK_WARMUP_DEADLINE_SECONDS", value)
+    assert resolve_warmup_deadline_seconds() == WARMUP_DEADLINE_SECONDS_DEFAULT

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -402,6 +402,7 @@ Selection logic: `src/exo/worker/engines/mlx/cache.py::make_kv_cache`. Some back
 | `SKULK_HOME` / `EXO_HOME` | Override the base data directory used to derive `SKULK_DATA_HOME` (and from there `SKULK_MODELS_DIR`, `SKULK_CUSTOM_MODEL_CARDS_DIR`, `SKULK_EVENT_LOG_DIR`). Default base: XDG-derived `~/.local/share/skulk` on Linux; `~/.skulk` on non-Linux. See `src/exo/shared/constants.py:34-149`. |
 | `SKULK_FAST_SYNCH` / `EXO_FAST_SYNCH` | Force `MLX_METAL_FAST_SYNCH` on (`"on"`) or off (`"off"`); overrides per-model card. Resolution order: operator override → card `metal_fast_synch` pin → OFF for speculative-decoding cards (`mtp_heads` / `mtp_sidecar_repo` / `assistant_model_repo`; FAST_SYNCH collapses the MTP loop ~46x, measured 2026-06-06) → cluster default (ON) |
 | `SKULK_PIPELINE_EVAL_TIMEOUT_SECONDS` | Per-eval timeout in pipeline collectives (default 60s) |
+| `SKULK_WARMUP_DEADLINE_SECONDS` / `EXO_WARMUP_DEADLINE_SECONDS` | Hard deadline for runner warmup (default 300s). A wedged Metal eval parks warmup forever at 0% CPU and silently blocks all dispatch; the watchdog hard-exits the runner instead (supervisor reports RunnerFailed, node keeps working) |
 | `SKULK_MLX_HANG_DEBUG` / `EXO_MLX_HANG_DEBUG` | Emit periodic stack traces from stuck phases |
 | `SKULK_MLX_HANG_DEBUG_INTERVAL_SECONDS` | Interval for above (default 30s) |
 | `SKULK_MAX_OUTPUT_TOKENS` / `EXO_MAX_TOKENS` | Default `max_tokens` (cluster default 4096; `DEFAULT_MAX_OUTPUT_TOKENS` constant) |


### PR DESCRIPTION
## PR C of the P1 launch sequence (MTP integrity)

Per the co-equal doctrine: the demo must work before anything else. Three fixes that keep the headline feature engaged and visible:

### 1. Companion repos fetched on every download path
The model-store downloader had four base-resolution paths and **three returned without fetching the card's companion repos** (MTP sidecar / assistant / vision weights) — the already-staged fast path, store staging, and direct-from-store. A staged base model loaded and silently ran without speculation (observed on kite1 in the launch smoke; the warning line is easy to miss). Now `ensure_shard` ensures companions after every base resolution, store-first via recursion (the store can serve sidecars; a store-miss asks the store host to fetch from HF — which also populates the store with the companion). Companion failures log loudly but never fail the base load. The HF downloader's triplicated companion construction is extracted to a shared `companion_download_specs`.

### 2. Warmup deadline (the silent node-killer's quieter sibling)
A faulted Metal eval parks warmup forever at 0% CPU — uninterruptible from Python — and the runner sat in `RunnerWarmingUp` indefinitely while every request on the node queued into client timeouts with zero surfaced error (observed 2026-06-05, 9+ minutes before manual kill). Warmup now runs under `deadline_watchdog` (default 300s, `SKULK_WARMUP_DEADLINE_SECONDS`): on overrun, CRITICAL diagnosis with the reboot-if-GPU-wedged runbook guidance, hard process exit, supervisor reports `RunnerFailed`, node keeps dispatching.

### 3. Loud diagnostics for disabled speculation
- Logits processors (typically `repetition_penalty` — some client libraries send one **by default**, which would make a reviewer's MTP benchmark silently fall back to plain decode): INFO → WARNING, names the cause and the fix.
- gemma 4 E-series pipeline rejection now explains itself in operator terms ("place on a single node — it fits") instead of KV-graph internals.

## Validation
- 12 new tests (4 store-companion incl. the exact kite1 fast-path case; 8 watchdog/resolver)
- Full suite 861 passed; basedpyright 0 errors; ruff/fmt clean
- CHANGELOG + architecture-reference env table updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)