### PR TITLE
fix(generate): bare repetition_penalty no longer crashes the runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- **A bare `repetition_penalty` no longer crashes the runner.** Requests
+  carrying `repetition_penalty` without `repetition_context_size` passed
+  the request's None straight into mlx-lm's processor builder, overriding
+  its default of 20; the penalty processor's `tokens[-None:]` slice then
+  raised and killed the runner on the first penalized request. Both call
+  sites now coerce None to the default. Found by the 2026-06-06
+  before/after benchmark matrix; applies to every model and every client
+  that sends a penalty alone (many do by default).
+
 ### Added
 
 - **Staged model copies now have a lifecycle, and nodes can report their

--- a/src/exo/worker/engines/mlx/generator/batch_generate.py
+++ b/src/exo/worker/engines/mlx/generator/batch_generate.py
@@ -296,7 +296,13 @@ class ExoBatchGenerator:
         logits_processors: list[Callable[[mx.array, mx.array], mx.array]] = (
             make_logits_processors(
                 repetition_penalty=task_params.repetition_penalty,
-                repetition_context_size=task_params.repetition_context_size,
+                # None must not override mlx-lm's default (see generate.py:
+                # a None context crashes the penalty processor).
+                repetition_context_size=(
+                    task_params.repetition_context_size
+                    if task_params.repetition_context_size is not None
+                    else 20
+                ),
             )
         )
         if is_bench:

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -2498,7 +2498,15 @@ def mlx_generate(
     logits_processors: list[Callable[[mx.array, mx.array], mx.array]] = (
         make_logits_processors(
             repetition_penalty=task.repetition_penalty,
-            repetition_context_size=task.repetition_context_size,
+            # None must not override mlx-lm's default context size: the
+            # penalty processor slices tokens[-context_size:], and a None
+            # context crashes the runner on the first penalized request
+            # (clients routinely send repetition_penalty alone).
+            repetition_context_size=(
+                task.repetition_context_size
+                if task.repetition_context_size is not None
+                else 20
+            ),
         )
     )
     if is_bench:

--- a/src/exo/worker/tests/unittests/test_mlx/test_repetition_penalty_processor.py
+++ b/src/exo/worker/tests/unittests/test_mlx/test_repetition_penalty_processor.py
@@ -1,0 +1,67 @@
+"""Regression: bare repetition_penalty must not crash the penalty processor.
+
+Clients routinely send ``repetition_penalty`` without
+``repetition_context_size``. Our call sites passed the request's None
+straight into ``make_logits_processors``, overriding mlx-lm's default of
+20 — and the processor's ``tokens[-context_size:]`` slice then raised
+``bad operand type for unary -`` and killed the runner (found by the
+2026-06-06 before/after benchmark matrix on gemma E2B; applies to every
+model).
+"""
+
+import mlx.core as mx
+from mlx_lm.sample_utils import make_logits_processors
+
+
+def _coerced_context_size(request_value: int | None) -> int:
+    """Mirror of the call-site coercion in generate.py / batch_generate.py."""
+    return request_value if request_value is not None else 20
+
+
+def test_bare_repetition_penalty_processes_without_crashing() -> None:
+    processors = make_logits_processors(
+        repetition_penalty=1.05,
+        repetition_context_size=_coerced_context_size(None),
+    )
+    assert processors, "penalty must produce a processor"
+
+    tokens = mx.array([1, 2, 3, 2, 1])
+    logits = mx.zeros((1, 16))
+    for processor in processors:
+        logits = processor(tokens, logits)
+    mx.eval(logits)
+    assert logits.shape == (1, 16)
+
+
+def test_none_context_size_reproduces_the_crash() -> None:
+    """Documents WHY the coercion exists: passing None through crashes."""
+    processors = make_logits_processors(
+        repetition_penalty=1.05,
+        repetition_context_size=None,
+    )
+    tokens = mx.array([1, 2, 3])
+    logits = mx.zeros((1, 16))
+    crashed = False
+    try:
+        for processor in processors:
+            logits = processor(tokens, logits)
+        mx.eval(logits)
+    except TypeError:
+        crashed = True
+    assert crashed, (
+        "mlx-lm accepted a None context size — the call-site coercion may "
+        "no longer be necessary; revisit before removing it"
+    )
+
+
+def test_explicit_context_size_is_respected() -> None:
+    processors = make_logits_processors(
+        repetition_penalty=1.05,
+        repetition_context_size=_coerced_context_size(64),
+    )
+    tokens = mx.array([1, 2, 3, 2, 1])
+    logits = mx.zeros((1, 16))
+    for processor in processors:
+        logits = processor(tokens, logits)
+    mx.eval(logits)
+    assert logits.shape == (1, 16)


### PR DESCRIPTION
## Severity 5, found by the before/after benchmark matrix

A request carrying `repetition_penalty` **without** `repetition_context_size` — which many clients send by default, and which is also our documented speculation-disable fallback — crashed the runner: both call sites passed the request's `None` straight into `make_logits_processors`, overriding mlx-lm's default of 20, and the penalty processor's `tokens[-None:]` slice raised `bad operand type for unary -`. The exception escaped the task loop and killed the runner; queued requests then timed out against the corpse.

## Fix
Coerce `None` to the mlx-lm default (20) at both call sites (`generate.py`, `batch_generate.py`).

## Tests
Three regression tests: the coerced path processes cleanly; the None path still crashes in mlx-lm (documents why the coercion exists and flags if a future mlx-lm makes it unnecessary); explicit sizes respected. Full suite 892 green.

## Follow-up noted (not in this PR)
A per-request exception should fail the task, not the runner — the containment gap that turned this into a runner death is filed in the launch plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)