### PR TITLE
feat(cards): gemma E-series mtp_max_depth 3 → 2 — measured optimum (+43%/+30%)

### DIFF
--- a/resources/inference_model_cards/mlx-community--gemma-4-e2b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e2b-it-8bit.toml
@@ -32,7 +32,7 @@ output_parser = "gemma4"
 # (slice boundaries cut K/V dependencies; rejected loudly) — at 5.5GB
 # this model never needs sharding.
 assistant_model_repo = "mlx-community/gemma-4-E2B-it-assistant-bf16"
-mtp_max_depth = 3
+mtp_max_depth = 2
 # Same FAST_SYNCH wedge guard as the other gemma4 cards.
 metal_fast_synch = false
 

--- a/resources/inference_model_cards/mlx-community--gemma-4-e2b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e2b-it-8bit.toml
@@ -26,11 +26,13 @@ tool_call_format = "gemma4"
 prompt_renderer = "gemma4"
 output_parser = "gemma4"
 # Companion drafter for speculative decoding (Gemma 4 assistant pattern).
-# Validated 2026-06-05 on M4/24GB under the bonus-driven cadence: depth 3
-# — 44% chained acceptance, 57.1 tok/s vs 36.7 vanilla (1.56x; depth 1:
-# 67%, 1.43x). KV-shared E-series models are NOT pipeline-shardable
-# (slice boundaries cut K/V dependencies; rejected loudly) — at 5.5GB
-# this model never needs sharding.
+# Depth swept 2026-06-07 on M4/24GB, production stack (3x200tok greedy,
+# medians): d1 46.9 / d2 54.0 / d3 45.1 tok/s vs 37.7 vanilla — depth 2
+# wins (+43%). Depth 3 over-drafts: the third verify column costs ~36%
+# of a forward (M4 quantized-matmul width cliff) but its declining
+# conditional acceptance returns less. KV-shared E-series models are
+# NOT pipeline-shardable (slice boundaries cut K/V dependencies;
+# rejected loudly) — at 5.5GB this model never needs sharding.
 assistant_model_repo = "mlx-community/gemma-4-E2B-it-assistant-bf16"
 mtp_max_depth = 2
 # Same FAST_SYNCH wedge guard as the other gemma4 cards.

--- a/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
@@ -33,7 +33,7 @@ output_parser = "gemma4"
 # artifact of the pre-cadence loop skipping post-correction drafts and is
 # retracted.
 assistant_model_repo = "mlx-community/gemma-4-E4B-it-assistant-bf16"
-mtp_max_depth = 3
+mtp_max_depth = 2
 # Same FAST_SYNCH wedge as the 26b card — GPU command queue stalls in the
 # pipeline-parallel inference path, kernel watchdog panics the box. Disable
 # until the upstream MLX issue is fixed or a cheap inference-side fence

--- a/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
+++ b/resources/inference_model_cards/mlx-community--gemma-4-e4b-it-8bit.toml
@@ -25,13 +25,15 @@ tool_call_format = "gemma4"
 prompt_renderer = "gemma4"
 output_parser = "gemma4"
 # Companion drafter for speculative decoding (Gemma 4 assistant pattern).
-# ACTIVE since gemma4-mtp Phase C; re-validated 2026-06-05 under the
-# bonus-driven cadence: depth 3 — 50% chained acceptance, 34.4 tok/s vs
-# 18.5 vanilla (1.86x; depth 1 reference: 74%, 1.68x). Beats upstream
-# mlx-vlm on identical artifacts (1.43x/1.66x at the same depths). The
-# earlier "chain acceptance decays on quantized targets" depth law was an
-# artifact of the pre-cadence loop skipping post-correction drafts and is
-# retracted.
+# ACTIVE since gemma4-mtp Phase C. Depth swept 2026-06-07 on M4/24GB,
+# production stack (3x200tok greedy, medians): d1 22.1 / d2 25.4 /
+# d3 24.2 tok/s vs 19.5 vanilla — depth 2 wins (+30%). Depth 3
+# over-drafts: the third verify column costs ~36% of a forward (M4
+# quantized-matmul width cliff) but its conditional acceptance returns
+# less. (Historical: the 2026-06-05 probe-rig numbers read higher in
+# absolute terms — different rig, not comparable to production figures;
+# the earlier "chain acceptance decays on quantized targets" depth law
+# was a pre-cadence-loop artifact and stays retracted.)
 assistant_model_repo = "mlx-community/gemma-4-E4B-it-assistant-bf16"
 mtp_max_depth = 2
 # Same FAST_SYNCH wedge as the 26b card — GPU command queue stalls in the


### PR DESCRIPTION
## What

Two-line card change: `mtp_max_depth = 3 → 2` for gemma-4-E2B-8bit and gemma-4-E4B-8bit.

## Why — full depth sweep (closes the pre-blog part of #221)

Measured on the post-#225 build, kite3 (M4 24GB), 3×200-token greedy runs per cell, runner-reported tok/s, medians:

| Config | d1 | **d2** | d3 (was shipped) | baseline | best Δ |
|---|---|---|---|---|---|
| E2B-8bit | 46.9 | **54.0** | 45.1 | 37.7 | **+43%** |
| E4B-8bit | 22.1 | **25.4** | 24.2 | 19.5 | **+30%** |
| 12B-4bit 2-node | 13.2 | **15.1** | — | 8.4 | +81% (shipped d2 confirmed) |
| Qwen3.5-9B-4bit | **28.8** | 16.2 (SSM replay pathology) | — | 21.3 | +35% (shipped d1 confirmed) |

Mechanism: the verify-width cliff (perf-evaluation doc, 2026-06-06) — verify is free at width 2, then ~+36% of a full forward per extra column. Depth 3's third draft column costs more than its declining conditional acceptance returns; depth 2 is the last cheap width. Four models, four measured optima, all consistent with the cliff.

Remaining #221 scope (gemma-family width-curve probe, 31B depth A/B) stays open post-launch.

## Validation

basedpyright 0 · ruff clean · nix fmt applied · 909 tests pass. The fleet has been running these exact card values since the sweep's round B with clean placements and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)