### PR TITLE
fix(net): Thunderbolt interface label survives device classification (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **The Thunderbolt interface label survives classification (#222).** The
+  hardware-port parser set "thunderbolt" from the port header, then the
+  device-line branch unconditionally rewrote every en2+ device to
+  `maybe_ethernet` — and Mac Thunderbolt ports are always en2+, so the
+  thunderbolt label could never exist on macOS and the ring's TB-first
+  transport priority was dead code (it worked only because maybe_ethernet
+  happened to outrank ethernet). The downgrade now applies only to the
+  genuinely ambiguous case (a generic "Ethernet Adapter" port on en2+, which
+  may be a USB dongle); specifically-classified ports keep their labels, and
+  unclassified ports (e.g. an iPhone tether) stay at lowest priority instead
+  of being promoted.
+
 - **GPU-wedge runner deaths are no longer retried (wired-memory leak).**
   Contrary to every other crash class, a runner hard-exited by the warmup
   deadline watchdog while its main thread is parked in a faulted Metal eval

--- a/src/skulk/utils/info_gatherer/system_info.py
+++ b/src/skulk/utils/info_gatherer/system_info.py
@@ -56,20 +56,25 @@ async def get_friendly_name() -> str:
     return process.stdout.decode("utf-8", errors="replace").strip() or hostname
 
 
-async def _get_interface_types_from_networksetup() -> dict[str, InterfaceType]:
-    """Parse networksetup -listallhardwareports to get interface types."""
-    if sys.platform != "darwin":
-        return {}
+def parse_hardware_port_types(listing: str) -> dict[str, InterfaceType]:
+    """Classify devices from ``networksetup -listallhardwareports`` output.
 
-    try:
-        result = await run_process(["networksetup", "-listallhardwareports"])
-    except CalledProcessError:
-        return {}
-
+    Pure parser (the subprocess lives at the caller). The port-name header
+    gives the specific class; the device line applies one downgrade: an enX
+    device beyond en0/en1 with a GENERIC "Ethernet" port name may be a USB
+    dongle rather than built-in ethernet, so only that ambiguous case becomes
+    ``maybe_ethernet``. A port the header classified specifically
+    ("Thunderbolt N" → thunderbolt, "Wi-Fi" → wifi) keeps its label — Mac
+    Thunderbolt ports are always en2+, so the previous unconditional
+    downgrade meant "thunderbolt" could never survive on macOS and the ring's
+    TB-first transport priority was dead code (#222). Unclassified enX ports
+    (e.g. "iPhone USB") stay "unknown" (lowest priority) instead of being
+    promoted to maybe_ethernet.
+    """
     types: dict[str, InterfaceType] = {}
     current_type: InterfaceType = "unknown"
 
-    for line in result.stdout.decode().splitlines():
+    for line in listing.splitlines():
         if line.startswith("Hardware Port:"):
             port_name = line.split(":", 1)[1].strip()
             if "Wi-Fi" in port_name:
@@ -82,12 +87,29 @@ async def _get_interface_types_from_networksetup() -> dict[str, InterfaceType]:
                 current_type = "unknown"
         elif line.startswith("Device:"):
             device = line.split(":", 1)[1].strip()
-            # enX is ethernet adapters or thunderbolt - these must be deprioritised
-            if device.startswith("en") and device not in ["en0", "en1"]:
-                current_type = "maybe_ethernet"
-            types[device] = current_type
+            device_type = current_type
+            if (
+                device.startswith("en")
+                and device not in ("en0", "en1")
+                and current_type == "ethernet"
+            ):
+                device_type = "maybe_ethernet"
+            types[device] = device_type
 
     return types
+
+
+async def _get_interface_types_from_networksetup() -> dict[str, InterfaceType]:
+    """Parse networksetup -listallhardwareports to get interface types."""
+    if sys.platform != "darwin":
+        return {}
+
+    try:
+        result = await run_process(["networksetup", "-listallhardwareports"])
+    except CalledProcessError:
+        return {}
+
+    return parse_hardware_port_types(result.stdout.decode())
 
 
 async def get_network_interfaces() -> list[NetworkInterfaceInfo]:

--- a/src/skulk/utils/info_gatherer/tests/test_hardware_port_types.py
+++ b/src/skulk/utils/info_gatherer/tests/test_hardware_port_types.py
@@ -1,0 +1,76 @@
+"""Regression tests for #222: the Thunderbolt interface label must survive.
+
+The Device-line downgrade previously rewrote EVERY enX≥2 device to
+``maybe_ethernet`` — and Mac Thunderbolt ports are always en2+, so
+"thunderbolt" could never exist on macOS and the ring's TB-first transport
+priority was dead code. Fixture captured verbatim from a 16GB M4 (kite2)
+with active Thunderbolt links.
+"""
+
+from skulk.utils.info_gatherer.system_info import parse_hardware_port_types
+
+_KITE2_LISTING = """\
+Hardware Port: Ethernet
+Device: en0
+Ethernet Address: 1c:f6:4c:3d:45:fa
+
+Hardware Port: Ethernet Adapter (en5)
+Device: en5
+Ethernet Address: aa:67:a6:29:f1:bf
+
+Hardware Port: Ethernet Adapter (en6)
+Device: en6
+Ethernet Address: aa:67:a6:29:f1:c0
+
+Hardware Port: Ethernet Adapter (en7)
+Device: en7
+Ethernet Address: aa:67:a6:29:f1:c2
+
+Hardware Port: Wi-Fi
+Device: en1
+Ethernet Address: 1c:f6:4c:3a:e0:12
+
+Hardware Port: Thunderbolt 1
+Device: en2
+Ethernet Address: 36:6f:45:4b:a9:80
+
+Hardware Port: Thunderbolt 2
+Device: en3
+Ethernet Address: 36:6f:45:4b:a9:84
+
+Hardware Port: Thunderbolt 4
+Device: en4
+Ethernet Address: 36:6f:45:4b:a9:8c
+
+VLAN Configurations
+===================
+"""
+
+
+def test_thunderbolt_label_survives():
+    types = parse_hardware_port_types(_KITE2_LISTING)
+    assert types["en2"] == "thunderbolt"
+    assert types["en3"] == "thunderbolt"
+    assert types["en4"] == "thunderbolt"
+
+
+def test_builtin_ethernet_and_wifi_keep_their_labels():
+    types = parse_hardware_port_types(_KITE2_LISTING)
+    assert types["en0"] == "ethernet"
+    assert types["en1"] == "wifi"
+
+
+def test_generic_ethernet_adapters_downgrade_to_maybe():
+    # "Ethernet Adapter (enX)" on en2+ may be a USB dongle — the one case
+    # that legitimately downgrades.
+    types = parse_hardware_port_types(_KITE2_LISTING)
+    assert types["en5"] == "maybe_ethernet"
+    assert types["en6"] == "maybe_ethernet"
+    assert types["en7"] == "maybe_ethernet"
+
+
+def test_unclassified_ports_stay_unknown():
+    # Previously promoted to maybe_ethernet (rank just below thunderbolt) —
+    # an iPhone tether must not outrank real ethernet for ring transport.
+    listing = "Hardware Port: iPhone USB\nDevice: en8\nEthernet Address: aa:bb\n"
+    assert parse_hardware_port_types(listing)["en8"] == "unknown"


### PR DESCRIPTION
Fixes #222. Second PR of the ring-networking hardening bundle (#266 → #222 → #265).

## The bug

`parse_hardware_port_types` (was inline in `_get_interface_types_from_networksetup`) classified "Thunderbolt N" ports correctly from the header, then the device-line branch unconditionally rewrote **every en2+ device** to `maybe_ethernet`. Mac Thunderbolt ports are always en2+, so the `thunderbolt` label could never exist on macOS — the ring's TB-first transport priority has been dead code, surviving only because `maybe_ethernet` happens to outrank `ethernet`. With the bundle's #265 work making transport priority actually load-bearing (TB must beat LAN must beat Tailscale, per operator direction), this label has to be real.

## The fix

Downgrade only the genuinely ambiguous case: a generic "Ethernet Adapter" port name on en2+ (possible USB dongle) → `maybe_ethernet`. Ports the header classified specifically keep their labels. Unclassified en-ports (e.g. "iPhone USB") now stay `unknown` (lowest priority) instead of being promoted above real ethernet — an iPhone tether should never win ring transport selection.

Parser extracted as a pure function with regression tests against a **verbatim kite2 listing** (3 active TB ports en2/en3/en4, three USB "Ethernet Adapter" entries, built-in ethernet + Wi-Fi) plus the iPhone-tether case.

Gauntlet: basedpyright 0, ruff clean, nix fmt applied, 992 passed.

Live validation lands with the bundle's E2E pass (TB-path verification via lsof on kite-pair rings is part of the battery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)