### PR TITLE
feat(cards): speculative_multi_node knob; disable 2-node MoE speculation where measured slower

### DIFF
--- a/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-26b-a4b-it-4bit.toml
@@ -39,6 +39,13 @@ assistant_model_repo = "mlx-community/gemma-4-26B-A4B-it-assistant-bf16"
 # WindowServer, and trips the macOS userspace watchdog into a kernel panic.
 # Reproduced 2026-04 on M4 (Mac16,10) with multinode pipeline-parallel.
 metal_fast_synch = false
+# Multi-node speculation measured SLOWER than plain sharded decode on this
+# MoE: 2026-06-06 matrix, 2-node pipeline on 2x M4 16GB — 30.2 tok/s plain
+# vs 28.2 with MTP (62-76% acceptance). Sharding halves the active-params
+# bandwidth bottleneck, so plain decode is already fast and the per-round
+# draft+verify overhead nets negative. Single-node MTP on this model
+# measures 2.2x (16 -> 35.1 tok/s) and stays enabled.
+speculative_multi_node = false
 
 [vision]
 image_token_id = 258880

--- a/src/exo/shared/models/model_cards.py
+++ b/src/exo/shared/models/model_cards.py
@@ -131,6 +131,22 @@ class VisionCardConfig(CamelCaseModel):
     eoi_token_id: int | None = None
 
 
+def multi_node_speculation_disabled(
+    runtime: "RuntimeCapabilityCardConfig | None", world_size: int
+) -> bool:
+    """True when the card forbids speculation for this placement size.
+
+    Shared by the runner's drafter-load gate and the generation loop's
+    distributed-agreement gate so both make the identical, rank-symmetric
+    decision from the card alone.
+    """
+    return (
+        world_size > 1
+        and runtime is not None
+        and runtime.speculative_multi_node is False
+    )
+
+
 class ReasoningFormat(str, Enum):
     """Reasoning marker formats used by model families."""
 
@@ -286,6 +302,21 @@ class RuntimeCapabilityCardConfig(CamelCaseModel):
     ``None`` falls through to the family default keyed off the detected
     sidecar layout.
     """
+    speculative_multi_node: bool | None = None
+    """Whether speculation may run on multi-node placements of this model.
+
+    ``None`` (default) places no restriction. Set ``False`` for models
+    where multi-node speculation is measured SLOWER than plain distributed
+    decode: the 2026-06-06 benchmark matrix found gemma-4-26B-A4B (MoE)
+    at 30.2 tok/s plain vs 28.2 with MTP on a 2-node pipeline (-7%), while
+    single-node MTP on the same model measures 2.2x — fast sharded MoE
+    decode plus modest acceptance makes the per-round draft+verify
+    overhead net negative. Single-node speculation is unaffected by this
+    knob. The decision is card-driven so every rank makes the same
+    speculate-or-not choice (the distributed agreement collective requires
+    rank symmetry).
+    """
+
     assistant_model_repo: str | None = None
     """Hugging Face repo ID of a companion *assistant* (drafter) model.
 

