### PR TITLE
fix(disk): event-log retention, free-space floor, ENOSPC init/compact hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Event logs can no longer eat the disk or kill nodes on a full one.**
+  The API-side event log — which records per-token chunk events and backs
+  only the `GET /events` diagnostic — had NO retention and grew for the
+  life of the session (54 MB in 9 idle hours on every node; the file a
+  node died writing during the launch smoke). It now ring-compacts past
+  256 MiB, keeping the most recent 20k events. Archive rotation is capped
+  by total bytes (1 GiB) in addition to count — five archives of
+  unbounded size defeated the count cap in practice (3.5 GB observed).
+  The remaining unguarded ENOSPC sites (`DiskEventLog.__init__` and
+  `compact()` — the former is exactly where a node died) now degrade to
+  the counting-only mode instead of crashing, and a proactive free-space
+  floor (2 GiB, checked every 1024 appends) degrades persistence BEFORE
+  the disk hits zero — a master on a full disk previously throttled the
+  whole cluster to ~0.5 tok/s before dying. Log noise that bloats piped
+  logs was also trimmed (per-minute download-coordinator path dumps), and
+  the speculative-decoding enable line now reports the card's actual
+  draft depth instead of a hardcoded "(D=1)".
+
 - **Multi-node placement is now reliable and placement failures are
   visible.** Four compounding issues fixed in the placement path:
   (1) memory admission is per node instead of summed across the cycle —

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -280,6 +280,16 @@ serve = cast(_HypercornServe, hypercorn_asyncio.serve)
 
 _API_EVENT_LOG_DIR = EXO_EVENT_LOG_DIR / "api"
 
+# Ring retention for the API event log. Unlike the master's log (compacted
+# after every snapshot), the API log had NO compaction and records per-token
+# ChunkGenerated events — it grew without bound for the whole session (54 MB
+# in 9 idle hours on every node; GBs/day under load; the file a node died
+# writing in the 2026-06-06 launch smoke). It only backs GET /events
+# diagnostics, so dropping the old tail is safe.
+_API_EVENT_LOG_MAX_ACTIVE_BYTES = 256 * 1024 * 1024
+_API_EVENT_LOG_COMPACT_KEEP_EVENTS = 20_000
+_API_EVENT_LOG_CHECK_INTERVAL_APPENDS = 4096
+
 # How long POST /place_instance waits for node memory info to finish
 # gossiping before giving up with 503. Covers the window between cluster
 # formation (identities present) and the first NodeGatheredInfo from every
@@ -501,6 +511,7 @@ class API:
     ) -> None:
         self.state = State()
         self._event_log = DiskEventLog(_API_EVENT_LOG_DIR) if enable_event_log else None
+        self._event_log_appends_since_retention_check = 0
         self._system_id = SystemId()
         self.command_sender = command_sender
         self.download_command_sender = download_command_sender
@@ -599,6 +610,7 @@ class API:
         if self._event_log is not None:
             self._event_log.close()
             self._event_log = DiskEventLog(_API_EVENT_LOG_DIR)
+            self._event_log_appends_since_retention_check = 0
         self.state = State()
         self._system_id = SystemId()
         self._text_generation_queues = {}
@@ -2846,6 +2858,33 @@ class API:
                 shutdown_trigger=ev.wait,
             )
 
+    def _maybe_compact_event_log(self) -> None:
+        """Ring retention for the diagnostics event log.
+
+        Every few thousand appends, check the active file size; past the
+        budget, compact away everything but the most recent tail. The log
+        only backs GET /events, so old history is droppable — and without
+        this it grows per generated token for the life of the session.
+        """
+        if self._event_log is None:
+            return
+        self._event_log_appends_since_retention_check += 1
+        if (
+            self._event_log_appends_since_retention_check
+            < _API_EVENT_LOG_CHECK_INTERVAL_APPENDS
+        ):
+            return
+        self._event_log_appends_since_retention_check = 0
+        if self._event_log.active_size_bytes <= _API_EVENT_LOG_MAX_ACTIVE_BYTES:
+            return
+        keep_from_idx = len(self._event_log) - _API_EVENT_LOG_COMPACT_KEEP_EVENTS
+        logger.info(
+            "API event log exceeded "
+            f"{_API_EVENT_LOG_MAX_ACTIVE_BYTES / 2**20:.0f} MiB; compacting "
+            f"to the most recent {_API_EVENT_LOG_COMPACT_KEEP_EVENTS} events"
+        )
+        self._event_log.compact(keep_from_idx)
+
     async def _apply_state(self):
         with self.event_receiver as events:
             async for i_event in events:
