### PR TITLE
fix(runner): default MLX_METAL_FAST_SYNCH off; pin hybrid + gpt-oss cards (refs #259, #236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- **`MLX_METAL_FAST_SYNCH` now defaults OFF cluster-wide.** The old ON default
+  had no measured upside (vanilla dense decode: 20.8 tok/s off vs 20.7 on) and
+  a catastrophic failure mode for any model without a curated card pin:
+  hybrid-SSM models wedge at warmup under the flag — gpt-oss hit the 300s
+  warmup deadline (#236, card-pinned off on 2026-06-07) and NemotronH-9B did
+  exactly the same (#259) — and the resulting deadline kill mid-GPU-work leaks
+  ~5GB of wired memory per attempt and degrades the node until reboot. With
+  the flag off, Nemotron-Nano-9B warms in seconds and decodes at 19+ tok/s.
+  All NemotronH/Nemotron-3-hybrid and gpt-oss cards also carry an explicit
+  `runtime.metal_fast_synch = false` pin now, and any model that measurably
+  benefits from FAST_SYNCH can pin it on per card; the operator override
+  (`--fast-synch`/`--no-fast-synch`) is unchanged.
+
 ### Added
 
 - **The dashboard now shows speculative-decoding status per instance.** Active

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4Bit.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-4Bit.toml
@@ -8,5 +8,8 @@ quantization = "4bit"
 base_model = "NVIDIA Nemotron-3-Nano-30B-A3B"
 capabilities = ["text"]
 
+[runtime]
+metal_fast_synch = false
+
 [storage_size]
 in_bytes = 17775342336

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-5Bit.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-5Bit.toml
@@ -8,5 +8,8 @@ quantization = "5bit"
 base_model = "NVIDIA Nemotron-3-Nano-30B-A3B"
 capabilities = ["text"]
 
+[runtime]
+metal_fast_synch = false
+
 [storage_size]
 in_bytes = 21721476864

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-6Bit.toml
@@ -8,5 +8,8 @@ quantization = "6bit"
 base_model = "NVIDIA Nemotron-3-Nano-30B-A3B"
 capabilities = ["text"]
 
+[runtime]
+metal_fast_synch = false
+
 [storage_size]
 in_bytes = 25667611392

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-8Bit.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-8Bit.toml
@@ -8,5 +8,8 @@ quantization = "8bit"
 base_model = "NVIDIA Nemotron-3-Nano-30B-A3B"
 capabilities = ["text"]
 
+[runtime]
+metal_fast_synch = false
+
 [storage_size]
 in_bytes = 33559880448

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-BF16.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-BF16.toml
@@ -8,5 +8,8 @@ quantization = "bf16"
 base_model = "NVIDIA Nemotron-3-Nano-30B-A3B"
 capabilities = ["text"]
 
+[runtime]
+metal_fast_synch = false
+
 [storage_size]
 in_bytes = 63155889408

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-MXFP4.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-MLX-MXFP4.toml
@@ -8,5 +8,8 @@ quantization = "4bit"
 base_model = "NVIDIA Nemotron-3-Nano-30B-A3B"
 capabilities = ["text"]
 
+[runtime]
+metal_fast_synch = false
+
 [storage_size]
 in_bytes = 16788808704

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4.toml
@@ -8,5 +8,8 @@ quantization = "4bit"
 base_model = "NVIDIA Nemotron-3-Nano-30B-A3B"
 capabilities = ["text"]
 
+[runtime]
+metal_fast_synch = false
+
 [storage_size]
 in_bytes = 19323906944

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-Nano-9B-v2-4bits.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-Nano-9B-v2-4bits.toml
@@ -15,5 +15,8 @@ format = "token_delimited"
 default_effort = "medium"
 disabled_effort = "none"
 
+[runtime]
+metal_fast_synch = false
+
 [storage_size]
 in_bytes = 5002791936

--- a/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-Nano-9B-v2-6bit.toml
+++ b/resources/inference_model_cards/mlx-community--NVIDIA-Nemotron-Nano-9B-v2-6bit.toml
@@ -14,5 +14,8 @@ format = "token_delimited"
 default_effort = "medium"
 disabled_effort = "none"
 
+[runtime]
+metal_fast_synch = false
+
 [storage_size]
 in_bytes = 7224298496

--- a/resources/inference_model_cards/mlx-community--gpt-oss-120b-MXFP4-Q8.toml
+++ b/resources/inference_model_cards/mlx-community--gpt-oss-120b-MXFP4-Q8.toml
@@ -23,4 +23,5 @@ builtin_tools = ["web_search", "open_url", "extract_page"]
 tool_call_format = "gpt_oss"
 
 [runtime]
+metal_fast_synch = false
 output_parser = "gpt_oss"

--- a/src/skulk/worker/runner/bootstrap.py
+++ b/src/skulk/worker/runner/bootstrap.py
@@ -31,12 +31,26 @@ logger: "loguru.Logger" = loguru.logger
 shutdown_requested: bool = False
 
 
-FAST_SYNCH_CLUSTER_DEFAULT: bool = True
+FAST_SYNCH_CLUSTER_DEFAULT: bool = False
 """Cluster-wide default for ``MLX_METAL_FAST_SYNCH`` when neither the operator
-nor the model card has expressed a preference. Currently True for backwards
-compatibility with existing deployments. Flipping this default is tracked
-under the env-var → typed-config migration; do not flip without measuring
-the perf delta on a representative workload first."""
+nor the model card has expressed a preference.
+
+OFF as of 2026-06-10. The old True default ("backwards compatibility") had no
+measured upside and a catastrophic failure mode for uncarded models:
+
+- Vanilla dense decode is unaffected by the flag (measured 2026-06-06,
+  Qwen3.5-9B-4bit on M4: 20.8 tok/s off vs 20.7 on).
+- Speculative-decoding loops collapse 46x under the flag (same measurement;
+  the spec-card rule below already forced those off).
+- Hybrid-SSM models WEDGE at warmup under the flag: gpt-oss hit the 300s
+  warmup deadline (#236, card-pinned off 2026-06-07) and NemotronH-9B did
+  the same (#259, 2026-06-10 — off, warmup completes in seconds and decode
+  runs 19+ tok/s; on, the deadline kill additionally leaks ~5GB of wired
+  GPU memory and degrades the node until reboot).
+
+Every model that benefits measurably from FAST_SYNCH can pin
+``runtime.metal_fast_synch = true`` on its card; the per-model card pin and
+the operator override both outrank this default."""
 
 
 def _card_declares_speculative_decoding(
@@ -79,7 +93,8 @@ def resolve_metal_fast_synch(card_runtime: RuntimeCapabilityCardConfig | None) -
        The per-round pattern of small evals across streams that
        speculative decoding requires is exactly the shape FAST_SYNCH's
        completion-signal path pathologizes.
-    4. **Cluster default.** ``FAST_SYNCH_CLUSTER_DEFAULT`` (True today).
+    4. **Cluster default.** ``FAST_SYNCH_CLUSTER_DEFAULT`` (False — see its
+       docstring for the 2026-06-10 rationale and measurements).
 
     Returns ``True`` when ``MLX_METAL_FAST_SYNCH`` should be ``"1"``.
     """


### PR DESCRIPTION
Root cause of the Nemotron warmup-wedge saga (#259) — and it unifies #236.

## The bug class
`MLX_METAL_FAST_SYNCH=1` — the cluster default for any model **without a curated card pin** — makes hybrid-SSM warmup glacial enough to cross the 300s warmup deadline. The deadline kill mid-GPU-work then **leaks ~5GB wired AND degrades the node's Metal state** so every subsequent GPU workload grinds (even bare mlx_lm) until reboot. That spiral consumed the kite3 test node six times across 2026-06-09/10 and produced a long chain of confounded bisections (BatchGenerator, FAST_SYNCH-on-poisoned-node, node freshness) before the clean-node matrix isolated it.

## The decisive measurements (clean-rebooted M4 24GB node, same model, same weights)
| Configuration | Result |
|---|---|
| bare mlx_lm (no FS env) | load 6.0s, **first token 0.3s**, 19.9 tok/s |
| Skulk, FS=1 (old default) | GPU 100%/CPU 0% grind → 300s deadline kill + ~5GB wired leak |
| Skulk, FS=off | warmup in seconds, **19.2 tok/s**, wired flat |
| Skulk, **this PR (no overrides)** | `Fast synch flag: 0`, **warmup 5s**, Paris/stop, 19.4 tok/s, wired flat |

## The smoking gun for the default flip
**gpt-oss-20b's card was already pinned `metal_fast_synch = false` on 2026-06-07 with the identical diagnosis** (#236: "with the flag off, single-node warmup clears in ~8s; left on, warmup hits the 300s deadline"). The knowledge existed in one card — the ON default kept the trap armed for the next uncarded model, which is exactly how Nemotron hit it. Defaults must be safe for the uncurated case; cards encode the exceptions.

## Changes
- `FAST_SYNCH_CLUSTER_DEFAULT` → **False** (docstring now carries the full measurement record: vanilla dense decode unaffected — 20.8 off vs 20.7 on; spec loops collapse 46×; hybrids wedge+leak).
- Explicit `runtime.metal_fast_synch = false` pins on all 9 NemotronH / Nemotron-3-hybrid cards + gpt-oss-120b (20b already had it).
- Card pin (both directions) and operator override (`--fast-synch`/`--no-fast-synch`) unchanged and still outrank the default.

## Supersedes
The `fix/nemotron-sequential-generator` branch (BatchGenerator was innocent — a confounded bisect; that branch is abandoned, no PR was opened).

## Validation
All 21 `resolve_metal_fast_synch` tests pass (they assert against the symbolic default). basedpyright 0, ruff clean, nix fmt clean. Live E2E proof above on the actual fleet. gpt-oss-20b retest (#236 close candidate) running next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)