### PR TITLE
chore(nix): point the binary cache at foxlight.cachix.org

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,8 +48,8 @@
   };
 
   nixConfig = {
-    extra-trusted-public-keys = "exo.cachix.org-1:okq7hl624TBeAR3kV+g39dUFSiaZgLRkLsFBCuJ2NZI=";
-    extra-substituters = "https://exo.cachix.org";
+    extra-trusted-public-keys = "foxlight.cachix.org-1:P6i/DsS8LTGVBe0Z5OD7mQo1jQH/SU6yEx7B1UndR9g=";
+    extra-substituters = "https://foxlight.cachix.org";
   };
 
   outputs =

--- a/nix/metal-toolchain.nix
+++ b/nix/metal-toolchain.nix
@@ -6,7 +6,7 @@ let
     message = ''
       The Metal Toolchain NAR must be available.
 
-      If you have cachix configured for exo.cachix.org (the legacy cache name), this should be automatic.
+      If you have cachix configured for foxlight.cachix.org, this should be automatic.
 
       Otherwise:
         1. Install Xcode 26+ from the App Store


### PR DESCRIPTION
The flake's `nixConfig` (substituter + trusted public key) and a toolchain hint still referenced the legacy `exo.cachix.org` cache inherited from the exo fork — Nix was ignoring it as untrusted, so it was pure dead weight pointing at a now-foreign cache.

Switches the substituter and trusted public key to **`foxlight.cachix.org`** (key provided by the maintainer), and updates the stale hint in `nix/metal-toolchain.nix`.

No functional change to the build; it just lets prebuilt artifacts be trusted from Foxlight's own cache instead of exo's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