@@ -2855,6 +2894,7 @@ class API:
                     and not isinstance(event, StateSnapshotHydrated)
                 ):
                     self._event_log.append(event)
+                    self._maybe_compact_event_log()
                 self.state = apply(self.state, i_event)
 
                 if isinstance(event, ChunkGenerated):

--- a/src/exo/download/coordinator.py
+++ b/src/exo/download/coordinator.py
@@ -546,6 +546,7 @@ class DownloadCoordinator:
 
     async def _emit_existing_download_progress(self) -> None:
         hf_scan_done = False
+        models_path_logged = False
         while True:
             try:
                 # HF download status scan — only run once at startup to detect
@@ -615,11 +616,16 @@ class DownloadCoordinator:
                             NodeDownloadProgress(download_progress=status)
                         )
 
-                # Scan EXO_MODELS_PATH for pre-downloaded models (runs every cycle)
-                import exo.shared.constants as _dbg_constants
+                # Scan EXO_MODELS_PATH for pre-downloaded models (runs every
+                # cycle). Log the search path once — repeating the full tuple
+                # every 60s was pure log noise that bloated piped logs.
+                if not models_path_logged:
+                    import exo.shared.constants as _dbg_constants
 
-                _search_paths = _dbg_constants.EXO_MODELS_PATH
-                logger.debug(f"DownloadCoordinator: EXO_MODELS_PATH={_search_paths}")
+                    logger.debug(
+                        f"DownloadCoordinator: EXO_MODELS_PATH={_dbg_constants.EXO_MODELS_PATH}"
+                    )
+                    models_path_logged = True
                 for card in await get_model_cards():
                     mid = card.model_id
                     if mid in self.active_downloads:
@@ -654,9 +660,6 @@ class DownloadCoordinator:
                             NodeDownloadProgress(download_progress=path_completed)
                         )
 
