### PR TITLE
feat(store): staged-copy lifecycle with recent-use grace budget; per-node storage summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Added
+
+- **Staged model copies now have a lifecycle, and nodes can report their
+  storage.** With the model store on, staged copies previously survived
+  instance deletion and node crashes forever (58-70 GB piles; one node
+  died of a full disk in the launch smoke). `cleanup_on_deactivate` now
+  defaults to true with a recent-use grace budget
+  (`staging_keep_recent_gb`, default 40 GiB): when an instance shuts
+  down — and at node startup, which reconciles copies orphaned by a
+  crash — not-in-use staged models are kept newest-first by last use up
+  to the budget and evicted beyond it. In-use detection includes
+  companion repos (MTP sidecar / assistant / vision weights) of active
+  models, so eviction can never corrupt a live runner. The grace budget
+  is deliberate: node deaths, restarts, and repeated place/delete cycles
+  of the same model do not re-pay the staging copy. New
+  `GET /store/storage` returns the local node's breakdown: staged models
+  with size/last-use/in-use, event-log bytes, and disk free.
+
 ### Fixed
 
 - **Multi-node placement is now reliable and placement failures are

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -3073,11 +3073,17 @@ class API:
                 with contextlib.suppress(OSError):
                     if file_path.is_file():
                         event_log_bytes += file_path.stat().st_size
+            # Report the volume that staging actually lives on (it may be a
+            # different disk from the models dir — e.g. an external store
+            # volume); fall back to the models dir when staging is off.
+            disk_probe_path = (
+                staging_root if staging_root is not None else EXO_MODELS_DIR
+            )
             try:
-                disk = shutil.disk_usage(EXO_MODELS_DIR)
+                disk = shutil.disk_usage(disk_probe_path)
                 disk_total_bytes, disk_free_bytes = disk.total, disk.free
             except OSError:
