### PR TITLE
feat(net): zero-config Thunderbolt/local + Tailscale clustering on macOS

### DIFF
--- a/rust/networking/src/discovery.rs
+++ b/rust/networking/src/discovery.rs
@@ -106,6 +106,14 @@ pub struct Behaviour {
     mdns_discovered: HashMap<PeerId, BTreeSet<Multiaddr>>,
     bootstrap_peers: Vec<Multiaddr>,
 
+    // Remote IPs we currently hold at least one connection to, ref-counted by
+    // connection. Bootstrap peers are dialed by address (no peer id, so libp2p
+    // cannot dedup them); without this, the periodic retry opens a *new*
+    // connection to each bootstrap peer every interval and never stops, leaking
+    // sockets unboundedly. We skip re-dialing a bootstrap address whose IP is
+    // already connected, and resume once it drops.
+    connected_ips: HashMap<IpAddr, usize>,
+
     retry_delay: Delay, // retry interval
 
     // pending events to emmit => waker-backed Deque to control polling
@@ -118,6 +126,7 @@ impl Behaviour {
             managed: managed::Behaviour::new(keypair)?,
             mdns_discovered: HashMap::new(),
             bootstrap_peers,
+            connected_ips: HashMap::new(),
             retry_delay: Delay::new(RETRY_CONNECT_INTERVAL),
             pending_events: WakerDeque::new(),
         })
