### PR TITLE
fix(api): guard blank-content messages, not just empty input (#233 follow-up)

### DIFF
--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -368,12 +368,25 @@ def validate_renderable_text_generation(
     Both are caught here, the single dispatch chokepoint shared by every wire
     format, so no adapter can route un-renderable work to a runner.
     """
-    if not task_params.input and not task_params.chat_template_messages:
+    # Mirror the runner's renderability test (utils_mlx builds
+    # formatted_messages): pre-formatted chat_template_messages or
+    # instructions render as-is, but the runner DROPS empty-content input
+    # messages before templating, so an empty resulting list crashes
+    # apply_chat_template with an IndexError. The chat adapter substitutes a
+    # single blank message for an empty `messages` array, which the runner
+    # then filters back to nothing — so "input is non-empty" is not a
+    # sufficient check; there must be actual content.
+    has_renderable = (
+        bool(task_params.chat_template_messages)
+        or bool(task_params.instructions)
+        or any(msg.content.strip() for msg in task_params.input)
+    )
+    if not has_renderable:
         raise HTTPException(
             status_code=400,
             detail=(
-                "the request has no messages to generate from "
-                "(messages / input must not be empty)"
+                "the request has no content to generate from "
+                "(messages / input must contain a non-empty message)"
             ),
         )
     if (

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -368,18 +368,21 @@ def validate_renderable_text_generation(
     Both are caught here, the single dispatch chokepoint shared by every wire
     format, so no adapter can route un-renderable work to a runner.
     """
-    # Mirror the runner's renderability test (utils_mlx builds
+    # Mirror the runner's renderability test EXACTLY (utils_mlx builds
     # formatted_messages): pre-formatted chat_template_messages or
-    # instructions render as-is, but the runner DROPS empty-content input
-    # messages before templating, so an empty resulting list crashes
-    # apply_chat_template with an IndexError. The chat adapter substitutes a
-    # single blank message for an empty `messages` array, which the runner
-    # then filters back to nothing — so "input is non-empty" is not a
-    # sufficient check; there must be actual content.
+    # instructions render as-is, but the runner drops input messages whose
+    # content is falsy (`if not msg.content: continue`) before templating,
+    # so an empty resulting list crashes apply_chat_template with an
+    # IndexError. The chat adapter substitutes a single empty-string
+    # message for an empty `messages` array, which the runner then filters
+    # back to nothing — so "input is non-empty" is not a sufficient check.
+    # Use the SAME truthiness test as the runner (not `.strip()`): a
+    # whitespace-only message is truthy and the runner renders it, so the
+    # guard must not reject inputs the runner can handle.
     has_renderable = (
         bool(task_params.chat_template_messages)
         or bool(task_params.instructions)
-        or any(msg.content.strip() for msg in task_params.input)
+        or any(msg.content for msg in task_params.input)
     )
     if not has_renderable:
         raise HTTPException(

--- a/src/skulk/api/tests/test_validate_renderable.py
+++ b/src/skulk/api/tests/test_validate_renderable.py
@@ -63,12 +63,14 @@ def test_blank_content_message_rejected() -> None:
     assert exc.value.status_code == 400
 
 
-def test_whitespace_only_content_rejected() -> None:
-    with pytest.raises(HTTPException) as exc:
-        validate_renderable_text_generation(
-            _params(input=[InputMessage(role="user", content="   \n\t ")])
-        )
-    assert exc.value.status_code == 400
+def test_whitespace_only_content_passes() -> None:
+    # The guard mirrors the runner's filter exactly (`if not msg.content`):
+    # whitespace-only content is truthy, so the runner renders it and the
+    # guard must NOT reject it — being stricter than the runner would 400
+    # inputs the runner can handle (review catch on PR #235).
+    validate_renderable_text_generation(
+        _params(input=[InputMessage(role="user", content="   \n\t ")])
+    )
 
 
 def test_instructions_only_request_passes() -> None:

--- a/src/skulk/api/tests/test_validate_renderable.py
+++ b/src/skulk/api/tests/test_validate_renderable.py
@@ -39,7 +39,7 @@ def test_empty_messages_rejected() -> None:
     with pytest.raises(HTTPException) as exc:
         validate_renderable_text_generation(_params(input=[]))
     assert exc.value.status_code == 400
-    assert "messages" in str(exc.value.detail).lower()
+    assert "content" in str(exc.value.detail).lower()
 
 
 def test_empty_input_and_empty_template_rejected() -> None:
@@ -48,6 +48,34 @@ def test_empty_input_and_empty_template_rejected() -> None:
             _params(input=[], chat_template_messages=[])
         )
     assert exc.value.status_code == 400
+
+
+def test_blank_content_message_rejected() -> None:
+    # The chat adapter substitutes [InputMessage(role="user", content="")]
+    # for an empty `messages` array; the runner filters blank content back
+    # to an empty list and crashes. The guard must catch this masked case,
+    # not just a literally-empty input list (#233 — the bug the first fix
+    # missed because `input` looked non-empty).
+    with pytest.raises(HTTPException) as exc:
+        validate_renderable_text_generation(
+            _params(input=[InputMessage(role="user", content="")])
+        )
+    assert exc.value.status_code == 400
+
+
+def test_whitespace_only_content_rejected() -> None:
+    with pytest.raises(HTTPException) as exc:
+        validate_renderable_text_generation(
+            _params(input=[InputMessage(role="user", content="   \n\t ")])
+        )
+    assert exc.value.status_code == 400
+
+
+def test_instructions_only_request_passes() -> None:
+    # A system-only request renders fine (instructions become a system turn).
+    validate_renderable_text_generation(
+        _params(input=[InputMessage(role="user", content="")], instructions="be brief")
+    )
 
 
 def test_zero_max_tokens_rejected() -> None:


### PR DESCRIPTION
## Why a follow-up

PR #234's guard checked `input` was non-empty — but **re-running the exact T3 fuzz on the live cluster after #234 merged showed empty `messages` STILL returned 200 and STILL crashed the runner.** I'd claimed it fixed without re-verifying on hardware; it didn't.

Root cause, one level deeper: the chat adapter substitutes `[InputMessage(role="user", content="")]` for an empty `messages[]` array, so `input` *looks* non-empty while carrying no content. The runner then drops empty-content messages before templating (`utils_mlx`: `if not msg.content: continue`), leaving `formatted_messages == []` → `apply_chat_template([])` → `IndexError`.

## Fix

The guard now mirrors the runner's actual renderability test: a request is renderable iff it has `chat_template_messages`, or `instructions`, or **at least one input message with non-blank content**. This catches the blank-masked case the adapter fallback creates, not just a literally-empty list.

(The `max_tokens <= 0` guard from #234 was already correct — verified returning 400 on the same live re-run.)

## Verification

This time, **on the live cluster before claiming fixed**: redeploy → re-run the exact T3 fuzz (empty messages, negative/zero max_tokens) → assert all 400 AND the runner survives a post-fuzz health check. Results in the PR thread before merge.

10 unit tests (added blank-content, whitespace-only, instructions-only-passes). basedpyright 0 · ruff clean.

Refs #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)