-                # Fresh node where the models dir doesn't exist yet — the
+                # Fresh node where the directory doesn't exist yet — the
                 # summary is best-effort, report zeros rather than 500.
                 disk_total_bytes, disk_free_bytes = 0, 0
             return NodeStorageSummary(

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -21,7 +21,7 @@ import httpx
 import hypercorn.asyncio as hypercorn_asyncio
 import psutil
 import yaml
-from anyio import BrokenResourceError
+from anyio import BrokenResourceError, to_thread
 from fastapi import FastAPI, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
@@ -96,6 +96,7 @@ from exo.api.types import (
     ModalitiesCapabilitySection,
     ModelList,
     ModelListModel,
+    NodeStorageSummary,
     OpenUrlToolRequest,
     OpenUrlToolResponse,
     PlaceInstanceParams,
@@ -159,6 +160,7 @@ from exo.shared.constants import (
     EXO_IMAGE_CACHE_DIR,
     EXO_IMAGE_TRANSPORT_DEBUG,
     EXO_MAX_CHUNK_SIZE,
+    EXO_MODELS_DIR,
     EXO_TRACING_CACHE_DIR,
     preferred_env_value,
 )
@@ -242,7 +244,7 @@ from exo.shared.types.worker.instances import Instance, InstanceId, InstanceMeta
 from exo.shared.types.worker.runners import RunnerId
 from exo.shared.types.worker.shards import Sharding
 from exo.shared.version import get_skulk_version, get_skulk_version_label
-from exo.store.config import resolve_config_path
+from exo.store.config import resolve_config_path, resolve_node_staging
 from exo.tools.web_search import default_browser_tool_provider
 from exo.utils.banner import print_startup_banner
 from exo.utils.channels import Receiver, Sender, channel
@@ -258,6 +260,7 @@ from exo.worker.engines.mlx.constants import (
 if TYPE_CHECKING:
     from exo.store.config import ExoConfig
     from exo.store.model_store_client import ModelStoreClient
+from exo.store.staging_eviction import list_staged_models
 
 JsonObject = dict[str, object]
 _DEFAULT_OPTIMIZER_CANDIDATE_BITS = [4, 8]
@@ -1146,6 +1149,18 @@ class API:
             summary="Purge staging caches",
             description="Broadcast a staging-cache purge request to nodes, optionally scoped to one model ID.",
         )(self.purge_staging_caches)
+        self.app.get(
+            "/store/storage",
+            tags=["Store"],
+            summary="Per-node storage breakdown (local node)",
+            description=(
+                "Return the local node's storage picture: every staged model with "
+                "its size, last-use time, and whether a live instance (or one of "
+                "its companion repos) currently depends on it, plus event-log "
+                "usage and free disk on the models volume. Cluster-wide views "
+                "should query each node's API."
+            ),
+        )(self.get_node_storage_summary)
         self.app.post(
             "/store/models/{model_id:path}/optimize",
             tags=["Store"],
@@ -3001,6 +3016,62 @@ class API:
             command_id=command.command_id,
             message=f"Purge staging command broadcast to all nodes{model_suffix}",
         )
+
+    def _store_models_in_use(self) -> frozenset[str]:
+        """Repo-form model IDs any live instance depends on, incl. companions."""
+        in_use: set[str] = set()
+        for instance in self.state.instances.values():
+            for shard in instance.shard_assignments.runner_to_shard.values():
+                card = shard.model_card
+                in_use.add(str(card.model_id))
+                if card.vision and card.vision.weights_repo:
+                    in_use.add(card.vision.weights_repo)
+                if card.runtime is not None:
+                    if card.runtime.mtp_sidecar_repo:
+                        in_use.add(card.runtime.mtp_sidecar_repo)
+                    if card.runtime.assistant_model_repo:
+                        in_use.add(card.runtime.assistant_model_repo)
+        return frozenset(in_use)
+
+    async def get_node_storage_summary(self) -> NodeStorageSummary:
+        """Compute the local node's storage breakdown.
+
+        Directory walks run in a worker thread — staged models are few large
+        files, but the event loop must not block on filesystem traversal.
+        """
+        staging_root: Path | None = None
+        if self._exo_config is not None and self._exo_config.model_store is not None:
+            staging = resolve_node_staging(
+                self._exo_config.model_store, str(self.node_id)
+            )
+            if staging.enabled:
+                staging_root = Path(staging.node_cache_path).expanduser()
+
+        in_use = self._store_models_in_use()
+
+        def _collect() -> NodeStorageSummary:
+            staged = (
+                list_staged_models(staging_root, in_use)
+                if staging_root is not None
+                else []
+            )
+            event_log_bytes = sum(
+                file_path.stat().st_size
+                for file_path in EXO_EVENT_LOG_DIR.rglob("*")
+                if file_path.is_file()
+            )
+            disk = shutil.disk_usage(EXO_MODELS_DIR)
+            return NodeStorageSummary(
+                node_id=str(self.node_id),
+                staging_root=str(staging_root) if staging_root is not None else None,
+                staged_models=staged,
+                staged_total_bytes=sum(info.size_bytes for info in staged),
+                event_log_bytes=event_log_bytes,
+                disk_total_bytes=disk.total,
+                disk_free_bytes=disk.free,
+            )
+
+        return await to_thread.run_sync(_collect)
 
     @staticmethod
     def _get_trace_path(task_id: str) -> Path:

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -3040,7 +3040,11 @@ class API:
         files, but the event loop must not block on filesystem traversal.
         """
         staging_root: Path | None = None
-        if self._exo_config is not None and self._exo_config.model_store is not None:
+        if (
+            self._exo_config is not None
+            and self._exo_config.model_store is not None
+            and self._exo_config.model_store.enabled
+        ):
             staging = resolve_node_staging(
                 self._exo_config.model_store, str(self.node_id)
             )
@@ -3055,11 +3059,13 @@ class API:
                 if staging_root is not None
                 else []
             )
-            event_log_bytes = sum(
-                file_path.stat().st_size
-                for file_path in EXO_EVENT_LOG_DIR.rglob("*")
-                if file_path.is_file()
-            )
+            event_log_bytes = 0
+            for file_path in EXO_EVENT_LOG_DIR.rglob("*"):
+                # Best-effort: archives rotate and files vanish mid-walk; a
+                # transient stat failure must not 500 the whole summary.
+                with contextlib.suppress(OSError):
+                    if file_path.is_file():
+                        event_log_bytes += file_path.stat().st_size
             disk = shutil.disk_usage(EXO_MODELS_DIR)
             return NodeStorageSummary(
                 node_id=str(self.node_id),

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -3018,9 +3018,16 @@ class API:
         )
 
     def _store_models_in_use(self) -> frozenset[str]:
-        """Repo-form model IDs any live instance depends on, incl. companions."""
+        """Repo-form model IDs THIS node's live shards depend on, incl. companions.
+
+        Node-scoped on purpose: the storage view describes this node's
+        staging directory, and an idle staged copy here is an eviction
+        candidate even when some other node runs the same model.
+        """
         in_use: set[str] = set()
         for instance in self.state.instances.values():
+            if self.node_id not in instance.shard_assignments.node_to_runner:
+                continue
             for shard in instance.shard_assignments.runner_to_shard.values():
                 card = shard.model_card
                 in_use.add(str(card.model_id))
@@ -3066,15 +3073,21 @@ class API:
                 with contextlib.suppress(OSError):
                     if file_path.is_file():
                         event_log_bytes += file_path.stat().st_size
-            disk = shutil.disk_usage(EXO_MODELS_DIR)
+            try:
+                disk = shutil.disk_usage(EXO_MODELS_DIR)
+                disk_total_bytes, disk_free_bytes = disk.total, disk.free
+            except OSError:
+                # Fresh node where the models dir doesn't exist yet — the
+                # summary is best-effort, report zeros rather than 500.
+                disk_total_bytes, disk_free_bytes = 0, 0
             return NodeStorageSummary(
                 node_id=str(self.node_id),
                 staging_root=str(staging_root) if staging_root is not None else None,
                 staged_models=staged,
                 staged_total_bytes=sum(info.size_bytes for info in staged),
                 event_log_bytes=event_log_bytes,
-                disk_total_bytes=disk.total,
-                disk_free_bytes=disk.free,
+                disk_total_bytes=disk_total_bytes,
+                disk_free_bytes=disk_free_bytes,
             )
 
         return await to_thread.run_sync(_collect)

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -3081,7 +3081,7 @@ class API:
                 # summary is best-effort, report zeros rather than 500.
                 disk_total_bytes, disk_free_bytes = 0, 0
             return NodeStorageSummary(
-                node_id=str(self.node_id),
+                node_id=self.node_id,
                 staging_root=str(staging_root) if staging_root is not None else None,
                 staged_models=staged,
                 staged_total_bytes=sum(info.size_bytes for info in staged),

--- a/src/exo/api/types/__init__.py
+++ b/src/exo/api/types/__init__.py
@@ -44,6 +44,7 @@ from .api import ModalitiesCapabilitySection as ModalitiesCapabilitySection
 from .api import ModelList as ModelList
 from .api import ModelListModel as ModelListModel
 from .api import NodePowerStats as NodePowerStats
+from .api import NodeStorageSummary as NodeStorageSummary
 from .api import OpenUrlToolRequest as OpenUrlToolRequest
 from .api import OpenUrlToolResponse as OpenUrlToolResponse
 from .api import PlaceInstanceParams as PlaceInstanceParams

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -12,6 +12,7 @@ from exo.shared.types.memory import Memory
 from exo.shared.types.text_generation import ReasoningEffort
 from exo.shared.types.worker.instances import Instance, InstanceId, InstanceMeta
 from exo.shared.types.worker.shards import Sharding, ShardMetadata
+from exo.store.staging_eviction import StagedModelInfo
 from exo.utils.pydantic_ext import CamelCaseModel
 
 FinishReason = Literal[
@@ -897,6 +898,29 @@ class PurgeStagingRequest(CamelCaseModel):
 class PurgeStagingResponse(CamelCaseModel):
     command_id: CommandId
     message: str
+
+
+class NodeStorageSummary(CamelCaseModel):
+    """Per-node storage breakdown for the local node.
+
+    Sizes are computed on demand by walking the relevant directories;
+    staged models include last-use times and whether a live instance
+    (or its companion repos) currently depends on them.
+    """
+
+    node_id: str
+    staging_root: str | None
+    """Resolved staging directory for this node, or None when the model
+    store / staging is not configured."""
+
+    staged_models: list[StagedModelInfo]
+    staged_total_bytes: int
+    event_log_bytes: int
+    """Total size of this node's event-log directory (active + archives)."""
+
+    disk_total_bytes: int
+    disk_free_bytes: int
+    """Capacity and free space of the volume holding the models directory."""
 
 
 TraceTaskKind = Literal["image", "text", "embedding"]

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -908,7 +908,7 @@ class NodeStorageSummary(CamelCaseModel):
     (or its companion repos) currently depends on them.
     """
 
-    node_id: str
+    node_id: NodeId
     staging_root: str | None
     """Resolved staging directory for this node, or None when the model
     store / staging is not configured."""

--- a/src/exo/api/types/api.py
+++ b/src/exo/api/types/api.py
@@ -920,7 +920,8 @@ class NodeStorageSummary(CamelCaseModel):
 
     disk_total_bytes: int
     disk_free_bytes: int
-    """Capacity and free space of the volume holding the models directory."""
+    """Capacity and free space of the volume holding the staging directory
+    (falls back to the models directory when staging is not configured)."""
 
 
 TraceTaskKind = Literal["image", "text", "embedding"]

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -56,7 +56,8 @@ Example ``exo.yaml``::
       staging:
         enabled: true
         node_cache_path: ~/.exo/staging
-        cleanup_on_deactivate: false
+        cleanup_on_deactivate: true       # evict staged copies on instance end
+        staging_keep_recent_gb: 40        # but keep this much recently-used data
 
       node_overrides:
         mac-studio-1:
@@ -144,16 +145,27 @@ class StagingNodeConfig(FrozenModel):
             where staged model files are written.  Each model occupies a
             subdirectory named ``<org>--<model>`` (e.g.
             ``mlx-community--Qwen3-30B-A3B-4bit``).
-        cleanup_on_deactivate: When ``True``, staged files are deleted when
-            the model instance is shut down, freeing local disk space at the
-            cost of making later placements cold again. The default keeps the
-            staged files so large models can be reused from local storage;
-            use the explicit staging-cache purge endpoint for cleanup.
+        cleanup_on_deactivate: When ``True`` (the default), staged copies
+            become eviction candidates when their model instance is shut
+            down, and the staging directory is held to the
+            ``staging_keep_recent_gb`` budget. Staged copies are cheap to
+            recreate from the LAN store, while local disk on small-disk
+            nodes is the scarce resource — unbounded staging filled two
+            nodes to 58-70 GB and killed one of them during the 2026-06-06
+            launch smoke. Set ``False`` to keep every staged copy and
+            manage cleanup manually via the purge endpoints.
+        staging_keep_recent_gb: Most-recently-used grace budget, in GiB.
+            Eviction never reduces the staging cache below this much of
+            recently used, not-in-use model data — so node crashes,
+            restarts, and repeated place/delete cycles of the same model
+            do not re-pay the staging copy every time. Set to ``0`` for
+            strict evict-on-deactivate.
     """
 
     enabled: bool = True
     node_cache_path: str = "~/.exo/staging"
-    cleanup_on_deactivate: bool = False
+    cleanup_on_deactivate: bool = True
+    staging_keep_recent_gb: float = 40.0
 
 
 @final

--- a/src/exo/store/config.py
+++ b/src/exo/store/config.py
@@ -165,7 +165,7 @@ class StagingNodeConfig(FrozenModel):
     enabled: bool = True
     node_cache_path: str = "~/.exo/staging"
     cleanup_on_deactivate: bool = True
-    staging_keep_recent_gb: float = 40.0
+    staging_keep_recent_gb: float = Field(default=40.0, ge=0)
 
 
 @final

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -85,6 +85,7 @@ from exo.shared.types.memory import Memory
 from exo.shared.types.worker.downloads import RepoDownloadProgress
 from exo.shared.types.worker.shards import ShardMetadata
 from exo.store.config import StagingNodeConfig
+from exo.store.staging_eviction import touch_last_used
 
 _CHUNK_SIZE = 8 * 1024 * 1024  # 8 MB per read/write chunk
 _CONNECT_TIMEOUT = 10.0  # seconds — abort if store host unreachable
@@ -789,6 +790,7 @@ class ModelStoreDownloader(ShardDownloader):
             logger.info(
                 f"ModelStoreDownloader: {model_id} already staged at {dest_path} — skipping availability probe"
             )
+            touch_last_used(dest_path)
             await self._emit_progress(shard, status="complete")
             return dest_path
 
@@ -809,6 +811,7 @@ class ModelStoreDownloader(ShardDownloader):
                         total_bytes=total,
                     ),
                 )
+                touch_last_used(path)
                 await self._emit_progress(shard, status="complete")
                 return path
             except ModelNotInStoreError:

--- a/src/exo/store/model_store_client.py
+++ b/src/exo/store/model_store_client.py
@@ -853,6 +853,7 @@ class ModelStoreDownloader(ShardDownloader):
                     total_bytes=total,
                 ),
             )
+            touch_last_used(path)
             await self._emit_progress(shard, status="complete")
             return path
 

--- a/src/exo/store/staging_eviction.py
+++ b/src/exo/store/staging_eviction.py
@@ -62,8 +62,19 @@ class StagedModelInfo(CamelCaseModel):
 
 
 def model_id_from_staging_directory_name(directory_name: str) -> str:
-    """Invert the ``org--name`` sanitization used for staging directories."""
+    """Best-effort inverse of the ``org--name`` directory sanitization.
+
+    Display/reporting only — the inverse is ambiguous when a repo name
+    itself contains ``--`` next to the separator, so MATCHING never uses
+    it: in-use checks compare forward-sanitized directory names instead
+    (see ``list_staged_models``).
+    """
     return directory_name.replace("--", "/", 1)
+
+
+def staging_directory_name(model_id: str) -> str:
+    """Forward sanitization for staging directory names (``org--name``)."""
+    return model_id.replace("/", "--")
 
 
 def touch_last_used(staged_model_directory: Path) -> None:
@@ -109,6 +120,12 @@ def list_staged_models(
     """
     if not staging_root.is_dir():
         return []
+    # In-use matching is by forward-sanitized DIRECTORY name: the inverse
+    # mapping is ambiguous for ids with "--" near the separator, and a
+    # mis-match here could evict a live model's files.
+    in_use_directory_names = {
+        staging_directory_name(model_id) for model_id in in_use_model_ids
+    }
     staged: list[StagedModelInfo] = []
     for entry in staging_root.iterdir():
         if not entry.is_dir():
@@ -120,7 +137,7 @@ def list_staged_models(
                 directory=str(entry),
                 size_bytes=_directory_size_bytes(entry),
                 last_used_epoch_seconds=_last_used_epoch_seconds(entry),
-                in_use=model_id in in_use_model_ids,
+                in_use=entry.name in in_use_directory_names,
             )
         )
     staged.sort(key=lambda info: info.last_used_epoch_seconds, reverse=True)

--- a/src/exo/store/staging_eviction.py
+++ b/src/exo/store/staging_eviction.py
@@ -1,0 +1,182 @@
+"""Staging-cache eviction: one budget mechanism, three triggers.
+
+The staging directory holds node-local copies of store-served models. Left
+unmanaged it grows without bound — every model ever staged survives both
+instance deletion and node crashes (58-70 GB piles observed; one node died
+of a full disk during the 2026-06-06 launch smoke).
+
+The policy here is deliberately a single mechanism:
+
+* A staged model is an **eviction candidate** when no live runner uses it
+  (including as a companion — an MTP sidecar or assistant of an active
+  model is in use even though no instance names it directly).
+* Candidates are kept, newest-first by last use, up to the
+  ``staging_keep_recent_gb`` grace budget; everything beyond it is
+  deleted. The grace budget exists because node deaths, restarts, and
+  repeated place/delete cycles of the same model should not re-pay the
+  staging copy every time.
+
+The same enforcement runs at instance deactivation, at node startup (which
+is what reconciles orphans left by a crashed session), and may be invoked
+by operator tooling.
+"""
+
+import contextlib
+import shutil
+import time
+from pathlib import Path
+
+from loguru import logger
+from pydantic import Field
+
+from exo.utils.pydantic_ext import CamelCaseModel
+
+LAST_USED_MARKER_FILENAME = ".last_used"
+"""Marker file touched whenever a staged model is resolved for loading.
+
+Directory mtimes change on content writes, not reads, so without the
+marker a model staged long ago but used constantly would look idle to the
+LRU ordering."""
+
+
+class StagedModelInfo(CamelCaseModel):
+    """One staged model directory, as seen by eviction and the storage API."""
+
+    model_id: str
+    """Model ID in repo form (``org/name``), reconstructed from the
+    directory name."""
+
+    directory: str
+    """Absolute path of the staged copy."""
+
+    size_bytes: int
+    """Total size of all files in the staged copy."""
+
+    last_used_epoch_seconds: float
+    """Best-known last-use time: the ``.last_used`` marker when present,
+    else the directory mtime."""
+
+    in_use: bool = False
+    """True when a live runner currently uses this model (directly or as a
+    companion). In-use models are never eviction candidates."""
+
+
+def model_id_from_staging_directory_name(directory_name: str) -> str:
+    """Invert the ``org--name`` sanitization used for staging directories."""
+    return directory_name.replace("--", "/", 1)
+
+
+def touch_last_used(staged_model_directory: Path) -> None:
+    """Record that a staged model was just resolved for loading.
+
+    Best-effort: a failed touch only weakens LRU ordering, it must never
+    interfere with the load path.
+    """
+    with contextlib.suppress(OSError):
+        (staged_model_directory / LAST_USED_MARKER_FILENAME).touch()
+
+
+def _directory_size_bytes(directory: Path) -> int:
+    total = 0
+    for file_path in directory.rglob("*"):
+        try:
+            if file_path.is_file():
+                total += file_path.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _last_used_epoch_seconds(directory: Path) -> float:
+    marker = directory / LAST_USED_MARKER_FILENAME
+    try:
+        if marker.exists():
+            return marker.stat().st_mtime
+        return directory.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def list_staged_models(
+    staging_root: Path,
+    in_use_model_ids: frozenset[str] = frozenset(),
+) -> list[StagedModelInfo]:
+    """Inventory the staging directory, newest-used first.
+
+    ``in_use_model_ids`` are repo-form IDs (``org/name``) of models a live
+    runner currently depends on — including companion repos of active
+    models.
+    """
+    if not staging_root.is_dir():
+        return []
+    staged: list[StagedModelInfo] = []
+    for entry in staging_root.iterdir():
+        if not entry.is_dir():
+            continue
+        model_id = model_id_from_staging_directory_name(entry.name)
+        staged.append(
+            StagedModelInfo(
+                model_id=model_id,
+                directory=str(entry),
+                size_bytes=_directory_size_bytes(entry),
+                last_used_epoch_seconds=_last_used_epoch_seconds(entry),
+                in_use=model_id in in_use_model_ids,
+            )
+        )
+    staged.sort(key=lambda info: info.last_used_epoch_seconds, reverse=True)
+    return staged
+
+
+class StagingEvictionReport(CamelCaseModel):
+    """Result of one budget enforcement pass."""
+
+    evicted_model_ids: list[str] = Field(default_factory=list)
+    evicted_bytes: int = 0
+    retained_candidate_bytes: int = 0
+    """Bytes of not-in-use staged data kept under the grace budget."""
+
+
+def enforce_staging_budget(
+    staging_root: Path,
+    keep_recent_bytes: int,
+    in_use_model_ids: frozenset[str] = frozenset(),
+) -> StagingEvictionReport:
+    """Evict least-recently-used staging candidates beyond the grace budget.
+
+    In-use models are never touched. Candidates are retained newest-first
+    until the grace budget is spent; the rest are deleted. With a budget of
+    0 this is strict evict-on-deactivate.
+
+    Deletion failures are logged and skipped — a partially evicted cache is
+    still a smaller cache, and the next enforcement pass retries.
+    """
+    report = StagingEvictionReport()
+    candidates = [
+        info
+        for info in list_staged_models(staging_root, in_use_model_ids)
+        if not info.in_use
+    ]
+
+    retained_bytes = 0
+    for info in candidates:
+        if retained_bytes + info.size_bytes <= keep_recent_bytes:
+            retained_bytes += info.size_bytes
+            continue
+        try:
+            shutil.rmtree(info.directory)
+        except OSError as error:
+            logger.warning(
+                f"Staging eviction could not remove {info.directory}: {error}"
+            )
+            continue
+        report.evicted_model_ids.append(info.model_id)
+        report.evicted_bytes += info.size_bytes
+        age_hours = (time.time() - info.last_used_epoch_seconds) / 3600
+        logger.info(
+            f"Evicted staged model {info.model_id} "
+            f"({info.size_bytes / 2**30:.1f} GiB, last used "
+            f"~{age_hours:.1f}h ago) — staging held to the "
+            f"{keep_recent_bytes / 2**30:.0f} GiB recent-use budget"
+        )
+    report.retained_candidate_bytes = retained_bytes
+    return report

--- a/src/exo/store/tests/test_config.py
+++ b/src/exo/store/tests/test_config.py
@@ -37,12 +37,18 @@ def test_node_matches_store_host_keeps_node_id_matching_exact() -> None:
     )
 
 
-def test_staging_cleanup_defaults_to_warm_cache() -> None:
+def test_staging_cleanup_defaults_to_budgeted_eviction() -> None:
+    """Eviction-on-deactivate with a recent-use grace budget is the default:
+    staged copies are cheap to recreate from the LAN store, local disk is
+    the scarce resource (two nodes filled to 58-70 GB in the launch smoke),
+    and the grace budget keeps crashes/restarts/repeat placements from
+    re-paying the staging copy (deliberate product decision, 2026-06-06)."""
     config = StagingNodeConfig()
 
     assert config.enabled
     assert config.node_cache_path == "~/.exo/staging"
-    assert not config.cleanup_on_deactivate
+    assert config.cleanup_on_deactivate
+    assert config.staging_keep_recent_gb == 40.0
 
 
 def test_resolve_node_staging_matches_local_hostname_alias(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/exo/store/tests/test_staging_eviction.py
+++ b/src/exo/store/tests/test_staging_eviction.py
@@ -114,3 +114,17 @@ def test_budget_counts_only_candidates_not_in_use_bytes(tmp_path: Path) -> None:
 
     assert report.evicted_model_ids == []
     assert report.retained_candidate_bytes == 50
+
+
+def test_store_host_direct_load_is_never_evicted(tmp_path: Path) -> None:
+    """SEV-5 guard (codex, #215): a store host whose node_cache_path IS the
+    canonical store directory must never run eviction there — the budget
+    pass would delete the cluster's only copy of every model beyond it.
+    Exercised at the worker layer via the path-equality guard; this test
+    pins the comparison semantics it relies on (expanduser + resolve)."""
+    store_dir = tmp_path / "store"
+    store_dir.mkdir()
+    alias = tmp_path / "alias" / ".." / "store"
+    (tmp_path / "alias").mkdir()
+
+    assert store_dir.resolve() == alias.resolve()

--- a/src/exo/store/tests/test_staging_eviction.py
+++ b/src/exo/store/tests/test_staging_eviction.py
@@ -1,0 +1,116 @@
+"""Tests for the staging-cache eviction budget.
+
+One mechanism, three triggers (deactivate / startup / tooling): not-in-use
+staged models are retained newest-first up to the grace budget, the rest
+are deleted. The grace budget is what keeps node crashes, restarts, and
+repeated place/delete cycles from re-paying the staging copy every time.
+"""
+
+import os
+import time
+from pathlib import Path
+
+from exo.store.staging_eviction import (
+    LAST_USED_MARKER_FILENAME,
+    enforce_staging_budget,
+    list_staged_models,
+    model_id_from_staging_directory_name,
+    touch_last_used,
+)
+
+_GIB = 1024**3
+
+
+def _stage_model(
+    root: Path, model_id: str, size_bytes: int, last_used_age_seconds: float
+) -> Path:
+    directory = root / model_id.replace("/", "--")
+    directory.mkdir(parents=True)
+    (directory / "model.safetensors").write_bytes(b"\0" * size_bytes)
+    marker = directory / LAST_USED_MARKER_FILENAME
+    marker.touch()
+    stamp = time.time() - last_used_age_seconds
+    os.utime(marker, (stamp, stamp))
+    return directory
+
+
+def test_directory_name_round_trip() -> None:
+    assert (
+        model_id_from_staging_directory_name("mlx-community--Qwen3.5-9B-MLX-4bit")
+        == "mlx-community/Qwen3.5-9B-MLX-4bit"
+    )
+
+
+def test_budget_retains_newest_and_evicts_oldest(tmp_path: Path) -> None:
+    _stage_model(tmp_path, "org/newest", size_bytes=100, last_used_age_seconds=10)
+    _stage_model(tmp_path, "org/middle", size_bytes=100, last_used_age_seconds=100)
+    _stage_model(tmp_path, "org/oldest", size_bytes=100, last_used_age_seconds=1000)
+
+    report = enforce_staging_budget(tmp_path, keep_recent_bytes=250)
+
+    assert report.evicted_model_ids == ["org/oldest"]
+    assert report.retained_candidate_bytes == 200
+    assert (tmp_path / "org--newest").exists()
+    assert (tmp_path / "org--middle").exists()
+    assert not (tmp_path / "org--oldest").exists()
+
+
+def test_zero_budget_is_strict_eviction(tmp_path: Path) -> None:
+    _stage_model(tmp_path, "org/a", size_bytes=10, last_used_age_seconds=10)
+    _stage_model(tmp_path, "org/b", size_bytes=10, last_used_age_seconds=20)
+
+    report = enforce_staging_budget(tmp_path, keep_recent_bytes=0)
+
+    assert sorted(report.evicted_model_ids) == ["org/a", "org/b"]
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_in_use_models_are_never_evicted(tmp_path: Path) -> None:
+    """The crash-recovery and live-runner cases: in-use models survive a
+    zero budget, including companions named only by the card."""
+    _stage_model(tmp_path, "org/base", size_bytes=10, last_used_age_seconds=10)
+    _stage_model(tmp_path, "FoxlightAI/base-mtp", size_bytes=5, last_used_age_seconds=10)
+    _stage_model(tmp_path, "org/idle", size_bytes=10, last_used_age_seconds=10)
+
+    report = enforce_staging_budget(
+        tmp_path,
+        keep_recent_bytes=0,
+        in_use_model_ids=frozenset({"org/base", "FoxlightAI/base-mtp"}),
+    )
+
+    assert report.evicted_model_ids == ["org/idle"]
+    assert (tmp_path / "org--base").exists()
+    assert (tmp_path / "FoxlightAI--base-mtp").exists()
+
+
+def test_touch_last_used_refreshes_lru_position(tmp_path: Path) -> None:
+    """A model staged long ago but used just now must sort newest."""
+    old_dir = _stage_model(tmp_path, "org/stale", size_bytes=10, last_used_age_seconds=10)
+    _stage_model(tmp_path, "org/fresh", size_bytes=10, last_used_age_seconds=100)
+
+    touch_last_used(old_dir)
+    staged = list_staged_models(tmp_path)
+
+    assert [info.model_id for info in staged] == ["org/stale", "org/fresh"]
+
+
+def test_missing_staging_root_is_empty(tmp_path: Path) -> None:
+    assert list_staged_models(tmp_path / "does-not-exist") == []
+    report = enforce_staging_budget(tmp_path / "does-not-exist", keep_recent_bytes=0)
+    assert report.evicted_model_ids == []
+
+
+def test_budget_counts_only_candidates_not_in_use_bytes(tmp_path: Path) -> None:
+    """In-use models must not consume the grace budget — a giant live model
+    would otherwise force-evict every idle candidate."""
+    _stage_model(tmp_path, "org/live-giant", size_bytes=1000, last_used_age_seconds=5)
+    _stage_model(tmp_path, "org/idle-small", size_bytes=50, last_used_age_seconds=50)
+
+    report = enforce_staging_budget(
+        tmp_path,
+        keep_recent_bytes=100,
+        in_use_model_ids=frozenset({"org/live-giant"}),
+    )
+
+    assert report.evicted_model_ids == []
+    assert report.retained_candidate_bytes == 50

--- a/src/exo/store/tests/test_staging_eviction.py
+++ b/src/exo/store/tests/test_staging_eviction.py
@@ -84,9 +84,17 @@ def test_in_use_models_are_never_evicted(tmp_path: Path) -> None:
 
 
 def test_touch_last_used_refreshes_lru_position(tmp_path: Path) -> None:
-    """A model staged long ago but used just now must sort newest."""
-    old_dir = _stage_model(tmp_path, "org/stale", size_bytes=10, last_used_age_seconds=10)
-    _stage_model(tmp_path, "org/fresh", size_bytes=10, last_used_age_seconds=100)
+    """A model staged long ago but used just now must sort newest.
+
+    The genuinely OLD model (age 1000s) sorts behind the newer one until
+    touched — so a broken touch_last_used cannot pass this test."""
+    old_dir = _stage_model(
+        tmp_path, "org/stale", size_bytes=10, last_used_age_seconds=1000
+    )
+    _stage_model(tmp_path, "org/fresh", size_bytes=10, last_used_age_seconds=10)
+
+    staged_before = list_staged_models(tmp_path)
+    assert [info.model_id for info in staged_before] == ["org/fresh", "org/stale"]
 
     touch_last_used(old_dir)
     staged = list_staged_models(tmp_path)

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -743,6 +743,25 @@ class Worker:
         if self._staging_config is None or not self._staging_config.enabled:
             return None
         staging_root = Path(self._staging_config.node_cache_path).expanduser()
+        # A store host configured for direct loading points node_cache_path
+        # at the CANONICAL store directory (a common override that was safe
+        # under the old no-cleanup default). Eviction there would delete the
+        # cluster's only copy of every model beyond the budget — refuse,
+        # whatever the config says (codex review on #215).
+        if self._store_client is not None:
+            local_store_path = self._store_client.local_store_path
+            if (
+                local_store_path is not None
+                and local_store_path.expanduser().resolve()
+                == staging_root.resolve()
+            ):
+                logger.warning(
+                    "Worker: staging eviction skipped — node_cache_path is "
+                    f"the canonical store directory ({staging_root}); the "
+                    "store is never evicted. Set a separate staging path if "
+                    "this node should have a managed staging cache."
+                )
+                return None
         keep_recent_bytes = int(
             self._staging_config.staging_keep_recent_gb * 1024**3
         )

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import anyio
-from anyio import BrokenResourceError, ClosedResourceError, fail_after
+from anyio import BrokenResourceError, ClosedResourceError, fail_after, to_thread
 from loguru import logger
 from PIL import Image
 
@@ -690,19 +690,48 @@ class Worker:
             or not self._staging_config.cleanup_on_deactivate
         ):
             return
-        report = self._enforce_staging_budget()
+        # The walk + rmtree are synchronous filesystem work on potentially
+        # tens of GB — run off the event loop so teardown doesn't stall
+        # other worker tasks.
+        report = await to_thread.run_sync(self._enforce_staging_budget)
         if report is None:
             return
-        # Reset download status for evicted models so the dashboard no
-        # longer shows them as downloaded on this node, and the planner
-        # re-stages instead of assuming the files are still here.
-        if str(shard.model_card.model_id) in report.evicted_model_ids:
-            cache_path = Path(self._staging_config.node_cache_path).expanduser()
+        await self._reset_download_state_for_evicted(report, shard)
+
+    async def _reset_download_state_for_evicted(
+        self, report: StagingEvictionReport, deactivated_shard: ShardMetadata
+    ) -> None:
+        """Reset download status for EVERY evicted model on this node.
+
+        The budget pass can evict models other than the one just torn down;
+        leaving them DownloadCompleted in master state would make the
+        planner skip re-staging and fail later loads. Shard metadata for
+        the other models comes from this node's own download-status state.
+        """
+        if self._staging_config is None:
+            return
+        cache_path = Path(self._staging_config.node_cache_path).expanduser()
+        own_downloads = {
+            str(progress.shard_metadata.model_card.model_id): progress.shard_metadata
+            for progress in self.state.downloads.get(self.node_id, [])
+        }
+        deactivated_model_id = str(deactivated_shard.model_card.model_id)
+        for evicted_model_id in report.evicted_model_ids:
+            shard_metadata = (
+                deactivated_shard
+                if evicted_model_id == deactivated_model_id
+                else own_downloads.get(evicted_model_id)
+            )
+            if shard_metadata is None:
+                # Never advertised as downloaded on this node — nothing to
+                # reset (e.g. a companion repo staged without its own
+                # download entry).
+                continue
             pending = DownloadPending(
-                shard_metadata=shard,
+                shard_metadata=shard_metadata,
                 node_id=self.node_id,
                 model_directory=str(
-                    cache_path / str(shard.model_card.model_id).replace("/", "--")
+                    cache_path / evicted_model_id.replace("/", "--")
                 ),
             )
             await self.event_sender.send(

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -14,7 +14,12 @@ from exo.api.types import ImageEditsTaskParams
 from exo.download.download_utils import resolve_model_in_path
 from exo.shared.apply import apply
 from exo.shared.constants import EXO_IMAGE_TRANSPORT_DEBUG
-from exo.shared.models.model_cards import ModelId, add_to_card_cache, delete_custom_card
+from exo.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    add_to_card_cache,
+    delete_custom_card,
+)
 from exo.shared.types.chunks import InputImageChunk
 from exo.shared.types.commands import (
     ForwarderCommand,
@@ -55,7 +60,11 @@ from exo.shared.types.tasks import (
     TextGeneration,
 )
 from exo.shared.types.topology import Connection, SocketConnection
-from exo.shared.types.worker.downloads import DownloadCompleted, DownloadPending
+from exo.shared.types.worker.downloads import (
+    DownloadCompleted,
+    DownloadOngoing,
+    DownloadPending,
+)
 from exo.shared.types.worker.runners import RunnerId
 from exo.shared.types.worker.shards import ShardMetadata
 from exo.store.config import StagingNodeConfig
@@ -71,6 +80,13 @@ from exo.utils.keyed_backoff import KeyedBackoff
 from exo.utils.task_group import TaskGroup
 from exo.worker.plan import plan
 from exo.worker.runner.runner_supervisor import RunnerSupervisor
+
+_STALE_RESET_MAX_WAIT_TICKS = 300
+"""How many ~100ms planning ticks to hold planning while stale download
+resets round-trip through the master (~30s). The deadline exists so a
+masterless interval cannot freeze the worker forever — past it, planning
+resumes and the download coordinator's missing-directory self-heal covers
+the residual risk."""
 
 
 def _summarize_worker_task(task: Task) -> str:
@@ -247,6 +263,7 @@ class Worker:
         # entries may still be replicating in; countered lazily by
         # plan_step once state carries them.
         self._stale_downloads_pending_reset: set[str] = set()
+        self._stale_reset_wait_ticks: int = 0
         self._tg: TaskGroup = TaskGroup()
 
         self._system_id = SystemId()
@@ -341,6 +358,23 @@ class Worker:
             await anyio.sleep(0.1)
             if self._stale_downloads_pending_reset:
                 await self._reset_stale_downloads_from_state()
+                if self._state_still_advertises_evicted_downloads():
+                    # The DownloadPending resets round-trip through the
+                    # master before our replicated state drops the stale
+                    # DownloadCompleted entries; planning against the
+                    # stale state could dispatch a load straight at the
+                    # files we just deleted. Skip planning until the
+                    # resets land (bounded: see the deadline below).
+                    self._stale_reset_wait_ticks += 1
+                    if self._stale_reset_wait_ticks <= _STALE_RESET_MAX_WAIT_TICKS:
+                        continue
+                    logger.warning(
+                        "Worker: stale download resets have not applied "
+                        f"after {_STALE_RESET_MAX_WAIT_TICKS} planning "
+                        "ticks; resuming planning anyway (the coordinator "
+                        "self-heals missing files at download time)"
+                    )
+                    self._stale_downloads_pending_reset.clear()
             task: Task | None = plan(
                 self.node_id,
                 self.runners,
@@ -667,9 +701,7 @@ class Worker:
         evicting one corrupts a live runner just the same — MLX loads
         weights lazily.
         """
-        in_use: set[str] = set()
-        for runner in self.runners.values():
-            card = runner.shard_metadata.model_card
+        def _add_card(card: ModelCard) -> None:
             in_use.add(str(card.model_id))
             if card.vision and card.vision.weights_repo:
                 in_use.add(card.vision.weights_repo)
@@ -679,6 +711,17 @@ class Worker:
                     in_use.add(runtime.mtp_sidecar_repo)
                 if runtime.assistant_model_repo:
                     in_use.add(runtime.assistant_model_repo)
+
+        in_use: set[str] = set()
+        for runner in self.runners.values():
+            _add_card(runner.shard_metadata.model_card)
+        # A store-backed download in progress has already created its
+        # staging directory but no runner exists yet — a concurrent
+        # teardown's budget pass must not delete a directory that is
+        # actively being written.
+        for progress in self.state.downloads.get(self.node_id, []):
+            if isinstance(progress, DownloadOngoing):
+                _add_card(progress.shard_metadata.model_card)
         return frozenset(in_use)
 
     async def _maybe_evict_shard(self, shard: ShardMetadata | None) -> None:
@@ -780,6 +823,18 @@ class Worker:
         except Exception as exc:
             logger.warning(f"Worker: staging budget enforcement failed: {exc}")
             return None
+
+    def _state_still_advertises_evicted_downloads(self) -> bool:
+        """True while replicated state shows DownloadCompleted for a model
+        whose staged files the startup pass deleted."""
+        for progress in self.state.downloads.get(self.node_id, []):
+            if (
+                isinstance(progress, DownloadCompleted)
+                and str(progress.shard_metadata.model_card.model_id)
+                in self._stale_downloads_pending_reset
+            ):
+                return True
+        return False
 
     async def _reset_stale_downloads_from_state(self) -> None:
         """Counter stale DownloadCompleted entries for startup-evicted models.

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -72,6 +72,7 @@ from exo.store.model_store_client import ModelStoreClient
 from exo.store.staging_eviction import (
     StagingEvictionReport,
     enforce_staging_budget,
+    staging_directory_name,
     touch_last_used,
 )
 from exo.utils.channels import Receiver, Sender, channel
@@ -779,16 +780,25 @@ class Worker:
         if self._staging_config is None:
             return
         cache_path = Path(self._staging_config.node_cache_path).expanduser()
+        # Keyed by forward-sanitized directory name: the report's model ids
+        # are best-effort inverses of directory names and can be ambiguous
+        # for ids containing "--" — sanitizing both sides forward makes the
+        # match exact.
         own_downloads = {
-            str(progress.shard_metadata.model_card.model_id): progress.shard_metadata
+            staging_directory_name(
+                str(progress.shard_metadata.model_card.model_id)
+            ): progress.shard_metadata
             for progress in self.state.downloads.get(self.node_id, [])
         }
-        deactivated_model_id = str(deactivated_shard.model_card.model_id)
+        deactivated_directory = staging_directory_name(
+            str(deactivated_shard.model_card.model_id)
+        )
         for evicted_model_id in report.evicted_model_ids:
+            evicted_directory = staging_directory_name(evicted_model_id)
             shard_metadata = (
                 deactivated_shard
-                if evicted_model_id == deactivated_model_id
-                else own_downloads.get(evicted_model_id)
+                if evicted_directory == deactivated_directory
+                else own_downloads.get(evicted_directory)
             )
             if shard_metadata is None:
                 # Never advertised as downloaded on this node — nothing to

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -60,6 +60,10 @@ from exo.shared.types.worker.runners import RunnerId
 from exo.shared.types.worker.shards import ShardMetadata
 from exo.store.config import StagingNodeConfig
 from exo.store.model_store_client import ModelStoreClient
+from exo.store.staging_eviction import (
+    StagingEvictionReport,
+    enforce_staging_budget,
+)
 from exo.utils.channels import Receiver, Sender, channel
 from exo.utils.info_gatherer.info_gatherer import GatheredInfo, InfoGatherer
 from exo.utils.info_gatherer.net_profile import check_reachable
@@ -253,6 +257,7 @@ class Worker:
 
     async def run(self):
         logger.info("Starting Worker")
+        self._reconcile_staging_on_startup()
 
         info_send, info_recv = channel[GatheredInfo]()
         info_gatherer: InfoGatherer = InfoGatherer(info_send)
@@ -648,8 +653,36 @@ class Worker:
             ),
         )
 
+    def _models_in_use(self) -> frozenset[str]:
+        """Repo-form IDs of every model a live runner depends on.
+
+        Includes companion repos (MTP sidecar, assistant, split vision
+        weights) of active models: no instance names them directly, but
+        evicting one corrupts a live runner just the same — MLX loads
+        weights lazily.
+        """
+        in_use: set[str] = set()
+        for runner in self.runners.values():
+            card = runner.shard_metadata.model_card
+            in_use.add(str(card.model_id))
+            if card.vision and card.vision.weights_repo:
+                in_use.add(card.vision.weights_repo)
+            runtime = card.runtime
+            if runtime is not None:
+                if runtime.mtp_sidecar_repo:
+                    in_use.add(runtime.mtp_sidecar_repo)
+                if runtime.assistant_model_repo:
+                    in_use.add(runtime.assistant_model_repo)
+        return frozenset(in_use)
+
     async def _maybe_evict_shard(self, shard: ShardMetadata | None) -> None:
-        """Evict staged shard files after runner teardown if configured."""
+        """Hold the staging cache to its recent-use budget after teardown.
+
+        The torn-down model becomes an eviction candidate like any other
+        not-in-use staged copy; the grace budget decides what actually goes
+        (so repeated place/delete cycles of the same model do not re-pay
+        the staging copy every time).
+        """
         if (
             shard is None
             or self._store_client is None
@@ -657,34 +690,65 @@ class Worker:
             or not self._staging_config.cleanup_on_deactivate
         ):
             return
-        model_id = str(shard.model_card.model_id)
-        # Skip eviction if another runner for the same model is still active —
-        # MLX loads weights lazily, so tearing down a sibling's staged files
-        # would corrupt the live runner.
-        if any(
-            str(r.shard_metadata.model_card.model_id) == model_id
-            for r in self.runners.values()
-        ):
-            logger.debug(
-                f"Worker: skipping eviction for {model_id} — another runner is still active"
-            )
+        report = self._enforce_staging_budget()
+        if report is None:
             return
-        cache_path = Path(self._staging_config.node_cache_path).expanduser()
-        try:
-            await self._store_client.evict_shard(model_id, cache_path)
-            logger.info(f"Worker: evicted staged files for {model_id}")
-            # Reset download status so the dashboard no longer shows
-            # this model as downloaded on this node.
+        # Reset download status for evicted models so the dashboard no
+        # longer shows them as downloaded on this node, and the planner
+        # re-stages instead of assuming the files are still here.
+        if str(shard.model_card.model_id) in report.evicted_model_ids:
+            cache_path = Path(self._staging_config.node_cache_path).expanduser()
             pending = DownloadPending(
                 shard_metadata=shard,
                 node_id=self.node_id,
-                model_directory=str(cache_path / model_id.replace("/", "--")),
+                model_directory=str(
+                    cache_path / str(shard.model_card.model_id).replace("/", "--")
+                ),
             )
             await self.event_sender.send(
                 NodeDownloadProgress(download_progress=pending)
             )
+
+    def _enforce_staging_budget(self) -> StagingEvictionReport | None:
+        """Run one staging-budget enforcement pass (best-effort)."""
+        if self._staging_config is None or not self._staging_config.enabled:
+            return None
+        staging_root = Path(self._staging_config.node_cache_path).expanduser()
+        keep_recent_bytes = int(
+            self._staging_config.staging_keep_recent_gb * 1024**3
+        )
+        try:
+            return enforce_staging_budget(
+                staging_root,
+                keep_recent_bytes,
+                self._models_in_use(),
+            )
         except Exception as exc:
-            logger.warning(f"Worker: evict_shard failed for {model_id}: {exc}")
+            logger.warning(f"Worker: staging budget enforcement failed: {exc}")
+            return None
+
+    def _reconcile_staging_on_startup(self) -> None:
+        """Reconcile staging orphans left by a crashed or killed session.
+
+        A node that dies never runs the deactivate-time eviction, so its
+        staged copies survive forever without this. At startup nothing is
+        in use yet, so every staged model is a candidate and the grace
+        budget alone decides what survives — which is exactly the crash
+        recovery behavior we want: recent models stay warm for the
+        restart, the old tail goes.
+        """
+        if (
+            self._staging_config is None
+            or not self._staging_config.cleanup_on_deactivate
+        ):
+            return
+        report = self._enforce_staging_budget()
+        if report is not None and report.evicted_model_ids:
+            logger.info(
+                "Worker: startup staging reconciliation evicted "
+                f"{len(report.evicted_model_ids)} orphaned model(s) "
+                f"({report.evicted_bytes / 2**30:.1f} GiB)"
+            )
 
     async def _poll_connection_updates(self):
         while True:

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -379,6 +379,8 @@ class Worker:
                         "self-heals missing files at download time)"
                     )
                     self._stale_downloads_pending_reset.clear()
+                    self._stale_resets_sent.clear()
+                    self._stale_reset_wait_ticks = 0
             task: Task | None = plan(
                 self.node_id,
                 self.runners,
@@ -745,8 +747,13 @@ class Worker:
             return
         # The walk + rmtree are synchronous filesystem work on potentially
         # tens of GB — run off the event loop so teardown doesn't stall
-        # other worker tasks.
-        report = await to_thread.run_sync(self._enforce_staging_budget)
+        # other worker tasks. The in-use snapshot is taken HERE, on the
+        # loop thread: the threaded pass must not iterate self.runners /
+        # self.state while the loop mutates them.
+        models_in_use = self._models_in_use()
+        report = await to_thread.run_sync(
+            self._enforce_staging_budget, models_in_use
+        )
         if report is None:
             return
         await self._reset_download_state_for_evicted(report, shard)
@@ -791,8 +798,15 @@ class Worker:
                 NodeDownloadProgress(download_progress=pending)
             )
 
-    def _enforce_staging_budget(self) -> StagingEvictionReport | None:
-        """Run one staging-budget enforcement pass (best-effort)."""
+    def _enforce_staging_budget(
+        self, models_in_use: frozenset[str]
+    ) -> StagingEvictionReport | None:
+        """Run one staging-budget enforcement pass (best-effort).
+
+        ``models_in_use`` is snapshotted by the caller on the event-loop
+        thread — this method may run in a worker thread and must not touch
+        the loop's mutable structures.
+        """
         if self._staging_config is None or not self._staging_config.enabled:
             return None
         staging_root = Path(self._staging_config.node_cache_path).expanduser()
@@ -822,7 +836,7 @@ class Worker:
             return enforce_staging_budget(
                 staging_root,
                 keep_recent_bytes,
-                self._models_in_use(),
+                models_in_use,
             )
         except Exception as exc:
             logger.warning(f"Worker: staging budget enforcement failed: {exc}")
@@ -889,6 +903,8 @@ class Worker:
             if model_id not in still_completed:
                 self._stale_downloads_pending_reset.discard(model_id)
                 self._stale_resets_sent.discard(model_id)
+        if not self._stale_downloads_pending_reset:
+            self._stale_reset_wait_ticks = 0
 
     def _reconcile_staging_on_startup(self) -> None:
         """Reconcile staging orphans left by a crashed or killed session.
@@ -905,7 +921,7 @@ class Worker:
             or not self._staging_config.cleanup_on_deactivate
         ):
             return
-        report = self._enforce_staging_budget()
+        report = self._enforce_staging_budget(self._models_in_use())
         if report is not None and report.evicted_model_ids:
             logger.info(
                 "Worker: startup staging reconciliation evicted "

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -72,6 +72,7 @@ from exo.store.model_store_client import ModelStoreClient
 from exo.store.staging_eviction import (
     StagingEvictionReport,
     enforce_staging_budget,
+    touch_last_used,
 )
 from exo.utils.channels import Receiver, Sender, channel
 from exo.utils.info_gatherer.info_gatherer import GatheredInfo, InfoGatherer
@@ -745,6 +746,13 @@ class Worker:
             or not self._staging_config.cleanup_on_deactivate
         ):
             return
+        # The just-deactivated model was in use until this very moment —
+        # refresh its last-use marker (and its companions') BEFORE the
+        # budget pass, or a long-staged but heavily-used model sorts as
+        # old and gets evicted despite being the most recently used thing
+        # on the node (the downloader only touches markers when it runs,
+        # and reuse from an existing DownloadCompleted skips it).
+        self._touch_staged_model_and_companions(shard.model_card)
         # The walk + rmtree are synchronous filesystem work on potentially
         # tens of GB — run off the event loop so teardown doesn't stall
         # other worker tasks. The in-use snapshot is taken HERE, on the
@@ -797,6 +805,24 @@ class Worker:
             await self.event_sender.send(
                 NodeDownloadProgress(download_progress=pending)
             )
+
+    def _touch_staged_model_and_companions(self, card: ModelCard) -> None:
+        """Refresh .last_used for a model (and companions) just taken out of use."""
+        if self._staging_config is None:
+            return
+        cache_path = Path(self._staging_config.node_cache_path).expanduser()
+        model_ids = [str(card.model_id)]
+        if card.vision and card.vision.weights_repo:
+            model_ids.append(card.vision.weights_repo)
+        if card.runtime is not None:
+            if card.runtime.mtp_sidecar_repo:
+                model_ids.append(card.runtime.mtp_sidecar_repo)
+            if card.runtime.assistant_model_repo:
+                model_ids.append(card.runtime.assistant_model_repo)
+        for model_id in model_ids:
+            staged_dir = cache_path / model_id.replace("/", "--")
+            if staged_dir.is_dir():
+                touch_last_used(staged_dir)
 
     def _enforce_staging_budget(
         self, models_in_use: frozenset[str]

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -243,6 +243,10 @@ class Worker:
 
         self.state: State = State()
         self.runners: dict[RunnerId, RunnerSupervisor] = {}
+        # Models evicted by startup reconciliation whose DownloadCompleted
+        # entries may still be replicating in; countered lazily by
+        # plan_step once state carries them.
+        self._stale_downloads_pending_reset: set[str] = set()
         self._tg: TaskGroup = TaskGroup()
 
         self._system_id = SystemId()
@@ -335,6 +339,8 @@ class Worker:
     async def plan_step(self):
         while True:
             await anyio.sleep(0.1)
+            if self._stale_downloads_pending_reset:
+                await self._reset_stale_downloads_from_state()
             task: Task | None = plan(
                 self.node_id,
                 self.runners,
@@ -775,6 +781,44 @@ class Worker:
             logger.warning(f"Worker: staging budget enforcement failed: {exc}")
             return None
 
+    async def _reset_stale_downloads_from_state(self) -> None:
+        """Counter stale DownloadCompleted entries for startup-evicted models.
+
+        Runs from plan_step while any evicted ID lacks its reset: once the
+        replicated state shows a DownloadCompleted for this node naming an
+        evicted model, emit DownloadPending with that entry's own shard
+        metadata so the planner re-stages instead of dispatching a load
+        against deleted files.
+        """
+        if self._staging_config is None:
+            self._stale_downloads_pending_reset.clear()
+            return
+        cache_path = Path(self._staging_config.node_cache_path).expanduser()
+        for progress in self.state.downloads.get(self.node_id, []):
+            if not isinstance(progress, DownloadCompleted):
+                continue
+            model_id = str(progress.shard_metadata.model_card.model_id)
+            if model_id not in self._stale_downloads_pending_reset:
+                continue
+            staged_dir = cache_path / model_id.replace("/", "--")
+            if staged_dir.exists():
+                # Re-staged since eviction — state is truthful again.
+                self._stale_downloads_pending_reset.discard(model_id)
+                continue
+            pending = DownloadPending(
+                shard_metadata=progress.shard_metadata,
+                node_id=self.node_id,
+                model_directory=str(staged_dir),
+            )
+            await self.event_sender.send(
+                NodeDownloadProgress(download_progress=pending)
+            )
+            self._stale_downloads_pending_reset.discard(model_id)
+            logger.info(
+                f"Worker: reset stale DownloadCompleted for {model_id} "
+                "(staged files were evicted at startup)"
+            )
+
     def _reconcile_staging_on_startup(self) -> None:
         """Reconcile staging orphans left by a crashed or killed session.
 
@@ -797,6 +841,14 @@ class Worker:
                 f"{len(report.evicted_model_ids)} orphaned model(s) "
                 f"({report.evicted_bytes / 2**30:.1f} GiB)"
             )
+            # The master may still hold DownloadCompleted entries for the
+            # files we just deleted, but this runs BEFORE state replay —
+            # there is no shard metadata to build the reset events from
+            # yet. Remember the IDs; plan_step counters the stale entries
+            # as soon as they appear in replicated state (the plan layer
+            # consults state.downloads, so leaving them would skip
+            # re-staging and fail a later load).
+            self._stale_downloads_pending_reset.update(report.evicted_model_ids)
 
     async def _poll_connection_updates(self):
         while True:

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -261,9 +261,10 @@ class Worker:
 
         self.state: State = State()
         self.runners: dict[RunnerId, RunnerSupervisor] = {}
-        # Models evicted by startup reconciliation whose DownloadCompleted
-        # entries may still be replicating in; countered lazily by
-        # plan_step once state carries them. IDs stay in the pending set
+        # Staging DIRECTORY NAMES (forward-sanitized) of models evicted by
+        # startup reconciliation whose DownloadCompleted entries may still
+        # be replicating in; countered lazily by
+        # plan_step once state carries them. Names stay in the pending set
         # until the reset has APPLIED (state stops advertising the stale
         # entry) — discarding on send would reopen the plan gate while the
         # event is still round-tripping through the master.
@@ -884,7 +885,9 @@ class Worker:
         for progress in self.state.downloads.get(self.node_id, []):
             if (
                 isinstance(progress, DownloadCompleted)
-                and str(progress.shard_metadata.model_card.model_id)
+                and staging_directory_name(
+                    str(progress.shard_metadata.model_card.model_id)
+                )
                 in self._stale_downloads_pending_reset
             ):
                 return True
@@ -909,16 +912,17 @@ class Worker:
             if not isinstance(progress, DownloadCompleted):
                 continue
             model_id = str(progress.shard_metadata.model_card.model_id)
-            if model_id not in self._stale_downloads_pending_reset:
+            directory_name = staging_directory_name(model_id)
+            if directory_name not in self._stale_downloads_pending_reset:
                 continue
-            staged_dir = cache_path / model_id.replace("/", "--")
+            staged_dir = cache_path / directory_name
             if staged_dir.exists():
                 # Re-staged since eviction — state is truthful again.
-                self._stale_downloads_pending_reset.discard(model_id)
-                self._stale_resets_sent.discard(model_id)
+                self._stale_downloads_pending_reset.discard(directory_name)
+                self._stale_resets_sent.discard(directory_name)
                 continue
-            still_completed.add(model_id)
-            if model_id in self._stale_resets_sent:
+            still_completed.add(directory_name)
+            if directory_name in self._stale_resets_sent:
                 continue  # reset in flight; keep gating until it applies
             pending = DownloadPending(
                 shard_metadata=progress.shard_metadata,
@@ -928,17 +932,17 @@ class Worker:
             await self.event_sender.send(
                 NodeDownloadProgress(download_progress=pending)
             )
-            self._stale_resets_sent.add(model_id)
+            self._stale_resets_sent.add(directory_name)
             logger.info(
                 f"Worker: reset stale DownloadCompleted for {model_id} "
                 "(staged files were evicted at startup)"
             )
         # Anything we sent a reset for that state no longer advertises has
         # APPLIED — only then does it stop gating the planner.
-        for model_id in list(self._stale_resets_sent):
-            if model_id not in still_completed:
-                self._stale_downloads_pending_reset.discard(model_id)
-                self._stale_resets_sent.discard(model_id)
+        for directory_name in list(self._stale_resets_sent):
+            if directory_name not in still_completed:
+                self._stale_downloads_pending_reset.discard(directory_name)
+                self._stale_resets_sent.discard(directory_name)
         if not self._stale_downloads_pending_reset:
             self._stale_reset_wait_ticks = 0
 
@@ -967,11 +971,16 @@ class Worker:
             # The master may still hold DownloadCompleted entries for the
             # files we just deleted, but this runs BEFORE state replay —
             # there is no shard metadata to build the reset events from
-            # yet. Remember the IDs; plan_step counters the stale entries
-            # as soon as they appear in replicated state (the plan layer
-            # consults state.downloads, so leaving them would skip
-            # re-staging and fail a later load).
-            self._stale_downloads_pending_reset.update(report.evicted_model_ids)
+            # yet. Remember the DIRECTORY names (forward-sanitized; the
+            # report's repo-form ids are best-effort inverses and would be
+            # ambiguous for ids containing "--"); plan_step counters the
+            # stale entries as soon as they appear in replicated state
+            # (the plan layer consults state.downloads, so leaving them
+            # would skip re-staging and fail a later load).
+            self._stale_downloads_pending_reset.update(
+                staging_directory_name(model_id)
+                for model_id in report.evicted_model_ids
+            )
 
     async def _poll_connection_updates(self):
         while True:

--- a/src/exo/worker/main.py
+++ b/src/exo/worker/main.py
@@ -261,8 +261,12 @@ class Worker:
         self.runners: dict[RunnerId, RunnerSupervisor] = {}
         # Models evicted by startup reconciliation whose DownloadCompleted
         # entries may still be replicating in; countered lazily by
-        # plan_step once state carries them.
+        # plan_step once state carries them. IDs stay in the pending set
+        # until the reset has APPLIED (state stops advertising the stale
+        # entry) — discarding on send would reopen the plan gate while the
+        # event is still round-tripping through the master.
         self._stale_downloads_pending_reset: set[str] = set()
+        self._stale_resets_sent: set[str] = set()
         self._stale_reset_wait_ticks: int = 0
         self._tg: TaskGroup = TaskGroup()
 
@@ -847,8 +851,10 @@ class Worker:
         """
         if self._staging_config is None:
             self._stale_downloads_pending_reset.clear()
+            self._stale_resets_sent.clear()
             return
         cache_path = Path(self._staging_config.node_cache_path).expanduser()
+        still_completed: set[str] = set()
         for progress in self.state.downloads.get(self.node_id, []):
             if not isinstance(progress, DownloadCompleted):
                 continue
@@ -859,7 +865,11 @@ class Worker:
             if staged_dir.exists():
                 # Re-staged since eviction — state is truthful again.
                 self._stale_downloads_pending_reset.discard(model_id)
+                self._stale_resets_sent.discard(model_id)
                 continue
+            still_completed.add(model_id)
+            if model_id in self._stale_resets_sent:
+                continue  # reset in flight; keep gating until it applies
             pending = DownloadPending(
                 shard_metadata=progress.shard_metadata,
                 node_id=self.node_id,
@@ -868,11 +878,17 @@ class Worker:
             await self.event_sender.send(
                 NodeDownloadProgress(download_progress=pending)
             )
-            self._stale_downloads_pending_reset.discard(model_id)
+            self._stale_resets_sent.add(model_id)
             logger.info(
                 f"Worker: reset stale DownloadCompleted for {model_id} "
                 "(staged files were evicted at startup)"
             )
+        # Anything we sent a reset for that state no longer advertises has
+        # APPLIED — only then does it stop gating the planner.
+        for model_id in list(self._stale_resets_sent):
+            if model_id not in still_completed:
+                self._stale_downloads_pending_reset.discard(model_id)
+                self._stale_resets_sent.discard(model_id)
 
     def _reconcile_staging_on_startup(self) -> None:
         """Reconcile staging orphans left by a crashed or killed session.

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -138,6 +138,7 @@ If this fails with `404 No instance found for model ...`, the placement is not r
 - `GET /store/models/{model_id}/download/status`
 - `DELETE /store/models/{model_id}`
 - `POST /store/purge-staging`
+- `GET /store/storage`
 - `POST /store/models/{model_id}/optimize`
 - `GET /store/models/{model_id}/optimize/status`
 - `GET /filesystem/browse`
@@ -558,6 +559,27 @@ Behavior note:
 
 - Skulk searches `mlx-community` first.
 - If that returns nothing, it falls back to a broader Hugging Face search.
+
+### Per-node storage breakdown
+
+**GET** `/store/storage`
+
+Returns the local node's storage picture: every staged model with its size,
+last-use time, and whether a live instance (or one of its companion repos —
+MTP sidecar, assistant, vision weights) currently depends on it, plus
+event-log usage and free disk on the models volume. Cluster-wide views query
+each node's API.
+
+```bash
+curl http://localhost:52415/store/storage
+```
+
+Staged copies are managed automatically when the model store is on: when an
+instance shuts down (and at node startup, which reconciles copies orphaned
+by a crash), not-in-use staged models are kept newest-first up to the
+`staging_keep_recent_gb` grace budget (default 40 GiB) and evicted beyond
+it. Set `cleanup_on_deactivate: false` in the staging config to keep every
+staged copy and manage cleanup manually via `POST /store/purge-staging`.
 
 ## Placement and Instance Management
 

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -191,6 +191,7 @@ Lives in `src/exo/api/main.py` (route registration in `API.__init__`).
 | `/place_instance` | POST | Place a model: master picks ranks. Takes `PlaceInstanceParams` (model id + placement preferences, optional `excluded_nodes: list[NodeId]` to exclude specific nodes from this placement); not interchangeable with `/instance`, which takes a fully-specified `CreateInstanceParams`. |
 | `/instance/{instance_id}` | GET / DELETE | Fetch / delete an instance |
 | `/instance/placement` | GET | Compute placement preview |
+| `/store/storage` | GET | Local node's storage breakdown: staged models (size, last-use, in-use incl. companions), event-log bytes, disk free. Staging eviction: `cleanup_on_deactivate` default true; not-in-use staged models kept newest-first up to `staging_keep_recent_gb` (40 GiB default), enforced at deactivate AND node startup (crash-orphan reconciliation); `src/exo/store/staging_eviction.py` |
 | `/instance/previews` | GET | List candidate placements |
 
 ### State / events

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -261,6 +261,8 @@ Models live under `SKULK_MODELS_DIR` — by default that resolves to `SKULK_DATA
 
 For multi-node deployments with shared filesystems, a model store hosts canonical model artifacts on one machine. Other nodes stage from the store (rsync-like) rather than each downloading from Hugging Face independently. This is a config-driven feature; without a store, each node downloads independently. See [Model Store](model-store) for setup details.
 
+Staged copies have a lifecycle: by default (`cleanup_on_deactivate: true`), a staged model becomes an eviction candidate when no live runner uses it — including as a companion repo (MTP sidecar, assistant, split vision weights), which no instance names directly but which a live runner depends on just the same. Candidates are kept newest-first by last use up to the `staging_keep_recent_gb` grace budget (default 40 GiB) and deleted beyond it. The same budget enforcement runs at instance deactivation and at node startup — the startup pass is what reconciles copies orphaned by a crashed session, and the grace budget is why a crash-restart cycle keeps its recent models warm instead of re-staging everything. `GET /store/storage` reports the per-node breakdown.
+
 ### Custom model cards
 
 User-added model cards live under `SKULK_CUSTOM_MODEL_CARDS_DIR` (default `SKULK_DATA_HOME/custom_model_cards`) as TOML files. On Linux that resolves to `~/.local/share/skulk/custom_model_cards`; on macOS/Windows to `~/.skulk/custom_model_cards`. Built-in cards live in `resources/inference_model_cards/`. The capability resolver reads both; custom cards override built-ins for the same `model_id`.


### PR DESCRIPTION
## PR A of the P1 launch sequence (store lifecycle — closes #212)

With the model store on, staged copies survived instance deletion and node crashes **forever** — the 58-70 GB piles that filled two nodes and killed one during the launch smoke. The existing `cleanup_on_deactivate` hook was defaulted off and never ran for dead sessions.

### Design: one mechanism, three triggers

A staged model is an **eviction candidate** when no live runner uses it — including as a companion (an MTP sidecar/assistant/vision repo of an active model is in-use even though no instance names it; evicting one corrupts a live runner because MLX loads lazily). Candidates are retained newest-first by last use up to the **`staging_keep_recent_gb` grace budget (default 40 GiB)** and deleted beyond it. The same enforcement runs:

1. at **instance deactivation** (`cleanup_on_deactivate` now defaults true),
2. at **node startup** — which is what reconciles orphans from crashed sessions, and
3. on demand (existing purge endpoints still work; `cleanup_on_deactivate: false` restores fully manual management).

The grace budget is a deliberate product decision: node deaths, restarts, and repeated place/delete cycles of the same model must not re-pay the staging copy every time. `.last_used` markers (touched on every staged-model resolution) drive the LRU ordering, since directory mtimes don't change on reads.

### Storage visibility

New **`GET /store/storage`**: the local node's breakdown — every staged model with size, last-use, and in-use status (companions included), event-log bytes, and disk capacity/free. This is the API surface for the storage health view (dashboard rendering joins the P3 audit; cluster-wide = query each node).

### Validation
- 7 new eviction tests (retention order, strict zero-budget, in-use + companion protection, budget-counts-candidates-only, LRU refresh, missing root) + config default pin updated to the new contract
- Full suite 852 passed; basedpyright 0 errors; ruff/fmt clean; OpenAPI export verified
- api-guide, architecture narrative + reference, CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)