### PR TITLE
chore(license): proper Apache 2.0 fork attribution via NOTICE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,6 +283,28 @@ The React dashboard has Storybook stories for key components:
 cd dashboard-react && npx storybook dev -p 6007
 ```
 
+## Licensing and File Headers
+
+Skulk is licensed under the Apache License, Version 2.0 (see `LICENSE`). The
+project began as a fork of exo, and the upstream attribution lives in the
+`NOTICE` file as Apache 2.0 intends; do not remove or edit the exo entry
+there.
+
+Header conventions:
+
+- New files authored for Skulk carry a Foxlight Foundation copyright header
+  in the file's comment style, for example
+  `<!-- Copyright 2025 Foxlight Foundation -->` or
+  `# Copyright 2025 Foxlight Foundation`.
+- Substantive modifications to files inherited from exo should add a
+  `Modifications Copyright 2025-2026 Foxlight Foundation` line beneath any
+  existing upstream header rather than replacing it. Where inherited files
+  have no header, the repository-level `NOTICE` and git history carry the
+  attribution.
+- Contributions are accepted under Apache 2.0 (inbound = outbound). By
+  submitting a pull request you license your contribution under the same
+  terms.
+
 ## Submitting Changes
 
 1. Fork the repository

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Exo Technologies Ltd
+   Copyright 2025-2026 Foxlight Foundation
+   Portions Copyright 2025 Exo Technologies Ltd (see NOTICE)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+Skulk
+Copyright 2025-2026 Foxlight Foundation
+
+This product includes software developed as part of the exo project
+(https://github.com/exo-explore/exo), Copyright 2025 Exo Technologies Ltd,
+licensed under the Apache License, Version 2.0.
+
+Skulk began as a fork of exo and has substantially diverged. The portions of
+this codebase derived from exo remain subject to Exo Technologies Ltd's
+copyright; all other portions are Copyright Foxlight Foundation. The entire
+work is distributed under the Apache License, Version 2.0 (see LICENSE).


### PR DESCRIPTION
Skulk's LICENSE was inherited verbatim from exo with Exo Technologies Ltd in the appendix block, no NOTICE file, and no stated header policy. This PR puts the attribution where Apache 2.0 intends it for a derivative work:

- **NOTICE** (new): Foxlight Foundation copyright for Skulk, plus the required attribution for the exo-derived portions (section 4(d)); downstream redistributors must preserve it.
- **LICENSE**: the appendix application block now names Foxlight as steward with "Portions Copyright 2025 Exo Technologies Ltd (see NOTICE)". Nothing is removed; the upstream copyright moves to the license's purpose-built mechanism and remains in the appendix as a Portions line.
- **CONTRIBUTING**: a Licensing and File Headers section codifying the conventions (Foxlight headers on new files, Modifications Copyright lines on substantively changed inherited files, inbound=outbound).

Intent is fairness in both directions: exo's contribution stays properly credited and legally intact; Foxlight's stewardship and authorship of the divergent majority is stated plainly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)