@@ -179,6 +188,10 @@ impl Behaviour {
         remote_ip: IpAddr,
         remote_tcp_port: u16,
     ) {
+        // track the connected IP so the retry loop stops re-dialing a bootstrap
+        // peer we already reached (see `connected_ips`)
+        *self.connected_ips.entry(remote_ip).or_insert(0) += 1;
+
         // send out connected event
         self.pending_events
             .push_back(ToSwarm::GenerateEvent(Event::ConnectionEstablished {
@@ -196,6 +209,15 @@ impl Behaviour {
         remote_ip: IpAddr,
         remote_tcp_port: u16,
     ) {
+        // drop the IP from the connected set once its last connection closes, so
+        // the retry loop will dial that bootstrap peer again
+        if let Some(count) = self.connected_ips.get_mut(&remote_ip) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                self.connected_ips.remove(&remote_ip);
+            }
+        }
+
         // send out disconnected event
         self.pending_events
             .push_back(ToSwarm::GenerateEvent(Event::ConnectionClosed {
@@ -370,10 +392,23 @@ impl NetworkBehaviour for Behaviour {
                     self.dial(p, ma)
                 }
             }
-            // dial bootstrap peers (for environments where mDNS is unavailable)
-            for addr in &self.bootstrap_peers {
+            // dial bootstrap peers (for environments where mDNS is unavailable),
+            // skipping any whose IP we already hold a connection to — bootstrap
+            // dials carry no peer id and so cannot be deduped by libp2p, so this
+            // guard is what prevents the retry loop from leaking a new socket to
+            // each bootstrap peer every interval.
+            let bootstrap_to_dial: Vec<Multiaddr> = self
+                .bootstrap_peers
+                .iter()
+                .filter(|addr| match addr.try_to_tcp_addr() {
+                    Some((ip, _)) => !self.connected_ips.contains_key(&ip),
+                    None => true,
+                })
+                .cloned()
+                .collect();
+            for addr in bootstrap_to_dial {
                 self.pending_events.push_back(ToSwarm::Dial {
-                    opts: DialOpts::unknown_peer_id().address(addr.clone()).build(),
+                    opts: DialOpts::unknown_peer_id().address(addr).build(),
                 })
             }
             self.retry_delay.reset(RETRY_CONNECT_INTERVAL) // reset timeout

--- a/src/skulk/connectivity/local_network.py
+++ b/src/skulk/connectivity/local_network.py
@@ -1,0 +1,108 @@
+"""macOS Local Network Privacy detection.
+
+macOS 15 (Sequoia) and 26 gate access to the *local network* — RFC-1918
+subnets (``192.168.x``, ``10.x``), link-local, multicast, and the Thunderbolt
+bridge — behind a per-application privacy permission. A process that has not
+been granted Local Network access receives ``EHOSTUNREACH`` (errno 65) the
+moment it tries to connect to a local-subnet peer, while internet-routed and
+VPN traffic (e.g. Tailscale's ``utun`` interface) are unaffected.
+
+The failure is silent and misleading: cluster discovery over Ethernet or
+Thunderbolt simply never connects, with no error a user would recognise. This
+module probes for the condition at startup so Skulk can tell the operator to
+grant the permission instead of failing mysteriously.
+
+The permission can only be granted from the GUI (System Settings → Privacy &
+Security → Local Network, or the one-time prompt macOS shows on first access).
+There is no supported command-line grant, so detection + a clear message is the
+best we can do programmatically.
+"""
+
+from __future__ import annotations
+
+import errno
+import platform
+import socket
+import subprocess
+from typing import Literal
+
+# Discard protocol port (RFC 863): almost always closed, so a *reachable* host
+# answers with a TCP reset (ECONNREFUSED) rather than accepting a connection.
+_PROBE_PORT = 9
+_PROBE_TIMEOUT_SECONDS = 2.0
+
+LocalNetworkStatus = Literal["ok", "blocked", "unknown"]
+
+
+def _default_gateway_ipv4() -> str | None:
+    """Return the IPv4 default-gateway address, or ``None`` if undiscoverable.
+
+    The gateway is a guaranteed local-subnet host, which makes it a reliable
+    target for distinguishing a Local Network Privacy denial (EHOSTUNREACH)
+    from a normal closed port (ECONNREFUSED).
+    """
+    try:
+        completed = subprocess.run(
+            ["route", "-n", "get", "default"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    for raw_line in completed.stdout.splitlines():
+        line = raw_line.strip()
+        if line.startswith("gateway:"):
+            gateway = line.split(":", 1)[1].strip()
+            # Guard against an IPv6 / link-local gateway sneaking in.
+            return gateway if gateway and ":" not in gateway else None
+    return None
+
+
+def check_local_network_access() -> LocalNetworkStatus:
+    """Best-effort probe for a macOS Local Network Privacy denial.
+
+    Returns:
+        ``"blocked"`` if a local-subnet connect fails with ``EHOSTUNREACH`` (the
+        Local Network Privacy signature); ``"ok"`` if the local network is
+        reachable; ``"unknown"`` when the check does not apply or is
+        inconclusive (non-macOS, no IPv4 gateway, probe error).
+
+    The probe is a single short-timeout TCP connect to the default gateway's
+    discard port. A denied process is rejected at the ``connect`` syscall with
+    ``EHOSTUNREACH``; a permitted process reaches the host and gets
+    ``ECONNREFUSED`` (or a timeout), both of which mean the local network is
+    usable.
+    """
+    if platform.system() != "Darwin":
+        return "unknown"
+
+    gateway = _default_gateway_ipv4()
+    if gateway is None:
+        return "unknown"
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(_PROBE_TIMEOUT_SECONDS)
+    try:
+        sock.connect((gateway, _PROBE_PORT))
+        return "ok"  # an open connection means the local network is reachable
+    except OSError as exc:
+        if exc.errno == errno.EHOSTUNREACH:
+            return "blocked"
+        # ECONNREFUSED / ETIMEDOUT / etc.: the host was reachable, so the
+        # local network is not blocked — only this port is.
+        return "ok"
+    finally:
+        sock.close()
+
+
+LOCAL_NETWORK_DENIED_MESSAGE = (
+    "macOS Local Network access appears to be DENIED for this process. Skulk "
+    "cannot reach peers on your local network or Thunderbolt bridge, so the "
+    "cluster will not form over Ethernet/Thunderbolt (a Tailscale overlay, if "
+    "present, is exempt and still works). Grant access: System Settings → "
+    "Privacy & Security → Local Network → enable the app you launched Skulk "
+    "from (e.g. Terminal), then restart Skulk. See "
+    "website/docs/thunderbolt-clustering.md for details."
+)

--- a/src/skulk/connectivity/local_network.py
+++ b/src/skulk/connectivity/local_network.py
@@ -103,6 +103,6 @@ LOCAL_NETWORK_DENIED_MESSAGE = (
     "cluster will not form over Ethernet/Thunderbolt (a Tailscale overlay, if "
     "present, is exempt and still works). Grant access: System Settings → "
     "Privacy & Security → Local Network → enable the app you launched Skulk "
-    "from (e.g. Terminal), then restart Skulk. See "
-    "website/docs/thunderbolt-clustering.md for details."
+    "from (e.g. Terminal), then restart Skulk. See the Thunderbolt clustering "
+    "guide in the Skulk documentation for details."
 )

--- a/src/skulk/connectivity/tailscale.py
+++ b/src/skulk/connectivity/tailscale.py
@@ -11,12 +11,40 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import shutil
 from typing import Any, final
 
 from loguru import logger
 from pydantic import Field
 
 from skulk.utils.pydantic_ext import FrozenModel
+
+# Common locations of the `tailscale` CLI. We resolve the binary explicitly
+# rather than relying on PATH, because Skulk is frequently launched from a
+# context with a minimal PATH (launchd agent, ssh, systemd) that does not
+# include /usr/local/bin where the standalone macOS installer puts it.
+_TAILSCALE_BINARY_CANDIDATES = (
+    "/usr/local/bin/tailscale",
+    "/opt/homebrew/bin/tailscale",
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+    "/usr/bin/tailscale",  # common on Linux
+)
+
+
+def _resolve_tailscale_binary() -> str | None:
+    """Return a path to the ``tailscale`` CLI, or ``None`` if not found.
+
+    Prefers a PATH lookup (honours a user's custom install) and falls back to
+    well-known install locations.
+    """
+    found = shutil.which("tailscale")
+    if found:
+        return found
+    return next(
+        (path for path in _TAILSCALE_BINARY_CANDIDATES if os.access(path, os.X_OK)),
+        None,
+    )
 
 
 @final
@@ -38,6 +66,10 @@ class TailscaleStatus(FrozenModel):
             ``tailnet-abc.ts.net``.  ``None`` when dns_name is absent or
             cannot be parsed.
         version: The tailscale client version string.
+        peer_ips: The Tailscale IPv4 (``100.x``) addresses of all other nodes
+            in the tailnet. Used to auto-populate libp2p bootstrap peers so a
+            Tailscale cluster needs no hand-maintained IP list — non-Skulk peers
+            simply fail the private-network handshake and are ignored.
     """
 
     running: bool = Field(description="True when tailscaled reports BackendState == 'Running'.")
@@ -46,6 +78,10 @@ class TailscaleStatus(FrozenModel):
     dns_name: str | None = Field(default=None, description="Fully-qualified Tailscale MagicDNS name.")
     tailnet: str | None = Field(default=None, description="Tailnet name derived from dns_name.")
     version: str | None = Field(default=None, description="Tailscale client version string.")
+    peer_ips: list[str] = Field(
+        default_factory=list,
+        description="Tailscale IPv4 addresses (100.x) of other tailnet nodes.",
+    )
 
 
 def parse_status_json(raw: dict[str, Any]) -> TailscaleStatus:
@@ -76,6 +112,17 @@ def parse_status_json(raw: dict[str, Any]) -> TailscaleStatus:
 
     version: str | None = raw.get("Version") or None
 
+    # Collect every peer's first Tailscale IPv4 (100.x) address. The "Peer" map
+    # is keyed by node public key; each value carries that peer's TailscaleIPs.
+    peers: dict[str, Any] = raw.get("Peer") or {}
+    peer_ips: list[str] = []
+    for key in peers:
+        peer: dict[str, Any] = peers.get(key) or {}
+        ips: list[str] = peer.get("TailscaleIPs") or []
+        peer_ip = next((ip for ip in ips if ip.startswith("100.")), None)
+        if peer_ip is not None:
+            peer_ips.append(peer_ip)
+
     return TailscaleStatus(
         running=running,
         self_ip=self_ip,
@@ -83,6 +130,7 @@ def parse_status_json(raw: dict[str, Any]) -> TailscaleStatus:
         dns_name=dns_name,
         tailnet=tailnet,
         version=version,
+        peer_ips=peer_ips,
     )
 
 
@@ -96,10 +144,15 @@ async def query_tailscale_status() -> TailscaleStatus:
 
     _not_running = TailscaleStatus(running=False)
 
+    binary = _resolve_tailscale_binary()
+    if binary is None:
+        logger.debug("tailscale binary not found; Tailscale not installed")
+        return _not_running
+
     try:
         process = await asyncio.wait_for(
             asyncio.create_subprocess_exec(
-                "tailscale",
+                binary,
                 "status",
                 "--json",
                 stdout=asyncio.subprocess.PIPE,

--- a/src/skulk/connectivity/tests/test_local_network.py
+++ b/src/skulk/connectivity/tests/test_local_network.py
@@ -1,0 +1,78 @@
+# pyright: reportPrivateUsage=false, reportAny=false
+"""Tests for macOS Local Network Privacy detection."""
+
+from __future__ import annotations
+
+import errno
+from unittest import mock
+
+from skulk.connectivity import local_network
+
+
+def test_non_darwin_is_unknown() -> None:
+    with mock.patch("platform.system", return_value="Linux"):
+        assert local_network.check_local_network_access() == "unknown"
+
+
+def test_no_gateway_is_unknown() -> None:
+    with (
+        mock.patch("platform.system", return_value="Darwin"),
+        mock.patch.object(local_network, "_default_gateway_ipv4", return_value=None),
+    ):
+        assert local_network.check_local_network_access() == "unknown"
+
+
+def test_ehostunreach_is_blocked() -> None:
+    """EHOSTUNREACH on a local-subnet connect is the Local Network denial signature."""
+    sock = mock.Mock()
+    sock.connect.side_effect = OSError(errno.EHOSTUNREACH, "No route to host")
+    with (
+        mock.patch("platform.system", return_value="Darwin"),
+        mock.patch.object(local_network, "_default_gateway_ipv4", return_value="192.168.0.1"),
+        mock.patch("socket.socket", return_value=sock),
+    ):
+        assert local_network.check_local_network_access() == "blocked"
+    sock.close.assert_called_once()
+
+
+def test_connection_refused_is_ok() -> None:
+    """A reachable host with a closed port (ECONNREFUSED) means access is allowed."""
+    sock = mock.Mock()
+    sock.connect.side_effect = OSError(errno.ECONNREFUSED, "Connection refused")
+    with (
+        mock.patch("platform.system", return_value="Darwin"),
+        mock.patch.object(local_network, "_default_gateway_ipv4", return_value="192.168.0.1"),
+        mock.patch("socket.socket", return_value=sock),
+    ):
+        assert local_network.check_local_network_access() == "ok"
+
+
+def test_successful_connect_is_ok() -> None:
+    sock = mock.Mock()
+    sock.connect.return_value = None
+    with (
+        mock.patch("platform.system", return_value="Darwin"),
+        mock.patch.object(local_network, "_default_gateway_ipv4", return_value="192.168.0.1"),
+        mock.patch("socket.socket", return_value=sock),
+    ):
+        assert local_network.check_local_network_access() == "ok"
+
+
+def test_gateway_parser_extracts_ipv4() -> None:
+    route_output = "   route to: default\n   gateway: 192.168.0.1\n   interface: en0\n"
+    completed = mock.Mock(stdout=route_output)
+    with mock.patch("subprocess.run", return_value=completed):
+        assert local_network._default_gateway_ipv4() == "192.168.0.1"
+
+
+def test_gateway_parser_rejects_ipv6() -> None:
+    route_output = "   gateway: fe80::1%en0\n"
+    completed = mock.Mock(stdout=route_output)
+    with mock.patch("subprocess.run", return_value=completed):
+        assert local_network._default_gateway_ipv4() is None
+
+
+def test_blocked_message_is_actionable() -> None:
+    msg = local_network.LOCAL_NETWORK_DENIED_MESSAGE
+    assert "Local Network" in msg
+    assert "System Settings" in msg

--- a/src/skulk/connectivity/tests/test_tailscale.py
+++ b/src/skulk/connectivity/tests/test_tailscale.py
@@ -57,3 +57,21 @@ def test_missing_self_returns_nones() -> None:
     assert status.hostname is None
     assert status.dns_name is None
     assert status.tailnet is None
+
+
+def test_peer_ips_collected_from_peer_map() -> None:
+    raw: dict[str, Any] = {
+        "BackendState": "Running",
+        "Self": {"TailscaleIPs": ["100.64.0.1"]},
+        "Peer": {
+            "keyA": {"TailscaleIPs": ["100.64.0.2", "fd7a::2"]},
+            "keyB": {"TailscaleIPs": ["100.64.0.3"]},
+        },
+    }
+    status = parse_status_json(raw)
+    assert status.peer_ips == ["100.64.0.2", "100.64.0.3"]
+
+
+def test_peer_ips_empty_when_no_peers() -> None:
+    raw: dict[str, Any] = {"BackendState": "Running", "Self": {}}
+    assert parse_status_json(raw).peer_ips == []

--- a/src/skulk/main.py
+++ b/src/skulk/main.py
@@ -724,9 +724,25 @@ def main():
         # cluster needs no hand-maintained IP list — just `enabled: true`. Each
         # peer is dialed on this node's libp2p port; non-Skulk tailnet peers
         # fail the private-network handshake and are harmlessly ignored.
-        _auto_peers = [
-            f"/ip4/{ip}/tcp/{args.libp2p_port}" for ip in _ts_status.peer_ips
-        ]
+        #
+        # Auto-discovery needs a fixed, known port to build the peer multiaddrs.
+        # With --libp2p-port 0 (OS-assigned) the listen port differs per node and
+        # is unknown to peers, so an auto-built /tcp/0 address could never be
+        # dialed. Skip auto-discovery in that case and tell the operator how to
+        # make it work, rather than silently producing dead /tcp/0 peers.
+        if args.libp2p_port == 0:
+            _auto_peers: list[str] = []
+            if _ts_status.peer_ips:
+                logger.warning(
+                    "Tailscale auto-discovery is enabled but --libp2p-port is 0 "
+                    "(OS-assigned); auto-discovered peers need a fixed port and were "
+                    "skipped. Set --libp2p-port / SKULK_LIBP2P_PORT (default 52416) or "
+                    "list connectivity.tailscale.bootstrap_peers explicitly."
+                )
+        else:
+            _auto_peers = [
+                f"/ip4/{ip}/tcp/{args.libp2p_port}" for ip in _ts_status.peer_ips
+            ]
         # Merge auto-discovered + config-listed peers, de-duplicating against
         # CLI/existing peers and each other while preserving order.
         _seen = set(args.bootstrap_peers)

--- a/src/skulk/main.py
+++ b/src/skulk/main.py
@@ -14,6 +14,10 @@ from pydantic import PositiveInt
 
 import skulk.routing.topics as topics
 from skulk.api.main import API
+from skulk.connectivity.local_network import (
+    LOCAL_NETWORK_DENIED_MESSAGE,
+    check_local_network_access,
+)
 from skulk.connectivity.tailscale import query_tailscale_status
 from skulk.download.coordinator import DownloadCoordinator
 from skulk.download.impl_shard_downloader import exo_shard_downloader
@@ -716,16 +720,36 @@ def main():
             logger.warning(
                 "Tailscale connectivity configured but tailscaled is not running"
             )
-        if _ts_config.bootstrap_peers:
-            _seen = set(args.bootstrap_peers)
-            _extra = [p for p in _ts_config.bootstrap_peers if p not in _seen]
-            if _extra:
-                args = args.model_copy(
-                    update={"bootstrap_peers": args.bootstrap_peers + _extra}
-                )
-                logger.info(
-                    f"Tailscale: added {len(_extra)} bootstrap peer(s) from config"
-                )
+        # Auto-discover tailnet peers as bootstrap addresses so a Tailscale
+        # cluster needs no hand-maintained IP list — just `enabled: true`. Each
+        # peer is dialed on this node's libp2p port; non-Skulk tailnet peers
+        # fail the private-network handshake and are harmlessly ignored.
+        _auto_peers = [
+            f"/ip4/{ip}/tcp/{args.libp2p_port}" for ip in _ts_status.peer_ips
+        ]
+        # Merge auto-discovered + config-listed peers, de-duplicating against
+        # CLI/existing peers and each other while preserving order.
+        _seen = set(args.bootstrap_peers)
+        _extra: list[str] = []
+        for _peer in _auto_peers + list(_ts_config.bootstrap_peers):
+            if _peer not in _seen:
+                _seen.add(_peer)
+                _extra.append(_peer)
+        if _extra:
+            args = args.model_copy(
+                update={"bootstrap_peers": args.bootstrap_peers + _extra}
+            )
+            logger.info(
+                f"Tailscale: added {len(_extra)} bootstrap peer(s) "
+                f"({len(_auto_peers)} auto-discovered, "
+                f"{len(_ts_config.bootstrap_peers)} from config)"
+            )
+
+    # macOS Local Network Privacy: a denied process silently fails to reach LAN
+    # / Thunderbolt peers (EHOSTUNREACH), so cluster discovery never forms.
+    # Detect it early and tell the operator how to grant access.
+    if check_local_network_access() == "blocked":
+        logger.warning(LOCAL_NETWORK_DENIED_MESSAGE)
 
     if args.offline:
         logger.info("Running in OFFLINE mode — no internet checks, local models only")
@@ -843,9 +867,15 @@ class Args(CamelCaseModel):
         parser.add_argument(
             "--libp2p-port",
             type=int,
-            default=0,
+            # Default to a fixed, well-known port rather than an OS-assigned one
+            # so that bootstrap-peer multiaddrs (Tailscale, cross-subnet) have a
+            # predictable port to dial — a user can write
+            # /ip4/<peer>/tcp/52416 without first inspecting each node's random
+            # port. mDNS discovery advertises the real port either way, so this
+            # is harmless on a single local network. Pass 0 for OS-assigned.
+            default=int(os.getenv("SKULK_LIBP2P_PORT", "52416")),
             dest="libp2p_port",
-            help="Fixed TCP port for libp2p to listen on (0 = OS-assigned).",
+            help="Fixed TCP port for libp2p to listen on (default 52416; 0 = OS-assigned; env: SKULK_LIBP2P_PORT).",
         )
         fast_synch_group = parser.add_mutually_exclusive_group()
         fast_synch_group.add_argument(

--- a/website/docs/tailscale-clustering.md
+++ b/website/docs/tailscale-clustering.md
@@ -26,40 +26,43 @@ On **every node** that will join the cluster:
 
 ## Setup
 
-### 1. Collect every node's Tailscale IP
+### 1. Enable Tailscale connectivity on every node
 
-On each machine:
+Add this to `skulk.yaml` on **every** node — the same three lines everywhere, no per-node IPs to manage:
 
-```bash
-tailscale ip -4
+```yaml
+connectivity:
+  tailscale:
+    enabled: true
 ```
 
-Write down the IP for every node in the cluster.
+With this set, each node queries its local tailnet and **auto-discovers every
+other node's `100.x` address as a bootstrap peer** — there is no list to
+maintain. Nodes are dialed on Skulk's libp2p port (default `52416`); peers that
+aren't running Skulk simply fail Skulk's private-network handshake and are
+ignored. When a node's Tailscale IP changes, discovery picks up the new one on
+the next restart with no config edit.
 
-### 2. Edit `skulk.yaml` on every node
+:::tip Local Network permission not needed over Tailscale
+The Tailscale overlay (a `utun` interface) is exempt from macOS Local Network
+Privacy, so — unlike a plain LAN/Thunderbolt cluster — you do **not** need to
+grant Local Network access for a Tailscale cluster to form. See
+[Thunderbolt clustering](thunderbolt-clustering) for the local-network case.
+:::
 
-Add a `connectivity` section listing the **other** nodes' Tailscale IPs. You don't list yourself — only peers.
+### 2. (Optional) Pin specific peers
 
-**Node A** (`100.101.102.101`) — lists B and C:
+Auto-discovery is enough for most setups. If you want to pin specific bootstrap
+addresses anyway — for example to dial a node on a non-default port, or to seed
+peers from outside the tailnet — list them explicitly; they are merged with the
+auto-discovered set:
 
 ```yaml
 connectivity:
   tailscale:
     enabled: true
     bootstrap_peers:
-      - /ip4/100.101.102.102/tcp/52416   # Node B
-      - /ip4/100.101.102.103/tcp/52416   # Node C
-```
-
-**Node B** (`100.101.102.102`) — lists A and C:
-
-```yaml
-connectivity:
-  tailscale:
-    enabled: true
-    bootstrap_peers:
-      - /ip4/100.101.102.101/tcp/52416   # Node A
-      - /ip4/100.101.102.103/tcp/52416   # Node C
+      - /ip4/100.101.102.103/tcp/52416   # pinned peer
 ```
 
 Port `52416` is Skulk's default libp2p port. If you changed it with `--libp2p-port`, use that port instead.

--- a/website/docs/thunderbolt-clustering.md
+++ b/website/docs/thunderbolt-clustering.md
@@ -1,0 +1,135 @@
+# Thunderbolt clustering (local setup)
+
+This guide walks through standing up a Skulk cluster on several Macs connected
+on the same local network — typically wired together with **Thunderbolt** for
+the high-bandwidth inference path. No Tailscale or cross-network configuration
+is required; that is covered separately in
+[Tailscale clustering](./tailscale-clustering.md).
+
+The happy path is deliberately small:
+
+1. Install Skulk on each node.
+2. **Grant macOS Local Network access** (the one step people miss — see below).
+3. Run `uv run skulk` on each node.
+
+Skulk discovers peers automatically over mDNS on your local network, and the
+inference data plane automatically prefers Thunderbolt links when present.
+
+## 1. Prerequisites
+
+- Two or more Apple-silicon Macs.
+- The Macs on the **same local network** (any of: a shared Ethernet/Wi-Fi LAN,
+  or a Thunderbolt Bridge — see [Thunderbolt wiring](#thunderbolt-wiring)).
+- [`uv`](https://docs.astral.sh/uv/) and Node.js installed on each node.
+
+## 2. Install (each node)
+
+```bash
+git clone https://github.com/Foxlight-Foundation/Skulk.git
+cd Skulk
+npm --prefix dashboard-react install
+npm --prefix dashboard-react run build
+uv sync
+```
+
+## 3. Grant macOS Local Network access (required)
+
+> **This is the most common reason a freshly-installed cluster "won't form."**
+
+macOS 15 (Sequoia) and macOS 26 gate access to the **local network** — your
+LAN, link-local addresses, multicast (which mDNS discovery relies on), and the
+Thunderbolt Bridge — behind a per-application privacy permission. Until the app
+you run Skulk from is granted Local Network access, Skulk **cannot discover or
+connect to peers on your local network or over Thunderbolt**. Every local
+connection fails with `No route to host` (`EHOSTUNREACH`), while internet and
+Tailscale traffic keep working — so the symptom is a cluster that silently
+stays at one node.
+
+When you first run Skulk, macOS shows a prompt:
+
+> *"Skulk" / "Terminal" would like to find and connect to devices on your local
+> network.*
+
+Click **Allow**. If you missed it (or are running over SSH and never saw it):
+
+1. Open **System Settings → Privacy & Security → Local Network**.
+2. Enable the toggle for the app you launch Skulk from — usually **Terminal**
+   (or iTerm, or your IDE). Tools launched from that app inherit its grant.
+3. Restart Skulk.
+
+Skulk detects this denial at startup and logs a warning telling you to grant
+access, so you are never left guessing.
+
+> **The grant follows the launching app.** macOS attributes Local Network
+> access to the app a process is launched *from*. Run Skulk from the **Terminal
+> you granted** (i.e. `uv run skulk` in that Terminal) and it inherits the
+> grant. A process **detached** from that Terminal — `nohup … &`, or some
+> background/service launchers that reparent it — is attributed separately and
+> may be denied even though the foreground command works. If you run Skulk
+> detached or as a background service and see the denial warning, grant Local
+> Network to that launcher too (see [Run as a service](./run-skulk-as-a-service)).
+
+> **Headless / SSH-only nodes:** macOS cannot show the Local Network prompt to
+> an SSH session, and there is no command-line way to grant the permission. Use
+> Screen Sharing (or a directly-attached display) once to enable Local Network
+> for Terminal in System Settings; the grant then persists across reboots. Run
+> Skulk in a foreground/attached Terminal session (e.g. via `tmux`/`screen` on
+> the console) rather than a detached `nohup … &`, so it inherits that grant.
+> Alternatively, run the cluster over [Tailscale](./tailscale-clustering.md),
+> whose overlay interface is exempt from Local Network Privacy.
+
+## 4. Run (each node)
+
+```bash
+uv run skulk
+```
+
+That's it. With Local Network access granted, each node's mDNS announcements
+reach the others, the cluster forms automatically, and a master is elected. No
+`--bootstrap-peers` or `--libp2p-port` flags are needed on a single local
+network.
+
+Open the dashboard on any node (`http://localhost:52415`) and confirm every
+node appears in the cluster topology.
+
+## Thunderbolt wiring
+
+Skulk does not require any Thunderbolt-specific configuration to *cluster* — the
+control plane (peer discovery, coordination) runs over whatever local network
+your Macs share. Thunderbolt matters for the **data plane**: when a model is
+placed across nodes, Skulk's placement automatically prefers Thunderbolt links
+for the high-bandwidth tensor exchange (ranked above Ethernet, Wi-Fi, and any
+overlay such as Tailscale).
+
+To use Thunderbolt:
+
+1. Cable the Macs together over Thunderbolt.
+2. macOS automatically creates a **Thunderbolt Bridge** network service that
+   carries traffic between the directly-connected Macs. The default
+   self-assigned (link-local) addressing is sufficient for the inference ring;
+   no manual IP assignment is required.
+3. Run Skulk as above. Placement uses the Thunderbolt path for inference
+   automatically — you can confirm the chosen interface in the placement
+   diagnostics.
+
+If your Macs are *only* connected by Thunderbolt (no shared Ethernet/Wi-Fi),
+peer discovery happens over the Thunderbolt Bridge segment — the same Local
+Network permission applies.
+
+## With or without Tailscale
+
+- **Without Tailscale (this guide):** nodes discover each other over mDNS on the
+  local network. Requires the Local Network permission above.
+- **With Tailscale:** useful when nodes are on different networks. Tailscale's
+  overlay is exempt from Local Network Privacy. See
+  [Tailscale clustering](./tailscale-clustering.md). You can run both — Skulk
+  still prefers the direct Thunderbolt/Ethernet path for the data plane.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Cluster stays at one node; dashboard shows only the local node | Local Network access denied (most common) | Grant it (section 3), restart Skulk |
+| Startup log: *"macOS Local Network access appears to be DENIED"* | Same as above | Grant it (section 3) |
+| Local connections log `No route to host` / `EHOSTUNREACH` but internet works | Local Network access denied | Grant it (section 3) |
+| Nodes on different subnets don't see each other | mDNS does not cross subnets | Use [Tailscale](./tailscale-clustering.md) or `--bootstrap-peers` |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -22,6 +22,7 @@ const sidebars: SidebarsConfig = {
       items: [
         "api-guide",
         "build-and-runtime",
+        "thunderbolt-clustering",
         "run-skulk-as-a-service",
         "external-logging",
         {


### PR DESCRIPTION
## What & why

A user with Thunderbolt-connected Macs should be able to clone Skulk, follow the docs, run `uv run skulk` on each node, and get a working cluster — **with or without Tailscale**. This branch makes that real and fixes the root cause that was silently breaking it.

### Root cause
On macOS 15/26, a process not granted **Local Network access** silently gets `EHOSTUNREACH` on *every* local-subnet connect, and mDNS multicast is blocked too — while internet and Tailscale (VPN-exempt) keep working. So cluster discovery over LAN/Thunderbolt failed with no recognizable error. (A sharp gotcha: the grant follows the *launching app*, so a process detached via `nohup &` is attributed to launchd and stays denied even when the foreground command works.)

## Changes
- **`fix(net)`: bootstrap re-dial leak** — bootstrap dials carry no peer id, so libp2p can't dedup them; the 5s retry loop leaked a socket per peer per interval (38→128+ on 3 nodes). Now tracks connected IPs and skips already-connected peers; connections hold steady.
- **`feat(net)`: Local Network Privacy detection** — startup self-check logs the exact fix instead of failing silently.
- **`feat(net)`: zero-config Tailscale** — `connectivity.tailscale.enabled: true` auto-discovers tailnet peers (no IP list); resolves the `tailscale` CLI by path (works under minimal launch PATH).
- **`feat(net)`: default `--libp2p-port` 52416** — was random `0`, which silently broke any bootstrap multiaddr.
- **Docs** — new `thunderbolt-clustering.md` + rewritten Tailscale guide (zero-config) + sidebar.

## Verified on hardware (3× Mac kites)
| | result |
|---|---|
| Without Tailscale (pure mDNS, `uv run skulk`, no config) | ✅ all 3 discover each other, single master, 2 conns steady |
| With Tailscale (one line `enabled: true`) | ✅ auto-discovers peers, single master, 2 conns steady |
| Single-node inference | ✅ coherent generations |
| **3-node clustered inference** (4B split across all nodes) | ✅ coherent answer, ~11s |

Fresh `git clone` + `uv sync` install validated from scratch. `basedpyright`, `ruff`, `nix fmt`, and `pytest` (937 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)