### PR TITLE
feat(cards): Qwen3.5-27B mtp_max_depth 2 → 1 (+67% measured, d2 was the SSM replay tax)

### DIFF
--- a/resources/inference_model_cards/mlx-community--Qwen3.5-27B-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3.5-27B-4bit.toml
@@ -15,15 +15,18 @@ format = "token_delimited"
 default_effort = "medium"
 disabled_effort = "none"
 
-# MTP speculative decoding re-validated 2026-06-05 on M4/24GB under the
-# bonus-driven cadence (deferred replay + quantize-on-load sidecar):
-# depth 2 — 82% acceptance, 10.5 tok/s vs ~5.4-6.0 vanilla (1.87x; depth 1
-# reference: 83%, 10.2 tok/s). Depth 2 still pays on models this size —
-# the trunk dominates the drafter's extra chain cost; the 9B stays at
-# depth 1 (Skulk #192 / PR #193 / bonus-driven cadence rework).
+# MTP speculative decoding. Depth swept 2026-06-07 on the production
+# 2-node pipeline (kite1+kite2, 3x200tok greedy, medians): d1 10.5 vs
+# d2 9.2 tok/s against a 6.3 vanilla baseline — depth 1 wins (+67%),
+# and d2's wide run-to-run spread (7.7-9.5) was the SSM deferred-replay
+# tax: GDN rejects restore a snapshot and ride the next verify, whose
+# extra columns cost ~36% of a forward past width 2 (M4 width cliff).
+# Same pattern as the 9B; the trunk size does not buy d2 back on GDN
+# hybrids. (The 2026-06-05 single-node probe-rig d2 advantage predates
+# the cliff measurement and is superseded.)
 [runtime]
 mtp_heads = true
-mtp_max_depth = 2
+mtp_max_depth = 1
 mtp_sidecar_repo = "FoxlightAI/qwen3-5-27b-mtp"
 
 [storage_size]


### PR DESCRIPTION
## What

One-line card change: Qwen3.5-27B-4bit `mtp_max_depth = 2 → 1`, with the runtime comment updated to carry the production sweep data.

## Why

First-ever production 2-node A/B for this model (kite1+kite2, post-#225 build, 3×200-token greedy, runner-reported medians):

| Arm | tok/s | Δ vs baseline |
|---|---|---|
| without MTP | 6.3 (×3 identical) | — |
| with MTP, d2 (was shipped) | 9.2 (spread 7.7–9.5) | +46% |
| **with MTP, d1** | **10.5 (spread 10.3–10.7)** | **+67%** |

The d2 run-to-run spread is the tell: GDN-hybrid rejects restore an SSM snapshot and defer committed tokens onto the next verify, whose extra columns cost ~36% of a forward past width 2 (the M4 verify-width cliff, perf-evaluation doc §3). At depth 2 the reject rate is high enough that the replay window inflates verify width on bad rounds — same mechanism that makes the 9B's d2 a −45% pathology, just milder on the bigger trunk. Depth 1 keeps every verify at the free width.

This supersedes the 2026-06-05 probe-rig finding that d2 paid on 27B-class trunks (it predates both the deferred-replay loop change and the cliff measurement). Completes the depth picture: **all GDN/SSM Qwen cards at d1, all gemma assistant cards at d2** (#226).

Sweep recorded in foxlight-docs benchmarks; remaining #221 scope (gemma width-curve probe, 31B A/B) stays post-launch.

## Validation

shared tests pass · nix fmt applied · the fleet has been running d1 on this card since the measurement with clean placements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)