### PR TITLE
fix(cards): gpt-oss-20b metal_fast_synch=false — fixes warmup wedge (#236)

### DIFF
--- a/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
+++ b/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
@@ -29,5 +29,5 @@ output_parser = "gpt_oss"
 # command-queue stall, same as the gemma4 cards). Verified 2026-06-07:
 # with the flag off, single-node warmup clears in ~8s and the model
 # serves correct harmony output; left on, warmup hits the 300s deadline
-# and the runner is killed. (Skulk#236)
+# and the runner is killed. (#236)
 metal_fast_synch = false

--- a/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
+++ b/resources/inference_model_cards/mlx-community--gpt-oss-20b-MXFP4-Q8.toml
@@ -25,3 +25,9 @@ tool_call_format = "gpt_oss"
 
 [runtime]
 output_parser = "gpt_oss"
+# gpt-oss wedges in warmup under the cluster-default FAST_SYNCH (Metal
+# command-queue stall, same as the gemma4 cards). Verified 2026-06-07:
+# with the flag off, single-node warmup clears in ~8s and the model
+# serves correct harmony output; left on, warmup hits the 300s deadline
+# and the runner is killed. (Skulk#236)
+metal_fast_synch = false


### PR DESCRIPTION
## Diagnosis (the `/goal` investigation)

gpt-oss-20b was found unusable during the non-MTP model sweep. Root-caused on the merged build with a clean reboot + isolation probe:

1. **Raw MLX, single-node, outside the cluster** (`probe_gptoss.py`): load 7.6s, prefill 1.4s, decode 20 tok 0.6s — **the model is fine.**
2. **In-cluster single-node, FAST_SYNCH on (the bug):** warmup hangs in the Metal command queue → 300s deadline watchdog kills the runner. gpt-oss declares no speculation, so it gets the cluster default `FAST_SYNCH=1` — the exact wedge the gemma4 cards disable.
3. **In-cluster single-node, FAST_SYNCH off (this fix):** warmup clears in ~8s; the model serves correctly — `132 tokens, finish=stop, "The three primary colors are red, yellow, and blue."`, with the harmony analysis channel correctly split into `reasoning_content`.

## Fix

One line on the card: `metal_fast_synch = false` (+ explanatory comment), mirroring the gemma4 cards.

## Out of scope (tracked in #236)
- **Multi-node ring decode** still fails (GPU timeout + `[ring] too many send/recv errors`) — a distributed-path issue, not the model (fine single-node). A 20B fits a single 24GB node, so single-node is the correct placement regardless.
- **Audit** other non-spec MoE/MXFP4 cards for the same default-FAST_SYNCH wedge (none others downloaded to test here).
- The GPU-timeout aborts leak wired memory (reboot to clear) — platform stayed up throughout (watchdog/supervisor contained every failure).

Verified end-to-end on the live cluster. shared tests pass.

Refs #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)