### PR TITLE
docs(changelog): session-reset hang fix and measured depth changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,30 @@ This project records release notes here and mirrors public-facing notes in
   responses close with an error event, non-streaming requests return a
   500. Found by the 2026-06-07 node-kill drill (#223).
 
+- **Master failover no longer strands open requests.** Killing the
+  master mid-generation starts a new cluster session that cannot carry
+  the old session's tasks, and the API's session reset replaced its
+  command-queue maps without closing the old streams — a guaranteed
+  permanent hang that the orphaned-task sweep above structurally could
+  not cover. The API now fails every open command stream at the session
+  boundary with a "cluster session changed, please retry" error.
+  Verified end-to-end: clients receive the error within ~4–6 seconds of
+  a node kill (master or worker rank), versus an indefinite hang before.
+
+### Changed
+
+- **Speculative-decoding draft depths are now per-card measured optima.**
+  A production depth sweep (3×200-token greedy A/Bs per cell) moved the
+  gemma E-series assistant cards from depth 3 to depth 2 — E2B-8bit
+  37.7 → 54.0 tok/s (+43%, was +20% at depth 3), E4B-8bit 19.5 → 25.4
+  (+30%) — and Qwen3.5-27B from depth 2 to depth 1 (6.3 → 10.5 tok/s on
+  a 2-node pipeline, +67%; depth 2's run-to-run spread was the
+  GDN/SSM deferred-replay tax). Mechanism: on M4-class GPUs the verify
+  forward is free at width 2 and costs ~36% of a full forward per extra
+  column after — depth 2 is the last cheap verify width, so deeper
+  drafting over-spends on every model measured. Rule of thumb: gemma
+  assistant cards depth 2, Qwen GDN sidecar cards depth 1.
+
 - **A bare `repetition_penalty` no longer crashes the runner.** Requests
   carrying `repetition_penalty` without `repetition_context_size` passed
   the request's None straight into mlx-lm's processor builder, overriding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ This project records release notes here and mirrors public-facing notes in
   command-queue maps without closing the old streams — a guaranteed
   permanent hang that the orphaned-task sweep above structurally could
   not cover. The API now fails every open command stream at the session
-  boundary with a "cluster session changed, please retry" error.
+  boundary with an error explaining the session changed and asking the
+  client to retry.
   Verified end-to-end: clients receive the error within ~4–6 seconds of
   a node kill (master or worker rank), versus an indefinite hang before.
 
@@ -37,11 +38,12 @@ This project records release notes here and mirrors public-facing notes in
   37.7 → 54.0 tok/s (+43%, was +20% at depth 3), E4B-8bit 19.5 → 25.4
   (+30%) — and Qwen3.5-27B from depth 2 to depth 1 (6.3 → 10.5 tok/s on
   a 2-node pipeline, +67%; depth 2's run-to-run spread was the
-  GDN/SSM deferred-replay tax). Mechanism: on M4-class GPUs the verify
-  forward is free at width 2 and costs ~36% of a full forward per extra
-  column after — depth 2 is the last cheap verify width, so deeper
-  drafting over-spends on every model measured. Rule of thumb: gemma
-  assistant cards depth 2, Qwen GDN sidecar cards depth 1.
+  GDN/SSM deferred-replay tax). Mechanism: on M4-class GPUs verifying up
+  to 2 candidate tokens per step is effectively free, but each candidate
+  beyond width 2 costs ~36% of a full forward pass — so drafting deeper
+  than depth 2 over-spends on every model measured, and SSM-hybrid
+  models pay an additional replay tax even at depth 2. Rule of thumb:
+  gemma assistant cards depth 2, Qwen GDN sidecar cards depth 1.
 
 - **A bare `repetition_penalty` no longer crashes the runner.** Requests
   carrying `repetition_penalty` without `repetition_context_size` passed


### PR DESCRIPTION
Catches the Unreleased section up to this weekend's merges:

- **Fixed**: master-failover stream stranding (#225) — the second half of the #223 hang class, with the verified ~4–6s end-to-end error latency from the kill drills.
- **Changed**: per-card measured MTP depths (#226: gemma E-series 3→2, +43%/+30%; #227: Qwen3.5-27B 2→1, +67%) with the width-cliff mechanism in one sentence.

Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)