### PR TITLE
fix(api): reject empty messages / non-positive max_tokens with 400 (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Empty `messages` (and non-positive `max_tokens`) are rejected with
+  400 instead of crashing the runner.** An empty message array was
+  accepted, then `apply_chat_template([])` raised `IndexError` inside the
+  runner — taking down the process serving that instance. A single
+  renderability guard at the shared text-generation dispatch chokepoint
+  (covering chat, Claude, Ollama, and Responses wire formats) now returns
+  400 before the request reaches a runner. Found by the post-rename
+  torture battery (#233).
+
 - **Requests no longer hang when a node dies mid-generation.** When an
   instance was lost (node disconnect, crash, or deletion with a request
   in flight), the master tore the instance down but left the task
@@ -60,15 +69,6 @@ This project records release notes here and mirrors public-facing notes in
   than depth 2 over-spends on every model measured, and SSM-hybrid
   models pay an additional replay tax even at depth 2. Rule of thumb:
   gemma assistant cards depth 2, Qwen GDN sidecar cards depth 1.
-
-- **Empty `messages` (and non-positive `max_tokens`) are rejected with
-  400 instead of crashing the runner.** An empty message array was
-  accepted, then `apply_chat_template([])` raised `IndexError` inside the
-  runner — taking down the process serving that instance. A single
-  renderability guard at the shared text-generation dispatch chokepoint
-  (covering chat, Claude, Ollama, and Responses wire formats) now returns
-  400 before the request reaches a runner. Found by the post-rename
-  torture battery (#233).
 
 - **A bare `repetition_penalty` no longer crashes the runner.** Requests
   carrying `repetition_penalty` without `repetition_context_size` passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ This project records release notes here and mirrors public-facing notes in
   models pay an additional replay tax even at depth 2. Rule of thumb:
   gemma assistant cards depth 2, Qwen GDN sidecar cards depth 1.
 
+- **Empty `messages` (and non-positive `max_tokens`) are rejected with
+  400 instead of crashing the runner.** An empty message array was
+  accepted, then `apply_chat_template([])` raised `IndexError` inside the
+  runner — taking down the process serving that instance. A single
+  renderability guard at the shared text-generation dispatch chokepoint
+  (covering chat, Claude, Ollama, and Responses wire formats) now returns
+  400 before the request reaches a runner. Found by the post-rename
+  torture battery (#233).
+
 - **A bare `repetition_penalty` no longer crashes the runner.** Requests
   carrying `repetition_penalty` without `repetition_context_size` passed
   the request's None straight into mlx-lm's processor builder, overriding

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -371,7 +371,10 @@ def validate_renderable_text_generation(
     if not task_params.input and not task_params.chat_template_messages:
         raise HTTPException(
             status_code=400,
-            detail="messages must not be empty",
+            detail=(
+                "the request has no messages to generate from "
+                "(messages / input must not be empty)"
+            ),
         )
     if (
         task_params.max_output_tokens is not None
@@ -379,7 +382,9 @@ def validate_renderable_text_generation(
     ):
         raise HTTPException(
             status_code=400,
-            detail="max_tokens must be a positive integer",
+            detail=(
+                "max_tokens (max_output_tokens) must be a positive integer"
+            ),
         )
 
 

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -355,6 +355,34 @@ def _text_image_hash_cache_enabled() -> bool:
     )
     return (value or "").strip().lower() in {"1", "true", "yes", "on"}
 
+
+def validate_renderable_text_generation(
+    task_params: TextGenerationTaskParams,
+) -> None:
+    """Reject text-generation requests the runner cannot render.
+
+    Raises ``HTTPException(400)`` so malformed input fails at the API instead
+    of reaching the runner. An empty message set produced an empty prompt
+    that crashed the runner inside ``apply_chat_template`` with an IndexError
+    (#233); a non-positive ``max_tokens`` would request zero/negative output.
+    Both are caught here, the single dispatch chokepoint shared by every wire
+    format, so no adapter can route un-renderable work to a runner.
+    """
+    if not task_params.input and not task_params.chat_template_messages:
+        raise HTTPException(
+            status_code=400,
+            detail="messages must not be empty",
+        )
+    if (
+        task_params.max_output_tokens is not None
+        and task_params.max_output_tokens <= 0
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="max_tokens must be a positive integer",
+        )
+
+
 API_TAGS_METADATA = [
     {
         "name": "Compatibility APIs",
@@ -1701,6 +1729,12 @@ class API:
     async def _send_text_generation_with_images(
         self, task_params: TextGenerationTaskParams
     ) -> TextGeneration:
+        # Single dispatch chokepoint for every text-generation wire format
+        # (chat, claude, ollama, responses, bench) — reject un-renderable
+        # requests here so malformed input is a clean 400 instead of an
+        # IndexError that crashes the runner (#233; empty messages reached
+        # apply_chat_template([]) -> list index out of range).
+        validate_renderable_text_generation(task_params)
         images = task_params.images
         if not images:
             command = TextGeneration(task_params=task_params)

--- a/src/skulk/api/tests/test_validate_renderable.py
+++ b/src/skulk/api/tests/test_validate_renderable.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 """Tests for the text-generation renderability guard (#233).
 
 An empty ``messages`` array was accepted with 200 and then crashed the

--- a/src/skulk/api/tests/test_validate_renderable.py
+++ b/src/skulk/api/tests/test_validate_renderable.py
@@ -1,0 +1,73 @@
+# pyright: reportPrivateUsage=false
+"""Tests for the text-generation renderability guard (#233).
+
+An empty ``messages`` array was accepted with 200 and then crashed the
+runner inside ``apply_chat_template([])`` with an IndexError. The guard at
+the single dispatch chokepoint rejects un-renderable requests with 400 so
+malformed input never reaches a runner.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from skulk.api.main import validate_renderable_text_generation
+from skulk.shared.types.common import ModelId
+from skulk.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+
+
+def _params(**overrides: object) -> TextGenerationTaskParams:
+    base: dict[str, object] = {
+        "model": ModelId("test-model"),
+        "input": [InputMessage(role="user", content="hi")],
+    }
+    base.update(overrides)
+    return TextGenerationTaskParams(**base)  # pyright: ignore[reportArgumentType]
+
+
+def test_normal_request_passes() -> None:
+    validate_renderable_text_generation(_params())
+
+
+def test_chat_template_only_request_passes() -> None:
+    # Some adapters carry chat_template_messages instead of input; a request
+    # with either is renderable.
+    validate_renderable_text_generation(
+        _params(input=[], chat_template_messages=[{"role": "user", "content": "hi"}])
+    )
+
+
+def test_empty_messages_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        validate_renderable_text_generation(_params(input=[]))
+    assert exc.value.status_code == 400
+    assert "messages" in str(exc.value.detail).lower()
+
+
+def test_empty_input_and_empty_template_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        validate_renderable_text_generation(
+            _params(input=[], chat_template_messages=[])
+        )
+    assert exc.value.status_code == 400
+
+
+def test_zero_max_tokens_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        validate_renderable_text_generation(_params(max_output_tokens=0))
+    assert exc.value.status_code == 400
+    assert "max_tokens" in str(exc.value.detail).lower()
+
+
+def test_negative_max_tokens_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        validate_renderable_text_generation(_params(max_output_tokens=-5))
+    assert exc.value.status_code == 400
+
+
+def test_none_max_tokens_allowed() -> None:
+    # Unset max_tokens is valid (runner applies its own default).
+    validate_renderable_text_generation(_params(max_output_tokens=None))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -172,6 +172,11 @@ For the full interactive reference with request/response schemas, see the [API R
 This is the main chat-generation endpoint for both text-only and multimodal
 models.
 
+Requests are validated before dispatch: an empty `messages` array or a
+non-positive `max_tokens` returns **400 Bad Request** rather than being
+accepted and failing during generation. (This applies across the Claude,
+Ollama, and Responses wire formats too, which share the same dispatch path.)
+
 ### OpenAI Python SDK Example
 
 ```python


### PR DESCRIPTION
## Problem

Found by the post-merge **merciless torture battery** (T3 bad-input fuzz). An empty `messages: []` was accepted with HTTP 200, then crashed the runner:

```
IndexError: list index out of range
  apply_chat_template([])  (mlx_lm tokenizer, via utils_mlx.py)
```

Pre-existing and inherited — same unguarded-bad-input class as the `repetition_penalty` runner crash (#216). The supervisor recovers, but a trivial malformed request shouldn't take a runner down (and concurrent work on that instance dies with it).

## Fix

A single renderability guard at `_send_text_generation_with_images` — the dispatch chokepoint **every** text-generation wire format converges on (chat completions, Claude messages, Ollama chat + generate, Responses, bench). One guard covers all of them, and it runs in request context so it returns a clean **400** instead of reaching a runner.

Extracted as the pure, unit-testable `validate_renderable_text_generation(task_params)`:
- rejects when **both** `input` and `chat_template_messages` are empty (some adapters carry one or the other — only un-renderable when both are empty)
- rejects `max_output_tokens <= 0`

## Tests

7 regression tests (`test_validate_renderable.py`): normal, template-only, empty-input, both-empty, zero/negative/None max_tokens. The torture harness's T3 already asserts runner-survives-fuzz at the integration layer.

## Docs

api-guide documents the 400; CHANGELOG entry under Fixed.

## Validation

basedpyright 0 · ruff clean · **917 tests pass** · nix fmt applied.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)