### PR TITLE
feat(inference): rational context-length control — reject long-context requests instead of OOM-crashing (#145 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Long-context requests are rejected cleanly instead of OOM-crashing the
+  runner (#145, phase 1).** The within-request KV cache grew one entry per
+  token with no bound and no preflight check, so a request whose prompt plus
+  output exceeded what the hosting node(s) could hold killed the runner
+  mid-generation with an unhandled Metal OOM (SIGABRT, broken stream or 500
+  for the client, wired GPU memory leaked). Each placed instance now carries
+  a static context-token ceiling — the smaller of the card's advertised
+  context length and the KV tokens that fit beside the weight share on every
+  hosting node — computed deterministically from gossiped node memory so all
+  ranks of a multi-node instance enforce the identical limit. Requests are
+  admitted against it before prefill: explicit `max_tokens` overflow and
+  window-filling prompts get an OpenAI-style `context_length_exceeded`
+  invalid-request error (400 at the API when detectable pre-dispatch), and an
+  omitted `max_tokens` is clamped to the remaining window so generation ends
+  with `finish_reason: "length"`. Unquantized KV only; quantized-KV budget
+  math is phase 2.
+
 - **Instance placements survive master failover (#273).** A newly-elected
   master previously always started its session from an empty state: the
   empty snapshot propagated to every follower, each worker's plan loop saw

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -25,7 +25,10 @@ from skulk.api.types import (
     Usage,
 )
 from skulk.download.download_utils import create_http_session
-from skulk.shared.constants import preferred_env_value
+from skulk.shared.constants import (
+    CONTEXT_LENGTH_EXCEEDED_PREFIX,
+    preferred_env_value,
+)
 from skulk.shared.models.capabilities import resolve_model_capability_profile
 from skulk.shared.models.model_cards import ModelCard
 from skulk.shared.types.chunks import (
@@ -51,6 +54,33 @@ def _thinking_stream_debug_enabled() -> bool:
     if value is None:
         return False
     return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def error_chunk_response(error_message: str | None) -> ErrorResponse:
+    """Map a runner ``ErrorChunk`` message to an OpenAI-style error envelope.
+
+    Context-admission rejections (#145) arrive as plain strings carrying the
+    ``CONTEXT_LENGTH_EXCEEDED_PREFIX`` sentinel (the chunk types are shared
+    across mixed-version clusters, so a structured field is not wire-safe);
+    they map to an ``invalid_request_error`` with code 400. Everything else
+    keeps the historical 500 internal-error shape.
+    """
+    message = error_message or "Internal server error"
+    if message.startswith(CONTEXT_LENGTH_EXCEEDED_PREFIX):
+        return ErrorResponse(
+            error=ErrorInfo(
+                message=message,
+                type="invalid_request_error",
+                code=400,
+            )
+        )
+    return ErrorResponse(
+        error=ErrorInfo(
+            message=message,
+            type="InternalServerError",
+            code=500,
+        )
+    )
 
 
 def extract_base64_from_data_url(data_url: str) -> str:
@@ -263,13 +293,7 @@ async def generate_chat_stream(
                 yield f": prefill_progress {chunk.model_dump_json()}\n\n"
 
             case ErrorChunk():
-                error_response = ErrorResponse(
-                    error=ErrorInfo(
-                        message=chunk.error_message or "Internal server error",
-                        type="InternalServerError",
-                        code=500,
-                    )
-                )
+                error_response = error_chunk_response(chunk.error_message)
                 yield f"data: {error_response.model_dump_json()}\n\n"
                 yield "data: [DONE]\n\n"
                 return
@@ -385,6 +409,12 @@ async def collect_chat_response(
                 finish_reason = chunk.finish_reason
 
     if error_message is not None:
+        if error_message.startswith(CONTEXT_LENGTH_EXCEEDED_PREFIX):
+            # The HTTP status is already committed (the body itself streams),
+            # so a runner-side context rejection surfaces as a structured
+            # OpenAI error envelope in the body rather than a broken stream.
+            yield error_chunk_response(error_message).model_dump_json()
+            return
         raise ValueError(error_message)
 
     combined_text = "".join(text_parts)

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -167,6 +167,7 @@ from skulk.shared.constants import (
 from skulk.shared.election import ElectionMessage
 from skulk.shared.logging import InterceptLogger
 from skulk.shared.models.capabilities import resolve_model_capability_profile
+from skulk.shared.models.memory_estimate import instance_context_token_limit
 from skulk.shared.models.model_cards import (
     ModelCard,
     ModelId,
@@ -1801,6 +1802,34 @@ class API:
             "TODO: we should send a notification to the user to download the model"
         )
 
+    def _context_token_limit_for_model(self, model_id: ModelId) -> int | None:
+        """Most permissive context-token ceiling across instances of a model.
+
+        The API cannot tokenize (tokenizers live with the model files on the
+        hosting nodes), so this limit supports only the exact pre-flight check
+        on ``max_tokens`` alone; the runner enforces the precise
+        prompt-inclusive limit per instance (#145). When several instances
+        serve the same model the request may be routed to any of them, so the
+        maximum avoids falsely rejecting a request the largest instance could
+        still serve.
+        """
+        node_ram_totals = {
+            node_id: usage.ram_total
+            for node_id, usage in self.state.node_memory.items()
+        }
+        limits = [
+            limit
+            for instance in self.state.instances.values()
+            if instance.shard_assignments.model_id == model_id
+            and (
+                limit := instance_context_token_limit(
+                    instance.shard_assignments, node_ram_totals
+                )
+            )
+            is not None
+        ]
+        return max(limits) if limits else None
+
     async def _send_text_generation_with_images(
         self, task_params: TextGenerationTaskParams
     ) -> TextGeneration:
@@ -1810,6 +1839,27 @@ class API:
         # IndexError that crashes the runner (#233; empty messages reached
         # apply_chat_template([]) -> list index out of range).
         validate_renderable_text_generation(task_params)
+        # Context admission pre-flight (#145): the API has no tokenizer, so
+        # only the prompt-independent certainty is checked here — an explicit
+        # max_tokens that cannot fit even before counting a single prompt
+        # token. The runner performs the exact prompt-inclusive check.
+        context_token_limit = self._context_token_limit_for_model(task_params.model)
+        if (
+            context_token_limit is not None
+            and task_params.max_output_tokens is not None
+            and task_params.max_output_tokens >= context_token_limit
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"context_length_exceeded: max_tokens "
+                    f"({task_params.max_output_tokens}) cannot fit within this "
+                    f"model's usable context limit of {context_token_limit} "
+                    f"tokens (the smaller of the model's advertised context "
+                    f"length and what fits in memory next to the model weights "
+                    f"on the hosting node(s))"
+                ),
+            )
         images = task_params.images
         if not images:
             command = TextGeneration(task_params=task_params)

--- a/src/skulk/shared/constants.py
+++ b/src/skulk/shared/constants.py
@@ -173,3 +173,11 @@ SKULK_MAX_CONCURRENT_REQUESTS = int(
     _env("SKULK_MAX_CONCURRENT_REQUESTS", "EXO_MAX_CONCURRENT_REQUESTS", "8") or "8"
 )
 
+
+# Wire-safe marker for context-length admission rejections. The runner embeds
+# this as a prefix in ``ErrorChunk.error_message`` / ``TaskFailed.error_message``
+# (both are plain strings shared across mixed-version clusters, so a new
+# structured field would break old nodes' ``extra=forbid`` validation); the API
+# adapters parse the prefix to surface an OpenAI-style ``context_length_exceeded``
+# invalid-request error instead of a generic 500.
+CONTEXT_LENGTH_EXCEEDED_PREFIX = "context_length_exceeded:"

--- a/src/skulk/shared/models/memory_estimate.py
+++ b/src/skulk/shared/models/memory_estimate.py
@@ -15,8 +15,18 @@ typical serving use) and runtime overhead is a multiplicative factor measured
 on real loads.
 """
 
+from collections.abc import Mapping
+
 from skulk.shared.models.model_cards import ModelCard
+from skulk.shared.types.common import NodeId
 from skulk.shared.types.memory import Memory
+from skulk.shared.types.worker.runners import ShardAssignments
+from skulk.shared.types.worker.shards import (
+    CfgShardMetadata,
+    PipelineShardMetadata,
+    ShardMetadata,
+    TensorShardMetadata,
+)
 
 MEMORY_OVERHEAD_FACTOR: float = 1.30
 """Multiplier on a shard's *weight* bytes covering runtime overhead that scales
@@ -108,3 +118,96 @@ def estimate_shard_footprint(
 def gpu_working_set_ceiling(ram_total: Memory) -> Memory:
     """Metal GPU working-set ceiling derived from total RAM (placement path)."""
     return ram_total * GPU_WORKING_SET_FRACTION
+
+
+def per_token_kv_bytes(model_card: ModelCard) -> int:
+    """Whole-model KV-cache bytes consumed by ONE token of context.
+
+    Covers all layers at fp16 (``KV_DTYPE_BYTES``); a node holding
+    ``shard_fraction`` of the model pays ``per_token_kv_bytes * shard_fraction``
+    per token. Returns 0 when the card lacks ``num_key_value_heads`` —
+    callers must treat 0 as "KV cost unknown, cannot enforce a memory ceiling".
+    """
+    kv_heads = model_card.num_key_value_heads
+    if kv_heads is None or model_card.n_layers <= 0:
+        return 0
+    return 2 * model_card.n_layers * kv_heads * KV_HEAD_DIM_FALLBACK * KV_DTYPE_BYTES
+
+
+def shard_fraction_of_model(shard: ShardMetadata) -> float | None:
+    """Fraction of the whole model's weights AND KV held by one shard.
+
+    Mirrors the placement-side accounting in ``estimate_shard_footprint``:
+    pipeline shards hold a contiguous layer range, tensor shards hold all
+    layers but ``1/world_size`` of each matrix and of the KV heads. CFG shards
+    (image models) have no text-generation KV admission story, so ``None``.
+    """
+    match shard:
+        case TensorShardMetadata():
+            return 1.0 / shard.world_size if shard.world_size > 0 else None
+        case PipelineShardMetadata():
+            if shard.n_layers <= 0:
+                return None
+            return (shard.end_layer - shard.start_layer) / shard.n_layers
+        case CfgShardMetadata():
+            return None
+
+
+def instance_context_token_limit(
+    shard_assignments: ShardAssignments,
+    node_ram_totals: Mapping[NodeId, Memory],
+) -> int | None:
+    """Deterministic context-token ceiling for one placed instance.
+
+    For each hosting node: tokens that fit in the GPU working set after the
+    node's weight share and overhead, at the shard's per-token KV cost. The
+    instance ceiling is the minimum across nodes (the smallest rank OOMs
+    first and takes the whole ring down), then min'd with the card's
+    advertised ``context_length`` (0 means unadvertised).
+
+    Determinism is load-bearing: on multi-rank instances every rank admits or
+    rejects a request independently, and divergent verdicts deadlock the
+    collectives. All inputs here are static — ``ram_total`` never changes for
+    a node, and placement only happens after the master has indexed memory
+    for every hosting node, so every worker computes the identical value.
+    Time-varying ``ram_available`` must NOT be used here.
+
+    Returns ``None`` when no ceiling is enforceable (unknown KV cost or
+    missing node memory, falling back to the card limit when that exists).
+    """
+    model_card: ModelCard | None = None
+    memory_limit: int | None = None
+    for shard in shard_assignments.runner_to_shard.values():
+        model_card = shard.model_card
+        break
+    if model_card is None:
+        return None
+
+    whole_model_token_bytes = per_token_kv_bytes(model_card)
+    if whole_model_token_bytes > 0:
+        node_to_runner = shard_assignments.node_to_runner
+        for node_id, runner_id in node_to_runner.items():
+            shard = shard_assignments.runner_to_shard[runner_id]
+            fraction = shard_fraction_of_model(shard)
+            ram_total = node_ram_totals.get(node_id)
+            if fraction is None or fraction <= 0.0 or ram_total is None:
+                memory_limit = None
+                break
+            kv_budget = (
+                gpu_working_set_ceiling(ram_total)
+                - model_card.storage_size * fraction * MEMORY_OVERHEAD_FACTOR
+                - MEMORY_OVERHEAD_FLOOR
+            )
+            node_tokens = max(
+                0, int(kv_budget.in_bytes / (whole_model_token_bytes * fraction))
+            )
+            memory_limit = (
+                node_tokens if memory_limit is None else min(memory_limit, node_tokens)
+            )
+
+    card_limit = model_card.context_length if model_card.context_length > 0 else None
+    if memory_limit is None:
+        return card_limit
+    if card_limit is None:
+        return memory_limit
+    return min(memory_limit, card_limit)

--- a/src/skulk/shared/models/tests/test_memory_estimate.py
+++ b/src/skulk/shared/models/tests/test_memory_estimate.py
@@ -66,3 +66,163 @@ def test_shard_footprint_fraction_scales_weights_and_kv_not_floor():
 def test_gpu_working_set_ceiling_is_fraction_of_total():
     expected = Memory.from_gb(16) * GPU_WORKING_SET_FRACTION
     assert gpu_working_set_ceiling(Memory.from_gb(16)).in_bytes == expected.in_bytes
+
+
+# --- Context-admission ceiling (#145) ---------------------------------------
+
+from skulk.shared.models.memory_estimate import (  # noqa: E402
+    KV_DTYPE_BYTES,
+    KV_HEAD_DIM_FALLBACK,
+    instance_context_token_limit,
+    per_token_kv_bytes,
+    shard_fraction_of_model,
+)
+from skulk.shared.types.common import NodeId  # noqa: E402
+from skulk.shared.types.worker.runners import RunnerId, ShardAssignments  # noqa: E402
+from skulk.shared.types.worker.shards import (  # noqa: E402
+    PipelineShardMetadata,
+    TensorShardMetadata,
+)
+
+
+def _assignments(
+    card: ModelCard,
+    shards: dict[str, tuple[PipelineShardMetadata | TensorShardMetadata, str]],
+) -> ShardAssignments:
+    """Build ShardAssignments from {runner_name: (shard, node_name)}."""
+    return ShardAssignments(
+        model_id=card.model_id,
+        runner_to_shard={
+            RunnerId(runner): shard for runner, (shard, _node) in shards.items()
+        },
+        node_to_runner={
+            NodeId(node): RunnerId(runner) for runner, (_shard, node) in shards.items()
+        },
+    )
+
+
+def _pipeline_shard(
+    card: ModelCard, *, start: int, end: int, rank: int = 0, world: int = 1
+) -> PipelineShardMetadata:
+    return PipelineShardMetadata(
+        model_card=card,
+        device_rank=rank,
+        world_size=world,
+        start_layer=start,
+        end_layer=end,
+        n_layers=card.n_layers,
+    )
+
+
+def test_per_token_kv_bytes_formula():
+    card = _card(4, kv_heads=8, n_layers=32)
+    assert per_token_kv_bytes(card) == 2 * 32 * 8 * KV_HEAD_DIM_FALLBACK * KV_DTYPE_BYTES
+
+
+def test_per_token_kv_bytes_zero_without_kv_heads():
+    assert per_token_kv_bytes(_card(4)) == 0
+
+
+def test_shard_fraction_tensor_is_inverse_world_size():
+    card = _card(4, kv_heads=8)
+    shard = TensorShardMetadata(
+        model_card=card,
+        device_rank=0,
+        world_size=2,
+        start_layer=0,
+        end_layer=32,
+        n_layers=32,
+    )
+    assert shard_fraction_of_model(shard) == 0.5
+
+
+def test_shard_fraction_pipeline_is_layer_share():
+    card = _card(4, kv_heads=8, n_layers=32)
+    assert shard_fraction_of_model(_pipeline_shard(card, start=0, end=8)) == 0.25
+
+
+def test_instance_limit_single_node_matches_independent_arithmetic():
+    card = _card(4, kv_heads=8, n_layers=32)
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    limit = instance_context_token_limit(
+        assignments, {NodeId("n0"): Memory.from_gb(16)}
+    )
+    gib = 1024**3
+    budget = (
+        round(16 * gib * GPU_WORKING_SET_FRACTION)
+        - round(4 * gib * MEMORY_OVERHEAD_FACTOR)
+        - MEMORY_OVERHEAD_FLOOR.in_bytes
+    )
+    assert limit == int(budget / (2 * 32 * 8 * KV_HEAD_DIM_FALLBACK * KV_DTYPE_BYTES))
+
+
+def test_instance_limit_is_min_across_nodes():
+    card = _card(4, kv_heads=8, n_layers=32)
+    half_a = _pipeline_shard(card, start=0, end=16, rank=0, world=2)
+    half_b = _pipeline_shard(card, start=16, end=32, rank=1, world=2)
+    assignments = _assignments(card, {"r0": (half_a, "big"), "r1": (half_b, "small")})
+    both_big = instance_context_token_limit(
+        assignments,
+        {NodeId("big"): Memory.from_gb(32), NodeId("small"): Memory.from_gb(32)},
+    )
+    constrained = instance_context_token_limit(
+        assignments,
+        {NodeId("big"): Memory.from_gb(32), NodeId("small"): Memory.from_gb(8)},
+    )
+    assert both_big is not None and constrained is not None
+    assert constrained < both_big
+
+
+def test_instance_limit_capped_by_card_context_length():
+    card = _card(1, kv_heads=8, n_layers=32).model_copy(
+        update={"context_length": 1000}
+    )
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    assert (
+        instance_context_token_limit(assignments, {NodeId("n0"): Memory.from_gb(64)})
+        == 1000
+    )
+
+
+def test_instance_limit_missing_node_memory_falls_back_to_card():
+    card = _card(4, kv_heads=8, n_layers=32).model_copy(
+        update={"context_length": 4096}
+    )
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    assert instance_context_token_limit(assignments, {}) == 4096
+
+
+def test_instance_limit_none_when_nothing_enforceable():
+    card = _card(4, kv_heads=8, n_layers=32)  # context_length defaults to 0
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    assert instance_context_token_limit(assignments, {}) is None
+
+
+def test_instance_limit_unknown_kv_cost_falls_back_to_card():
+    card = _card(4, n_layers=32).model_copy(update={"context_length": 2048})
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    assert (
+        instance_context_token_limit(assignments, {NodeId("n0"): Memory.from_gb(16)})
+        == 2048
+    )
+
+
+def test_instance_limit_zero_when_weights_leave_no_kv_room():
+    card = _card(64, kv_heads=8, n_layers=32)
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    assert (
+        instance_context_token_limit(assignments, {NodeId("n0"): Memory.from_gb(16)})
+        == 0
+    )

--- a/src/skulk/worker/engines/mlx/generator/batch_generate.py
+++ b/src/skulk/worker/engines/mlx/generator/batch_generate.py
@@ -35,6 +35,7 @@ from skulk.worker.engines.mlx.cache import (
     make_kv_cache,
 )
 from skulk.worker.engines.mlx.constants import DEFAULT_TOP_LOGPROBS, MAX_TOKENS
+from skulk.worker.engines.mlx.generator.context_admission import admit_max_tokens
 from skulk.worker.engines.mlx.generator.generate import (
     ban_token_ids,
     eos_ids_from_tokenizer,
@@ -94,6 +95,9 @@ class SkulkBatchGenerator:
     group: mx.distributed.Group | None
     kv_prefix_cache: KVPrefixCache | None
     vision_processor: VisionProcessor | None = None
+    # Static per-instance context ceiling for request admission (#145); None
+    # preserves the historical unbounded behavior.
+    context_token_limit: int | None = None
 
     _mlx_gen: MlxBatchGenerator = field(init=False)
     _active_tasks: dict[int, _EngineTask] = field(default_factory=dict, init=False)
@@ -173,6 +177,17 @@ class SkulkBatchGenerator:
         if vision is not None:
             all_prompt_tokens = vision.prompt_tokens
             media_regions = vision.media_regions
+
+        # Context admission: after vision finalizes the token count, before
+        # the prefix cache or prefill collectives. Deterministic across ranks
+        # (same tokens, same static limit) so every rank rejects in lockstep
+        # rather than deadlocking the ring (#145).
+        max_tokens = admit_max_tokens(
+            prompt_tokens=len(all_prompt_tokens),
+            requested_max_output_tokens=task_params.max_output_tokens,
+            default_max_output_tokens=MAX_TOKENS,
+            context_token_limit=self.context_token_limit,
+        )
 
         is_bench = task_params.bench
 
@@ -310,8 +325,7 @@ class SkulkBatchGenerator:
             eos_ids = eos_ids_from_tokenizer(self.tokenizer)
             logits_processors = [ban_token_ids(eos_ids)] + logits_processors
 
-        max_tokens = task_params.max_output_tokens or MAX_TOKENS
-
+        # max_tokens was resolved by context admission above, before prefill.
         uids = self._mlx_gen.insert(
             prompts=[last_tokens.tolist()],
             max_tokens=[max_tokens],

--- a/src/skulk/worker/engines/mlx/generator/context_admission.py
+++ b/src/skulk/worker/engines/mlx/generator/context_admission.py
@@ -1,0 +1,113 @@
+"""Request-time context-length admission for the LLM runner (#145).
+
+The within-request KV cache grows one entry per token with no upper bound, so
+before this module existed a request whose prompt + output exceeded what the
+hosting node(s) could hold crashed the runner mid-generation with an unhandled
+Metal OOM (SIGABRT, wired GPU memory leaked). Admission converts that crash
+into a deterministic, client-visible rejection *before* prefill starts.
+
+The token limit itself (``instance_context_token_limit``) is computed once per
+instance by the worker from static inputs and handed to the runner at spawn;
+see ``skulk.shared.models.memory_estimate``. Every rank of a multi-node
+instance computes the same verdict from the same inputs — divergent verdicts
+would deadlock the ring collectives, which is why admission happens after
+tokenization (identical on every rank) and never consults live memory.
+"""
+
+from typing import final
+
+from skulk.shared.constants import CONTEXT_LENGTH_EXCEEDED_PREFIX
+
+
+@final
+class ContextLengthExceededError(Exception):
+    """A request that cannot fit the instance's usable context window.
+
+    The message is prefixed with ``CONTEXT_LENGTH_EXCEEDED_PREFIX`` so the API
+    layer can recognize the rejection inside plain-string error fields and
+    surface an OpenAI-style ``context_length_exceeded`` error instead of a 500.
+    """
+
+    def __init__(
+        self,
+        *,
+        prompt_tokens: int,
+        requested_max_output_tokens: int | None,
+        context_token_limit: int,
+    ) -> None:
+        self.prompt_tokens = prompt_tokens
+        self.requested_max_output_tokens = requested_max_output_tokens
+        self.context_token_limit = context_token_limit
+        if requested_max_output_tokens is None:
+            detail = (
+                f"the prompt alone is {prompt_tokens} tokens, which leaves no "
+                f"room for output within this instance's usable context limit "
+                f"of {context_token_limit} tokens"
+            )
+        else:
+            detail = (
+                f"the prompt ({prompt_tokens} tokens) plus max_tokens "
+                f"({requested_max_output_tokens}) exceeds this instance's "
+                f"usable context limit of {context_token_limit} tokens"
+            )
+        super().__init__(
+            f"{CONTEXT_LENGTH_EXCEEDED_PREFIX} {detail}. Reduce the prompt "
+            f"length or max_tokens. The limit is the smaller of the model's "
+            f"advertised context length and what fits in memory next to the "
+            f"model weights on the hosting node(s)."
+        )
+
+
+def admit_max_tokens(
+    *,
+    prompt_tokens: int,
+    requested_max_output_tokens: int | None,
+    default_max_output_tokens: int,
+    context_token_limit: int | None,
+) -> int:
+    """Resolve the output-token budget for a request, or reject it.
+
+    Semantics follow the OpenAI API: a request whose prompt cannot fit (or
+    whose *explicit* ``max_tokens`` cannot fit on top of the prompt) is
+    rejected; an omitted ``max_tokens`` is clamped to the remaining context so
+    generation ends with ``finish_reason="length"`` instead of overrunning.
+
+    Args:
+        prompt_tokens: Full tokenized prompt length, including any
+            prefix-cache hit (the cached prefix still occupies KV memory).
+        requested_max_output_tokens: The client's explicit ``max_tokens``,
+            or ``None`` when omitted.
+        default_max_output_tokens: Server default applied when the client
+            omits ``max_tokens``.
+        context_token_limit: The instance's usable context ceiling, or
+            ``None`` when no ceiling is enforceable (preserves pre-#145
+            behavior).
+
+    Returns:
+        The admitted output-token budget (always >= 1).
+
+    Raises:
+        ContextLengthExceededError: When the request cannot fit.
+    """
+    if context_token_limit is None:
+        return (
+            requested_max_output_tokens
+            if requested_max_output_tokens is not None
+            else default_max_output_tokens
+        )
+    if prompt_tokens >= context_token_limit:
+        raise ContextLengthExceededError(
+            prompt_tokens=prompt_tokens,
+            requested_max_output_tokens=requested_max_output_tokens,
+            context_token_limit=context_token_limit,
+        )
+    remaining = context_token_limit - prompt_tokens
+    if requested_max_output_tokens is not None:
+        if requested_max_output_tokens > remaining:
+            raise ContextLengthExceededError(
+                prompt_tokens=prompt_tokens,
+                requested_max_output_tokens=requested_max_output_tokens,
+                context_token_limit=context_token_limit,
+            )
+        return requested_max_output_tokens
+    return min(default_max_output_tokens, remaining)

--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -72,6 +72,7 @@ from skulk.worker.engines.mlx.constants import (
     MAX_TOKENS,
 )
 from skulk.worker.engines.mlx.drafters import Drafter, build_drafter
+from skulk.worker.engines.mlx.generator.context_admission import admit_max_tokens
 from skulk.worker.engines.mlx.generator.speculative_sampling import (
     SamplingParams,
     ratio_accept,
@@ -2452,6 +2453,7 @@ def mlx_generate(
     mtp_weights: "dict[str, mx.array] | None" = None,
     assistant_model: object | None = None,
     model_card: ModelCard | None = None,
+    context_token_limit: int | None = None,
 ) -> Generator[GenerationResponse]:
     # Ensure that generation stats only contains peak memory for this generation
     mx.reset_peak_memory()
@@ -2548,6 +2550,18 @@ def mlx_generate(
             "prompt_tokens": len(all_prompt_tokens),
             **_vision_trace_attrs(vision),
         },
+    )
+
+    # Context admission must happen here: after vision (which finalizes the
+    # token count) and before any prefix-cache work or collective. Every rank
+    # tokenizes the identical prompt against the identical static limit, so
+    # all ranks reach the same verdict in lockstep — a rank-divergent
+    # rejection would deadlock the ring collectives (#145).
+    max_tokens = admit_max_tokens(
+        prompt_tokens=len(all_prompt_tokens),
+        requested_max_output_tokens=task.max_output_tokens,
+        default_max_output_tokens=MAX_TOKENS,
+        context_token_limit=context_token_limit,
     )
 
     # Do not use the prefix cache if we are trying to do benchmarks.
@@ -2868,7 +2882,7 @@ def mlx_generate(
     # token.
     last_token = prompt_tokens[-1:] if uses_pipeline_decode else prompt_tokens[-2:]
 
-    max_tokens = task.max_output_tokens or MAX_TOKENS
+    # max_tokens was resolved by context admission above, before prefill.
     accumulated_text = ""
     generated_text_parts: list[str] = []
     generation_start_time = time.perf_counter()

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -18,6 +18,7 @@ from skulk.shared.constants import SKULK_IMAGE_TRANSPORT_DEBUG
 from skulk.shared.models.memory_estimate import (
     estimate_shard_footprint,
     gpu_working_set_ceiling,
+    instance_context_token_limit,
 )
 from skulk.shared.models.model_cards import (
     ModelCard,
@@ -854,9 +855,26 @@ class Worker:
             f"world_size={shard.world_size}, "
             f"layers={shard.start_layer}:{shard.end_layer})"
         )
+        # Context-admission ceiling (#145): derived exclusively from static
+        # inputs (per-node ram_total, card, shard fractions) so every rank of
+        # a multi-node instance computes the identical limit — placement only
+        # happens after the master indexed memory for all hosting nodes, so
+        # the replicated state already carries every entry we need here.
+        context_token_limit = instance_context_token_limit(
+            task.bound_instance.instance.shard_assignments,
+            {
+                node_id: usage.ram_total
+                for node_id, usage in self.state.node_memory.items()
+            },
+        )
+        logger.info(
+            "Context admission limit for instance "
+            f"{task.instance_id}: {context_token_limit} tokens"
+        )
         runner = RunnerSupervisor.create(
             bound_instance=task.bound_instance,
             event_sender=self.event_sender.clone(),
+            context_token_limit=context_token_limit,
         )
         self.runners[task.bound_instance.bound_runner_id] = runner
         self._tg.start_soon(runner.run)

--- a/src/skulk/worker/runner/bootstrap.py
+++ b/src/skulk/worker/runner/bootstrap.py
@@ -389,6 +389,7 @@ def entrypoint(
     task_receiver: MpReceiver[Task],
     cancel_receiver: MpReceiver[TaskId],
     _logger: "loguru.Logger",
+    context_token_limit: int | None = None,
 ) -> None:
     global logger
     logger = _logger
@@ -454,7 +455,11 @@ def entrypoint(
             apply_mlx_patches()
 
             runner = Runner(
-                bound_instance, event_sender, task_receiver, cancel_receiver
+                bound_instance,
+                event_sender,
+                task_receiver,
+                cancel_receiver,
+                context_token_limit=context_token_limit,
             )
             runner.main()
 

--- a/src/skulk/worker/runner/llm_inference/batch_generator.py
+++ b/src/skulk/worker/runner/llm_inference/batch_generator.py
@@ -24,6 +24,9 @@ from skulk.shared.types.worker.runner_response import (
 from skulk.utils.channels import MpReceiver, MpSender
 from skulk.worker.engines.mlx.cache import KVPrefixCache
 from skulk.worker.engines.mlx.generator.batch_generate import SkulkBatchGenerator
+from skulk.worker.engines.mlx.generator.context_admission import (
+    ContextLengthExceededError,
+)
 from skulk.worker.engines.mlx.generator.generate import (
     PrefillCancelled,
     mlx_generate,
@@ -148,6 +151,8 @@ class SequentialGenerator(InferenceGenerator):
     mtp_weights: "dict[str, mx.array] | None" = None
     assistant_model: object | None = None
     check_for_cancel_every: int = 50
+    # Static per-instance context ceiling for request admission (#145).
+    context_token_limit: int | None = None
 
     _cancelled_tasks: set[TaskId] = field(default_factory=set, init=False)
     _maybe_queue: list[TextGeneration] = field(default_factory=list, init=False)
@@ -272,6 +277,25 @@ class SequentialGenerator(InferenceGenerator):
             record_runner_phase(
                 "completion",
                 event="decode_complete",
+                task_id=task.task_id,
+                command_id=str(task.command_id),
+                include_memory=True,
+            )
+            output.append((task.task_id, Finished()))
+            self._active = None
+            if self._queue:
+                self._start_next()
+
+        except ContextLengthExceededError as e:
+            # Deterministic pre-prefill rejection (#145): every rank raises
+            # this in lockstep before any collective, so the task terminates
+            # cleanly (error chunk + Finished) and the runner stays alive —
+            # unlike the generic arm below, which escalates to a runner crash.
+            self._record_decode_span(task.task_id)
+            self._send_error(task, e)
+            record_runner_phase(
+                "completion",
+                event="context_admission_rejected",
                 task_id=task.task_id,
                 command_id=str(task.command_id),
                 include_memory=True,
@@ -447,6 +471,7 @@ class SequentialGenerator(InferenceGenerator):
             trace_rank=self.device_rank,
             mtp_weights=self.mtp_weights,
             assistant_model=self.assistant_model,
+            context_token_limit=self.context_token_limit,
             model_card=self.model_card,
         )
 
@@ -484,6 +509,8 @@ class BatchGenerator(InferenceGenerator):
     vision_processor: VisionProcessor | None = None
     mtp_weights: "dict[str, mx.array] | None" = None
     assistant_model: object | None = None
+    # Static per-instance context ceiling for request admission (#145).
+    context_token_limit: int | None = None
 
     _cancelled_tasks: set[TaskId] = field(default_factory=set, init=False)
     _maybe_queue: list[TextGeneration] = field(default_factory=list, init=False)
@@ -503,6 +530,7 @@ class BatchGenerator(InferenceGenerator):
             group=self.group,
             kv_prefix_cache=self.kv_prefix_cache,
             vision_processor=self.vision_processor,
+            context_token_limit=self.context_token_limit,
         )
 
     def warmup(self):
@@ -578,6 +606,11 @@ class BatchGenerator(InferenceGenerator):
         if not self._queue:
             self.agree_on_tasks()
 
+        # Tasks rejected by context admission before reaching the engine
+        # (#145): they terminate with an error chunk + Finished, and the
+        # runner keeps serving.
+        rejected: list[tuple[TaskId, Finished]] = []
+
         # Submit any queued tasks to the engine
         while self._queue and len(self._active_tasks) < SKULK_MAX_CONCURRENT_REQUESTS:
             task = self._queue.popleft()
@@ -601,6 +634,20 @@ class BatchGenerator(InferenceGenerator):
             try:
                 uid = self._start_task(task)
             except PrefillCancelled:
+                continue
+            except ContextLengthExceededError as e:
+                # Deterministic pre-prefill rejection: all ranks agree (same
+                # tokens, same static limit), so finishing the task here keeps
+                # the batch engine in lockstep across the ring.
+                self._send_error(task, e)
+                record_runner_phase(
+                    "completion",
+                    event="context_admission_rejected",
+                    task_id=task.task_id,
+                    command_id=str(task.command_id),
+                    include_memory=True,
+                )
+                rejected.append((task.task_id, Finished()))
                 continue
             except Exception as e:
                 self._send_error(task, e)
@@ -631,7 +678,7 @@ class BatchGenerator(InferenceGenerator):
             )
 
         if not self._mlx_gen.has_work:
-            return self._apply_cancellations()
+            return itertools.chain(rejected, self._apply_cancellations())
 
         shared_task_ids = [active.task.task_id for active in self._active_tasks.values()]
         decode_step_start_us = now_us()
@@ -698,7 +745,7 @@ class BatchGenerator(InferenceGenerator):
                 output.append((task.task_id, Finished()))
                 del self._active_tasks[uid]
 
-        return itertools.chain(output, self._apply_cancellations())
+        return itertools.chain(rejected, output, self._apply_cancellations())
 
     def _apply_cancellations(
         self,

--- a/src/skulk/worker/runner/llm_inference/runner.py
+++ b/src/skulk/worker/runner/llm_inference/runner.py
@@ -135,11 +135,16 @@ class Runner:
         event_sender: MpSender[Event],
         task_receiver: MpReceiver[Task],
         cancel_receiver: MpReceiver[TaskId],
+        context_token_limit: int | None = None,
     ):
         self.event_sender = event_sender
         self.task_receiver = task_receiver
         self.cancel_receiver = cancel_receiver
         self.bound_instance = bound_instance
+        # Static per-instance context ceiling for request admission (#145),
+        # computed by the worker from gossiped node memory before spawn so
+        # every rank of a multi-node instance enforces the identical limit.
+        self.context_token_limit = context_token_limit
 
         self.instance, self.runner_id, self.shard_metadata = (
             self.bound_instance.instance,
@@ -162,6 +167,7 @@ class Runner:
             self.event_sender,
             self.cancel_receiver,
             self.shard_metadata.model_card,
+            context_token_limit=self.context_token_limit,
         )
 
         self.seen: set[TaskId] = set()
@@ -733,6 +739,8 @@ class Builder:
     vision_processor: VisionProcessor | None = None
     mtp_weights: dict[str, mx.array] | None = None
     assistant_model: object | None = None
+    # Static per-instance context ceiling for request admission (#145).
+    context_token_limit: int | None = None
 
     def build(
         self,
@@ -841,6 +849,7 @@ class Builder:
                 vision_processor=vision_processor,
                 mtp_weights=self.mtp_weights,
                 assistant_model=self.assistant_model,
+                context_token_limit=self.context_token_limit,
             )
         logger.info("using BatchGenerator")
         return BatchGenerator(
@@ -856,4 +865,5 @@ class Builder:
             event_sender=self.event_sender,
             vision_processor=vision_processor,
             mtp_weights=self.mtp_weights,
+            context_token_limit=self.context_token_limit,
         )

--- a/src/skulk/worker/runner/runner_supervisor.py
+++ b/src/skulk/worker/runner/runner_supervisor.py
@@ -151,7 +151,14 @@ class RunnerSupervisor:
         bound_instance: BoundInstance,
         event_sender: Sender[Event],
         initialize_timeout: float = 400,
+        context_token_limit: int | None = None,
     ) -> Self:
+        """Spawn the runner subprocess for one shard of a placed instance.
+
+        ``context_token_limit`` is the instance's static context-admission
+        ceiling (#145), threaded through the local (same-binary) process
+        boundary precisely so no gossiped type needs a new field.
+        """
         ev_send, ev_recv = mp_channel[Event]()
         diag_send, diag_recv = mp_channel[RunnerDiagnosticUpdate](max_buffer_size=256)
         task_sender, task_recv = mp_channel[Task]()
@@ -166,6 +173,7 @@ class RunnerSupervisor:
                 task_recv,
                 cancel_recv,
                 logger,
+                context_token_limit,
             ),
             daemon=True,
         )

--- a/src/skulk/worker/tests/unittests/test_context_admission.py
+++ b/src/skulk/worker/tests/unittests/test_context_admission.py
@@ -1,0 +1,110 @@
+"""Unit coverage for request-time context-length admission (#145)."""
+
+import pytest
+
+from skulk.shared.constants import CONTEXT_LENGTH_EXCEEDED_PREFIX
+from skulk.worker.engines.mlx.generator.context_admission import (
+    ContextLengthExceededError,
+    admit_max_tokens,
+)
+
+
+def test_no_limit_preserves_legacy_behavior():
+    assert (
+        admit_max_tokens(
+            prompt_tokens=1_000_000,
+            requested_max_output_tokens=None,
+            default_max_output_tokens=4096,
+            context_token_limit=None,
+        )
+        == 4096
+    )
+    assert (
+        admit_max_tokens(
+            prompt_tokens=1_000_000,
+            requested_max_output_tokens=7,
+            default_max_output_tokens=4096,
+            context_token_limit=None,
+        )
+        == 7
+    )
+
+
+def test_omitted_max_tokens_is_clamped_to_remaining_context():
+    assert (
+        admit_max_tokens(
+            prompt_tokens=80,
+            requested_max_output_tokens=None,
+            default_max_output_tokens=4096,
+            context_token_limit=100,
+        )
+        == 20
+    )
+
+
+def test_omitted_max_tokens_keeps_default_when_it_fits():
+    assert (
+        admit_max_tokens(
+            prompt_tokens=80,
+            requested_max_output_tokens=None,
+            default_max_output_tokens=10,
+            context_token_limit=100,
+        )
+        == 10
+    )
+
+
+def test_explicit_max_tokens_that_fits_is_honored_exactly():
+    assert (
+        admit_max_tokens(
+            prompt_tokens=80,
+            requested_max_output_tokens=20,
+            default_max_output_tokens=4096,
+            context_token_limit=100,
+        )
+        == 20
+    )
+
+
+def test_explicit_max_tokens_overflow_is_rejected_not_clamped():
+    with pytest.raises(ContextLengthExceededError):
+        admit_max_tokens(
+            prompt_tokens=80,
+            requested_max_output_tokens=21,
+            default_max_output_tokens=4096,
+            context_token_limit=100,
+        )
+
+
+def test_prompt_filling_the_window_is_rejected_even_without_max_tokens():
+    with pytest.raises(ContextLengthExceededError):
+        admit_max_tokens(
+            prompt_tokens=100,
+            requested_max_output_tokens=None,
+            default_max_output_tokens=4096,
+            context_token_limit=100,
+        )
+
+
+def test_zero_limit_rejects_everything():
+    with pytest.raises(ContextLengthExceededError):
+        admit_max_tokens(
+            prompt_tokens=1,
+            requested_max_output_tokens=None,
+            default_max_output_tokens=4096,
+            context_token_limit=0,
+        )
+
+
+def test_rejection_message_carries_the_wire_sentinel():
+    with pytest.raises(ContextLengthExceededError) as excinfo:
+        admit_max_tokens(
+            prompt_tokens=200,
+            requested_max_output_tokens=50,
+            default_max_output_tokens=4096,
+            context_token_limit=100,
+        )
+    assert str(excinfo.value).startswith(CONTEXT_LENGTH_EXCEEDED_PREFIX)
+    assert "200" in str(excinfo.value)
+    assert "50" in str(excinfo.value)
+    assert "100" in str(excinfo.value)

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -177,6 +177,27 @@ non-positive `max_tokens` returns **400 Bad Request** rather than being
 accepted and failing during generation. (This applies across the Claude,
 Ollama, and Responses wire formats too, which share the same dispatch path.)
 
+### Context-length limits
+
+Every placed instance has a usable context limit: the smaller of the model's
+advertised context length and the number of KV-cache tokens that fit in memory
+next to the model weights on the hosting node(s). Requests are admitted
+against that limit instead of growing the KV cache until the node runs out of
+memory:
+
+- A `max_tokens` value that cannot fit in the limit at all returns
+  **400 Bad Request** immediately (`context_length_exceeded: ...`).
+- After tokenization on the serving instance, a prompt that fills the window,
+  or a prompt plus an explicit `max_tokens` that exceeds the limit, is
+  rejected with an OpenAI-style `invalid_request_error` whose message starts
+  with `context_length_exceeded:`. For streaming requests this arrives as the
+  first SSE `data:` event; for non-streaming requests the response body is the
+  error envelope (the HTTP status is already committed when the rejection is
+  computed on the serving node).
+- When `max_tokens` is omitted, the server default output budget is clamped to
+  the remaining window, so generation ends with `finish_reason: "length"`
+  instead of overrunning the context.
+
 ### OpenAI Python SDK Example
 
 ```python


### PR DESCRIPTION
Closes nothing yet — phase 1 of #145 (unquantized KV). Phase 2 (quantized-KV budget math, MTP × quantization) tracked separately.

## Problem

The within-request KV cache grows one entry per generated token with **no bound and no preflight check** (`make_kv_cache` is never passed `max_kv_size`; the card's `context_length` is enforced nowhere at request time; `max_tokens` is never clamped). A request whose prompt + output exceeds what the hosting node(s) can hold kills the runner mid-generation with an unhandled Metal OOM: SIGABRT, broken stream or 500 for the client, wired GPU memory leaked. On a multi-node ring, one rank OOMing tears down the whole placement. Other inference platforms reject these requests cleanly; we just grew until the kernel killed us.

## Design

**One static ceiling per instance.** `instance_context_token_limit()` (new, in `memory_estimate.py`, reusing the placement fit-check's KV byte math) computes:

```
min over hosting nodes of:
  (ram_total × GPU_WORKING_SET_FRACTION − weights_share × 1.30 − floor) / (per_token_kv_bytes × shard_fraction)
then min'd with the card's advertised context_length
```

**Why only static inputs (`ram_total`, card, shard fractions) — never `ram_available`:** every rank of a multi-node instance admits or rejects each request independently, and a divergent verdict deadlocks the ring collectives. Static inputs + identical tokenization ⇒ identical verdicts in lockstep. Placement only happens after the master indexed memory for all hosting nodes (and the #274 failover seed carries `node_memory` at event 0), so the replicated state always has the needed entries at `CreateRunner` time.

**Where the value flows:** worker computes it at runner spawn → `RunnerSupervisor.create` → `mp.Process` entrypoint → generators. The value crosses only the local, version-locked worker→runner boundary — **no gossiped type gains a field** (mixed-version clusters with `extra=forbid` stay safe).

**Admission semantics (OpenAI-compatible), enforced after tokenization, before any prefill collective**, in both `mlx_generate` (sequential) and `SkulkBatchGenerator.submit` (batch):
- prompt fills the window → reject
- explicit `max_tokens` that can't fit on top of the prompt → reject (OpenAI rejects, doesn't clamp)
- omitted `max_tokens` → default output budget clamped to the remaining window ⇒ `finish_reason="length"`

**Rejection is not a crash.** New `ContextLengthExceededError` is handled in both generator classes as clean task termination (error chunk + `Finished`, `TaskStatus.Complete`) — the runner keeps serving and the crash-breaker is not tripped. The generic exception path (ErrorChunk + re-raise → runner death) is unchanged for real failures.

**Error surface.** Rejections carry a `context_length_exceeded:` prefix inside the existing plain-string `error_message` fields (wire-safe sentinel; a structured field on `ErrorChunk`/`TaskFailed` would break old nodes). The chat-completions adapter maps the sentinel to an OpenAI-style `invalid_request_error` envelope on both streaming and non-streaming paths. The API additionally pre-flights the prompt-independent certainty — explicit `max_tokens` ≥ the model's best instance limit — as a **true HTTP 400** at the shared dispatch chokepoint (all wire formats). The API has no tokenizer (tokenizers live with model files on hosting nodes), so prompt-inclusive checks belong to the runner.

## Useful properties

- A placement admitted by the fit-check always yields a ceiling ≥ 8192 tokens (`KV_CONTEXT_BUDGET_TOKENS`), since the runtime formula is the same arithmetic with the same working-set ceiling.
- `context_token_limit=None` (unknown KV cost AND no card limit) preserves today's behavior exactly.
- Gemma 4 26B's 262k-token card limit on 16 GB nodes — the exact #145 scenario — now computes a memory-bound ceiling instead of trusting the card.

## Known gaps (deliberate, phase 2+)

- Concurrent batched requests are admitted per-request, not against an aggregate KV budget.
- Co-placed instances on one node are not subtracted from each other's budgets (placement already gates the load; the static formula must stay instance-deterministic).
- Quantized-KV backends change per-token byte math — phase 2.
- Non-streaming runner-side rejections return HTTP 200 with the error envelope in the body (the status line is committed before the serving node tokenizes; a first-chunk-peek could upgrade this to a real 400 later).

## Validation

- `uv run basedpyright` 0 errors, `uv run ruff check` clean, `nix fmt` no changes
- Full `uv run pytest`: 1033 passed (the 2 `test_model_store_progress` failures were pre-existing #268 staging contamination, green after cleanup)
- New unit tests: 8 admission-semantics tests (pure function) + 10 ceiling-math tests (per-token bytes, shard fractions, min-across-nodes, card cap, fallbacks, zero-room case)
- Live cluster E2E (boundary requests single + multi-node) planned on the kites before merge — will report results on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)