-                logger.debug(
-                    "DownloadCoordinator: Done emitting existing download progress."
-                )
             except Exception as e:
                 logger.error(
                     f"DownloadCoordinator: Error emitting existing download progress: {e}"

--- a/src/exo/utils/disk_event_log.py
+++ b/src/exo/utils/disk_event_log.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import shutil
 from collections import OrderedDict
 from collections.abc import Iterator
 from datetime import datetime, timezone
@@ -19,6 +20,25 @@ _EVENT_ADAPTER: TypeAdapter[Event] = TypeAdapter(Event)
 _HEADER_SIZE = 4  # uint32 big-endian
 _OFFSET_CACHE_SIZE = 128
 _MAX_ARCHIVES = 5
+
+_MAX_ARCHIVE_TOTAL_BYTES = 1024 * 1024 * 1024  # 1 GiB
+"""Total size budget for compressed archives, enforced alongside the count
+cap. Five archives of unbounded size defeated the count cap in practice
+(3.5 GB of event logs observed on a 16 GB node during the launch smoke)."""
+
+_FREE_SPACE_FLOOR_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+"""Free-disk floor below which the log proactively stops persisting.
+
+Running the disk to zero kills nodes in ways the append-time ENOSPC guard
+cannot fully contain (metadata writes at init/compact, and everything else
+on the machine starts failing too — the 2026-06-06 launch smoke lost a
+node this way and throttled the whole cluster first). Dropping into the
+degraded counting-only mode while 2 GiB remain keeps the node alive and
+loudly diagnosable instead."""
+
+_DISK_CHECK_INTERVAL_APPENDS = 1024
+"""How many appends between free-space checks (a statvfs call is cheap but
+not free; per-token chunk events make append a hot path)."""
 
 
 class EventLogMetadata(CamelCaseModel):
@@ -79,7 +99,6 @@ class DiskEventLog:
 
     def __init__(self, directory: Path) -> None:
         self._directory = directory
-        self._directory.mkdir(parents=True, exist_ok=True)
         self._active_path = directory / "events.bin"
         self._metadata_path = directory / "events.meta.json"
         self._offset_cache: OrderedDict[int, int] = OrderedDict()
@@ -88,19 +107,44 @@ class DiskEventLog:
         # Set on the first failed disk write (e.g. ENOSPC); the log then
         # counts events without persisting so indices stay coherent.
         self._persistence_failed: bool = False
+        self._appends_since_disk_check: int = 0
+        self._file: BufferedRandom | None = None
 
-        # Rotate stale active file from a previous session/crash
-        if self._active_path.exists():
-            self._rotate(self._active_path, self._directory)
-        with contextlib.suppress(FileNotFoundError):
-            self._metadata_path.unlink()
+        # A full disk at construction time must not take the component down
+        # (the API event log's init-time metadata write crashed a node with
+        # ENOSPC during the launch smoke): degrade to counting-only from
+        # birth instead.
+        try:
+            self._directory.mkdir(parents=True, exist_ok=True)
+            # Rotate stale active file from a previous session/crash
+            if self._active_path.exists():
+                self._rotate(self._active_path, self._directory)
+            with contextlib.suppress(FileNotFoundError):
+                self._metadata_path.unlink()
 
-        self._file: BufferedRandom = open(self._active_path, "w+b")  # noqa: SIM115
-        self._write_metadata()
+            self._file = open(self._active_path, "w+b")  # noqa: SIM115
+            self._write_metadata()
+        except OSError as error:
+            self._enter_degraded_mode(f"initialization failed: {error}")
 
     @property
     def start_idx(self) -> int:
         return self._base_idx
+
+    @property
+    def active_size_bytes(self) -> int:
+        """Size of the active (uncompressed) log file in bytes.
+
+        Returns 0 in degraded mode — there is no coherent active file to
+        measure, and callers use this to drive retention decisions that no
+        longer apply.
+        """
+        if self._persistence_failed or self._file is None:
+            return 0
+        try:
+            return self._file.tell()
+        except (OSError, ValueError):
+            return 0
 
     def _write_metadata(self) -> None:
         self._metadata_path.write_text(
@@ -138,6 +182,26 @@ class DiskEventLog:
 
         self._cache_offset(target_idx, f.tell())
 
+    def _enter_degraded_mode(self, reason: str) -> None:
+        """Switch to counting-only persistence with one CRITICAL line.
+
+        Disposes the (possibly dirty) file handle: buffered record bytes may
+        be stranded and any later flush would raise again. All write and
+        read paths are short-circuited by the flag from here.
+        """
+        if self._persistence_failed:
+            return
+        self._persistence_failed = True
+        if self._file is not None:
+            with contextlib.suppress(Exception):
+                self._file.close()
+        logger.critical(
+            "Event-log persistence is now DISABLED for this session "
+            f"({reason}); the node continues with in-memory state only — "
+            "follower replay from this node's disk log will be unavailable. "
+            "Free disk space and restart to restore persistence."
+        )
+
     def append(self, event: Event) -> None:
         # Persistence failures (disk full being the canonical case) must
         # NEVER take down the event processor: the in-memory state apply
@@ -149,6 +213,7 @@ class DiskEventLog:
         if self._persistence_failed:
             self._count += 1
             return
+        assert self._file is not None
         counted = False
         try:
             packed = _serialize_event(event)
@@ -163,19 +228,26 @@ class DiskEventLog:
             # the increment already done.
             if not counted:
                 self._count += 1
-            self._persistence_failed = True
-            # Dispose the dirty handle: buffered record bytes may be
-            # stranded and any later flush would raise again. All write
-            # and read paths are short-circuited by the flag from here.
-            with contextlib.suppress(Exception):
-                self._file.close()
-            logger.critical(
-                "Event-log persistence failed and is now DISABLED for this "
-                f"session ({error}); the node continues with in-memory state "
-                "only — follower replay from this node's disk log will be "
-                "unavailable. Free disk space and restart to restore "
-                "persistence."
-            )
+            self._enter_degraded_mode(f"append failed: {error}")
+            return
+
+        # Proactive free-space floor: stop persisting BEFORE the disk hits
+        # zero. Running a node's disk to 0 bytes fails everything on the
+        # machine (and a master in that state throttled the whole cluster
+        # before dying in the 2026-06-06 smoke); degrading at the floor
+        # keeps the node alive and loudly diagnosable.
+        self._appends_since_disk_check += 1
+        if self._appends_since_disk_check >= _DISK_CHECK_INTERVAL_APPENDS:
+            self._appends_since_disk_check = 0
+            try:
+                free_bytes = shutil.disk_usage(self._directory).free
+            except OSError:
+                return
+            if free_bytes < _FREE_SPACE_FLOOR_BYTES:
+                self._enter_degraded_mode(
+                    f"free disk space below the {_FREE_SPACE_FLOOR_BYTES / 2**30:.0f} GiB "
+                    f"floor ({free_bytes / 2**30:.2f} GiB left on the event-log volume)"
+                )
 
     def compact(self, keep_from_idx: int) -> None:
         """Discard events before ``keep_from_idx`` while preserving absolute indices."""
@@ -217,22 +289,34 @@ class DiskEventLog:
             )
             return
 
-        replacement_path = self._directory / "events.bin.tmp"
-        with open(replacement_path, "w+b") as replacement_file:
-            for event in retained_events:
-                packed = _serialize_event(event)
-                replacement_file.write(
-                    len(packed).to_bytes(_HEADER_SIZE, byteorder="big")
-                )
-                replacement_file.write(packed)
+        assert self._file is not None
+        # Compaction writes a full replacement file plus fresh metadata —
+        # both can hit ENOSPC. Degrade to counting-only instead of letting
+        # the exception escape into the master's snapshot path (the
+        # init/compact metadata writes were the unguarded ENOSPC sites that
+        # killed a node in the 2026-06-06 smoke).
+        try:
+            replacement_path = self._directory / "events.bin.tmp"
+            with open(replacement_path, "w+b") as replacement_file:
+                for event in retained_events:
+                    packed = _serialize_event(event)
+                    replacement_file.write(
+                        len(packed).to_bytes(_HEADER_SIZE, byteorder="big")
+                    )
+                    replacement_file.write(packed)
 
-        self._file.close()
-        replacement_path.replace(self._active_path)
-        self._file = open(self._active_path, "r+b")  # noqa: SIM115
-        self._base_idx = keep_from_idx
-        self._count = len(retained_events)
-        self._offset_cache.clear()
-        self._write_metadata()
+            self._file.close()
+            replacement_path.replace(self._active_path)
+            self._file = open(self._active_path, "r+b")  # noqa: SIM115
+            self._base_idx = keep_from_idx
+            self._count = len(retained_events)
+            self._offset_cache.clear()
+            self._write_metadata()
+        except OSError as error:
+            # Index bookkeeping must stay coherent even when the rewrite
+            # failed partway: keep the pre-compaction logical range (the
+            # in-memory count is authoritative for future indices).
+            self._enter_degraded_mode(f"compaction failed: {error}")
 
     def read_range(self, start: int, end: int) -> Iterator[Event]:
         """Yield events from index start (inclusive) to end (exclusive)."""
@@ -249,6 +333,7 @@ class DiskEventLog:
             return
 
         base_idx_at_open = self._base_idx
+        assert self._file is not None
         self._file.flush()
         with open(self._active_path, "rb") as f:
             self._seek_to(f, start)
@@ -274,6 +359,7 @@ class DiskEventLog:
         """Yield all events from the log one at a time."""
         if self._persistence_failed or self._count == 0:
             return
+        assert self._file is not None
         self._file.flush()
         with open(self._active_path, "rb") as f:
             for _ in range(self._count):
@@ -290,9 +376,11 @@ class DiskEventLog:
         if self._persistence_failed:
             # The active file holds an incomplete tail; archiving it would
             # preserve a corrupt log. Leave it for post-mortem inspection.
-            with contextlib.suppress(Exception):
-                self._file.close()
+            if self._file is not None:
+                with contextlib.suppress(Exception):
+                    self._file.close()
             return
+        assert self._file is not None
         if self._file.closed:
             return
         self._file.close()
@@ -319,10 +407,23 @@ class DiskEventLog:
             source.unlink()
             logger.info(f"Rotated event log: {source} -> {dest}")
 
-            # Prune oldest archives beyond the limit
+            # Prune oldest archives beyond the count limit, then enforce the
+            # total-bytes budget — five archives of unbounded size defeated
+            # the count cap in practice.
             archives = sorted(directory.glob("events.*.bin.zst"))
             for old in archives[:-_MAX_ARCHIVES]:
                 old.unlink()
+            archives = sorted(directory.glob("events.*.bin.zst"))
+            total_bytes = sum(archive.stat().st_size for archive in archives)
+            for old in archives:
+                if total_bytes <= _MAX_ARCHIVE_TOTAL_BYTES:
+                    break
+                total_bytes -= old.stat().st_size
+                old.unlink()
+                logger.info(
+                    f"Pruned event-log archive {old.name} to honor the "
+                    f"{_MAX_ARCHIVE_TOTAL_BYTES / 2**30:.0f} GiB archive budget"
+                )
         except Exception as e:
             logger.opt(exception=e).warning(f"Failed to rotate event log {source}")
             # Clean up the source even if compression fails

--- a/src/exo/utils/disk_event_log.py
+++ b/src/exo/utils/disk_event_log.py
@@ -308,6 +308,11 @@ class DiskEventLog:
             self._file.close()
             replacement_path.replace(self._active_path)
             self._file = open(self._active_path, "r+b")  # noqa: SIM115
+            # r+b opens with the cursor at 0 — appending from there would
+            # OVERWRITE the retained tail record by record. Seek to EOF so
+            # appends extend the file (this also keeps active_size_bytes,
+            # which reads the cursor, truthful right after compaction).
+            self._file.seek(0, 2)
             self._base_idx = keep_from_idx
             self._count = len(retained_events)
             self._offset_cache.clear()
@@ -316,6 +321,11 @@ class DiskEventLog:
             # Index bookkeeping must stay coherent even when the rewrite
             # failed partway: keep the pre-compaction logical range (the
             # in-memory count is authoritative for future indices).
+            # Best-effort removal of the partial replacement file — on
+            # ENOSPC an orphaned tmp would keep eating the disk we just
+            # ran out of.
+            with contextlib.suppress(OSError):
+                (self._directory / "events.bin.tmp").unlink()
             self._enter_degraded_mode(f"compaction failed: {error}")
 
     def read_range(self, start: int, end: int) -> Iterator[Event]:

--- a/src/exo/utils/tests/test_event_log.py
+++ b/src/exo/utils/tests/test_event_log.py
@@ -456,3 +456,22 @@ def test_active_size_bytes_tracks_appends(log_dir: Path):
     log.append(TestEvent())
     assert log.active_size_bytes > 0
     log.close()
+
+
+def test_append_after_compact_does_not_overwrite_tail(log_dir: Path):
+    """Regression: compact() reopened the active file with the cursor at 0,
+    so the next append overwrote the retained tail record by record. The
+    master's post-snapshot compaction always had this; the API log's ring
+    retention makes it fire constantly."""
+    log = DiskEventLog(log_dir)
+    for _ in range(10):
+        log.append(TestEvent())
+
+    log.compact(6)  # retain absolute indices [6, 10)
+    log.append(TestEvent())  # must append, not overwrite index 6
+
+    events = list(log.read_range(6, 11))
+    assert len(events) == 5
+    assert len(log) == 11
+    assert log.active_size_bytes > 0
+    log.close()

--- a/src/exo/utils/tests/test_event_log.py
+++ b/src/exo/utils/tests/test_event_log.py
@@ -286,6 +286,7 @@ def test_persistence_failure_degrades_without_losing_indices(log_dir: Path):
     log.append(TestEvent())
     assert len(log) == 1
 
+    assert log._file is not None
     log._file.close()  # next write raises ValueError... use a stub instead
 
     class _FullDisk:
@@ -342,4 +343,116 @@ def test_metadata_failure_counts_exactly_once(log_dir: Path):
     assert log._persistence_failed
     log.append(TestEvent())
     assert len(log) == 3
+    log.close()
+
+
+def test_init_on_failing_disk_degrades_instead_of_crashing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A full disk at construction time (the unguarded ENOSPC site that
+    killed a node in the 2026-06-06 smoke via the API event log) must yield
+    a degraded counting-only log, not an exception."""
+    import builtins
+
+    target = tmp_path / "event_log"
+    real_open = builtins.open
+
+    def _failing_open(file: object, *args: object, **kwargs: object) -> object:
+        if str(file).endswith("events.bin"):
+            raise OSError(28, "No space left on device")
+        return real_open(file, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "open", _failing_open)
+    log = DiskEventLog(target)
+
+    # Counting-only from birth: indices stay coherent, reads are empty.
+    log.append(TestEvent())
+    log.append(TestEvent())
+    assert len(log) == 2
+    assert list(log.read_all()) == []
+    log.close()
+
+
+def test_compact_failure_degrades_instead_of_raising(log_dir: Path):
+    """ENOSPC during compaction's rewrite must degrade, not escape into the
+    master's snapshot path."""
+    import builtins
+
+    log = DiskEventLog(log_dir)
+    for _ in range(10):
+        log.append(TestEvent())
+
+    real_open = builtins.open
+
+    def _failing_open(file: object, *args: object, **kwargs: object) -> object:
+        if str(file).endswith("events.bin.tmp"):
+            raise OSError(28, "No space left on device")
+        return real_open(file, *args, **kwargs)  # type: ignore[arg-type]
+
+    import unittest.mock
+
+    with unittest.mock.patch("builtins.open", _failing_open):
+        log.compact(5)
+
+    # Logical range preserved; log keeps counting in degraded mode.
+    assert len(log) == 10
+    log.append(TestEvent())
+    assert len(log) == 11
+    assert list(log.read_all()) == []
+    log.close()
+
+
+def test_free_space_floor_triggers_degraded_mode(
+    log_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Dropping below the free-space floor proactively degrades the log
+    instead of running the disk to zero."""
+    import shutil as _shutil
+
+    import exo.utils.disk_event_log as del_module
+
+    log = DiskEventLog(log_dir)
+    monkeypatch.setattr(del_module, "_DISK_CHECK_INTERVAL_APPENDS", 2)
+
+    fake_usage = _shutil.disk_usage(log_dir)._replace(free=1)
+
+    def _fake_disk_usage(_path: Path) -> object:
+        return fake_usage
+
+    monkeypatch.setattr(del_module.shutil, "disk_usage", _fake_disk_usage)
+
+    log.append(TestEvent())
+    log.append(TestEvent())  # triggers the check
+
+    assert log._persistence_failed
+    # Indices keep advancing in degraded mode.
+    log.append(TestEvent())
+    assert len(log) == 3
+    log.close()
+
+
+def test_archive_total_bytes_budget(log_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    """Archives are pruned to the byte budget, not just the count cap."""
+    import exo.utils.disk_event_log as del_module
+
+    monkeypatch.setattr(del_module, "_MAX_ARCHIVE_TOTAL_BYTES", 1)
+
+    for _session in range(3):
+        log = DiskEventLog(log_dir)
+        for _ in range(5):
+            log.append(TestEvent())
+        log.close()
+
+    archives = sorted(log_dir.glob("events.*.bin.zst"))
+    # With a 1-byte budget every archive beyond the newest is pruned; the
+    # loop never deletes the final remaining archive mid-iteration, so at
+    # most one survives.
+    assert len(archives) <= 1
+
+
+def test_active_size_bytes_tracks_appends(log_dir: Path):
+    log = DiskEventLog(log_dir)
+    assert log.active_size_bytes == 0
+    log.append(TestEvent())
+    assert log.active_size_bytes > 0
     log.close()

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -2826,7 +2826,17 @@ def mlx_generate(
                         else None,
                     )
                 if _drafter is not None:
-                    logger.info("MTP speculative decoding enabled (D=1)")
+                    _card_draft_depth = (
+                        model_card.runtime.mtp_max_depth
+                        if model_card is not None
+                        and model_card.runtime is not None
+                        and model_card.runtime.mtp_max_depth is not None
+                        else 1
+                    )
+                    logger.info(
+                        "MTP speculative decoding enabled "
+                        f"(D={_card_draft_depth})"
+                    )
 
     # Gate the agreement on the model CARD declaring speculation — the card
     # is identical on every rank, so the collective count stays symmetric;

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -90,7 +90,7 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 
 ### Storage
 
-- **Event log:** `src/exo/utils/disk_event_log.py` — append-only length-prefixed msgpack records (`events.bin`, uncompressed live); rotated archives are zstd-compressed (`events.*.bin.zst`) on rotation/close
+- **Event log:** `src/exo/utils/disk_event_log.py` — append-only length-prefixed msgpack records (`events.bin`, uncompressed live); rotated archives are zstd-compressed (`events.*.bin.zst`) on rotation/close. Disk is treated as bounded: archives are capped by count (5) AND total bytes (1 GiB); any persistence failure (ENOSPC at init, append, or compaction) drops the log into a degraded counting-only mode with one CRITICAL line — indices keep advancing so follower replay coherence survives — and a proactive free-space floor (2 GiB, checked every 1024 appends) degrades BEFORE the disk hits zero. The API-side log (`event_log/api/`, backs `GET /events` diagnostics only and records per-token chunk events) additionally ring-compacts: past 256 MiB of active file it keeps only the most recent 20k events.
 - **Model cache:** `SKULK_MODELS_DIR` (default `SKULK_DATA_HOME/models`; on Linux that's `~/.local/share/skulk/models` via XDG, on macOS/Windows it's `~/.skulk/models`); `SKULK_HOME` and `SKULK_MODELS_DIR` env overrides apply
 - **Custom cards:** `SKULK_CUSTOM_MODEL_CARDS_DIR` (default `SKULK_DATA_HOME/custom_model_cards`) as TOML
 - **Built-in cards:** `resources/inference_model_cards/` as TOML


### PR DESCRIPTION
## PR B of the P1 launch sequence (stability)

Disk is now a bounded resource for the event logs. The launch smoke lost a node to exactly this class: the API event log filled the disk, the master throttled the whole cluster to ~0.5 tok/s indexing chunk events against a full volume, then died with an unhandled ENOSPC in an unguarded metadata write.

### What changes

| Grower | Before | After |
|---|---|---|
| API event log (per-token chunk events, backs `GET /events` only) | **no retention, grew for the session** (54 MB/9 idle hours on every node) | ring-compacts past 256 MiB, keeps newest 20k events |
| Rotated archives | count cap only (5 × unbounded size; 3.5 GB observed) | + 1 GiB total-bytes budget |
| ENOSPC at `__init__`/`compact()` | unhandled → component crash (the node-killer) | degrades to counting-only mode, one CRITICAL line, indices stay coherent |
| Disk runs to zero | nothing stops it | free-space floor: below 2 GiB the log proactively degrades persistence (checked every 1024 appends) |
| Log chatter | full models-path tuple dumped every 60s; hardcoded "(D=1)" | path logged once; enable line reports the card's actual draft depth |

### Validation
- 5 new tests: degraded-from-birth init (the exact node-killer site), compact-failure degradation, floor trigger, archive byte budget, size accessor — plus the existing degraded-mode suite still green
- Full suite 850 passed; basedpyright 0 errors; ruff/fmt clean
- CHANGELOG + architecture-reference updated

Complements #213 (PR C, MTP integrity). PR A (store lifecycle, #212) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)