### PR TITLE
fix(api): session reset must fail open command streams — master death still hung clients

### DIFF
--- a/src/exo/api/main.py
+++ b/src/exo/api/main.py
@@ -21,7 +21,7 @@ import httpx
 import hypercorn.asyncio as hypercorn_asyncio
 import psutil
 import yaml
-from anyio import BrokenResourceError, ClosedResourceError, to_thread
+from anyio import BrokenResourceError, ClosedResourceError, WouldBlock, to_thread
 from fastapi import FastAPI, File, Form, HTTPException, Query, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
@@ -618,6 +618,7 @@ class API:
             self._event_log_appends_since_retention_check = 0
         self.state = State()
         self._system_id = SystemId()
+        self._fail_open_command_streams_for_session_reset()
         self._text_generation_queues = {}
         self._image_generation_queues = {}
         self._embedding_queues = {}
@@ -626,6 +627,43 @@ class API:
         self.event_receiver.close()
         self.event_receiver = event_receiver
         self._tg.start_soon(self._apply_state)
+
+    def _fail_open_command_streams_for_session_reset(self) -> None:
+        """Terminate every open command stream when the cluster session changes.
+
+        A new session (master failover) cannot carry the previous session's
+        tasks, so in-flight requests are unrecoverable — and the old queue
+        maps are about to be replaced, leaving their senders unreachable by
+        chunk dispatch, cancellation, AND the orphaned-task sweep (whose
+        TaskFailed can only reference the new session's state). Found by the
+        #223 verification drill: killing the MASTER mid-generation still hung
+        the client after the master-side sweep landed.
+
+        Best-effort error chunk (the consumer is normally parked on the
+        queue, so zero-buffer send_nowait delivers), then close — close alone
+        still ends the stream rather than hanging it.
+        """
+        error_message = (
+            "The cluster session changed (master failover) while this "
+            "request was in flight; please retry"
+        )
+        for queue_map in (
+            self._text_generation_queues,
+            self._image_generation_queues,
+            self._embedding_queues,
+        ):
+            for sender in list(queue_map.values()):
+                # The originating task is gone with the old session, so the
+                # true model id is unknowable here.
+                error_chunk = ErrorChunk(
+                    model=ModelId("unknown"), error_message=error_message
+                )
+                with contextlib.suppress(
+                    WouldBlock, BrokenResourceError, ClosedResourceError
+                ):
+                    sender.send_nowait(error_chunk)
+                with contextlib.suppress(ClosedResourceError):
+                    sender.close()
 
     def unpause(self, result_clock: int, master_node_id: NodeId | None = None):
         logger.info("Unpausing API")

--- a/src/exo/api/tests/test_task_failed_stream_termination.py
+++ b/src/exo/api/tests/test_task_failed_stream_termination.py
@@ -109,5 +109,37 @@ async def test_task_failed_with_closed_queue_drops_entry() -> None:
     assert command_id not in api._text_generation_queues
 
 
+async def test_session_reset_fails_open_streams() -> None:
+    """Master failover starts a new session that cannot carry the old
+    session's tasks; reset() used to replace the queue maps without closing
+    the old senders, leaving open requests unreachable by dispatch, cancel,
+    and the orphaned-task sweep — a guaranteed hang (#223 drill 2)."""
+    from anyio import EndOfStream
+
+    api = _make_api()
+    command_id = CommandId()
+    sender, receiver = channel[Any]()
+    api._text_generation_queues[command_id] = sender
+
+    api._fail_open_command_streams_for_session_reset()
+
+    chunk = receiver.receive_nowait()
+    assert isinstance(chunk, ErrorChunk)
+    assert "session changed" in chunk.error_message
+    with pytest.raises(EndOfStream):
+        receiver.receive_nowait()
+
+
+async def test_session_reset_with_already_closed_queue_is_silent() -> None:
+    api = _make_api()
+    command_id = CommandId()
+    sender, receiver = channel[Any]()
+    receiver.close()
+    sender.close()
+    api._text_generation_queues[command_id] = sender
+    # Must not raise despite the dead channel.
+    api._fail_open_command_streams_for_session_reset()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

The #224 verification drill (kill the **master** mid-generation on the deployed build) still hung the client for the full client timeout. The master-side orphaned-task sweep from #224 was working as designed — and structurally cannot cover this case:

- Killing the master triggers an election → a **new session** → the newly promoted master constructs a fresh `Master(...)` whose state has no record of the old session's tasks (verified live: `instances: 0, tasks: 0` post-failover). No `TaskFailed` can ever be emitted for them.
- Worse, `API.reset()` (the session-change handler) **replaced the command-queue maps with fresh dicts without closing the old senders**. The open streams' receiver ends became unreachable by `ChunkGenerated` dispatch, by `cancel_command`, and by the new TaskFailed handler — a guaranteed permanent hang on every master failover with a request in flight.

## Fix

`reset()` now calls `_fail_open_command_streams_for_session_reset()` before discarding the maps: best-effort terminal `ErrorChunk` via zero-buffer `send_nowait` (the consumer is normally parked on the queue, so it delivers), then `close()` — close alone still ends the stream rather than hanging it. The model id is reported as `unknown` because the originating task is gone with the old session.

This completes the #223 hang-class coverage matrix:

| Trigger | Covered by |
|---|---|
| Non-master node disconnect | #224 (orphan sweep) |
| Node timeout (wedged, still in topology) | #224 (timed-out-node sweep ordering) |
| Operator instance deletion | #224 (Cancelled-status termination) |
| **Master death / any session change** | **this PR (reset-boundary stream failure)** |

## Tests

- `test_session_reset_fails_open_streams`: ErrorChunk delivered, then EndOfStream.
- `test_session_reset_with_already_closed_queue_is_silent`: dead channel doesn't raise into reset.

## Validation

basedpyright 0 errors · ruff clean · nix fmt applied · full suite 909 passed, 1 skipped.

Will rerun the master-kill drill on the live cluster after merge — pass condition: client receives the failover error within seconds of the election, instead of hanging to its timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)