### PR TITLE
fix(worker): make crash breaker edge-triggered (closes #250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ This project records release notes here and mirrors public-facing notes in
   state before its `DeleteInstance` landed could re-accumulate and re-trip,
   emitting duplicate `DeleteInstance` commands and "giving up on instance" logs.
   `InstanceId`s are unique, so the retained failure history can never collide
-  with a future instance. (Follow-up to #243.)
+  with a future instance, and the worker reclaims breaker entries for deleted
+  instances each planning tick (`CrashWindow.retain`) so the history can't grow
+  unbounded. (Follow-up to #243.)
 - **Oversized model placements no longer brick a node.** Placing a model whose
   shard does not fit a node's memory previously passed an over-optimistic
   admission check (1.05x weights against gossiped `ram_available` only),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Crash circuit breaker now trips once per crash loop, not once per failure.**
+  `CrashWindow.record()` is edge-triggered: it returns `True` only when the
+  in-window failure count *crosses* the threshold and stays latched (returning
+  `False`) until the window drains below it, and `_give_up_on_instance` no
+  longer clears the window. Previously the trip was level-triggered and the
+  window was cleared on give-up, so a doomed instance lingering in replicated
+  state before its `DeleteInstance` landed could re-accumulate and re-trip,
+  emitting duplicate `DeleteInstance` commands and "giving up on instance" logs.
+  `InstanceId`s are unique, so the retained failure history can never collide
+  with a future instance. (Follow-up to #243.)
 - **Oversized model placements no longer brick a node.** Placing a model whose
   shard does not fit a node's memory previously passed an over-optimistic
   admission check (1.05x weights against gossiped `ram_available` only),

--- a/src/skulk/utils/crash_window.py
+++ b/src/skulk/utils/crash_window.py
@@ -8,7 +8,7 @@ fails once an hour never trips — only a tight crash loop does.
 """
 
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Container
 from typing import Generic, TypeVar
 
 K = TypeVar("K")
@@ -62,19 +62,39 @@ class CrashWindow(Generic[K]):
             for stamp in self._failures.get(key, [])
             if now - stamp < self._window_seconds
         ]
+        # Release the latch based on the PRUNED, pre-append count: if the prior
+        # loop has drained below the threshold, the next failure starts a fresh
+        # loop and must be allowed to re-cross. Deciding this before appending is
+        # what makes the edge detection correct for every threshold — including
+        # threshold == 1, where appending first would keep the count permanently
+        # at/above the threshold and the latch could never release.
+        if len(recent) < self._threshold:
+            self._tripped.discard(key)
         recent.append(now)
         self._failures[key] = recent
-        if len(recent) >= self._threshold:
-            if key in self._tripped:
-                return False  # already tripped this loop; edge already fired
+        # Edge: this failure crosses into tripped territory and we are not
+        # already latched from the current loop.
+        if len(recent) >= self._threshold and key not in self._tripped:
             self._tripped.add(key)
             return True
-        # Window drained below threshold — release the latch so a fresh loop
-        # (threshold failures within a new window) can trip again.
-        self._tripped.discard(key)
         return False
 
     def clear(self, key: K) -> None:
         """Forget all recorded failures and the trip latch for ``key``."""
         self._failures.pop(key, None)
         self._tripped.discard(key)
+
+    def retain(self, live_keys: Container[K]) -> None:
+        """Drop tracked failures/latches for keys not in ``live_keys``.
+
+        A key's timestamps are pruned only when that key is recorded again, so
+        keys for entities that fail a few times and then disappear would
+        otherwise linger forever. A caller that knows the current live key set
+        (e.g. the worker's live instance ids) calls this periodically to bound
+        growth. ``_tripped`` is a subset of the ``_failures`` keys, so iterating
+        the latter is sufficient.
+        """
+        dead = [key for key in self._failures if key not in live_keys]
+        for key in dead:
+            self._failures.pop(key, None)
+            self._tripped.discard(key)

--- a/src/skulk/utils/crash_window.py
+++ b/src/skulk/utils/crash_window.py
@@ -35,12 +35,26 @@ class CrashWindow(Generic[K]):
         self._window_seconds = window_seconds
         self._clock = clock
         self._failures: dict[K, list[float]] = {}
+        # Keys currently latched as tripped. The trip is edge-triggered: once a
+        # key crosses the threshold it returns True exactly once and stays
+        # latched (returning False) for every further failure while it remains
+        # at/above the threshold, so callers don't re-run trip side effects
+        # (e.g. sending DeleteInstance repeatedly). The latch releases only when
+        # the window drains back below the threshold, letting a genuinely fresh
+        # crash loop trip again.
+        self._tripped: set[K] = set()
 
     def record(self, key: K) -> bool:
-        """Record a failure for ``key``; return ``True`` if the breaker tripped.
+        """Record a failure for ``key``; return ``True`` only on the edge where
+        the in-window count *crosses* the threshold.
 
-        Prunes failures older than the window before counting, so the return
-        reflects only failures inside ``window_seconds`` of now.
+        Prunes failures older than the window before counting, so the count
+        reflects only failures inside ``window_seconds`` of now. Returns ``True``
+        the first time the count reaches ``threshold`` and ``False`` on
+        subsequent failures while it stays at/above the threshold — so the
+        caller's trip handler runs once per crash loop, not once per failure.
+        Once the window drains below the threshold the latch resets and a new
+        loop can trip again.
         """
         now = self._clock()
         recent = [
@@ -50,8 +64,17 @@ class CrashWindow(Generic[K]):
         ]
         recent.append(now)
         self._failures[key] = recent
-        return len(recent) >= self._threshold
+        if len(recent) >= self._threshold:
+            if key in self._tripped:
+                return False  # already tripped this loop; edge already fired
+            self._tripped.add(key)
+            return True
+        # Window drained below threshold — release the latch so a fresh loop
+        # (threshold failures within a new window) can trip again.
+        self._tripped.discard(key)
+        return False
 
     def clear(self, key: K) -> None:
-        """Forget all recorded failures for ``key`` (e.g. after giving up)."""
+        """Forget all recorded failures and the trip latch for ``key``."""
         self._failures.pop(key, None)
+        self._tripped.discard(key)

--- a/src/skulk/utils/tests/test_crash_window.py
+++ b/src/skulk/utils/tests/test_crash_window.py
@@ -21,6 +21,31 @@ def test_trips_exactly_at_threshold_within_window():
     assert breaker.record("a") is True  # 3rd -> trips
 
 
+def test_trip_is_edge_triggered_not_level_triggered():
+    # Once tripped, further failures inside the window must NOT re-trip, so a
+    # caller's trip handler (e.g. sending DeleteInstance) runs once per loop.
+    clock = _FakeClock()
+    breaker: CrashWindow[str] = CrashWindow(3, 60.0, clock=clock)
+    assert breaker.record("a") is False  # 1st
+    assert breaker.record("a") is False  # 2nd
+    assert breaker.record("a") is True  # 3rd -> crosses, trips once
+    assert breaker.record("a") is False  # 4th -> still tripped, no re-fire
+    assert breaker.record("a") is False  # 5th -> still tripped, no re-fire
+
+
+def test_latch_releases_after_window_drains_then_retrips():
+    # When the window drains below the threshold the latch resets, so a
+    # genuinely fresh crash loop trips again.
+    clock = _FakeClock()
+    breaker: CrashWindow[str] = CrashWindow(2, 60.0, clock=clock)
+    assert breaker.record("a") is False  # t=0, count 1
+    assert breaker.record("a") is True  # t=0, count 2 -> trips
+    assert breaker.record("a") is False  # t=0, count 3 -> latched, no re-fire
+    clock.now = 100.0  # all earlier failures now outside the 60s window
+    assert breaker.record("a") is False  # fresh count 1, latch released
+    assert breaker.record("a") is True  # fresh count 2 -> trips again
+
+
 def test_failures_outside_window_are_forgotten():
     clock = _FakeClock()
     breaker: CrashWindow[str] = CrashWindow(3, 60.0, clock=clock)

--- a/src/skulk/utils/tests/test_crash_window.py
+++ b/src/skulk/utils/tests/test_crash_window.py
@@ -46,6 +46,33 @@ def test_latch_releases_after_window_drains_then_retrips():
     assert breaker.record("a") is True  # fresh count 2 -> trips again
 
 
+def test_threshold_one_trips_each_time_after_window_drains():
+    # threshold == 1 is the edge case for latch release: every isolated failure
+    # (outside the prior window) must re-trip, but a burst still trips only once.
+    clock = _FakeClock()
+    breaker: CrashWindow[str] = CrashWindow(1, 60.0, clock=clock)
+    assert breaker.record("a") is True  # 1st failure -> trips
+    assert breaker.record("a") is False  # same instant, still latched
+    clock.now = 100.0  # prior failure aged out
+    assert breaker.record("a") is True  # fresh isolated failure -> trips again
+
+
+def test_fresh_crossing_after_partial_drain_retrips():
+    # threshold=3, failures at t=0,1,2 trip at t=2. At t=60.5 the t=0 stamp has
+    # aged out, so the pruned count is 2 (< threshold) and the latch must release
+    # BEFORE the new failure brings the count back to 3 — a genuine fresh edge.
+    clock = _FakeClock()
+    breaker: CrashWindow[str] = CrashWindow(3, 60.0, clock=clock)
+    clock.now = 0.0
+    assert breaker.record("a") is False
+    clock.now = 1.0
+    assert breaker.record("a") is False
+    clock.now = 2.0
+    assert breaker.record("a") is True  # trips
+    clock.now = 60.5  # t=0 now outside the 60s window; t=1,t=2 remain (count 2)
+    assert breaker.record("a") is True  # 2 -> 3 is a fresh crossing
+
+
 def test_failures_outside_window_are_forgotten():
     clock = _FakeClock()
     breaker: CrashWindow[str] = CrashWindow(3, 60.0, clock=clock)
@@ -72,6 +99,21 @@ def test_clear_resets_a_key():
     breaker.record("a")
     breaker.clear("a")
     assert breaker.record("a") is False  # count restarted at 1
+
+
+def test_retain_drops_dead_keys_and_keeps_live_ones():
+    clock = _FakeClock()
+    breaker: CrashWindow[str] = CrashWindow(2, 60.0, clock=clock)
+    breaker.record("live")
+    breaker.record("live")  # trips -> latched
+    breaker.record("dead")  # one failure recorded for a key about to disappear
+
+    breaker.retain({"live"})  # "dead" is no longer a live key
+
+    # "dead" was fully forgotten: it starts counting from scratch.
+    assert breaker.record("dead") is False
+    # "live" kept both its history and its latch (still tripped, no re-fire).
+    assert breaker.record("live") is False
 
 
 def test_threshold_must_be_positive():

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -464,6 +464,12 @@ class Worker:
                     self._stale_downloads_pending_reset.clear()
                     self._stale_resets_sent.clear()
                     self._stale_reset_wait_ticks = 0
+            # Bound the crash breaker's memory: drop entries for instances that
+            # no longer exist. We deliberately don't clear on give-up (that would
+            # let a lingering instance re-trip and re-send DeleteInstance), so
+            # this is where dead-instance keys are reclaimed.
+            self._crash_breaker.retain(self.state.instances)
+
             task: Task | None = plan(
                 self.node_id,
                 self.runners,

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -348,10 +348,14 @@ class Worker:
 
         Sends ``DeleteInstance`` to the master so the doomed instance stops
         being reconciled into fresh runners — each relaunch risks another
-        leak-on-abort. Clears the local failure record.
+        leak-on-abort. The crash window is deliberately NOT cleared: the trip is
+        edge-triggered, so leaving the failure history in place keeps the latch
+        set and suppresses re-tripping (and duplicate ``DeleteInstance``) while
+        the instance lingers in replicated state before the deletion lands.
+        ``InstanceId``s are unique, so the stale entry can never collide with a
+        future instance.
         """
         logger.error(f"Worker: giving up on instance {instance_id}: {reason}")
-        self._crash_breaker.clear(instance_id)
         await self.command_sender.send(
             ForwarderCommand(
                 origin=self._system_id,


### PR DESCRIPTION
Closes #250. Follow-up to #243.

## Problem
`CrashWindow.record()` was **level-triggered** — it returned `True` for *every* failure once `len(recent) >= threshold` — and `_give_up_on_instance()` **cleared** the window before sending `DeleteInstance`. A doomed instance that kept generating failing `CreateRunner`/`LoadModel` tasks before its `DeleteInstance` propagated could re-accumulate the (cleared) window and trip again, emitting **duplicate `DeleteInstance` commands** and duplicate "giving up on instance" warning logs.

Bounded (DeleteInstance is idempotent — `apply_instance_deleted` filters by the unique `InstanceId`), so this was triaged sev-2 and deferred out of #243 rather than fixed at merge time.

## Fix
- **`record()` is now edge-triggered with a latch:** returns `True` only on the edge where the in-window count crosses `threshold`, `False` while it stays at/above it, and releases the latch when the window drains below `threshold` so a genuinely fresh crash loop can trip again.
- **`_give_up_on_instance` no longer clears the window.** `InstanceId`s are unique, so the retained failure history can't collide with a future instance, and keeping it holds the latch — suppressing re-tripping while the instance lingers in replicated state.

Net effect: the trip handler runs **once per crash loop**, not once per failure.

## Tests
- `test_trip_is_edge_triggered_not_level_triggered` — 4th/5th in-window failures return `False` after the 3rd trips.
- `test_latch_releases_after_window_drains_then_retrips` — after the window ages out, a fresh loop trips again.
- Existing `CrashWindow` tests unchanged (none re-called `record()` post-trip, so all still pass).

## Validation
`basedpyright` 0 errors · `ruff` clean · `nix fmt` clean · 246 passed (crash_window + full worker suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)