### PR TITLE
fix(ring): group-connect deadline + VPN-last transport selection (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **A stalled distributed group can no longer hang an instance forever, and
+  ring transport selection follows operator intent (#265).** Two changes:
+  (1) `mx.distributed.init` now runs under a hard deadline (default 120s,
+  `SKULK_GROUP_CONNECT_DEADLINE_SECONDS`) — the ring backend with
+  `strict=True` blocks indefinitely when a neighbor socket fails its
+  post-TCP rank handshake, which left a 4-node placement looping request
+  timeouts and cancels for 30+ minutes with no recovery; expiry now exits
+  the runner via the wedge path, the worker gives the instance up on the
+  first failure, and the fresh placement mints a new ring port (also
+  clearing stale-socket handshake collisions from same-port retries).
+  (2) VPN/overlay addresses (Tailscale CGNAT `100.64/10` and
+  `fd7a:115c:a1e0::/48`, detected by address since utun interfaces gossip
+  as "unknown") now rank strictly last in ring transport selection —
+  Tailscale exists for external reachability and may be DERP-relayed (a
+  ring link between two machines on the same switch was observed riding
+  the Dallas relay); a pair with any Thunderbolt/LAN candidate never
+  selects the overlay, while genuinely cross-network pairs still work.
+  First test coverage for `get_mlx_ring_hosts_by_node` and the transport
+  ranking.
+
 - **GPU-wedge runner deaths are no longer retried (wired-memory leak).**
   Contrary to every other crash class, a runner hard-exited by the warmup
   deadline watchdog while its main thread is parked in a faulted Metal eval

--- a/src/skulk/master/placement_utils.py
+++ b/src/skulk/master/placement_utils.py
@@ -1,3 +1,4 @@
+import ipaddress
 from collections.abc import Generator, Mapping
 from typing import final
 
@@ -501,6 +502,52 @@ def _find_connection_ip(
             yield connection.sink_multiaddr.ip_address
 
 
+def _is_vpn_address(ip: str) -> bool:
+    """Whether an address belongs to a VPN/overlay network (Tailscale).
+
+    Detected by ADDRESS, not by the gossiped interface label: utun
+    interfaces never appear in ``networksetup`` output so their gossiped
+    type is "unknown", and adding a new ``InterfaceType`` literal would
+    break old nodes decoding gossiped ``NetworkInterfaceInfo`` in a
+    mixed-version rollout. Tailscale assigns from CGNAT ``100.64.0.0/10``
+    (IPv4) and ``fd7a:115c:a1e0::/48`` (IPv6).
+    """
+    try:
+        address = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    if isinstance(address, ipaddress.IPv4Address):
+        return address in ipaddress.IPv4Network("100.64.0.0/10")
+    return address in ipaddress.IPv6Network("fd7a:115c:a1e0::/48")
+
+
+# Transport ranking for ring placements: VPN/overlay addresses are the LAST
+# resort, below even "unknown" — Tailscale exists for reaching a node from
+# OUTSIDE its local network and may be DERP-relayed (observed live: a
+# kite-pair ring link riding the Dallas relay between two machines on the
+# same switch). A pair whose only observed path is the overlay (genuinely
+# cross-network placement) still works; a pair with any TB/LAN candidate
+# never selects it (#265).
+_RING_TRANSPORT_PRIORITY: dict[str, int] = {
+    "thunderbolt": 0,
+    "maybe_ethernet": 1,
+    "ethernet": 2,
+    "wifi": 3,
+    "unknown": 4,
+    "vpn": 5,
+}
+
+# RDMA/jaccl coordinator preference (control plane, not the data path).
+_JACCL_TRANSPORT_PRIORITY: dict[str, int] = {
+    "ethernet": 0,
+    "wifi": 1,
+    "unknown": 2,
+    "maybe_ethernet": 3,
+    "thunderbolt": 4,
+    "vpn": 5,
+}
+
+
 def _find_ip_prioritised(
     node_id: NodeId,
     other_node_id: NodeId,
@@ -508,9 +555,14 @@ def _find_ip_prioritised(
     node_network: Mapping[NodeId, NodeNetworkInfo],
     ring: bool,
 ) -> str | None:
-    """Find an IP address between nodes with prioritization.
+    """Find an IP address between nodes with transport prioritization.
 
-    Priority: ethernet > wifi > unknown > thunderbolt
+    Candidates are the OBSERVED libp2p connections between the pair, ranked
+    by the sink node's gossiped interface type — ring placements prefer the
+    fastest local interconnect (TB first), and VPN/overlay addresses rank
+    strictly last regardless of gossiped label (see ``_is_vpn_address``).
+
+    TODO: Profile and get actual connection speeds.
     """
     ips = list(_find_connection_ip(node_id, other_node_id, cycle_digraph))
     if not ips:
@@ -519,28 +571,14 @@ def _find_ip_prioritised(
     ip_to_type = {
         iface.ip_address: iface.interface_type for iface in other_network.interfaces
     }
+    priority = _RING_TRANSPORT_PRIORITY if ring else _JACCL_TRANSPORT_PRIORITY
 
-    # Ring should prioritise fastest connection. As a best-effort, we prioritise TB.
-    # TODO: Profile and get actual connection speeds.
-    if ring:
-        priority = {
-            "thunderbolt": 0,
-            "maybe_ethernet": 1,
-            "ethernet": 2,
-            "wifi": 3,
-            "unknown": 4,
-        }
+    def transport_rank(ip: str) -> int:
+        if _is_vpn_address(ip):
+            return priority["vpn"]
+        return priority.get(ip_to_type.get(ip, "unknown"), priority["unknown"])
 
-    # RDMA prefers ethernet coordinator
-    else:
-        priority = {
-            "ethernet": 0,
-            "wifi": 1,
-            "unknown": 2,
-            "maybe_ethernet": 3,
-            "thunderbolt": 4,
-        }
-    return min(ips, key=lambda ip: priority.get(ip_to_type.get(ip, "unknown"), 2))
+    return min(ips, key=transport_rank)
 
 
 def get_mlx_ring_hosts_by_node(

--- a/src/skulk/master/tests/test_ring_transport_selection.py
+++ b/src/skulk/master/tests/test_ring_transport_selection.py
@@ -1,0 +1,184 @@
+# pyright: reportPrivateUsage=false
+"""Ring hostfile transport-selection tests (#265).
+
+First coverage for ``get_mlx_ring_hosts_by_node`` and the per-pair transport
+ranking. Pins the operator-directed policy: Thunderbolt first whenever the
+pair has a TB path, LAN next, and VPN/overlay (Tailscale) strictly last —
+the overlay exists for reaching nodes from OUTSIDE the local network and may
+be DERP-relayed, so it must never win against any local candidate (the
+2026-06-10 incident rode the Dallas relay between two machines on the same
+switch).
+"""
+
+import pytest
+
+from skulk.master.placement_utils import (
+    _find_ip_prioritised,
+    _is_vpn_address,
+    get_mlx_ring_hosts_by_node,
+)
+from skulk.shared.topology import Topology
+from skulk.shared.types.common import NodeId
+from skulk.shared.types.multiaddr import Multiaddr
+from skulk.shared.types.profiling import NetworkInterfaceInfo, NodeNetworkInfo
+from skulk.shared.types.topology import Connection, Cycle, SocketConnection
+
+_TB_IP = "169.254.10.2"
+_LAN_IP = "192.168.0.20"
+_VPN_IP = "100.79.166.20"
+
+
+def _socket(ip: str) -> SocketConnection:
+    return SocketConnection(sink_multiaddr=Multiaddr(address=f"/ip4/{ip}/tcp/52416"))
+
+
+def _pair_topology(
+    node_a: NodeId, node_b: NodeId, ips_to_b: list[str], ips_to_a: list[str]
+) -> Topology:
+    topology = Topology()
+    topology.add_node(node_a)
+    topology.add_node(node_b)
+    for ip in ips_to_b:
+        topology.add_connection(
+            Connection(source=node_a, sink=node_b, edge=_socket(ip))
+        )
+    for ip in ips_to_a:
+        topology.add_connection(
+            Connection(source=node_b, sink=node_a, edge=_socket(ip))
+        )
+    return topology
+
+
+def _network(*entries: tuple[str, str]) -> NodeNetworkInfo:
+    return NodeNetworkInfo(
+        interfaces=[
+            NetworkInterfaceInfo(name="enX", ip_address=ip, interface_type=kind)  # type: ignore[arg-type]
+            for ip, kind in entries
+        ]
+    )
+
+
+def test_vpn_address_detection():
+    assert _is_vpn_address("100.64.0.1")
+    assert _is_vpn_address("100.79.166.20")
+    assert _is_vpn_address("100.127.255.254")
+    assert not _is_vpn_address("100.63.255.255")  # below CGNAT range
+    assert not _is_vpn_address("100.128.0.1")  # above CGNAT range
+    assert not _is_vpn_address("192.168.0.20")
+    assert not _is_vpn_address("169.254.10.2")
+    assert _is_vpn_address("fd7a:115c:a1e0::1")  # Tailscale IPv6
+    assert not _is_vpn_address("not-an-ip")
+
+
+def test_thunderbolt_beats_lan():
+    node_a, node_b = NodeId(), NodeId()
+    topology = _pair_topology(node_a, node_b, [_LAN_IP, _TB_IP], [])
+    node_network = {
+        node_b: _network((_TB_IP, "thunderbolt"), (_LAN_IP, "ethernet"))
+    }
+    chosen = _find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+    assert chosen == _TB_IP
+
+
+def test_vpn_never_beats_lan():
+    # The tailscale candidate's gossiped label is "unknown" (utun never
+    # appears in networksetup output) — but the policy must hold even if a
+    # label lies, so the address check is what demotes it.
+    node_a, node_b = NodeId(), NodeId()
+    topology = _pair_topology(node_a, node_b, [_VPN_IP, _LAN_IP], [])
+    node_network = {
+        node_b: _network((_VPN_IP, "unknown"), (_LAN_IP, "ethernet"))
+    }
+    chosen = _find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+    assert chosen == _LAN_IP
+
+
+def test_vpn_demoted_even_with_lying_label():
+    # Address-based detection overrides the gossiped interface label: a CGNAT
+    # address claiming to be "thunderbolt" still ranks last.
+    node_a, node_b = NodeId(), NodeId()
+    topology = _pair_topology(node_a, node_b, [_VPN_IP, _LAN_IP], [])
+    node_network = {
+        node_b: _network((_VPN_IP, "thunderbolt"), (_LAN_IP, "ethernet"))
+    }
+    chosen = _find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+    assert chosen == _LAN_IP
+
+
+def test_vpn_only_pair_still_connects():
+    # Genuinely cross-network placement: the overlay is the only path and
+    # must remain usable.
+    node_a, node_b = NodeId(), NodeId()
+    topology = _pair_topology(node_a, node_b, [_VPN_IP], [])
+    node_network = {node_b: _network((_VPN_IP, "unknown"))}
+    chosen = _find_ip_prioritised(node_a, node_b, topology, node_network, ring=True)
+    assert chosen == _VPN_IP
+
+
+def test_ring_hostfile_shape_and_neighbor_selection():
+    # 4-node ring: each rank gets self at 0.0.0.0, real IPs for both
+    # neighbors (TB preferred), and inert TEST-NET-2 placeholders elsewhere.
+    nodes = [NodeId() for _ in range(4)]
+    topology = Topology()
+    for node in nodes:
+        topology.add_node(node)
+    ips = {}
+    for i in range(4):
+        j = (i + 1) % 4
+        ip_forward = f"169.254.{i}.{j}"
+        ip_back = f"169.254.{j}.{i}"
+        ips[(i, j)] = ip_forward
+        ips[(j, i)] = ip_back
+        topology.add_connection(
+            Connection(source=nodes[i], sink=nodes[j], edge=_socket(ip_forward))
+        )
+        topology.add_connection(
+            Connection(source=nodes[j], sink=nodes[i], edge=_socket(ip_back))
+        )
+    node_network: dict[NodeId, NodeNetworkInfo] = {}
+    for i, node in enumerate(nodes):
+        entries: list[tuple[str, str]] = [
+            (ips[(j, i)], "thunderbolt") for j in range(4) if (j, i) in ips
+        ]
+        node_network[node] = _network(*entries)
+
+    hosts_by_node = get_mlx_ring_hosts_by_node(
+        selected_cycle=Cycle(node_ids=nodes),
+        cycle_digraph=topology,
+        ephemeral_port=50000,
+        node_network=node_network,
+    )
+
+    for rank, node in enumerate(nodes):
+        hosts = hosts_by_node[node]
+        assert len(hosts) == 4
+        assert hosts[rank].ip == "0.0.0.0"
+        assert hosts[rank].port == 50000
+        left, right = (rank - 1) % 4, (rank + 1) % 4
+        for idx, host in enumerate(hosts):
+            if idx == rank:
+                continue
+            if idx in (left, right):
+                assert host.ip == ips[(rank, idx)]
+                assert host.port == 50000
+            else:
+                assert host.ip == "198.51.100.1"
+                assert host.port == 0
+
+
+def test_ring_requires_neighbor_connectivity():
+    nodes = [NodeId() for _ in range(3)]
+    topology = Topology()
+    for node in nodes:
+        topology.add_node(node)
+    # Only one edge of the 3-cycle exists — neighbor connectivity is missing.
+    topology.add_connection(
+        Connection(source=nodes[0], sink=nodes[1], edge=_socket(_LAN_IP))
+    )
+    with pytest.raises(ValueError, match="requires connectivity"):
+        get_mlx_ring_hosts_by_node(
+            selected_cycle=Cycle(node_ids=nodes),
+            cycle_digraph=topology,
+            ephemeral_port=50000,
+            node_network={},
+        )

--- a/src/skulk/worker/runner/bootstrap.py
+++ b/src/skulk/worker/runner/bootstrap.py
@@ -151,6 +151,53 @@ during rolling upgrades.
 """
 
 
+GROUP_CONNECT_DEADLINE_SECONDS_DEFAULT: float = 120.0
+"""Deadline for distributed group formation (``mx.distributed.init``).
+
+The ring backend with ``strict=True`` blocks FOREVER when any of its four
+neighbor sockets fails the post-TCP rank-identity handshake — observed live
+(#265): a 4-node ring sat with all links ESTABLISHED while every rank looped
+connect retries, and the cluster spent 30+ minutes in a probe-timeout/
+CancelTask loop with no recovery. Healthy group formation completes in
+seconds even over slow paths; 120s is generous. On expiry the runner exits
+via the wedge path, the worker gives the instance up on the first failure
+(#260), and a fresh placement mints a NEW ephemeral port — which also clears
+the stale-socket handshake collisions that same-port retries can hit.
+Override with SKULK_GROUP_CONNECT_DEADLINE_SECONDS.
+"""
+
+
+def resolve_group_connect_deadline_seconds() -> float:
+    """Resolve the group-connect deadline, honoring the operator override."""
+    raw = preferred_env_value(
+        "SKULK_GROUP_CONNECT_DEADLINE_SECONDS", "EXO_GROUP_CONNECT_DEADLINE_SECONDS"
+    )
+    if raw is not None:
+        try:
+            parsed = float(raw)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+        logger.warning(
+            "Ignoring invalid group-connect deadline override "
+            f"(SKULK_GROUP_CONNECT_DEADLINE_SECONDS) value {raw!r}; using "
+            f"default {GROUP_CONNECT_DEADLINE_SECONDS_DEFAULT:.0f}s"
+        )
+    return GROUP_CONNECT_DEADLINE_SECONDS_DEFAULT
+
+
+GROUP_CONNECT_STALL_DIAGNOSIS: str = (
+    "the distributed group never formed (ring init blocks forever when a "
+    "neighbor socket fails the rank handshake — stale peer from a prior "
+    "attempt, unreachable advertised address, or a dropped link). "
+    "Terminating this runner so the instance fails cleanly instead of "
+    "looping request timeouts; a fresh placement gets a new ring port."
+)
+"""Diagnosis for a group-connect stall — a NETWORK condition, not a GPU
+wedge, so the watchdog's default Metal guidance would mislead operators."""
+
+
 def resolve_warmup_deadline_seconds() -> float:
     """Resolve the warmup deadline, honoring the operator env override."""
     raw = preferred_env_value(
@@ -172,11 +219,36 @@ def resolve_warmup_deadline_seconds() -> float:
     return WARMUP_DEADLINE_SECONDS_DEFAULT
 
 
+def deadline_message(
+    description: str, seconds: float, diagnosis: str | None = None
+) -> str:
+    """Build the CRITICAL line the deadline watchdog logs before exiting.
+
+    Pure so the operator-facing text is testable (the default timeout action
+    itself ends in ``os._exit``). ``diagnosis`` defaults to the GPU-wedge
+    guidance; non-Metal call sites (group connect, #265) supply their own so
+    the log doesn't send operators chasing the wrong subsystem.
+    """
+    explanation = (
+        diagnosis
+        if diagnosis is not None
+        else (
+            "the GPU may be wedged (a faulted Metal eval blocks forever at "
+            "0% CPU). Terminating this runner so the node can keep "
+            "dispatching. If runners keep dying here, test the GPU with a "
+            "small matmul; if that hangs too, the machine needs a reboot to "
+            "reset the Metal device queue."
+        )
+    )
+    return f"{description} exceeded its {seconds:.0f}s deadline — {explanation}"
+
+
 @contextlib.contextmanager
 def deadline_watchdog(
     seconds: float,
     description: str,
     on_timeout: Callable[[], None] | None = None,
+    diagnosis: str | None = None,
 ) -> Iterator[None]:
     """Hard deadline for a block that may wedge uninterruptibly.
 
@@ -193,18 +265,15 @@ def deadline_watchdog(
             CRITICAL log line).
         on_timeout: Test seam — replaces the default log-and-``os._exit``
             action when provided.
+        diagnosis: Operator-facing explanation appended to the CRITICAL log
+            line. Defaults to the GPU-wedge guidance; non-Metal call sites
+            (group connect, #265) supply their own so the log doesn't send
+            operators chasing the wrong subsystem.
     """
     finished = threading.Event()
 
     def _default_timeout_action() -> None:
-        logger.critical(
-            f"{description} exceeded its {seconds:.0f}s deadline — the GPU "
-            "may be wedged (a faulted Metal eval blocks forever at 0% CPU). "
-            "Terminating this runner so the node can keep dispatching. If "
-            "runners keep dying here, test the GPU with a small matmul; if "
-            "that hangs too, the machine needs a reboot to reset the Metal "
-            "device queue."
-        )
+        logger.critical(deadline_message(description, seconds, diagnosis))
         # Deliberately NO _release_metal_resources() here: mx.clear_cache()
         # would touch the very Metal device this watchdog assumes is wedged
         # and could block before the exit.

--- a/src/skulk/worker/runner/llm_inference/runner.py
+++ b/src/skulk/worker/runner/llm_inference/runner.py
@@ -72,8 +72,10 @@ from skulk.worker.engines.mlx.utils_mlx import (
 )
 from skulk.worker.engines.mlx.vision import VisionProcessor
 from skulk.worker.runner.bootstrap import (
+    GROUP_CONNECT_STALL_DIAGNOSIS,
     deadline_watchdog,
     logger,
+    resolve_group_connect_deadline_seconds,
     resolve_warmup_deadline_seconds,
 )
 from skulk.worker.runner.diagnostics import record_runner_phase, runner_phase
@@ -250,11 +252,25 @@ class Runner:
                 self.update_status(RunnerConnecting())
                 self.acknowledge_task(task)
 
-                with runner_phase(
-                    "connect_group",
-                    detail="initialize_mlx",
-                    task_id=task.task_id,
-                    include_memory=True,
+                # Ring init with strict=True blocks FOREVER when a neighbor
+                # socket fails the post-TCP rank handshake (#265) — without
+                # this deadline the instance never becomes ready and the
+                # cluster loops request-timeout/cancel indefinitely. Expiry
+                # exits via the wedge path: the worker gives the instance up
+                # on the first failure (#260) and a fresh placement mints a
+                # new ring port, which also clears stale-socket collisions.
+                with (
+                    deadline_watchdog(
+                        resolve_group_connect_deadline_seconds(),
+                        f"Group connect for {self.model_id}",
+                        diagnosis=GROUP_CONNECT_STALL_DIAGNOSIS,
+                    ),
+                    runner_phase(
+                        "connect_group",
+                        detail="initialize_mlx",
+                        task_id=task.task_id,
+                        include_memory=True,
+                    ),
                 ):
                     self.generator.group = initialize_mlx(self.bound_instance)
 

--- a/src/skulk/worker/tests/unittests/test_group_connect_deadline.py
+++ b/src/skulk/worker/tests/unittests/test_group_connect_deadline.py
@@ -1,0 +1,72 @@
+"""Group-connect deadline tests (#265).
+
+``mx.distributed.init(backend="ring", strict=True)`` blocks forever when a
+neighbor socket fails the post-TCP rank handshake; the ConnectToGroup site
+now runs under ``deadline_watchdog`` so a stalled group becomes a clean
+runner death (wedge path, #260: first-failure give-up, fresh placement,
+fresh ring port) instead of an eternal probe-timeout/cancel loop.
+"""
+
+import threading
+
+import pytest
+
+from skulk.worker.runner.bootstrap import (
+    GROUP_CONNECT_DEADLINE_SECONDS_DEFAULT,
+    GROUP_CONNECT_STALL_DIAGNOSIS,
+    deadline_message,
+    deadline_watchdog,
+    resolve_group_connect_deadline_seconds,
+)
+
+
+def test_default_deadline(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("SKULK_GROUP_CONNECT_DEADLINE_SECONDS", raising=False)
+    monkeypatch.delenv("EXO_GROUP_CONNECT_DEADLINE_SECONDS", raising=False)
+    assert (
+        resolve_group_connect_deadline_seconds()
+        == GROUP_CONNECT_DEADLINE_SECONDS_DEFAULT
+    )
+
+
+def test_operator_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SKULK_GROUP_CONNECT_DEADLINE_SECONDS", "45")
+    assert resolve_group_connect_deadline_seconds() == 45.0
+
+
+def test_invalid_override_falls_back(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SKULK_GROUP_CONNECT_DEADLINE_SECONDS", "-3")
+    assert (
+        resolve_group_connect_deadline_seconds()
+        == GROUP_CONNECT_DEADLINE_SECONDS_DEFAULT
+    )
+    monkeypatch.setenv("SKULK_GROUP_CONNECT_DEADLINE_SECONDS", "soon")
+    assert (
+        resolve_group_connect_deadline_seconds()
+        == GROUP_CONNECT_DEADLINE_SECONDS_DEFAULT
+    )
+
+
+def test_deadline_message_uses_network_diagnosis():
+    # The group-connect site must not emit the GPU-wedge guidance — a ring
+    # stall is a NETWORK condition; "test the GPU with a small matmul" would
+    # send operators chasing the wrong subsystem.
+    message = deadline_message(
+        "Group connect for test-model", 120.0, GROUP_CONNECT_STALL_DIAGNOSIS
+    )
+    assert "distributed group never formed" in message
+    assert "GPU" not in message
+    # And the default keeps the Metal guidance for eval/warmup sites.
+    default = deadline_message("Warmup of test-model", 300.0)
+    assert "GPU may be wedged" in default
+
+
+def test_watchdog_fires_on_stall_and_not_on_completion():
+    fired = threading.Event()
+    with deadline_watchdog(0.05, "stall", on_timeout=fired.set):
+        assert fired.wait(2.0)
+
+    fired_fast = threading.Event()
+    with deadline_watchdog(5.0, "fast block", on_timeout=fired_fast.set):
+        pass
+    assert not fired_fast.wait(0.2)

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -404,8 +404,9 @@ Selection logic: `src/skulk/worker/engines/mlx/cache.py::make_kv_cache`. Some ba
 | Var | What |
 |---|---|
 | `SKULK_HOME` / `SKULK_HOME` | Override the base data directory used to derive `SKULK_DATA_HOME` (and from there `SKULK_MODELS_DIR`, `SKULK_CUSTOM_MODEL_CARDS_DIR`, `SKULK_EVENT_LOG_DIR`). Default base: XDG-derived `~/.local/share/skulk` on Linux; `~/.skulk` on non-Linux. See `src/skulk/shared/constants.py:34-149`. |
-| `SKULK_FAST_SYNCH` / `SKULK_FAST_SYNCH` | Force `MLX_METAL_FAST_SYNCH` on (`"on"`) or off (`"off"`); overrides per-model card. Resolution order: operator override → card `metal_fast_synch` pin → OFF for speculative-decoding cards (`mtp_heads` / `mtp_sidecar_repo` / `assistant_model_repo`; FAST_SYNCH collapses the MTP loop ~46x, measured 2026-06-06) → cluster default (ON) |
+| `SKULK_FAST_SYNCH` / `SKULK_FAST_SYNCH` | Force `MLX_METAL_FAST_SYNCH` on (`"on"`) or off (`"off"`); overrides per-model card. Resolution order: operator override → card `metal_fast_synch` pin → OFF for speculative-decoding cards (`mtp_heads` / `mtp_sidecar_repo` / `assistant_model_repo`; FAST_SYNCH collapses the MTP loop ~46x, measured 2026-06-06) → cluster default (OFF since #261) |
 | `SKULK_PIPELINE_EVAL_TIMEOUT_SECONDS` | Per-eval timeout in pipeline collectives (default 60s) |
+| `SKULK_GROUP_CONNECT_DEADLINE_SECONDS` | Hard deadline for distributed group formation (`mx.distributed.init`, default 120s). Ring init with `strict=True` blocks forever when a neighbor socket fails the post-TCP rank handshake (#265); on expiry the runner exits via the wedge path, the worker gives the instance up on first failure (#260), and a fresh placement mints a new ring port (also clearing stale-socket handshake collisions) |
 | `SKULK_WARMUP_DEADLINE_SECONDS` / `SKULK_WARMUP_DEADLINE_SECONDS` | Hard deadline for runner warmup (default 300s). A wedged Metal eval parks warmup forever at 0% CPU and silently blocks all dispatch; the watchdog hard-exits the runner instead (supervisor reports RunnerFailed, node keeps working) |
 | `SKULK_MLX_HANG_DEBUG` / `SKULK_MLX_HANG_DEBUG` | Emit periodic stack traces from stuck phases |
 | `SKULK_MLX_HANG_DEBUG_INTERVAL_SECONDS` | Interval for above (default 30s) |
@@ -420,7 +421,7 @@ Selection logic: `src/skulk/worker/engines/mlx/cache.py::make_kv_cache`. Some ba
 | `SKULK_OFFLINE` | Run without internet checks (no model fetching) |
 | `SKULK_TEST_DISTRIBUTED_MODEL` | Tests only: force the distributed/prefix-cache slow-test model (`gpt-oss-20b` or `llama-3.2-1b`); default auto-selects by Metal working-set size |
 | `MLX_METAL_FAST_SYNCH` | Set by Skulk based on resolved card preference; not for direct operator use |
-| `MLX_HOSTFILE`, `MLX_RANK`, `MLX_RING_VERBOSE`, `MLX_IBV_DEVICES`, `MLX_JACCL_COORDINATOR` | MLX upstream env vars; auto-set by Skulk during distributed init |
+| `MLX_HOSTFILE`, `MLX_RANK`, `MLX_RING_VERBOSE`, `MLX_IBV_DEVICES`, `MLX_JACCL_COORDINATOR` | MLX upstream env vars; auto-set by Skulk during distributed init. Ring hostfile addresses are chosen per neighbor pair from OBSERVED libp2p connections, ranked thunderbolt > maybe_ethernet > ethernet > wifi > unknown > VPN/overlay — Tailscale CGNAT (100.64/10, fd7a:115c:a1e0::/48) addresses are detected by ADDRESS (utun types don't gossip) and rank strictly last: the overlay exists for external reachability and may be DERP-relayed, so it is only used when a pair has no local candidate (#265). Selection lives in `_find_ip_prioritised` / `get_mlx_ring_hosts_by_node` (`src/skulk/master/placement_utils.py`) |
 
 ### CLI flags
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -183,6 +183,8 @@ Inference happens entirely inside the runner subprocess. Skulk wraps MLX (and th
 
 For models too large for a single device, Skulk splits the layer stack across ranks. Each rank holds a contiguous range of layers (`start_layer` to `end_layer`). Layers communicate via `mlx.distributed.send` / `recv_like` over the `ring` backend (sockets) or `jaccl` (RDMA, when available).
 
+The ring's per-rank addresses are chosen at placement time from the libp2p connections the cluster has *observed* between each neighbor pair, ranked by transport: Thunderbolt first, then ethernet/Wi-Fi, with VPN/overlay addresses (Tailscale's CGNAT range, detected by address) strictly last — the overlay exists for reaching nodes from outside the local network and may be relayed through a distant server, so it is only used when a pair genuinely has no local path (#265). Group formation itself runs under a hard deadline (`SKULK_GROUP_CONNECT_DEADLINE_SECONDS`, default 120s): ring init blocks forever if a neighbor socket fails its post-TCP rank handshake, so on expiry the runner exits via the wedge path, the worker gives the instance up on the first failure, and a fresh placement — with a fresh ring port — is the recovery, instead of an instance that sits broken behind request timeouts indefinitely.
+
 The pipeline forward pass per rank:
 
 1. **Receive** activations from the previous rank (or read input embeddings if rank 0).


### PR DESCRIPTION
Fixes #265. Third PR of the ring-networking hardening bundle (#266 → #222 → #265).

## Half 1: the forever-hang

`mx.distributed.init(backend="ring", strict=True)` blocks indefinitely when any neighbor socket fails its post-TCP rank-identity handshake. Live failure (2026-06-10, twice): a 4-node placement with **all four neighbor links TCP-ESTABLISHED** sat looping `[ring] connecting/accepting` retries; the instance never became ready; the cluster spent 30+ minutes in a 95s probe-timeout/CancelTask loop. No recovery exists — the crash breaker never fires because nothing *crashes*.

ConnectToGroup now runs under the existing `deadline_watchdog` (default **120s**, `SKULK_GROUP_CONNECT_DEADLINE_SECONDS`), with a network-specific diagnosis string (the watchdog's default "test the GPU with a small matmul" guidance would send operators chasing the wrong subsystem — `deadline_watchdog` gained a `diagnosis` parameter). Expiry exits via the wedge path, so #260's machinery gives the instance up on the **first** failure and the re-placement mints a **new ephemeral ring port** — which additionally clears the stale-socket handshake collisions that same-port retries can hit (root-cause analysis on the issue).

## Half 2: transport policy (operator-directed)

Per the operator direction on the issue: TB-interconnected pairs must use TB; Tailscale exists for reaching nodes from *outside* the local network and must never be favored for local interconnect. Ring selection now ranks `thunderbolt > maybe_ethernet > ethernet > wifi > unknown > vpn`, where VPN is detected **by address** (CGNAT `100.64.0.0/10` + Tailscale IPv6 `fd7a:115c:a1e0::/48`):
- utun interfaces never appear in `networksetup`, so their gossiped label is "unknown" — and adding a new `InterfaceType` literal would break old nodes decoding gossiped `NetworkInterfaceInfo` mid-rollout. Address detection needs no wire change and also defeats lying labels.
- A pair with any TB/LAN candidate never selects the overlay (we observed a kite-pair ring link riding the **Dallas DERP relay** between two machines on the same switch); a genuinely cross-network pair still works.
- Combined with #222 (TB label survives classification), the TB-first ranking is now real rather than accidental.

## Tests

First-ever coverage for `get_mlx_ring_hosts_by_node` + the ranking: hostfile shape (self `0.0.0.0`, real neighbor IPs, inert TEST-NET-2 placeholders), TB-over-LAN, VPN-never-over-LAN, address-detection-overrides-lying-label, VPN-only pair still connects, missing-connectivity `ValueError`. Plus deadline resolver (default/override/invalid) and watchdog message/diagnosis tests.

Docs: architecture.md narrative + architecture-reference env table (also fixed the FAST_SYNCH row still claiming "cluster default ON" — drift from #261). CHANGELOG updated.

Gauntlet: basedpyright 0, ruff clean, nix fmt applied, **1000 passed**.

## Live E2E (next, on the integrated bundle)

The battery: original 4-node gemma-26b repro, induced group-connect stall (deadline → clean give-up), churn storm (#269's fix), TB-path verification via lsof, representative matrix slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)