### PR TITLE
test: preflight_mem.sh — gate test runs on leaked wired memory

### DIFF
--- a/tests/preflight_mem.sh
+++ b/tests/preflight_mem.sh
@@ -1,0 +1,36 @@
+#!/bin/zsh
+# preflight_mem.sh — fail fast if any fleet node has leaked (unreleased) wired
+# memory before a test run. Abnormal Metal terminations (warmup-wedge SIGKILL,
+# GPU-timeout abort) leak wired memory that only a reboot reclaims; a poisoned
+# node silently causes false 400s and GPU-timeouts that get mis-blamed on
+# code bugs (see gpt-oss / Skulk#236). Run this BEFORE any benchmark/torture.
+#
+# Signal: a node with ZERO active runner processes should sit near its idle
+# baseline (~2GB wired). Wired above the threshold with no runners == leak.
+# Usage: preflight_mem.sh [node1 node2 ...]   (default: kite1 kite2 kite3)
+set -u
+NODES=("$@"); (( ${#NODES} )) || NODES=(kite1 kite2 kite3)
+THRESHOLD_GB=5.0   # idle baseline ~2GB; poisoned observed 13.2GB
+poisoned=0
+
+for n in $NODES; do
+  read -r wired runners <<<"$(ssh -o ConnectTimeout=8 "$n" '
+    w=$(vm_stat | awk "/wired/{gsub(/\./,\"\",\$4); print \$4}")
+    r=$(pgrep -fc "entrypoint|[b]in/skulk.*runner" 2>/dev/null || echo 0)
+    echo "$(echo "$w*16384/2^30" | bc -l) $r" ' 2>/dev/null)"
+  if [ -z "$wired" ]; then echo "WARN  $n: unreachable"; continue; fi
+  wired_fmt=$(printf "%.1f" "$wired")
+  over=$(echo "$wired > $THRESHOLD_GB" | bc -l)
+  if [ "$runners" = "0" ] && [ "$over" = "1" ]; then
+    echo "POISONED $n: wired=${wired_fmt}GB with 0 runner procs (> ${THRESHOLD_GB}GB) — leaked memory; REBOOT before testing"
+    poisoned=1
+  else
+    echo "OK       $n: wired=${wired_fmt}GB runner_procs=$runners"
+  fi
+done
+
+if [ "$poisoned" = 1 ]; then
+  echo "PREFLIGHT FAIL: reboot poisoned node(s) (osascript -e 'tell app \"System Events\" to restart') before running tests."
+  exit 1
+fi
+echo "PREFLIGHT OK: no leaked memory detected."

--- a/tests/preflight_mem.sh
+++ b/tests/preflight_mem.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 # preflight_mem.sh — fail fast if any fleet node has leaked (unreleased) wired
 # memory before a test run. Abnormal Metal terminations (warmup-wedge SIGKILL,
 # GPU-timeout abort) leak wired memory that only a reboot reclaims; a poisoned
@@ -7,24 +7,29 @@
 # memory-starved node's GPU timeout read as a "distributed ring bug" that did
 # not exist (Skulk#236).
 #
-# Signal: a node with NO active inference runners should sit near its idle
+# Signal: a node with NO live inference runners should sit near its idle
 # baseline (~2GB wired on the M4 kites). Wired above the threshold with zero
-# active runners == leaked memory; reboot to reclaim.
+# live runners == leaked memory; reboot to reclaim.
+#
+# The gate FAILS CLOSED: an unreachable node, an unreadable field, or a
+# parse failure flags the node rather than passing it — a gate that cannot
+# verify a node must not green-light it.
 #
 # Usage: tests/preflight_mem.sh [node1 node2 ...]   (default: kite1 kite2 kite3)
 # Workstation-side: it SSHes each node (the kites can't ssh each other).
-set -u
-NODES=("$@"); (( ${#NODES} )) || NODES=(kite1 kite2 kite3)
-THRESHOLD_GB=5.0   # idle baseline ~2GB; poisoned observed 13.2GB
+set -uo pipefail
+NODES=("$@"); (( ${#NODES[@]} )) || NODES=(kite1 kite2 kite3)
+THRESHOLD_GB=5                     # idle baseline ~2GB; poisoned observed 13.2GB
+THRESHOLD_BYTES=$(( THRESHOLD_GB * 1024 * 1024 * 1024 ))
 API_PORT=52415
 SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=8)
 flagged=0
+is_uint() { [[ "$1" =~ ^[0-9]+$ ]]; }
 
 for n in "${NODES[@]}"; do
   # One round-trip: page size (don't assume 16K), wired pages, and the local
-  # node's active-runner count from its own API (authoritative — avoids
-  # pgrep -f matching this very probe's shell). API down => 0 runners, the
-  # correct assumption for a leak check.
+  # node's LIVE-runner count from its own API (authoritative — avoids pgrep -f
+  # matching this probe's shell, and skips retained dead supervisors).
   out=$(ssh "${SSH_OPTS[@]}" "$n" '
     ps=$(sysctl -n hw.pagesize)
     wp=$(vm_stat | awk "/wired/{gsub(/[^0-9]/,\"\",\$NF); print \$NF}")
@@ -32,26 +37,22 @@ for n in "${NODES[@]}"; do
       | python3 -c "import json,sys
 try:
   rs=json.load(sys.stdin).get(\"supervisorRunners\",[])
-  # Only LIVE subprocesses hold memory. supervisorRunners retains entries
-  # for crashed/killed runners (processAlive=false) — counting those would
-  # read a poisoned node (its runners warmup-killed) as OK, the exact
-  # false negative this gate must avoid.
   print(sum(1 for r in rs if r.get(\"processAlive\")))
 except Exception: print(0)" 2>/dev/null || echo 0)
     echo "$ps $wp $runners"
-  ' 2>/dev/null) || { echo "FAIL $n: unreachable — cannot verify, failing preflight"; flagged=1; continue; }
+  ' 2>/dev/null) || { echo "FAIL     $n: unreachable — cannot verify, failing preflight"; flagged=1; continue; }
 
-  pagesize=${out%% *}; rest=${out#* }; wpages=${rest%% *}; runners=${rest##* }
-  if [ -z "$pagesize" ] || [ -z "$wpages" ]; then
-    echo "FAIL $n: could not read memory state — failing preflight"; flagged=1; continue
+  read -r pagesize wpages runners <<<"$out"
+  if ! is_uint "${pagesize:-}" || ! is_uint "${wpages:-}" || ! is_uint "${runners:-}"; then
+    echo "FAIL     $n: unreadable memory/runner state ('$out') — failing preflight"; flagged=1; continue
   fi
-  wired_gb=$(echo "scale=1; $wpages * $pagesize / 2^30" | bc -l)
-  over=$(echo "$wired_gb > $THRESHOLD_GB" | bc -l)
-  if [ "$runners" = "0" ] && [ "$over" = "1" ]; then
-    echo "POISONED $n: wired=${wired_gb}GB, 0 active runners (> ${THRESHOLD_GB}GB) — leaked; REBOOT before testing"
+  wired_bytes=$(( wpages * pagesize ))
+  wired_gb=$(awk "BEGIN{printf \"%.1f\", $wired_bytes/2^30}")
+  if [ "$runners" = "0" ] && (( wired_bytes > THRESHOLD_BYTES )); then
+    echo "POISONED $n: wired=${wired_gb}GB, 0 live runners (> ${THRESHOLD_GB}GB) — leaked; REBOOT before testing"
     flagged=1
   else
-    echo "OK       $n: wired=${wired_gb}GB active_runners=$runners"
+    echo "OK       $n: wired=${wired_gb}GB live_runners=$runners"
   fi
 done
 

--- a/tests/preflight_mem.sh
+++ b/tests/preflight_mem.sh
@@ -11,12 +11,16 @@
 # baseline (~2GB wired on the M4 kites). Wired above the threshold with zero
 # live runners == leaked memory; reboot to reclaim.
 #
-# The gate FAILS CLOSED: an unreachable node, an unreadable field, or a
-# parse failure flags the node rather than passing it — a gate that cannot
-# verify a node must not green-light it.
+# Fail-closed policy: an unreachable node or unreadable wired memory always
+# flags. When wired is OVER the threshold, anything that prevents confirming
+# the node is actively serving (diagnostics unreachable / not a NodeDiagnostics
+# payload) also flags — a high-wired node we can't clear must not be
+# green-lit. Wired BELOW the threshold is safe regardless of runner state.
 #
 # Usage: tests/preflight_mem.sh [node1 node2 ...]   (default: kite1 kite2 kite3)
-# Workstation-side: it SSHes each node (the kites can't ssh each other).
+# Node args are ssh targets: bare aliases (kite1) resolve per-node users via
+# ~/.ssh/config; pass user@host explicitly if you have no alias. Runs on the
+# workstation and SSHes each node (the kites can't ssh each other).
 set -uo pipefail
 NODES=("$@"); (( ${#NODES[@]} )) || NODES=(kite1 kite2 kite3)
 THRESHOLD_GB=5                     # idle baseline ~2GB; poisoned observed 13.2GB
@@ -40,8 +44,11 @@ for n in "${NODES[@]}"; do
     diag=$(curl -s --max-time 5 http://localhost:'"$API_PORT"'/v1/diagnostics/node)
     runners=$(printf "%s" "$diag" | python3 -c "import json,sys
 try:
-  rs=json.load(sys.stdin).get(\"supervisorRunners\",[])
-  print(sum(1 for r in rs if r.get(\"processAlive\")))
+  d=json.load(sys.stdin)
+  # Must be a real NodeDiagnostics payload; an error JSON (e.g. FastAPI
+  # {\"detail\":...} on 404) lacks supervisorRunners and is NOT a verified 0.
+  if not isinstance(d, dict) or \"supervisorRunners\" not in d: print(\"NA\")
+  else: print(sum(1 for r in d[\"supervisorRunners\"] if r.get(\"processAlive\")))
 except Exception: print(\"NA\")" 2>/dev/null || echo NA)
     echo "$ps $wp $runners"
   ' 2>/dev/null) || { echo "FAIL     $n: unreachable — cannot verify, failing preflight"; flagged=1; continue; }
@@ -76,7 +83,9 @@ except Exception: print(\"NA\")" 2>/dev/null || echo NA)
 done
 
 if [ "$flagged" = 1 ]; then
-  echo "PREFLIGHT FAIL: reboot flagged node(s) (osascript -e 'tell app \"System Events\" to restart') and re-run."
+  echo "PREFLIGHT FAIL: reboot each flagged node, then re-run. From this"
+  echo "workstation: ssh <node> 'osascript -e \"tell app \\\"System Events\\\" to restart\"'"
+  echo "(run remotely per node — NOT locally, which would reboot this workstation)."
   exit 1
 fi
 echo "PREFLIGHT OK: no leaked memory detected."

--- a/tests/preflight_mem.sh
+++ b/tests/preflight_mem.sh
@@ -30,7 +30,13 @@ for n in "${NODES[@]}"; do
     wp=$(vm_stat | awk "/wired/{gsub(/[^0-9]/,\"\",\$NF); print \$NF}")
     runners=$(curl -s --max-time 5 http://localhost:'"$API_PORT"'/v1/diagnostics/node \
       | python3 -c "import json,sys
-try: print(len(json.load(sys.stdin).get(\"supervisorRunners\",[])))
+try:
+  rs=json.load(sys.stdin).get(\"supervisorRunners\",[])
+  # Only LIVE subprocesses hold memory. supervisorRunners retains entries
+  # for crashed/killed runners (processAlive=false) — counting those would
+  # read a poisoned node (its runners warmup-killed) as OK, the exact
+  # false negative this gate must avoid.
+  print(sum(1 for r in rs if r.get(\"processAlive\")))
 except Exception: print(0)" 2>/dev/null || echo 0)
     echo "$ps $wp $runners"
   ' 2>/dev/null) || { echo "FAIL $n: unreachable — cannot verify, failing preflight"; flagged=1; continue; }

--- a/tests/preflight_mem.sh
+++ b/tests/preflight_mem.sh
@@ -2,35 +2,55 @@
 # preflight_mem.sh — fail fast if any fleet node has leaked (unreleased) wired
 # memory before a test run. Abnormal Metal terminations (warmup-wedge SIGKILL,
 # GPU-timeout abort) leak wired memory that only a reboot reclaims; a poisoned
-# node silently causes false 400s and GPU-timeouts that get mis-blamed on
-# code bugs (see gpt-oss / Skulk#236). Run this BEFORE any benchmark/torture.
+# node silently causes false placement 400s and decode GPU-timeouts that get
+# mis-blamed on code bugs — it cost a multi-hour gpt-oss misdiagnosis where a
+# memory-starved node's GPU timeout read as a "distributed ring bug" that did
+# not exist (Skulk#236).
 #
-# Signal: a node with ZERO active runner processes should sit near its idle
-# baseline (~2GB wired). Wired above the threshold with no runners == leak.
-# Usage: preflight_mem.sh [node1 node2 ...]   (default: kite1 kite2 kite3)
+# Signal: a node with NO active inference runners should sit near its idle
+# baseline (~2GB wired on the M4 kites). Wired above the threshold with zero
+# active runners == leaked memory; reboot to reclaim.
+#
+# Usage: tests/preflight_mem.sh [node1 node2 ...]   (default: kite1 kite2 kite3)
+# Workstation-side: it SSHes each node (the kites can't ssh each other).
 set -u
 NODES=("$@"); (( ${#NODES} )) || NODES=(kite1 kite2 kite3)
 THRESHOLD_GB=5.0   # idle baseline ~2GB; poisoned observed 13.2GB
-poisoned=0
+API_PORT=52415
+SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=8)
+flagged=0
 
-for n in $NODES; do
-  read -r wired runners <<<"$(ssh -o ConnectTimeout=8 "$n" '
-    w=$(vm_stat | awk "/wired/{gsub(/\./,\"\",\$4); print \$4}")
-    r=$(pgrep -fc "entrypoint|[b]in/skulk.*runner" 2>/dev/null || echo 0)
-    echo "$(echo "$w*16384/2^30" | bc -l) $r" ' 2>/dev/null)"
-  if [ -z "$wired" ]; then echo "WARN  $n: unreachable"; continue; fi
-  wired_fmt=$(printf "%.1f" "$wired")
-  over=$(echo "$wired > $THRESHOLD_GB" | bc -l)
+for n in "${NODES[@]}"; do
+  # One round-trip: page size (don't assume 16K), wired pages, and the local
+  # node's active-runner count from its own API (authoritative — avoids
+  # pgrep -f matching this very probe's shell). API down => 0 runners, the
+  # correct assumption for a leak check.
+  out=$(ssh "${SSH_OPTS[@]}" "$n" '
+    ps=$(sysctl -n hw.pagesize)
+    wp=$(vm_stat | awk "/wired/{gsub(/[^0-9]/,\"\",\$NF); print \$NF}")
+    runners=$(curl -s --max-time 5 http://localhost:'"$API_PORT"'/v1/diagnostics/node \
+      | python3 -c "import json,sys
+try: print(len(json.load(sys.stdin).get(\"supervisorRunners\",[])))
+except Exception: print(0)" 2>/dev/null || echo 0)
+    echo "$ps $wp $runners"
+  ' 2>/dev/null) || { echo "FAIL $n: unreachable — cannot verify, failing preflight"; flagged=1; continue; }
+
+  pagesize=${out%% *}; rest=${out#* }; wpages=${rest%% *}; runners=${rest##* }
+  if [ -z "$pagesize" ] || [ -z "$wpages" ]; then
+    echo "FAIL $n: could not read memory state — failing preflight"; flagged=1; continue
+  fi
+  wired_gb=$(echo "scale=1; $wpages * $pagesize / 2^30" | bc -l)
+  over=$(echo "$wired_gb > $THRESHOLD_GB" | bc -l)
   if [ "$runners" = "0" ] && [ "$over" = "1" ]; then
-    echo "POISONED $n: wired=${wired_fmt}GB with 0 runner procs (> ${THRESHOLD_GB}GB) — leaked memory; REBOOT before testing"
-    poisoned=1
+    echo "POISONED $n: wired=${wired_gb}GB, 0 active runners (> ${THRESHOLD_GB}GB) — leaked; REBOOT before testing"
+    flagged=1
   else
-    echo "OK       $n: wired=${wired_fmt}GB runner_procs=$runners"
+    echo "OK       $n: wired=${wired_gb}GB active_runners=$runners"
   fi
 done
 
-if [ "$poisoned" = 1 ]; then
-  echo "PREFLIGHT FAIL: reboot poisoned node(s) (osascript -e 'tell app \"System Events\" to restart') before running tests."
+if [ "$flagged" = 1 ]; then
+  echo "PREFLIGHT FAIL: reboot flagged node(s) (osascript -e 'tell app \"System Events\" to restart') and re-run."
   exit 1
 fi
 echo "PREFLIGHT OK: no leaked memory detected."

--- a/tests/preflight_mem.sh
+++ b/tests/preflight_mem.sh
@@ -30,25 +30,44 @@ for n in "${NODES[@]}"; do
   # One round-trip: page size (don't assume 16K), wired pages, and the local
   # node's LIVE-runner count from its own API (authoritative — avoids pgrep -f
   # matching this probe's shell, and skips retained dead supervisors).
+  # The remote emits the live-runner count, or the literal "NA" when the
+  # diagnostics endpoint can't be fetched/parsed — so we never silently
+  # conflate "couldn't check" with "verified zero". (A diagnostics fetch
+  # that connects and parses but holds no live runners is a real 0.)
   out=$(ssh "${SSH_OPTS[@]}" "$n" '
     ps=$(sysctl -n hw.pagesize)
     wp=$(vm_stat | awk "/wired/{gsub(/[^0-9]/,\"\",\$NF); print \$NF}")
-    runners=$(curl -s --max-time 5 http://localhost:'"$API_PORT"'/v1/diagnostics/node \
-      | python3 -c "import json,sys
+    diag=$(curl -s --max-time 5 http://localhost:'"$API_PORT"'/v1/diagnostics/node)
+    runners=$(printf "%s" "$diag" | python3 -c "import json,sys
 try:
   rs=json.load(sys.stdin).get(\"supervisorRunners\",[])
   print(sum(1 for r in rs if r.get(\"processAlive\")))
-except Exception: print(0)" 2>/dev/null || echo 0)
+except Exception: print(\"NA\")" 2>/dev/null || echo NA)
     echo "$ps $wp $runners"
   ' 2>/dev/null) || { echo "FAIL     $n: unreachable — cannot verify, failing preflight"; flagged=1; continue; }
 
   read -r pagesize wpages runners <<<"$out"
-  if ! is_uint "${pagesize:-}" || ! is_uint "${wpages:-}" || ! is_uint "${runners:-}"; then
-    echo "FAIL     $n: unreadable memory/runner state ('$out') — failing preflight"; flagged=1; continue
+  if ! is_uint "${pagesize:-}" || ! is_uint "${wpages:-}"; then
+    echo "FAIL     $n: unreadable memory state ('$out') — failing preflight"; flagged=1; continue
   fi
   wired_bytes=$(( wpages * pagesize ))
   wired_gb=$(awk "BEGIN{printf \"%.1f\", $wired_bytes/2^30}")
-  if [ "$runners" = "0" ] && (( wired_bytes > THRESHOLD_BYTES )); then
+  over=$(( wired_bytes > THRESHOLD_BYTES ? 1 : 0 ))
+
+  if ! is_uint "${runners:-}"; then
+    # Runner state unknown (diagnostics unreachable/unparseable). Fail closed
+    # ONLY when it matters — i.e. wired is already over the threshold and we
+    # can't rule out a leak. Low wired is safe regardless of runner state.
+    if (( over )); then
+      echo "FAIL     $n: wired=${wired_gb}GB (> ${THRESHOLD_GB}GB) but runner state UNVERIFIABLE (diagnostics unreachable) — failing closed; check/reboot"
+      flagged=1
+    else
+      echo "OK       $n: wired=${wired_gb}GB (runner state unverifiable, but wired is low)"
+    fi
+    continue
+  fi
+
+  if [ "$runners" = "0" ] && (( over )); then
     echo "POISONED $n: wired=${wired_gb}GB, 0 live runners (> ${THRESHOLD_GB}GB) — leaked; REBOOT before testing"
     flagged=1
   else


### PR DESCRIPTION
## Why

Tom's call after the gpt-oss investigation (#236): we should check for unreleased memory before test runs.

That whole multi-hour detour happened because a node was silently poisoned — 13.2GB wired with **zero runner processes**, leaked by abnormal Metal terminations (the FAST_SYNCH warmup-wedge SIGKILLs). A memory-starved kite3 then GPU-timed-out during decode, which I mis-read as a distributed "ring bug" that didn't exist. A 5-second preflight would have flagged the node and pointed straight at "reboot," not "debug the ring."

## What

`tests/preflight_mem.sh` — workstation-side (sshes each node; the kites can't ssh each other). For each node: if there are **zero active runner processes** but wired memory is above ~5GB (idle baseline measured ~1.8–2.3GB; poisoned was 13.2GB), flag it as leaked and exit non-zero with a reboot instruction. Run before any benchmark/torture battery.

```
$ tests/preflight_mem.sh
OK       kite1: wired=1.8GB runner_procs=0
OK       kite2: wired=2.3GB runner_procs=0
OK       kite3: wired=2.0GB runner_procs=0
PREFLIGHT OK: no leaked memory detected.
```

Lives in `tests/` alongside the other fleet-orchestration scripts (auto_bench, eval_tool_calls). Longer-term home is a `doctor` check in the skulk-test-harness; this is the immediate, durable version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)