### PR TITLE
fix(api): terminate open requests when their instance dies mid-generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Requests no longer hang when a node dies mid-generation.** When an
+  instance was lost (node disconnect, crash, or deletion with a request
+  in flight), the master tore the instance down but left the task
+  orphaned — the API never received a terminal chunk, so the open HTTP
+  connection hung until the client's own timeout. The master's plan loop
+  now emits `TaskFailed` for in-flight API tasks whose instance is gone,
+  and the API turns that into a terminal error chunk: streaming
+  responses close with an error event, non-streaming requests return a
+  500. Found by the 2026-06-07 node-kill drill (#223).
+
 - **A bare `repetition_penalty` no longer crashes the runner.** Requests
   carrying `repetition_penalty` without `repetition_context_size` passed
   the request's None straight into mlx-lm's processor builder, overriding

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -21,7 +21,7 @@ import httpx
 import hypercorn.asyncio as hypercorn_asyncio
 import psutil
 import yaml
-from anyio import BrokenResourceError, to_thread
+from anyio import BrokenResourceError, ClosedResourceError, to_thread
 from fastapi import FastAPI, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
@@ -234,6 +234,7 @@ from exo.shared.types.events import (
     IndexedEvent,
     StateSnapshotHydrated,
     TaskFailed,
+    TaskStatusUpdated,
     TracesMerged,
 )
 from exo.shared.types.memory import Memory
@@ -2937,11 +2938,31 @@ class API:
                         except BrokenResourceError:
                             self._embedding_queues.pop(event.command_id, None)
                 if isinstance(event, TaskFailed):
-                    await self._terminate_failed_command_stream(event)
+                    await self._terminate_command_stream(
+                        event.task_id,
+                        event.error_message
+                        or "The instance executing this request was lost",
+                    )
+                if (
+                    isinstance(event, TaskStatusUpdated)
+                    and event.task_status == task_types.TaskStatus.Cancelled
+                ):
+                    # Operator-initiated instance deletion cancels in-flight
+                    # tasks (get_transition_events); without a terminal chunk
+                    # those requests would hang exactly like node-death ones.
+                    # Client-initiated cancels already closed their queue, so
+                    # this is a no-op for them.
+                    await self._terminate_command_stream(
+                        event.task_id,
+                        "The request was cancelled because its instance "
+                        "was deleted",
+                    )
                 if isinstance(event, TracesMerged):
                     self._save_merged_trace(event)
 
-    async def _terminate_failed_command_stream(self, event: TaskFailed) -> None:
+    async def _terminate_command_stream(
+        self, task_id: task_types.TaskId, error_message: str
+    ) -> None:
         """Deliver a terminal ErrorChunk for a task the master declared dead.
 
         Without this, a request whose instance died mid-generation never
@@ -2951,7 +2972,7 @@ class API:
         error chunk and close, and non-streaming handlers raise their
         existing finish_reason == "error" path.
         """
-        task = self.state.tasks.get(event.task_id)
+        task = self.state.tasks.get(task_id)
         if not isinstance(
             task,
             (
@@ -2966,8 +2987,7 @@ class API:
         # already ModelId.
         error_chunk = ErrorChunk(
             model=ModelId(task.task_params.model),
-            error_message=event.error_message
-            or "The instance executing this request was lost",
+            error_message=error_message,
         )
         for queue_map in (
             self._text_generation_queues,
@@ -2977,7 +2997,7 @@ class API:
             if queue := queue_map.get(task.command_id):
                 try:
                     await queue.send(error_chunk)
-                except BrokenResourceError:
+                except (BrokenResourceError, ClosedResourceError):
                     queue_map.pop(task.command_id, None)
 
     def _save_merged_trace(self, event: TracesMerged) -> None:

--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -233,6 +233,7 @@ from exo.shared.types.events import (
     Event,
     IndexedEvent,
     StateSnapshotHydrated,
+    TaskFailed,
     TracesMerged,
 )
 from exo.shared.types.memory import Memory
@@ -2935,8 +2936,49 @@ class API:
                             await queue.send(event.chunk)
                         except BrokenResourceError:
                             self._embedding_queues.pop(event.command_id, None)
+                if isinstance(event, TaskFailed):
+                    await self._terminate_failed_command_stream(event)
                 if isinstance(event, TracesMerged):
                     self._save_merged_trace(event)
+
+    async def _terminate_failed_command_stream(self, event: TaskFailed) -> None:
+        """Deliver a terminal ErrorChunk for a task the master declared dead.
+
+        Without this, a request whose instance died mid-generation never
+        receives a terminal chunk and the HTTP connection hangs until the
+        client's own timeout (#223). The chunk flows through the same
+        per-command queue as runner output, so streaming responses emit an
+        error chunk and close, and non-streaming handlers raise their
+        existing finish_reason == "error" path.
+        """
+        task = self.state.tasks.get(event.task_id)
+        if not isinstance(
+            task,
+            (
+                task_types.TextGeneration,
+                task_types.ImageGeneration,
+                task_types.ImageEdits,
+                task_types.TextEmbedding,
+            ),
+        ):
+            return
+        # Image task params carry the wire-form model string; the others are
+        # already ModelId.
+        error_chunk = ErrorChunk(
+            model=ModelId(task.task_params.model),
+            error_message=event.error_message
+            or "The instance executing this request was lost",
+        )
+        for queue_map in (
+            self._text_generation_queues,
+            self._image_generation_queues,
+            self._embedding_queues,
+        ):
+            if queue := queue_map.get(task.command_id):
+                try:
+                    await queue.send(error_chunk)
+                except BrokenResourceError:
+                    queue_map.pop(task.command_id, None)
 
     def _save_merged_trace(self, event: TracesMerged) -> None:
         traces = [

--- a/src/exo/api/tests/test_task_failed_stream_termination.py
+++ b/src/exo/api/tests/test_task_failed_stream_termination.py
@@ -1,0 +1,101 @@
+# pyright: reportPrivateUsage=false, reportAny=false
+"""Tests for the API terminating open command streams on TaskFailed (#223).
+
+The API half of the node-death fix: when the master declares a task dead,
+the per-command chunk queue must receive a terminal ErrorChunk so streaming
+responses close with an error and non-streaming handlers raise — instead of
+the HTTP connection hanging until the client's own timeout.
+"""
+
+from typing import Any
+
+import pytest
+
+from exo.api.main import API
+from exo.shared.types.chunks import ErrorChunk
+from exo.shared.types.common import CommandId, ModelId
+from exo.shared.types.events import TaskFailed
+from exo.shared.types.state import State
+from exo.shared.types.tasks import TaskId, TaskStatus
+from exo.shared.types.tasks import TextGeneration as TextGenerationTask
+from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+from exo.shared.types.worker.instances import InstanceId
+from exo.utils.channels import channel
+
+
+def _make_api() -> Any:
+    api = object.__new__(API)
+    api._text_generation_queues = {}
+    api._image_generation_queues = {}
+    api._embedding_queues = {}
+    return api
+
+
+def _failed_task(command_id: CommandId) -> TextGenerationTask:
+    return TextGenerationTask(
+        task_id=TaskId(),
+        instance_id=InstanceId(),
+        task_status=TaskStatus.Failed,
+        command_id=command_id,
+        task_params=TextGenerationTaskParams(
+            model=ModelId("test-model"),
+            input=[InputMessage(role="user", content="hi")],
+        ),
+        error_type="instance_lost",
+        error_message="instance gone",
+    )
+
+
+async def test_task_failed_delivers_error_chunk() -> None:
+    api = _make_api()
+    command_id = CommandId()
+    task = _failed_task(command_id)
+    api.state = State().model_copy(update={"tasks": {task.task_id: task}})
+
+    sender, receiver = channel[Any]()
+    api._text_generation_queues[command_id] = sender
+
+    await api._terminate_failed_command_stream(
+        TaskFailed(
+            task_id=task.task_id,
+            error_type="instance_lost",
+            error_message="instance gone",
+        )
+    )
+
+    chunk = receiver.receive_nowait()
+    assert isinstance(chunk, ErrorChunk)
+    assert chunk.finish_reason == "error"
+    assert chunk.error_message == "instance gone"
+    assert chunk.model == ModelId("test-model")
+
+
+async def test_task_failed_for_unknown_task_is_ignored() -> None:
+    api = _make_api()
+    api.state = State()
+    # No queues registered, no task in state — must not raise.
+    await api._terminate_failed_command_stream(
+        TaskFailed(task_id=TaskId(), error_type="x", error_message="y")
+    )
+
+
+async def test_task_failed_with_closed_queue_drops_entry() -> None:
+    """A request that disconnected concurrently leaves a broken queue; the
+    handler must drop it rather than raise into the event-apply loop."""
+    api = _make_api()
+    command_id = CommandId()
+    task = _failed_task(command_id)
+    api.state = State().model_copy(update={"tasks": {task.task_id: task}})
+
+    sender, receiver = channel[Any]()
+    receiver.close()
+    api._text_generation_queues[command_id] = sender
+
+    await api._terminate_failed_command_stream(
+        TaskFailed(task_id=task.task_id, error_type="x", error_message="y")
+    )
+    assert command_id not in api._text_generation_queues
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/exo/api/tests/test_task_failed_stream_termination.py
+++ b/src/exo/api/tests/test_task_failed_stream_termination.py
@@ -14,7 +14,6 @@ import pytest
 from exo.api.main import API
 from exo.shared.types.chunks import ErrorChunk
 from exo.shared.types.common import CommandId, ModelId
-from exo.shared.types.events import TaskFailed
 from exo.shared.types.state import State
 from exo.shared.types.tasks import TaskId, TaskStatus
 from exo.shared.types.tasks import TextGeneration as TextGenerationTask
@@ -55,13 +54,7 @@ async def test_task_failed_delivers_error_chunk() -> None:
     sender, receiver = channel[Any]()
     api._text_generation_queues[command_id] = sender
 
-    await api._terminate_failed_command_stream(
-        TaskFailed(
-            task_id=task.task_id,
-            error_type="instance_lost",
-            error_message="instance gone",
-        )
-    )
+    await api._terminate_command_stream(task.task_id, "instance gone")
 
     chunk = receiver.receive_nowait()
     assert isinstance(chunk, ErrorChunk)
@@ -74,9 +67,30 @@ async def test_task_failed_for_unknown_task_is_ignored() -> None:
     api = _make_api()
     api.state = State()
     # No queues registered, no task in state — must not raise.
-    await api._terminate_failed_command_stream(
-        TaskFailed(task_id=TaskId(), error_type="x", error_message="y")
+    await api._terminate_command_stream(TaskId(), "y")
+
+
+async def test_cancelled_status_delivers_error_chunk() -> None:
+    """Operator instance deletion cancels in-flight tasks via
+    TaskStatusUpdated(Cancelled); those requests must terminate too (#224
+    review catch)."""
+    api = _make_api()
+    command_id = CommandId()
+    task = _failed_task(command_id).model_copy(
+        update={"task_status": TaskStatus.Cancelled}
     )
+    api.state = State().model_copy(update={"tasks": {task.task_id: task}})
+
+    sender, receiver = channel[Any]()
+    api._text_generation_queues[command_id] = sender
+
+    await api._terminate_command_stream(
+        task.task_id, "The request was cancelled because its instance was deleted"
+    )
+
+    chunk = receiver.receive_nowait()
+    assert isinstance(chunk, ErrorChunk)
+    assert "cancelled" in chunk.error_message
 
 
 async def test_task_failed_with_closed_queue_drops_entry() -> None:
@@ -91,9 +105,7 @@ async def test_task_failed_with_closed_queue_drops_entry() -> None:
     receiver.close()
     api._text_generation_queues[command_id] = sender
 
-    await api._terminate_failed_command_stream(
-        TaskFailed(task_id=task.task_id, error_type="x", error_message="y")
-    )
+    await api._terminate_command_stream(task.task_id, "y")
     assert command_id not in api._text_generation_queues
 
 

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -1,4 +1,5 @@
 import copy
+from collections.abc import Set as AbstractSet
 from datetime import datetime, timedelta, timezone
 from typing import cast
 
@@ -48,6 +49,7 @@ from exo.shared.types.events import (
     NodeTimedOut,
     TaskCreated,
     TaskDeleted,
+    TaskFailed,
     TaskStatusUpdated,
     TraceEventData,
     TracesCollected,
@@ -84,6 +86,57 @@ EVENT_LOG_REPLAY_BATCH_SIZE = 10_000
 SNAPSHOT_EVENT_CADENCE = 10_000
 REPLAY_TAIL_RETENTION_EVENTS = SNAPSHOT_EVENT_CADENCE
 JsonObject = dict[str, object]
+
+# API-facing task types: the ones whose loss strands an open HTTP request.
+# Worker lifecycle tasks (CreateRunner, LoadModel, ...) are reconciled by the
+# worker's own plan loop and must not be failed from here.
+_COMMAND_TASK_TYPES = (
+    TextGenerationTask,
+    ImageGenerationTask,
+    ImageEditsTask,
+    TextEmbeddingTask,
+)
+
+
+def orphaned_task_failure_events(
+    state: State,
+    dying_instance_ids: AbstractSet[InstanceId],
+) -> list[TaskFailed]:
+    """Fail in-flight API tasks whose instance is gone or being torn down.
+
+    Without this, a node death mid-generation leaves the task in state
+    forever and the API's chunk queue never receives a terminal chunk — the
+    client request hangs until its own timeout (issue #223). The master is
+    the only component with the global view to declare these tasks dead.
+
+    Pure function of the master's current state so it can be tested without
+    channel plumbing; ``dying_instance_ids`` covers instances whose
+    InstanceDeleted was emitted in the same plan pass (state still lists
+    them until the event round-trips through indexing and apply).
+    """
+    events: list[TaskFailed] = []
+    for task_id, task in state.tasks.items():
+        if not isinstance(task, _COMMAND_TASK_TYPES):
+            continue
+        if task.task_status not in (TaskStatus.Pending, TaskStatus.Running):
+            continue
+        instance_gone = (
+            task.instance_id not in state.instances
+            or task.instance_id in dying_instance_ids
+        )
+        if not instance_gone:
+            continue
+        events.append(
+            TaskFailed(
+                task_id=task_id,
+                error_type="instance_lost",
+                error_message=(
+                    "The instance executing this request was lost "
+                    "(node disconnected or instance deleted)"
+                ),
+            )
+        )
+    return events
 
 
 class Master:
@@ -494,13 +547,28 @@ class Master:
         while True:
             # kill broken instances
             connected_node_ids = set(self.state.topology.list_nodes())
+            dying_instance_ids: set[InstanceId] = set()
             for instance_id, instance in self.state.instances.items():
                 for node_id in instance.shard_assignments.node_to_runner:
                     if node_id not in connected_node_ids:
+                        dying_instance_ids.add(instance_id)
                         await self.event_sender.send(
                             InstanceDeleted(instance_id=instance_id)
                         )
                         break
+
+            # Fail in-flight API tasks stranded by a dead or deleted instance
+            # so open HTTP requests terminate with an error instead of
+            # hanging (#223). TaskFailed flips task_status to Failed on
+            # apply, so each task is emitted at most once across passes.
+            for task_failed in orphaned_task_failure_events(
+                self.state, dying_instance_ids
+            ):
+                logger.warning(
+                    f"Failing orphaned task {task_failed.task_id}: "
+                    f"{task_failed.error_message}"
+                )
+                await self.event_sender.send(task_failed)
 
             # time out dead nodes
             for node_id, time in self.state.last_seen.items():

--- a/src/exo/master/main.py
+++ b/src/exo/master/main.py
@@ -98,6 +98,27 @@ _COMMAND_TASK_TYPES = (
 )
 
 
+def instances_on_dead_nodes(
+    state: State,
+    connected_node_ids: AbstractSet[NodeId],
+    timed_out_node_ids: AbstractSet[NodeId],
+) -> set[InstanceId]:
+    """Instances with at least one shard on a disconnected or timed-out node.
+
+    Timed-out nodes matter even while still present in topology: NodeTimedOut
+    removes the node's instances AND their tasks from state in one apply, so
+    any TaskFailed for those tasks must be emitted before that event — a
+    later plan pass would no longer see them (#224 review catch).
+    """
+    dying: set[InstanceId] = set()
+    for instance_id, instance in state.instances.items():
+        for node_id in instance.shard_assignments.node_to_runner:
+            if node_id not in connected_node_ids or node_id in timed_out_node_ids:
+                dying.add(instance_id)
+                break
+    return dying
+
+
 def orphaned_task_failure_events(
     state: State,
     dying_instance_ids: AbstractSet[InstanceId],
@@ -545,22 +566,24 @@ class Master:
     # These plan loops are the cracks showing in our event sourcing architecture - more things could be commands
     async def _plan(self) -> None:
         while True:
-            # kill broken instances
             connected_node_ids = set(self.state.topology.list_nodes())
-            dying_instance_ids: set[InstanceId] = set()
-            for instance_id, instance in self.state.instances.items():
-                for node_id in instance.shard_assignments.node_to_runner:
-                    if node_id not in connected_node_ids:
-                        dying_instance_ids.add(instance_id)
-                        await self.event_sender.send(
-                            InstanceDeleted(instance_id=instance_id)
-                        )
-                        break
+            now = datetime.now(tz=timezone.utc)
+            timed_out_node_ids = {
+                node_id
+                for node_id, time in self.state.last_seen.items()
+                if now - time > timedelta(seconds=30)
+            }
+            dying_instance_ids = instances_on_dead_nodes(
+                self.state, connected_node_ids, timed_out_node_ids
+            )
 
-            # Fail in-flight API tasks stranded by a dead or deleted instance
+            # Fail in-flight API tasks stranded by a dead or dying instance
             # so open HTTP requests terminate with an error instead of
-            # hanging (#223). TaskFailed flips task_status to Failed on
-            # apply, so each task is emitted at most once across passes.
+            # hanging (#223). Emitted BEFORE InstanceDeleted/NodeTimedOut so
+            # TaskFailed indexes ahead of the applies that remove the task
+            # from state (NodeTimedOut deletes its instances' tasks
+            # outright). TaskFailed flips task_status to Failed on apply, so
+            # each task is emitted at most once across passes.
             for task_failed in orphaned_task_failure_events(
                 self.state, dying_instance_ids
             ):
@@ -570,12 +593,19 @@ class Master:
                 )
                 await self.event_sender.send(task_failed)
 
+            # kill broken instances
+            for instance_id, instance in self.state.instances.items():
+                for node_id in instance.shard_assignments.node_to_runner:
+                    if node_id not in connected_node_ids:
+                        await self.event_sender.send(
+                            InstanceDeleted(instance_id=instance_id)
+                        )
+                        break
+
             # time out dead nodes
-            for node_id, time in self.state.last_seen.items():
-                now = datetime.now(tz=timezone.utc)
-                if now - time > timedelta(seconds=30):
-                    logger.info(f"Manually removing node {node_id} due to inactivity")
-                    await self.event_sender.send(NodeTimedOut(node_id=node_id))
+            for node_id in timed_out_node_ids:
+                logger.info(f"Manually removing node {node_id} due to inactivity")
+                await self.event_sender.send(NodeTimedOut(node_id=node_id))
 
             await anyio.sleep(10)
 

--- a/src/exo/master/tests/test_orphaned_task_failures.py
+++ b/src/exo/master/tests/test_orphaned_task_failures.py
@@ -135,6 +135,31 @@ def test_terminal_task_not_failed_again() -> None:
         assert orphaned_task_failure_events(state, frozenset()) == []
 
 
+def test_sweep_is_idempotent_after_apply() -> None:
+    """Applying the emitted TaskFailed must silence the next plan pass.
+
+    Review catch on #224: apply_task_failed originally stored only the error
+    fields without flipping task_status, so a task whose API never sent
+    TaskFinished (e.g. the API restarted) was re-failed every 10 seconds
+    forever — unbounded event-log growth.
+    """
+    from exo.shared.apply import apply_task_failed
+
+    instance_id = InstanceId()
+    task_id = TaskId()
+    state = _state({task_id: _text_task(task_id, instance_id)}, {})
+
+    events = orphaned_task_failure_events(state, frozenset())
+    assert len(events) == 1
+
+    state_after = apply_task_failed(events[0], state)
+    failed_task = state_after.tasks[task_id]
+    assert isinstance(failed_task, TextGenerationTask)
+    assert failed_task.task_status == TaskStatus.Failed
+    assert failed_task.error_type == "instance_lost"
+    assert orphaned_task_failure_events(state_after, frozenset()) == []
+
+
 def test_worker_lifecycle_task_not_failed() -> None:
     """Worker-emitted lifecycle tasks are reconciled by the worker's own plan
     loop; the master must not fail them from here."""

--- a/src/exo/master/tests/test_orphaned_task_failures.py
+++ b/src/exo/master/tests/test_orphaned_task_failures.py
@@ -7,7 +7,7 @@ master-side half of the fix: it declares in-flight API tasks dead when their
 instance is gone (or being torn down in the same plan pass).
 """
 
-from exo.master.main import orphaned_task_failure_events
+from exo.master.main import instances_on_dead_nodes, orphaned_task_failure_events
 from exo.shared.models.model_cards import ModelCard, ModelTask
 from exo.shared.types.common import CommandId, ModelId, NodeId
 from exo.shared.types.memory import Memory
@@ -133,6 +133,28 @@ def test_terminal_task_not_failed_again() -> None:
             {task_id: _text_task(task_id, instance_id, status=terminal)}, {}
         )
         assert orphaned_task_failure_events(state, frozenset()) == []
+
+
+def test_instance_on_timed_out_node_is_dying() -> None:
+    """A node can exceed its last_seen timeout while still present in
+    topology (wedged process, live TCP). NodeTimedOut removes the node's
+    instances AND their tasks in one apply, so the sweep must treat those
+    instances as dying in the same pass — a later pass can no longer see
+    the tasks (#224 review catch)."""
+    instance_id = InstanceId()
+    node_id = NodeId("test-node")  # matches _instance's node
+    state = _state({}, {instance_id: _instance(instance_id)})
+
+    # connected and not timed out -> healthy
+    assert (
+        instances_on_dead_nodes(state, frozenset({node_id}), frozenset()) == set()
+    )
+    # connected but timed out -> dying
+    assert instances_on_dead_nodes(
+        state, frozenset({node_id}), frozenset({node_id})
+    ) == {instance_id}
+    # disconnected -> dying
+    assert instances_on_dead_nodes(state, frozenset(), frozenset()) == {instance_id}
 
 
 def test_sweep_is_idempotent_after_apply() -> None:

--- a/src/exo/master/tests/test_orphaned_task_failures.py
+++ b/src/exo/master/tests/test_orphaned_task_failures.py
@@ -1,0 +1,153 @@
+"""Tests for the master failing API tasks stranded by a lost instance (#223).
+
+A node death mid-generation deletes the instance but used to leave the task
+in state forever — the API never received a terminal chunk and the client
+request hung until its own timeout. ``orphaned_task_failure_events`` is the
+master-side half of the fix: it declares in-flight API tasks dead when their
+instance is gone (or being torn down in the same plan pass).
+"""
+
+from exo.master.main import orphaned_task_failure_events
+from exo.shared.models.model_cards import ModelCard, ModelTask
+from exo.shared.types.common import CommandId, ModelId, NodeId
+from exo.shared.types.memory import Memory
+from exo.shared.types.state import State
+from exo.shared.types.tasks import (
+    LoadModel,
+    Task,
+    TaskId,
+    TaskStatus,
+)
+from exo.shared.types.tasks import (
+    TextGeneration as TextGenerationTask,
+)
+from exo.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+from exo.shared.types.worker.instances import (
+    Instance,
+    InstanceId,
+    MlxRingInstance,
+    RunnerId,
+    ShardAssignments,
+)
+from exo.shared.types.worker.shards import PipelineShardMetadata
+
+
+def _instance(instance_id: InstanceId) -> Instance:
+    model_card = ModelCard(
+        model_id=ModelId("test-model"),
+        n_layers=16,
+        storage_size=Memory.from_bytes(1024),
+        hidden_size=64,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+    )
+    node_id = NodeId("test-node")
+    runner_id = RunnerId()
+    return MlxRingInstance(
+        instance_id=instance_id,
+        shard_assignments=ShardAssignments(
+            model_id=ModelId("test-model"),
+            runner_to_shard={
+                runner_id: PipelineShardMetadata(
+                    start_layer=0,
+                    end_layer=16,
+                    n_layers=16,
+                    model_card=model_card,
+                    device_rank=0,
+                    world_size=1,
+                )
+            },
+            node_to_runner={node_id: runner_id},
+        ),
+        hosts_by_node={node_id: []},
+        ephemeral_port=12345,
+    )
+
+
+def _text_task(
+    task_id: TaskId,
+    instance_id: InstanceId,
+    status: TaskStatus = TaskStatus.Running,
+) -> TextGenerationTask:
+    return TextGenerationTask(
+        task_id=task_id,
+        instance_id=instance_id,
+        task_status=status,
+        command_id=CommandId(),
+        task_params=TextGenerationTaskParams(
+            model=ModelId("test-model"),
+            input=[InputMessage(role="user", content="hi")],
+        ),
+    )
+
+
+def _state(
+    tasks: dict[TaskId, Task],
+    instances: dict[InstanceId, Instance],
+) -> State:
+    return State().model_copy(update={"tasks": tasks, "instances": instances})
+
+
+def test_healthy_task_not_failed() -> None:
+    instance_id = InstanceId()
+    task_id = TaskId()
+    state = _state(
+        {task_id: _text_task(task_id, instance_id)},
+        {instance_id: _instance(instance_id)},
+    )
+    assert orphaned_task_failure_events(state, frozenset()) == []
+
+
+def test_task_with_missing_instance_is_failed() -> None:
+    instance_id = InstanceId()
+    task_id = TaskId()
+    state = _state({task_id: _text_task(task_id, instance_id)}, {})
+    events = orphaned_task_failure_events(state, frozenset())
+    assert len(events) == 1
+    assert events[0].task_id == task_id
+    assert events[0].error_type == "instance_lost"
+
+
+def test_task_on_dying_instance_is_failed_same_pass() -> None:
+    """An instance whose InstanceDeleted was emitted this pass is still in
+    state (the event has not round-tripped through apply yet) — the dying-set
+    parameter covers it."""
+    instance_id = InstanceId()
+    task_id = TaskId()
+    state = _state(
+        {task_id: _text_task(task_id, instance_id)},
+        {instance_id: _instance(instance_id)},
+    )
+    events = orphaned_task_failure_events(state, {instance_id})
+    assert len(events) == 1
+    assert events[0].task_id == task_id
+
+
+def test_terminal_task_not_failed_again() -> None:
+    """Failed/Complete tasks are skipped, making re-emission across plan
+    passes idempotent once the first TaskFailed applies."""
+    instance_id = InstanceId()
+    for terminal in (TaskStatus.Failed, TaskStatus.Complete, TaskStatus.Cancelled):
+        task_id = TaskId()
+        state = _state(
+            {task_id: _text_task(task_id, instance_id, status=terminal)}, {}
+        )
+        assert orphaned_task_failure_events(state, frozenset()) == []
+
+
+def test_worker_lifecycle_task_not_failed() -> None:
+    """Worker-emitted lifecycle tasks are reconciled by the worker's own plan
+    loop; the master must not fail them from here."""
+    instance_id = InstanceId()
+    task_id = TaskId()
+    state = _state(
+        {
+            task_id: LoadModel(
+                task_id=task_id,
+                instance_id=instance_id,
+                task_status=TaskStatus.Running,
+            )
+        },
+        {},
+    )
+    assert orphaned_task_failure_events(state, frozenset()) == []

--- a/src/exo/shared/apply.py
+++ b/src/exo/shared/apply.py
@@ -184,8 +184,16 @@ def apply_task_failed(event: TaskFailed, state: State) -> State:
         # maybe should raise
         return state
 
+    # Failed is terminal: the runner supervisor's terminal-status set and the
+    # master's orphaned-task sweep both rely on a failed task not being
+    # re-processed — without the status flip the sweep would re-emit
+    # TaskFailed for a lingering task every plan pass.
     updated_task = state.tasks[event.task_id].model_copy(
-        update={"error_type": event.error_type, "error_message": event.error_message}
+        update={
+            "task_status": TaskStatus.Failed,
+            "error_type": event.error_type,
+            "error_message": event.error_message,
+        }
     )
     new_tasks: Mapping[TaskId, Task] = {**state.tasks, event.task_id: updated_task}
     return state.model_copy(update={"tasks": new_tasks})


### PR DESCRIPTION
## Problem

Found by the 2026-06-07 node-kill drill on the merged launch build: kill a pipeline rank mid-generation and the cluster recovers cleanly (election +3s, orphan runner SIGKILL escalation +44s) — but the in-flight `POST /v1/chat/completions` is never terminated. The client hangs until its own timeout; with no client timeout it dangles indefinitely.

Root cause: **no production code path ever emitted `TaskFailed`** (the event type existed, `apply` handled it, zero emitters outside tests). When an instance died, its task was silently orphaned and the API's per-command chunk queue had nothing to react to.

## Fix

**Master** (`master/main.py`): the `_plan` loop — the existing reconciliation point that already kills instances on dead nodes — now emits `TaskFailed(error_type="instance_lost")` for in-flight API tasks (TextGeneration / ImageGeneration / ImageEdits / TextEmbedding) whose instance is missing from state or being torn down in the same pass. Pure function `orphaned_task_failure_events(state, dying_instance_ids)` for testability. Worker lifecycle tasks (CreateRunner, LoadModel, …) are deliberately excluded — the worker's plan loop owns those. Idempotent across passes: `TaskFailed` flips `task_status` to `Failed` on apply and terminal tasks are skipped.

**API** (`api/main.py`): `_apply_state` now reacts to `TaskFailed` by delivering a terminal `ErrorChunk` into the task's command queue (`_terminate_failed_command_stream`). Every consumer already handled the error case — `generate_chat_stream`/`collect_chat_response` have `case ErrorChunk():` branches, the bench/image paths raise on `finish_reason == "error"`, embeddings handle `ErrorChunk` explicitly. Only the signal was missing. Closed-queue (`BrokenResourceError`) drops the stale entry instead of raising into the event-apply loop.

Result: streaming responses close with an error event, non-streaming requests return 500, within one plan-loop pass (≤10s) of the instance being declared dead.

## Tests

- `master/tests/test_orphaned_task_failures.py`: healthy task untouched; missing-instance task failed; same-pass dying-instance covered via the dying-set param; terminal statuses skipped (idempotency); lifecycle tasks excluded.
- `api/tests/test_task_failed_stream_termination.py`: ErrorChunk delivered with the task's model + error message; unknown task ignored; broken queue dropped cleanly.

## Validation

`basedpyright` 0 errors · `ruff` clean · `nix fmt` applied · full suite 904 passed, 1 skipped.

Drill re-run on the live cluster planned post-merge to confirm end-to-end (kill kite2 mid-generation → client receives error within ~10s instead of hanging 120s).

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)