### PR TITLE
test(web-search): make the non-2xx metadata test hermetic

### DIFF
--- a/src/skulk/tools/tests/test_web_search.py
+++ b/src/skulk/tools/tests/test_web_search.py
@@ -242,6 +242,14 @@ async def test_fetch_url_keeps_non_2xx_status_metadata(
         fake_async_client,
     )
 
+    # Stub the SSRF guard's DNS lookup to a public address so the test does
+    # not depend on real resolution of example.com (CI runners can sit behind
+    # flaky or restricted DNS). Mirrors the sibling validation tests.
+    def fake_getaddrinfo(*_args: object, **_kwargs: object) -> list[tuple[Any, ...]]:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    monkeypatch.setattr("skulk.tools.web_search.socket.getaddrinfo", fake_getaddrinfo)
+
     response = await provider.open_url("https://example.com/missing")
 
     assert response.status_code == 404


### PR DESCRIPTION
The only failing job on `dev` was `ci-pipeline / Test`: one test out of 969, `test_fetch_url_keeps_non_2xx_status_metadata`, failing with `ValueError: Could not resolve URL host during validation: example.com`.

**Root cause:** the test mocks `httpx.AsyncClient` but not the SSRF guard in `_validate_public_http_target`, which does a real `socket.getaddrinfo` on the target host before any fetch. On a self-hosted runner behind flaky/restricted DNS (our known router-DNS condition), resolving `example.com` failed and the guard correctly raised. The product code is right; the test was non-hermetic.

**Fix:** stub `socket.getaddrinfo` to a public address, exactly as the sibling validation tests in this same file already do (`test_browser_tools_reject_loopback_dns_targets`, `test_browser_tools_fail_closed_when_dns_validation_cannot_resolve`). No product change.

Verified locally: full `test_web_search.py` 20/20 green, basedpyright/ruff/nix-fmt clean. First PR opened against `dev` under the new branching model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)