### PR TITLE
fix(worker): stop InfoGatherer cleanly when its consumer closes (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Peer churn can no longer crash healthy bystander nodes (#266).** When a
+  master transition replaced the worker, the telemetry forwarder exited first
+  (its event stream closes), and the InfoGatherer's next send raced into the
+  closed channel — the unhandled `BrokenResourceError` took the entire
+  process down (observed twice in one night, once on the cluster hub). A
+  closed/broken telemetry channel is now treated as the stop signal it is:
+  the gatherer exits cleanly (the replacement worker brings a fresh one), and
+  the per-monitor `except Exception` blocks — which exist to survive flaky
+  *gathering* — explicitly re-raise channel closure instead of swallowing it
+  and spinning on a dead channel.
+
 - **GPU-wedge runner deaths are no longer retried (wired-memory leak).**
   Contrary to every other crash class, a runner hard-exited by the warmup
   deadline watchdog while its main thread is parked in a faulted Metal eval

--- a/src/skulk/utils/info_gatherer/info_gatherer.py
+++ b/src/skulk/utils/info_gatherer/info_gatherer.py
@@ -7,7 +7,13 @@ from dataclasses import dataclass, field
 from typing import Self
 
 import anyio
-from anyio import fail_after, open_process, to_thread
+from anyio import (
+    BrokenResourceError,
+    ClosedResourceError,
+    fail_after,
+    open_process,
+    to_thread,
+)
 from anyio.streams.buffered import BufferedByteReceiveStream
 from loguru import logger
 from pydantic import ValidationError
@@ -471,30 +477,54 @@ class InfoGatherer:
     _tg: TaskGroup = field(init=False, default_factory=TaskGroup)
 
     async def run(self):
-        async with self._tg as tg:
-            if IS_DARWIN:
-                if (mactop_path := shutil.which("mactop")) is not None:
-                    tg.start_soon(self._monitor_mactop, mactop_path)
-                else:
-                    # mactop not installed — fall back to psutil for memory.
-                    # (mactop replaced macmon, whose IOGPUFamily GPU polling
-                    # crashed/hung MLX inference — see mactop.py / exo#2088.)
-                    logger.warning(
-                        "mactop not found, falling back to psutil for memory monitoring"
-                    )
-                    self.memory_poll_rate = 1
-                tg.start_soon(self._monitor_system_profiler_thunderbolt_data)
-                tg.start_soon(self._monitor_thunderbolt_bridge_status)
-                tg.start_soon(self._monitor_rdma_ctl_status)
-            tg.start_soon(self._watch_system_info)
-            tg.start_soon(self._monitor_memory_usage)
-            tg.start_soon(self._monitor_misc)
-            tg.start_soon(self._monitor_static_info)
-            tg.start_soon(self._monitor_disk_usage)
+        try:
+            async with self._tg as tg:
+                if IS_DARWIN:
+                    if (mactop_path := shutil.which("mactop")) is not None:
+                        tg.start_soon(self._monitor_mactop, mactop_path)
+                    else:
+                        # mactop not installed — fall back to psutil for memory.
+                        # (mactop replaced macmon, whose IOGPUFamily GPU polling
+                        # crashed/hung MLX inference — see mactop.py / exo#2088.)
+                        logger.warning(
+                            "mactop not found, falling back to psutil for "
+                            "memory monitoring"
+                        )
+                        self.memory_poll_rate = 1
+                    tg.start_soon(self._monitor_system_profiler_thunderbolt_data)
+                    tg.start_soon(self._monitor_thunderbolt_bridge_status)
+                    tg.start_soon(self._monitor_rdma_ctl_status)
+                tg.start_soon(self._watch_system_info)
+                tg.start_soon(self._monitor_memory_usage)
+                tg.start_soon(self._monitor_misc)
+                tg.start_soon(self._monitor_static_info)
+                tg.start_soon(self._monitor_disk_usage)
 
-            nc = await NodeConfig.gather()
-            if nc is not None:
-                await self.info_sender.send(nc)
+                nc = await NodeConfig.gather()
+                if nc is not None:
+                    await self.info_sender.send(nc)
+        except BaseExceptionGroup as exception_group:
+            # A closed/broken info channel means our consumer is gone — the
+            # worker is shutting down or being replaced on a master
+            # transition (main.py tears down the old Worker and builds a
+            # fresh one with a fresh gatherer). That is a stop signal, not a
+            # fault: crashing here took down whole healthy nodes when a PEER
+            # restarted (#266 — the consumer's forwarder exits first when
+            # the event stream closes, and the next telemetry send raced
+            # into the closed channel). anyio folds body and child-task
+            # exceptions into one group, so this covers every send site.
+            # Any non-channel exception still propagates.
+            consumer_gone, other = exception_group.split(
+                (ClosedResourceError, BrokenResourceError)
+            )
+            if other is not None:
+                raise other from exception_group
+            assert consumer_gone is not None
+            logger.info(
+                "InfoGatherer stopped: telemetry consumer closed its channel "
+                "(worker shutdown/replacement); the replacement worker's "
+                "gatherer owns telemetry from here"
+            )
 
     def shutdown(self):
         self._tg.cancel_tasks()
@@ -506,6 +536,12 @@ class InfoGatherer:
             try:
                 with fail_after(30):
                     await self.info_sender.send(await StaticNodeInformation.gather())
+            except (ClosedResourceError, BrokenResourceError):
+                # Consumer gone (worker shutdown/replacement): a stop signal,
+                # not a gathering fault — must escape this per-iteration
+                # catch-all or the loop spins on a dead channel (#266).
+                # run() converts it into a clean stop.
+                raise
             except Exception as e:
                 logger.warning(f"Error gathering static node info: {e}")
             await anyio.sleep(self.static_info_poll_interval)
@@ -517,6 +553,12 @@ class InfoGatherer:
             try:
                 with fail_after(10):
                     await self.info_sender.send(await MiscData.gather())
+            except (ClosedResourceError, BrokenResourceError):
+                # Consumer gone (worker shutdown/replacement): a stop signal,
+                # not a gathering fault — must escape this per-iteration
+                # catch-all or the loop spins on a dead channel (#266).
+                # run() converts it into a clean stop.
+                raise
             except Exception as e:
                 logger.warning(f"Error gathering misc data: {e}")
             await anyio.sleep(self.misc_poll_interval)
@@ -560,6 +602,12 @@ class InfoGatherer:
                         else []
                     )
                     await self.info_sender.send(MacThunderboltConnections(conns=conns))
+            except (ClosedResourceError, BrokenResourceError):
+                # Consumer gone (worker shutdown/replacement): a stop signal,
+                # not a gathering fault — must escape this per-iteration
+                # catch-all or the loop spins on a dead channel (#266).
+                # run() converts it into a clean stop.
+                raise
             except Exception as e:
                 logger.warning(f"Error gathering Thunderbolt data: {e}")
             await anyio.sleep(self.system_profiler_interval)
@@ -578,6 +626,12 @@ class InfoGatherer:
                 await self.info_sender.send(
                     MemoryUsage.from_psutil(override_memory=override_memory)
                 )
+            except (ClosedResourceError, BrokenResourceError):
+                # Consumer gone (worker shutdown/replacement): a stop signal,
+                # not a gathering fault — must escape this per-iteration
+                # catch-all or the loop spins on a dead channel (#266).
+                # run() converts it into a clean stop.
+                raise
             except Exception as e:
                 logger.warning(f"Error gathering memory usage: {e}")
             await anyio.sleep(self.memory_poll_rate)
@@ -590,6 +644,12 @@ class InfoGatherer:
                 with fail_after(10):
                     nics = await get_network_interfaces()
                     await self.info_sender.send(NodeNetworkInterfaces(ifaces=nics))
+            except (ClosedResourceError, BrokenResourceError):
+                # Consumer gone (worker shutdown/replacement): a stop signal,
+                # not a gathering fault — must escape this per-iteration
+                # catch-all or the loop spins on a dead channel (#266).
+                # run() converts it into a clean stop.
+                raise
             except Exception as e:
                 logger.warning(f"Error gathering network interfaces: {e}")
             await anyio.sleep(self.interface_watcher_interval)
@@ -603,6 +663,12 @@ class InfoGatherer:
                     curr = await ThunderboltBridgeInfo.gather()
                     if curr is not None:
                         await self.info_sender.send(curr)
+            except (ClosedResourceError, BrokenResourceError):
+                # Consumer gone (worker shutdown/replacement): a stop signal,
+                # not a gathering fault — must escape this per-iteration
+                # catch-all or the loop spins on a dead channel (#266).
+                # run() converts it into a clean stop.
+                raise
             except Exception as e:
                 logger.warning(f"Error gathering Thunderbolt Bridge status: {e}")
             await anyio.sleep(self.thunderbolt_bridge_poll_interval)
@@ -615,6 +681,12 @@ class InfoGatherer:
                 curr = await RdmaCtlStatus.gather()
                 if curr is not None:
                     await self.info_sender.send(curr)
+            except (ClosedResourceError, BrokenResourceError):
+                # Consumer gone (worker shutdown/replacement): a stop signal,
+                # not a gathering fault — must escape this per-iteration
+                # catch-all or the loop spins on a dead channel (#266).
+                # run() converts it into a clean stop.
+                raise
             except Exception as e:
                 logger.warning(f"Error gathering RDMA ctl status: {e}")
             await anyio.sleep(self.rdma_ctl_poll_interval)
@@ -626,6 +698,12 @@ class InfoGatherer:
             try:
                 with fail_after(5):
                     await self.info_sender.send(await NodeDiskUsage.gather())
+            except (ClosedResourceError, BrokenResourceError):
+                # Consumer gone (worker shutdown/replacement): a stop signal,
+                # not a gathering fault — must escape this per-iteration
+                # catch-all or the loop spins on a dead channel (#266).
+                # run() converts it into a clean stop.
+                raise
             except Exception as e:
                 logger.warning(f"Error gathering disk usage: {e}")
             await anyio.sleep(self.disk_poll_interval)
@@ -698,6 +776,12 @@ class InfoGatherer:
                 logger.warning(
                     f"mactop produced no output for {read_timeout}s, restarting"
                 )
+            except (ClosedResourceError, BrokenResourceError):
+                # Consumer gone (worker shutdown/replacement): a stop signal,
+                # not a gathering fault — must escape this per-iteration
+                # catch-all or the loop spins on a dead channel (#266).
+                # run() converts it into a clean stop.
+                raise
             except Exception as e:
                 # anyio's open_process()/async-with does not raise
                 # CalledProcessError (no check=True semantics); mactop dying just

--- a/src/skulk/utils/info_gatherer/info_gatherer.py
+++ b/src/skulk/utils/info_gatherer/info_gatherer.py
@@ -517,9 +517,13 @@ class InfoGatherer:
             consumer_gone, other = exception_group.split(
                 (ClosedResourceError, BrokenResourceError)
             )
+            if consumer_gone is None:
+                # Nothing channel-related in the group — re-raise it exactly
+                # as it arrived (a `from` link here would point the group's
+                # __cause__ at itself).
+                raise
             if other is not None:
                 raise other from exception_group
-            assert consumer_gone is not None
             logger.info(
                 "InfoGatherer stopped: telemetry consumer closed its channel "
                 "(worker shutdown/replacement); the replacement worker's "

--- a/src/skulk/utils/info_gatherer/tests/test_consumer_gone.py
+++ b/src/skulk/utils/info_gatherer/tests/test_consumer_gone.py
@@ -1,0 +1,76 @@
+"""Regression tests for #266: a closed telemetry consumer must stop the
+InfoGatherer cleanly, never crash the node.
+
+The live failure: during peer churn the worker's info forwarder exits first
+(its downstream event stream closes on a master transition), closing the
+info channel's receive side; the gatherer's next send raised
+``BrokenResourceError`` through the task group and took the entire process
+down — twice in one night, once on the cluster hub.
+"""
+
+import anyio
+import pytest
+
+from skulk.utils.channels import Sender, channel
+from skulk.utils.info_gatherer.info_gatherer import GatheredInfo, InfoGatherer
+
+
+def _quiet_gatherer(info_send: Sender[GatheredInfo]) -> InfoGatherer:
+    """A gatherer whose periodic monitors are all disabled, so the only
+    send is the startup NodeConfig — the exact line that crashed in #266."""
+    return InfoGatherer(
+        info_sender=info_send,
+        interface_watcher_interval=None,
+        misc_poll_interval=None,
+        system_profiler_interval=None,
+        memory_poll_rate=None,
+        mactop_interval=None,
+        thunderbolt_bridge_poll_interval=None,
+        static_info_poll_interval=None,
+        rdma_ctl_poll_interval=None,
+        disk_poll_interval=None,
+    )
+
+
+async def test_closed_consumer_stops_run_cleanly():
+    # Receiver closed before the gatherer ever sends — run() must return,
+    # not raise, within a bounded time.
+    info_send, info_recv = channel[GatheredInfo]()
+    gatherer = _quiet_gatherer(info_send)
+    info_recv.close()
+    with anyio.fail_after(30):
+        await gatherer.run()
+
+
+async def test_consumer_closing_mid_run_stops_cleanly():
+    # Consumer disappears while the gatherer is live (the churn ordering):
+    # a fast monitor keeps sending; the receiver reads one item then closes.
+    info_send, info_recv = channel[GatheredInfo]()
+    gatherer = _quiet_gatherer(info_send)
+    gatherer.static_info_poll_interval = 0.05
+
+    async def consume_one_then_leave():
+        with info_recv as stream:
+            async for _ in stream:
+                return
+
+    with anyio.fail_after(30):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(consume_one_then_leave)
+            await gatherer.run()
+
+
+async def test_real_errors_still_propagate(monkeypatch: pytest.MonkeyPatch):
+    # The consumer-gone handling must not swallow genuine faults.
+    from skulk.utils.info_gatherer import info_gatherer as module
+
+    async def explode():
+        raise ValueError("genuine gatherer fault")
+
+    monkeypatch.setattr(module.NodeConfig, "gather", explode)
+    info_send, _info_recv = channel[GatheredInfo]()
+    gatherer = _quiet_gatherer(info_send)
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        with anyio.fail_after(30):
+            await gatherer.run()
+    assert exc_info.group_contains(ValueError)


### PR DESCRIPTION
Fixes #266. First PR of the ring-networking hardening bundle (#266 → #222 → #265).

## The crash

During a master transition the worker is replaced: its telemetry forwarder exits first (downstream event stream closes), closing the info channel's receive side — and the sibling InfoGatherer's next send raised `BrokenResourceError` through the task group, killing the **entire process**. Two healthy nodes died this way within an hour on 2026-06-10, one of them the cluster hub, both triggered by a *different* node restarting.

## The fix

Channel closure = "my consumer is gone" = stop signal, not fault:
- `InfoGatherer.run()` catches the task-group exception group, `split()`s out `ClosedResourceError`/`BrokenResourceError`, logs a clean stop (the replacement worker brings a fresh gatherer — verified that `main.py` tears down and re-creates the Worker on master transitions), and re-raises anything else (`from` the original group).
- The nine per-monitor `except Exception` blocks — there to survive flaky *gathering* — now explicitly re-raise channel closure first. Without this, `_monitor_static_info` et al. swallowed it and spun warning-spam on a dead channel forever (caught live by the new mid-run test).

## Tests

- `test_closed_consumer_stops_run_cleanly` — receiver closed before the startup NodeConfig send (the exact line that crashed).
- `test_consumer_closing_mid_run_stops_cleanly` — consumer vanishes while a monitor is sending (the churn ordering; this test caught the swallow-and-spin bug).
- `test_real_errors_still_propagate` — genuine faults still raise.

Gauntlet: basedpyright 0, ruff clean, nix fmt applied, 991 passed. (One pre-existing env-dependent store test failure root-caused and filed as #268 — unrelated.)

Live E2E (churn storm while serving) lands with the bundle's final validation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)