--- a/src/exo/shared/tests/test_multi_node_speculation_gate.py
+++ b/src/exo/shared/tests/test_multi_node_speculation_gate.py
@@ -1,0 +1,51 @@
+"""Tests for the multi-node speculation card gate.
+
+Cards can forbid speculation on multi-node placements where it is
+measured slower than plain distributed decode (2026-06-06 matrix:
+gemma-4-26B-A4B 2-node pipeline, 30.2 plain vs 28.2 with MTP). The
+predicate is shared by the drafter-load gate and the distributed
+agreement gate so every rank decides identically from the card.
+"""
+
+from exo.shared.models.model_cards import (
+    RuntimeCapabilityCardConfig,
+    multi_node_speculation_disabled,
+)
+
+
+def test_unset_knob_places_no_restriction() -> None:
+    runtime = RuntimeCapabilityCardConfig(
+        assistant_model_repo="mlx-community/gemma-4-26B-A4B-it-assistant-bf16"
+    )
+    assert not multi_node_speculation_disabled(runtime, 1)
+    assert not multi_node_speculation_disabled(runtime, 2)
+
+
+def test_false_knob_blocks_multi_node_only() -> None:
+    runtime = RuntimeCapabilityCardConfig(
+        speculative_multi_node=False,
+        assistant_model_repo="mlx-community/gemma-4-26B-A4B-it-assistant-bf16",
+    )
+    assert not multi_node_speculation_disabled(runtime, 1)
+    assert multi_node_speculation_disabled(runtime, 2)
+    assert multi_node_speculation_disabled(runtime, 3)
+
+
+def test_true_knob_and_missing_runtime_allow_everything() -> None:
+    assert not multi_node_speculation_disabled(None, 2)
+    runtime = RuntimeCapabilityCardConfig(speculative_multi_node=True)
+    assert not multi_node_speculation_disabled(runtime, 2)
+
+
+def test_26b_card_pins_the_measured_negative() -> None:
+    import asyncio
+
+    from exo.shared.models.model_cards import ModelCard, ModelId
+
+    card = asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+        ModelCard.load(ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"))
+    )
+    assert card.runtime is not None
+    assert card.runtime.speculative_multi_node is False
+    assert multi_node_speculation_disabled(card.runtime, 2)
+    assert not multi_node_speculation_disabled(card.runtime, 1)

--- a/src/exo/worker/engines/mlx/generator/generate.py
+++ b/src/exo/worker/engines/mlx/generator/generate.py
@@ -35,7 +35,7 @@ from exo.api.types import (
     Usage,
 )
 from exo.shared.constants import preferred_env_value
-from exo.shared.models.model_cards import ModelCard
+from exo.shared.models.model_cards import ModelCard, multi_node_speculation_disabled
 from exo.shared.tracing import TraceAttrValue, record_trace_marker, trace
 from exo.shared.types.common import ModelId
 from exo.shared.types.memory import Memory
@@ -2799,6 +2799,7 @@ def mlx_generate(
         and group is not None
         and group.size() > 1
         and _has_pipeline_communication_layer(model)
+        and not multi_node_speculation_disabled(model_card.runtime, group.size())
     )
     if _speculation_assets or _pipeline_assistant_mode:
         if logits_processors:
@@ -2853,6 +2854,13 @@ def mlx_generate(
         and (
             model_card.runtime.mtp_sidecar_repo is not None
             or model_card.runtime.assistant_model_repo is not None
+        )
+        # A card that forbids multi-node speculation does not declare it
+        # for this placement — no rank opens the agreement collective and
+        # every rank skips it identically (the knob is card-driven, hence
+        # rank-symmetric).
+        and not multi_node_speculation_disabled(
+            model_card.runtime, 1 if group is None else group.size()
         )
     )
     if _card_declares_speculation and group is not None and group.size() > 1:

--- a/src/exo/worker/engines/mlx/utils_mlx.py
+++ b/src/exo/worker/engines/mlx/utils_mlx.py
@@ -36,6 +36,7 @@ from exo.shared.models.model_cards import (
     PromptRendererType,
     ToolCallFormat,
     get_card,
+    multi_node_speculation_disabled,
 )
 from exo.worker.engines.mlx.constants import TRUST_REMOTE_CODE
 
@@ -708,6 +709,19 @@ def load_mlx_items(
     # (#201 Track 2b); don't pay assistant memory for speculation that
     # will never run, and on tight shard fits the eager load could OOM.
     single_node = group is None or group.size() <= 1
+    # Cards can forbid speculation on multi-node placements outright
+    # (measured slower than plain distributed decode — e.g. sharded MoE);
+    # skip the drafter weights entirely so no rank pays the memory.
+    speculation_blocked_for_placement = multi_node_speculation_disabled(
+        runtime, 1 if group is None else group.size()
+    )
+    if speculation_blocked_for_placement and runtime is not None:
+        logger.info(
+            "Speculative decoding disabled for this placement by the model "
+            f"card (speculative_multi_node=false, world_size={group.size() if group else 1}); "
+            "running plain distributed decode (single-node placements of "
+            "this model keep speculation)."
+        )
     # Assistants on pipeline placements load on the LAST rank only (#201
     # Track 2b): the assistant cross-attends the target's last
     # full-attention and sliding KV layers, which live in the final slice —
@@ -722,8 +736,13 @@ def load_mlx_items(
         single_node
         or isinstance(bound_shard, TensorShardMetadata)
         or is_last_pipeline_rank
-    )
-    if runtime and runtime.mtp_sidecar_repo and runtime.mtp_heads:
+    ) and not speculation_blocked_for_placement
+    if (
+        runtime
+        and runtime.mtp_sidecar_repo
+        and runtime.mtp_heads
+        and not speculation_blocked_for_placement
+    ):
         # Sidecar repos carry only mtp.safetensors (no config.json), so they
         # must be resolved with the sidecar resolver — build_model_path's
         # model-completeness check rejects their directories.

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -316,7 +316,7 @@ Note: there is no `master_node_id` field on `State`. Master identity lives outsi
 - `reasoning: ReasoningCardConfig | None` — supports_toggle, supports_budget, format, default_effort
 - `modalities: ModalitiesCardConfig | None` — supports_native_multimodal, supports_audio_input
 - `tooling: ToolingCardConfig | None` — tool_call_format, supports_tool_calling, builtin_tools
-- `runtime: RuntimeCapabilityCardConfig | None` — prompt_renderer, output_parser, metal_fast_synch, mtp_heads, mtp_max_depth, mtp_sidecar_repo, mtp_norm_convention, mtp_concat_order, assistant_model_repo
+- `runtime: RuntimeCapabilityCardConfig | None` — prompt_renderer, output_parser, metal_fast_synch, mtp_heads, mtp_max_depth, mtp_sidecar_repo, mtp_norm_convention, mtp_concat_order, assistant_model_repo, speculative_multi_node (set `false` where multi-node speculation measures slower than plain sharded decode — e.g. gemma-4-26B-A4B MoE, 2026-06-06 matrix: 30.2 plain vs 28.2 MTP on 2 nodes; single-node speculation unaffected; card-driven so the agreement collective stays rank-symmetric)
 
 ### Capability profile
 


### PR DESCRIPTION
## Why

The 2026-06-06 before/after benchmark matrix produced a clean negative: **gemma-4-26B-A4B (MoE) on a 2-node pipeline runs FASTER without speculation** — 30.2 tok/s plain vs 28.2 with MTP at 62–76% acceptance. Sharding halves the active-params bandwidth bottleneck, so plain sharded MoE decode is already fast, and the per-round draft+verify overhead nets −7%. Single-node MTP on the same model measures **2.2×** (16 → 35.1) and must stay enabled. (This corroborates the Qwen3.5-35B-A3B negative from the cadence work, whose cards already omit MTP entirely.)

Policy (Tupp): every measured-negative configuration gets speculation disabled; all negatives noted for investigation.

## What

- `runtime.speculative_multi_node: bool | None` — default unrestricted; `false` = speculation on single-node placements only
- Shared predicate `multi_node_speculation_disabled(runtime, world_size)` enforced at both decision points: the drafter weight load in `load_mlx_items` (no rank pays assistant memory) and the generation loop's pipeline-assistant-mode + distributed-agreement gates — card-driven, hence rank-symmetric by construction
- gemma-4-26B-A4B card pins `false` with the measurement in a comment
- 4 gate tests incl. a card-pin regression test; full suite 893 green
- CHANGELOG + architecture-reference updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)