### PR TITLE
feat(telemetry): node telemetry plane, node_resources off the log (#279 phase 1 slice 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Components communicate via typed pub/sub topics (src/skulk/routing/topics.py):
 - `STATE_SYNC_MESSAGES`: Followers request the current session snapshot before replaying the retained tail
 - `ELECTION_MESSAGES`: Election protocol messages
 - `CONNECTION_MESSAGES`: libp2p connection updates
+- `TELEMETRY`: Workers gossip `NodeTelemetry` (last-write-wins node readings — currently `NodeResources`: participation role + backends) into an in-memory `TelemetryView`, NOT the event log. First slice of the control/telemetry/data plane separation (#279); read by the planner for placement eligibility. `node_resources` lives here, not in `State`.
 
 ### Event Sourcing
 The system uses event sourcing for state management:

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -246,6 +246,7 @@ from skulk.shared.types.events import (
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.profiling import MemoryUsage, read_wired_memory_bytes
 from skulk.shared.types.state import State
+from skulk.shared.types.telemetry import TelemetryView
 from skulk.shared.types.text_generation import TextGenerationTaskParams
 from skulk.shared.types.worker.downloads import DownloadCompleted
 from skulk.shared.types.worker.instances import Instance, InstanceId, InstanceMeta
@@ -604,8 +605,14 @@ class API:
         store_client: "ModelStoreClient | None" = None,
         enable_event_log: bool = True,
         mount_dashboard: bool = True,
+        telemetry_view: "TelemetryView | None" = None,
     ) -> None:
         self.state = State()
+        # Node telemetry off the event log (#279): placement previews read
+        # node_resources from the live view, matching what the master enforces.
+        self._telemetry_view = (
+            telemetry_view if telemetry_view is not None else TelemetryView()
+        )
         self._event_log = DiskEventLog(_API_EVENT_LOG_DIR) if enable_event_log else None
         self._event_log_appends_since_retention_check = 0
         self._system_id = SystemId()
@@ -1418,7 +1425,7 @@ class API:
                     node_network=self.state.node_network,
                     download_status=self.state.downloads,
                     excluded_nodes=set(command.excluded_nodes),
-                    node_resources=self.state.node_resources,
+                    node_resources=self._telemetry_view.node_resources,
                 )
                 break
             except PlacementInfoPendingError as exc:
@@ -1486,7 +1493,7 @@ class API:
                 topology=self.state.topology,
                 current_instances=self.state.instances,
                 download_status=self.state.downloads,
-                node_resources=self.state.node_resources,
+                node_resources=self._telemetry_view.node_resources,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1553,7 +1560,7 @@ class API:
                     required_nodes=required_nodes,
                     download_status=self.state.downloads,
                     excluded_nodes=excluded_nodes,
-                    node_resources=self.state.node_resources,
+                    node_resources=self._telemetry_view.node_resources,
                 )
             except ValueError as exc:
                 if (model_card.model_id, sharding, instance_meta, 0) not in seen:

--- a/src/skulk/main.py
+++ b/src/skulk/main.py
@@ -676,6 +676,13 @@ class Node:
                             ),
                             store_client=self.store_client,
                             staging_config=elect_staging2,
+                            # Must match Node.create's Worker wiring: without this
+                            # the recreated worker stops publishing NodeResources
+                            # telemetry, and after a master restart (fresh
+                            # telemetry_view) the node never reappears in
+                            # node_resources, so placement silently treats a
+                            # management/edge node as eligible (#279 review).
+                            telemetry_sender=self.router.sender(topics.TELEMETRY),
                         )
                         self._tg.start_soon(self.worker.run)
                         if self.api is not None:

--- a/src/skulk/main.py
+++ b/src/skulk/main.py
@@ -35,6 +35,7 @@ from skulk.shared.session_carryover import seed_state_for_new_session
 from skulk.shared.types.commands import ForwarderDownloadCommand, SyncConfig
 from skulk.shared.types.common import NodeId, SessionId, SystemId
 from skulk.shared.types.state_sync import StateSyncMessage
+from skulk.shared.types.telemetry import NodeTelemetry, TelemetryView
 from skulk.startup_recovery import preflight_api_port
 from skulk.store.config import (
     SkulkConfig,
@@ -139,6 +140,10 @@ class Node:
     exo_config: SkulkConfig | None
     store_client: ModelStoreClient | None
     store_server: ModelStoreServer | None
+    # Live node telemetry off the event log (#279). Node-owned so it survives
+    # master re-election; the subscriber feeds it, the master/API read it.
+    telemetry_view: TelemetryView
+    telemetry_receiver: Receiver[NodeTelemetry]
     _tg: TaskGroup = field(init=False, default_factory=TaskGroup)
 
     @classmethod
@@ -158,6 +163,8 @@ class Node:
         await router.register_topic(topics.CONNECTION_MESSAGES)
         await router.register_topic(topics.DOWNLOAD_COMMANDS)
         await router.register_topic(topics.STATE_SYNC_MESSAGES)
+        await router.register_topic(topics.TELEMETRY)
+        telemetry_view = TelemetryView()
         event_router = EventRouter(
             node_id,
             session_id,
@@ -268,6 +275,7 @@ class Node:
                 election_receiver=router.receiver(topics.ELECTION_MESSAGES),
                 exo_config=exo_config,
                 store_client=store_client,
+                telemetry_view=telemetry_view,
             )
         else:
             api = None
@@ -290,6 +298,7 @@ class Node:
                 event_sender=event_router.sender(),
                 command_sender=router.sender(topics.COMMANDS),
                 download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
+                telemetry_sender=router.sender(topics.TELEMETRY),
                 store_client=worker_store_client,
                 staging_config=worker_staging_cfg,
             )
@@ -310,6 +319,7 @@ class Node:
             state_sync_receiver=router.receiver(topics.STATE_SYNC_MESSAGES),
             state_sync_sender=router.sender(topics.STATE_SYNC_MESSAGES),
             download_command_sender=router.sender(topics.DOWNLOAD_COMMANDS),
+            telemetry_view=telemetry_view,
         )
 
         er_send, er_recv = channel[ElectionResult]()
@@ -340,6 +350,8 @@ class Node:
             exo_config,
             store_client,
             store_server,
+            telemetry_view,
+            router.receiver(topics.TELEMETRY),
         )
 
     async def run(self):
@@ -349,6 +361,7 @@ class Node:
             tg.start_soon(self.router.run)
             tg.start_soon(self.event_router.run)
             tg.start_soon(self.election.run)
+            tg.start_soon(self._run_telemetry)
             if self.store_server:
                 tg.start_soon(self.store_server.start)
             if self.download_coordinator:
@@ -360,6 +373,17 @@ class Node:
             if self.api:
                 tg.start_soon(self.api.run)
             tg.start_soon(self._elect_loop)
+
+    async def _run_telemetry(self) -> None:
+        """Maintain the node-owned TelemetryView from the telemetry plane (#279).
+
+        Runs for the node's lifetime, independent of master election, so the
+        view of every node's resources persists across a master flip. Each
+        message coalesces last-write-wins; there is no ordering or persistence.
+        """
+        with self.telemetry_receiver as messages:
+            async for message in messages:
+                self.telemetry_view.apply(message)
 
     def shutdown(self):
         # if this is our second call to shutdown, just sys.exit
@@ -552,6 +576,7 @@ class Node:
                         download_command_sender=self.router.sender(
                             topics.DOWNLOAD_COMMANDS
                         ),
+                        telemetry_view=self.telemetry_view,
                     )
                     self._tg.start_soon(self.master.run)
                 elif (

--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -76,6 +76,7 @@ from skulk.shared.types.tasks import (
 from skulk.shared.types.tasks import (
     TextGeneration as TextGenerationTask,
 )
+from skulk.shared.types.telemetry import TelemetryView
 from skulk.shared.types.worker.instances import InstanceId
 from skulk.store.config import resolve_config_path
 from skulk.utils.channels import Receiver, Sender
@@ -191,9 +192,16 @@ class Master:
         download_command_sender: Sender[ForwarderDownloadCommand],
         snapshot_event_cadence: int = SNAPSHOT_EVENT_CADENCE,
         initial_state: State | None = None,
+        telemetry_view: TelemetryView | None = None,
     ):
         self.node_id = node_id
         self.session_id = session_id
+        # Live node telemetry off the event log (#279). Node-owned so it
+        # survives this master's election: a freshly promoted master keeps the
+        # cluster's current node_resources instead of starting blind and
+        # risking a placement on a management node. None only in tests/standalone
+        # construction; the planner falls back to "no telemetry constraints".
+        self._telemetry_view = telemetry_view if telemetry_view is not None else TelemetryView()
         # A promoted master seeds its session from the node's prior
         # replicated state (shared/session_carryover.py) so placements
         # survive failover (#273) — previously every new session started
@@ -543,7 +551,7 @@ class Master:
                                 self.state.node_network,
                                 download_status=self.state.downloads,
                                 excluded_nodes=set(command.excluded_nodes),
-                                node_resources=self.state.node_resources,
+                                node_resources=self._telemetry_view.node_resources,
                             )
                             transition_events = get_transition_events(
                                 self.state.instances, placement, self.state.tasks

--- a/src/skulk/routing/topics.py
+++ b/src/skulk/routing/topics.py
@@ -9,6 +9,7 @@ from skulk.shared.types.events import (
     LocalForwarderEvent,
 )
 from skulk.shared.types.state_sync import StateSyncMessage
+from skulk.shared.types.telemetry import NodeTelemetry
 from skulk.utils.pydantic_ext import CamelCaseModel
 
 
@@ -53,3 +54,6 @@ DOWNLOAD_COMMANDS = TypedTopic(
 STATE_SYNC_MESSAGES = TypedTopic(
     "state_sync_messages", PublishPolicy.Always, StateSyncMessage
 )
+# Telemetry plane (#279): per-node live readings gossiped last-write-wins,
+# off the event log. Slice 1 carries NodeResources only.
+TELEMETRY = TypedTopic("telemetry", PublishPolicy.Always, NodeTelemetry)

--- a/src/skulk/shared/apply.py
+++ b/src/skulk/shared/apply.py
@@ -435,10 +435,12 @@ def apply_node_gathered_info(event: NodeGatheredInfo, state: State) -> State:
                 ),
             }
         case NodeResources():
-            update["node_resources"] = {
-                **state.node_resources,
-                event.node_id: info,
-            }
+            # NodeResources travels the telemetry plane (#279), not the event
+            # log — the worker routes it to the TELEMETRY topic and it lands in
+            # TelemetryView, never here. Kept as an explicit no-op so the match
+            # over GatheredInfo stays exhaustive and a stray log-path delivery
+            # is harmless rather than a crash.
+            pass
 
     return state.model_copy(update=update)
 

--- a/src/skulk/shared/tests/test_node_election_reset.py
+++ b/src/skulk/shared/tests/test_node_election_reset.py
@@ -16,6 +16,7 @@ from skulk.shared.election import Election, ElectionResult
 from skulk.shared.types.common import NodeId, SessionId
 from skulk.shared.types.state import State
 from skulk.shared.types.state_sync import StateSnapshot, StateSyncMessage
+from skulk.shared.types.telemetry import NodeTelemetry, TelemetryView
 from skulk.utils.channels import channel
 from skulk.worker.main import Worker
 
@@ -146,6 +147,8 @@ async def test_election_restarts_event_router_after_receivers_are_rewired(
         exo_config=None,
         store_client=None,
         store_server=None,
+        telemetry_view=TelemetryView(),
+        telemetry_receiver=channel[NodeTelemetry]()[1],
     )
     node._tg = _FakeTaskGroup(order_events)  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -238,6 +241,8 @@ async def test_new_master_does_not_wait_on_unavailable_state_sync_config(
         exo_config=None,
         store_client=None,
         store_server=None,
+        telemetry_view=TelemetryView(),
+        telemetry_receiver=channel[NodeTelemetry]()[1],
     )
     node._tg = _FakeTaskGroup(order_events)  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -287,6 +292,8 @@ async def test_request_cluster_config_ignores_non_master_origin() -> None:
         exo_config=None,
         store_client=None,
         store_server=None,
+        telemetry_view=TelemetryView(),
+        telemetry_receiver=channel[NodeTelemetry]()[1],
     )
 
     session_id = SessionId(master_node_id=NodeId("master"), election_clock=9)

--- a/src/skulk/shared/tests/test_state_serialization.py
+++ b/src/skulk/shared/tests/test_state_serialization.py
@@ -53,3 +53,49 @@ def test_state_snapshot_serialization_roundtrip() -> None:
     assert restored.last_event_applied_idx == snapshot.last_event_applied_idx
     assert restored.state.last_event_applied_idx == snapshot.state.last_event_applied_idx
     assert restored.state.topology.to_snapshot() == snapshot.state.topology.to_snapshot()
+
+
+def test_state_ignores_legacy_node_resources_from_old_snapshot() -> None:
+    """A pre-#279 snapshot carrying ``nodeResources`` must still hydrate.
+
+    ``node_resources`` moved to the telemetry plane (#279), but ``State`` keeps
+    ``extra="forbid"``. Without the legacy-key strip, an upgraded follower
+    rejects an old master's state-sync snapshot, falls back to replay from
+    index 0, and loses instances/topology that lived only in an already-
+    compacted log prefix (the #273 outage class). This pins that an inbound
+    payload containing the removed key validates instead of raising.
+    """
+    node_id = NodeId("node-a")
+    state = State(last_event_applied_idx=7)
+    state.topology.add_node(node_id)
+
+    # Simulate the wire payload an older binary would emit: the current JSON
+    # plus the removed camelCase field.
+    payload = state.model_dump(mode="json", by_alias=True)
+    payload["nodeResources"] = {
+        str(node_id): {"backends": ["mlx"], "participation": "management"}
+    }
+
+    restored = State.model_validate(payload)
+
+    assert restored.last_event_applied_idx == 7
+    assert restored.topology.to_snapshot().nodes == state.topology.to_snapshot().nodes
+    # The legacy field is dropped, not surfaced anywhere on the model.
+    assert not hasattr(restored, "node_resources")
+
+
+def test_state_still_forbids_genuinely_unknown_fields() -> None:
+    """The legacy strip must not weaken the forbid-extra guard otherwise.
+
+    Only the known-removed ``node_resources`` key is tolerated; a truly
+    unknown field (e.g. one a NEWER binary added) must still raise so a stale
+    binary fails loudly instead of silently dropping state it can't model.
+    """
+    import pytest
+    from pydantic import ValidationError
+
+    payload = State().model_dump(mode="json", by_alias=True)
+    payload["someFutureField"] = 123
+
+    with pytest.raises(ValidationError):
+        State.model_validate(payload)

--- a/src/skulk/shared/types/state.py
+++ b/src/skulk/shared/types/state.py
@@ -2,7 +2,13 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any, cast
 
-from pydantic import ConfigDict, Field, field_serializer, field_validator
+from pydantic import (
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 from pydantic.alias_generators import to_camel
 
 from skulk.shared.topology import Topology, TopologySnapshot
@@ -63,6 +69,29 @@ class State(CamelCaseModel):
 
     # Detected cycles where all nodes have Thunderbolt bridge enabled (>2 nodes)
     thunderbolt_bridge_cycles: Sequence[Sequence[NodeId]] = []
+
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_legacy_node_resources(cls, data: object) -> object:
+        """Strip the removed ``node_resources`` field from inbound payloads.
+
+        ``node_resources`` moved to the telemetry plane (#279), but ``State``
+        keeps ``extra="forbid"`` so a newer binary's unknown fields are caught
+        rather than silently dropped. Without this, a state-sync snapshot from
+        a pre-#279 master (which still carries ``nodeResources``) fails
+        validation on an upgraded follower; the follower then discards the
+        snapshot and falls back to replay from index 0, losing any
+        instances/topology that lived only in an already-compacted log prefix
+        (the #273 outage class). Popping the known-removed key — and only that
+        key — preserves rolling-upgrade hydration without weakening the
+        forbid-extra guard for genuinely unknown fields.
+        """
+        if not isinstance(data, dict):
+            return data
+        cleaned: dict[str, object] = dict(cast("dict[str, object]", data))
+        cleaned.pop("nodeResources", None)
+        cleaned.pop("node_resources", None)
+        return cleaned
 
     @field_serializer("topology", mode="plain")
     def _encode_topology(self, value: Topology) -> TopologySnapshot:

--- a/src/skulk/shared/types/state.py
+++ b/src/skulk/shared/types/state.py
@@ -13,7 +13,6 @@ from skulk.shared.types.profiling import (
     NodeIdentity,
     NodeNetworkInfo,
     NodeRdmaCtlStatus,
-    NodeResources,
     NodeThunderboltInfo,
     SystemPerformanceProfile,
     ThunderboltBridgeStatus,
@@ -59,7 +58,8 @@ class State(CamelCaseModel):
     node_thunderbolt: Mapping[NodeId, NodeThunderboltInfo] = {}
     node_thunderbolt_bridge: Mapping[NodeId, ThunderboltBridgeStatus] = {}
     node_rdma_ctl: Mapping[NodeId, NodeRdmaCtlStatus] = {}
-    node_resources: Mapping[NodeId, NodeResources] = {}
+    # node_resources moved to the telemetry plane (#279) — it is gossiped
+    # last-write-wins off the event log and lives in TelemetryView, not here.
 
     # Detected cycles where all nodes have Thunderbolt bridge enabled (>2 nodes)
     thunderbolt_bridge_cycles: Sequence[Sequence[NodeId]] = []

--- a/src/skulk/shared/types/telemetry.py
+++ b/src/skulk/shared/types/telemetry.py
@@ -1,0 +1,50 @@
+"""The telemetry plane (#279): per-node live readings, off the event log.
+
+Telemetry is gossiped last-write-wins on its own topic and kept in a
+``TelemetryView`` that lives outside the event-sourced ``State``. It is never
+indexed by the master and never persisted: a stale reading coalesces under the
+next one instead of inflating the log. This is the plane a management/edge node
+subscribes to so it can render the dashboard and route placement without
+joining the inference data plane.
+
+Phase 1 slice 1 carries only ``NodeResources`` here (single reader: the
+planner); memory and the rest of the ``node_*`` maps migrate in later slices.
+"""
+
+from __future__ import annotations
+
+from skulk.shared.types.common import NodeId
+from skulk.shared.types.profiling import NodeResources
+from skulk.utils.info_gatherer.info_gatherer import GatheredInfo
+from skulk.utils.pydantic_ext import CamelCaseModel
+
+
+class NodeTelemetry(CamelCaseModel):
+    """A single node's latest telemetry reading, published on the TELEMETRY
+    topic. Mirrors ``NodeGatheredInfo`` but is a plain message, not a log
+    event: it is gossiped node -> all and never enters the event log."""
+
+    node_id: NodeId
+    info: GatheredInfo
+
+
+class TelemetryView:
+    """Latest-per-node telemetry, maintained outside event-sourced ``State``.
+
+    Owned by the ``Node`` so it survives master re-election (a freshly elected
+    master keeps the cluster's current readings instead of starting blind and
+    risking a placement on a management node during the repopulation window).
+    Updated only by the telemetry subscriber; readers (planner, API previews)
+    hold a reference and read the maps directly.
+    """
+
+    def __init__(self) -> None:
+        self.node_resources: dict[NodeId, NodeResources] = {}
+
+    def apply(self, message: NodeTelemetry) -> None:
+        """Coalesce one telemetry message into the latest-value view."""
+        info = message.info
+        if isinstance(info, NodeResources):
+            self.node_resources[message.node_id] = info
+        # Other GatheredInfo variants still travel the event log in slice 1;
+        # they migrate onto this plane (and this dispatch) in later slices.

--- a/src/skulk/shared/types/tests/test_telemetry.py
+++ b/src/skulk/shared/types/tests/test_telemetry.py
@@ -1,0 +1,37 @@
+"""Telemetry plane coverage (#279): wire round-trip + view coalescing.
+
+The NodeTelemetry message must survive the gossip path (model_dump_json ->
+bytes -> model_validate_json under the topic codec) or node telemetry never
+reaches the view and the planner reads nothing. Mirrors the #287 lesson where
+an in-process-only test missed a strict round-trip failure.
+"""
+
+from skulk.routing.topics import TELEMETRY
+from skulk.shared.types.common import NodeId
+from skulk.shared.types.profiling import NodeResources
+from skulk.shared.types.telemetry import NodeTelemetry, TelemetryView
+
+
+def test_node_telemetry_survives_topic_codec_round_trip() -> None:
+    msg = NodeTelemetry(
+        node_id=NodeId("node-a"),
+        info=NodeResources(backends=frozenset({"mlx"}), participation="management"),
+    )
+    restored = TELEMETRY.deserialize(TELEMETRY.serialize(msg))
+    assert restored == msg
+    assert isinstance(restored.info, NodeResources)
+    assert restored.info.participation == "management"
+    assert restored.info.backends == frozenset({"mlx"})
+
+
+def test_view_keeps_latest_per_node() -> None:
+    view = TelemetryView()
+    node = NodeId("node-a")
+    view.apply(NodeTelemetry(node_id=node, info=NodeResources(participation="full")))
+    assert view.node_resources[node].participation == "full"
+    # last write wins — a later reading replaces the earlier one
+    view.apply(
+        NodeTelemetry(node_id=node, info=NodeResources(participation="management"))
+    )
+    assert view.node_resources[node].participation == "management"
+    assert len(view.node_resources) == 1

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -52,7 +52,7 @@ from skulk.shared.types.events import (
     TopologyEdgeDeleted,
 )
 from skulk.shared.types.multiaddr import Multiaddr
-from skulk.shared.types.profiling import MemoryUsage
+from skulk.shared.types.profiling import MemoryUsage, NodeResources
 from skulk.shared.types.state import State
 from skulk.shared.types.tasks import (
     CancelTask,
@@ -67,6 +67,7 @@ from skulk.shared.types.tasks import (
     TaskStatus,
     TextGeneration,
 )
+from skulk.shared.types.telemetry import NodeTelemetry
 from skulk.shared.types.topology import Connection, SocketConnection
 from skulk.shared.types.worker.downloads import (
     DownloadCompleted,
@@ -302,6 +303,7 @@ class Worker:
         # but I think it's the correct way to be thinking about commands
         command_sender: Sender[ForwarderCommand],
         download_command_sender: Sender[ForwarderDownloadCommand],
+        telemetry_sender: Sender[NodeTelemetry] | None = None,
         store_client: ModelStoreClient | None = None,
         staging_config: StagingNodeConfig | None = None,
     ):
@@ -310,6 +312,7 @@ class Worker:
         self.event_sender = event_sender
         self.command_sender = command_sender
         self.download_command_sender = download_command_sender
+        self._telemetry_sender = telemetry_sender
         self._store_client = store_client
         self._staging_config = staging_config
 
@@ -437,6 +440,17 @@ class Worker:
         with recv as info_stream:
             async for info in info_stream:
                 try:
+                    # Telemetry plane (#279): NodeResources is gossiped on the
+                    # telemetry topic, off the event log. Everything else still
+                    # travels as an indexed NodeGatheredInfo event in slice 1.
+                    if (
+                        isinstance(info, NodeResources)
+                        and self._telemetry_sender is not None
+                    ):
+                        await self._telemetry_sender.send(
+                            NodeTelemetry(node_id=self.node_id, info=info)
+                        )
+                        continue
                     await self.event_sender.send(
                         NodeGatheredInfo(
                             node_id=self.node_id,

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -109,6 +109,13 @@ Defined in `src/skulk/routing/topics.py`.
 | `STATE_SYNC_MESSAGES` | `StateSyncMessage` | bidirectional: followers publish `kind="request"` for snapshot/config bootstrap; master publishes `kind="response"` with the requested payload (`StateSnapshotHydrated` etc.) | All nodes (request: followers; response: master) | All nodes |
 | `ELECTION_MESSAGES` | `ElectionMessage` | bully election rounds | All nodes | All nodes |
 | `CONNECTION_MESSAGES` | libp2p connection updates | peer arrivals / departures | Router | All nodes |
+| `TELEMETRY` | `NodeTelemetry` | `GatheredInfo` (currently `NodeResources` — participation role + backends) | Workers | All nodes (applied into `TelemetryView`) |
+
+### Telemetry plane (#279)
+
+`TELEMETRY` is the first slice of the control/telemetry/data plane separation (#279). Node readings that are **last-write-wins and not decisions** are gossiped on this topic instead of being event-sourced into `State`. They land in an in-memory `TelemetryView` (`src/skulk/shared/types/telemetry.py`), held per-`Node` and read by the planner (placement eligibility) and the API placement previews — they are **not** persisted in the event log or carried in snapshots.
+
+`node_resources` (a node's `participation` role and `backends`) moved here out of `State`: the worker forwards `NodeResources` to the telemetry sender (`worker/main.py`), and `apply_node_gathered_info` treats `NodeResources` as a no-op (`shared/apply.py`). The `TelemetryView` survives master re-election (Node-owned), so a freshly promoted master does not start blind. Rolling-upgrade note: an old worker that still emits `NodeResources` as a `NodeGatheredInfo` event no longer feeds the view (the legacy path is a no-op) — tracked for #279 slice 2.
 
 ## Events
 
@@ -289,6 +296,7 @@ Lives in `src/skulk/api/main.py` (route registration in `API.__init__`).
 - `tracing_enabled: bool` — cluster-wide tracing flag
 - `last_event_applied_idx: int` — water mark for the local apply
 - `node_identities`, `node_memory`, `node_disk`, `node_system`, `node_network`, `node_thunderbolt`, `node_thunderbolt_bridge`, `node_rdma_ctl: Mapping[NodeId, *]` — granular per-node telemetry that updates at independent frequencies
+- `node_resources` (participation role + backends) is **not** a `State` field — it moved to the telemetry plane (`TelemetryView`, gossiped on `TELEMETRY`, see "Telemetry plane" above) as part of #279. `State` keeps `extra="forbid"`, so a pre-#279 snapshot carrying the old `nodeResources` key is stripped by a before-validator on hydrate rather than rejected (rolling-upgrade compatibility).
 - `thunderbolt_bridge_cycles: Sequence[Sequence[NodeId]]` — detected Thunderbolt-bridge cycles where every node has it enabled (>2 nodes)
 
 Note: there is no `master_node_id` field on `State`. Master identity lives outside the event-sourced state — each node tracks the current master independently via the election protocol (`src/skulk/shared/election.py`). `placements` is also not a field; placement information is derived from `instances` (each `Instance` has its own shard assignments).

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -51,7 +51,8 @@ flowchart TB
 
 Each subsystem has its own concern:
 
-- **Router** wraps libp2p (via PyO3 Rust bindings) and exposes typed pub/sub topics: `GLOBAL_EVENTS`, `LOCAL_EVENTS`, `COMMANDS`, `DOWNLOAD_COMMANDS`, `STATE_SYNC_MESSAGES`, `ELECTION_MESSAGES`, `CONNECTION_MESSAGES`. Components subscribe by topic; payloads are validated Pydantic types.
+- **Router** wraps libp2p (via PyO3 Rust bindings) and exposes typed pub/sub topics: `GLOBAL_EVENTS`, `LOCAL_EVENTS`, `COMMANDS`, `DOWNLOAD_COMMANDS`, `STATE_SYNC_MESSAGES`, `ELECTION_MESSAGES`, `CONNECTION_MESSAGES`, `TELEMETRY`. Components subscribe by topic; payloads are validated Pydantic types.
+- **Telemetry plane** (`TELEMETRY` topic, #279) carries last-write-wins node readings that are *not* decisions — currently each node's `participation` role and `backends`. They are gossiped into an in-memory `TelemetryView` (read by the planner for placement eligibility) instead of being event-sourced into `State`, so routine readings don't bloat the event log. This is the first slice of separating the control plane (decisions, event-sourced) from telemetry and data planes.
 - **Election** runs the bully algorithm and broadcasts `ELECTION_MESSAGES`. The winner takes the master role.
 - **Master** indexes incoming events into the event log (writing them to disk via `DiskEventLog`), publishes indexed events on `GLOBAL_EVENTS` for followers, and decides instance placements when a model is launched.
 - **Worker** receives indexed events, applies them to its local view of `State`, downloads model weights to disk when assigned a placement, and spawns / supervises runner subprocesses. Before spawning, it refuses a shard that won't fit local memory — a last-resort guard below the master's admission check, using the same shared estimator — and a crash circuit breaker gives up on a runner that keeps failing rather than relaunching it into another GPU-memory leak.

--- a/website/docs/runtime-plane-separation.md
+++ b/website/docs/runtime-plane-separation.md
@@ -1,0 +1,443 @@
+---
+id: runtime-plane-separation
+title: Runtime Plane Separation
+sidebar_position: 95
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+# Runtime Plane Separation
+
+This is a design proposal for separating Skulk's runtime traffic into three
+planes:
+
+- **control plane**: durable cluster decisions and live task lifecycle
+- **telemetry plane**: current observations where only the latest value matters
+- **data plane**: generated tokens, images, embeddings, input payload bytes, and
+  trace payloads
+
+The goal is to keep cluster synchronization deterministic without forcing every
+token, telemetry sample, and old task cleanup event through the same
+master-indexed event log.
+
+## Problem
+
+The current event stream mixes different kinds of information:
+
+- placements and task lifecycle events that change cluster state
+- telemetry updates such as node memory, disk, network, and topology readings
+- generated output chunks such as `ChunkGenerated(TokenChunk(...))`
+- input payload chunks such as `InputChunkReceived`
+- diagnostic trace payloads
+
+That makes the event log look like the cluster's source of truth for
+everything, even when the event has no lasting state consequence. In practice
+this creates several failure modes:
+
+- followers can spend time replaying stale operational history instead of
+  hydrating current state
+- token streaming goes through master indexing and global event fan-out before
+  the API can write to the HTTP stream
+- per-token events can be serialized and appended to disk despite not changing
+  `State`
+- telemetry history consumes replay budget even though placement only needs the
+  freshest observations
+- diagnostics and traces compete with control-plane events for ordering and
+  backpressure
+
+Issue #278 exposed the replay side of this design smell: large session history
+and repeated task lifecycle events made catch-up expensive enough to destabilize
+elections. The token path exposes the throughput side: generated chunks are
+data-plane payloads, but they are currently represented as cluster events.
+
+## Design Principle
+
+Skulk should replicate **current state plus a bounded recent tail**, not a
+cluster diary.
+
+The cluster only needs old history when that history is still the cheapest way
+to bridge a recent gap. Once a snapshot covers the consequence of an event, the
+event itself is no longer part of synchronization.
+
+The invariant:
+
+> No healthy node should need to replay more than the retained control tail to
+> become synchronized. If its gap predates the retained tail, it must hydrate a
+> fresh snapshot.
+
+The corollary:
+
+> Data-plane payloads and soft telemetry must never be required for follower
+> replay.
+
+## Target Architecture
+
+```mermaid
+flowchart TB
+  Client["HTTP client"]
+  API["Origin API<br/>owns command stream"]
+  Master["Master<br/>orders durable control"]
+  Worker["Worker<br/>runs planner"]
+  Runner["Runner subprocess<br/>generates output"]
+  Snapshot["State snapshot<br/>plus short control tail"]
+  Telemetry["Latest telemetry cache<br/>TTL/coalesced"]
+  Diagnostics["Bounded diagnostics<br/>local or explicit upload"]
+
+  Client --> API
+  API -->|"Command"| Master
+  Master -->|"Control events"| Worker
+  Master --> Snapshot
+  Worker --> Runner
+  Runner -->|"Data stream chunks<br/>targeted to origin API"| API
+  Worker -->|"Task terminal status"| Master
+  Worker -->|"Current readings"| Telemetry
+  Runner -->|"Trace artifact / diagnostic sample"| Diagnostics
+  API --> Client
+```
+
+The master remains responsible for ordering durable control-plane decisions.
+It is not on the generated-token hot path.
+
+## Event Taxonomy
+
+### Durable Control
+
+Durable control events are the only events that belong in the master-indexed
+replay tail.
+
+Examples:
+
+- `InstanceCreated`
+- `InstanceDeleted`
+- `TaskCreated` for live tasks
+- `TaskAcknowledged` while the task is live
+- `TaskStatusUpdated` while the task is live
+- `TaskFailed` while the task is live
+- `TaskDeleted` as a live-task tombstone until the next snapshot
+- `TracingStateChanged`
+- `CustomModelCardAdded`
+- `CustomModelCardDeleted`
+- failover seed events such as `StateSnapshotHydrated`
+
+Retention rule:
+
+- snapshots are authoritative
+- the replay tail is bounded by age and count
+- `TaskDeleted` and terminal task statuses may be dropped after a snapshot in
+  which the task is absent
+- a replay request older than the retained tail returns "snapshot required"
+  rather than clamping to the oldest retained index
+
+### Soft Telemetry
+
+Soft telemetry is current observation, not durable history.
+
+Examples:
+
+- `NodeGatheredInfo`
+- `NodeDownloadProgress` progress percentages
+- runner phase and memory samples
+- topology edge observations
+- liveness timestamps
+- RDMA, Thunderbolt, disk, and network readings
+
+Target behavior:
+
+- publish on a telemetry topic or state-sync side channel
+- keep latest value by `(node_id, metric_kind)` with sequence and timestamp
+- coalesce frequent updates before publication
+- expire values by TTL
+- include only fresh latest values in snapshots
+- never require telemetry replay for follower bootstrap
+
+Some telemetry still informs placement. That does not make it durable control
+state. The master should plan from its latest observed telemetry view. Followers
+may display the same latest view, but old samples should not participate in
+catch-up.
+
+### Data Plane
+
+Data-plane messages are request payloads and generated outputs.
+
+Examples:
+
+- token chunks
+- tool-call chunks
+- image chunks
+- embedding chunks
+- input image chunks
+- trace payloads
+
+Target behavior:
+
+- send directly to the node/API stream that requested the command
+- preserve per-command ordering with a local sequence number
+- rely on transport backpressure, not the master event log
+- send a terminal data-plane chunk to finish the client stream
+- separately emit a compact control-plane task outcome for cluster state
+- never write generated chunks to the master event log
+- do not replay old generated chunks to bootstrapping followers
+
+## Data Stream Protocol
+
+Introduce a data-stream message family separate from `Event`.
+
+Minimal shape:
+
+```python
+class DataStreamChunk(CamelCaseModel):
+    command_id: CommandId
+    task_id: TaskId
+    target_node_id: NodeId
+    producer_node_id: NodeId
+    sequence: int
+    chunk: GenerationChunk
+
+
+class DataStreamClosed(CamelCaseModel):
+    command_id: CommandId
+    task_id: TaskId
+    target_node_id: NodeId
+    producer_node_id: NodeId
+    final_sequence: int
+    outcome: Literal["complete", "cancelled", "failed"]
+    error_message: str | None = None
+```
+
+The `target_node_id` is the API node that owns the HTTP response stream. The
+API includes this route when it submits the command. The master records the
+route in the live task metadata, and the worker passes it to the runner.
+
+The first implementation can use a typed `DATA_STREAM_MESSAGES` topic with
+target filtering if that is the fastest path through the existing router. That
+still removes master indexing, disk persistence, and global state replay from
+the token path. The preferred final implementation is a direct libp2p stream or
+request-response channel between the producing worker and the origin API node,
+so non-target nodes do not even receive the payload.
+
+Ordering is per command:
+
+- the producer increments `sequence` for every emitted chunk
+- the origin API expects a contiguous sequence
+- a gap or duplicate is a stream error, not a replay request
+- on stream error, the origin API sends `TaskCancelled` and terminates the HTTP
+  stream with an error
+
+Generated output is not durable cluster state. If the client disconnects, the
+API cancels the task. If the API node dies, the stream dies; the control plane
+cleans up the live task and runners.
+
+## Control Snapshot And Replay Protocol
+
+The control plane keeps the current snapshot and a bounded tail.
+
+Required behavior:
+
+1. The master persists and serves `StateSnapshot(session_id, revision, state)`.
+2. The master retains only recent control events after the latest durable
+   snapshot.
+3. Followers bootstrap from snapshot first.
+4. Followers replay only events after the snapshot revision.
+5. If a follower requests a revision older than the retained tail, the master
+   responds with `SnapshotRequired`.
+6. The follower clears its event buffer, hydrates a fresh snapshot, and requests
+   only the tail after that snapshot.
+
+The master must not satisfy stale replay by silently clamping the requested
+index to `event_log.start_idx`. Clamping can leave the follower waiting for an
+event it will never receive, or can make it apply a tail against the wrong local
+base.
+
+Retention should be bounded by both count and age:
+
+- count bound protects replay and disk under high event rate
+- age bound preserves the operational intent that catch-up is for recent gaps
+- five minutes is a reasonable default target for live catch-up
+
+The exact constants can be tuned, but replay should be an optimization, not a
+requirement for correctness.
+
+## Telemetry Protocol
+
+Telemetry needs latest-value convergence, not historical replay.
+
+Introduce a `TELEMETRY_MESSAGES` family or equivalent state-sync payload:
+
+```python
+class TelemetrySample(CamelCaseModel):
+    node_id: NodeId
+    kind: TelemetryKind
+    sequence: int
+    observed_at: datetime
+    expires_at: datetime
+    payload: TelemetryPayload
+```
+
+Rules:
+
+- accept a sample only if it is newer than the current sample for that node and
+  kind
+- expire stale samples without creating tombstone events
+- coalesce high-frequency updates before publishing
+- snapshot only non-expired latest samples
+- derive liveness from fresh samples and connection state, not from replayed
+  old samples
+
+Placement still sees telemetry through `State` or a master-local view, but
+historical telemetry is not part of durable recovery.
+
+## Diagnostics And Traces
+
+Diagnostics should be explicit artifacts, not hidden state-replay payloads.
+
+Rules:
+
+- runner flight recorders remain local bounded rings
+- trace payloads are uploaded or fetched through diagnostics APIs
+- saved traces are retained by diagnostic retention policy
+- diagnostics never block control replay
+- diagnostics never ride the per-token stream unless the client explicitly
+  requested trace output
+
+This preserves forensic value without letting diagnostics affect election,
+placement, or token throughput.
+
+## Migration Plan
+
+### Phase 1: Stop Logging Data-Plane Events
+
+Goal: remove the worst throughput and disk pressure without changing transport.
+
+- exclude `ChunkGenerated`, `InputChunkReceived`, `TracesMerged`, and
+  `TracesCollected` from master and API disk event logs
+- keep enough in-memory routing to preserve current behavior during migration
+- add metrics for chunk count, stream latency, and event-log append count
+- prove generated chunks no longer increase event-log size
+
+This phase does not fully separate the master path yet, but it makes data-plane
+events non-durable.
+
+### Phase 2: Add Targeted Data Stream
+
+Goal: remove master indexing from generated output.
+
+- add `DATA_STREAM_MESSAGES`
+- include origin API route information in generated task metadata
+- have runner/worker send chunks to the origin API stream via data messages
+- keep task lifecycle events on the control plane
+- make API stream completion depend on terminal data message or terminal control
+  failure, whichever arrives first
+- gate with a compatibility flag until all nodes support the topic
+
+This phase eliminates the master as the token fan-out point.
+
+### Phase 3: Move Input Payloads Off The Control Plane
+
+Goal: keep large request bodies out of the ordered control stream.
+
+- replace `SendInputChunk` -> `InputChunkReceived` with data-plane upload
+  messages or object-store references
+- keep only payload references, hashes, and readiness state in control metadata
+- let workers fetch or receive payload bytes before dispatch
+- expire payload blobs when the task finishes or is cancelled
+
+This protects VLM and image-edit workloads from the same data/control mixing.
+
+### Phase 4: Split Telemetry From Durable Control
+
+Goal: stop replaying old observations.
+
+- introduce latest-value telemetry messages with TTL
+- remove high-frequency `NodeGatheredInfo` history from the durable event tail
+- snapshot only current fresh telemetry
+- make placement explicitly tolerate missing or stale telemetry with typed
+  pending-info errors
+- keep liveness/election independent of replayed telemetry
+
+This keeps placement state fresh without making catch-up process old samples.
+
+### Phase 5: Enforce Snapshot-First Recovery
+
+Goal: make replay bounded by design.
+
+- add a `SnapshotRequired` response for stale `RequestEventLog`
+- remove replay-index clamping as a recovery mechanism
+- test follower bootstrap when requested index predates retained tail
+- test election churn with high historical event counts
+- assert startup catch-up time stays below the liveness timeout budget
+
+This phase closes the #278 class of failures.
+
+### Phase 6: Direct Transport
+
+Goal: remove non-target network fan-out.
+
+- replace target-filtered data pub/sub with direct libp2p stream or
+  request-response transport
+- apply flow control at the stream layer
+- cancel generation when the origin stream closes
+- keep target-filtered pub/sub only as a compatibility fallback
+
+This is the final throughput-oriented architecture.
+
+## Acceptance Criteria
+
+The migration is complete when these statements are true:
+
+- generated token chunks never enter the master event log
+- generated token chunks are not replayed to new followers
+- generated token chunks do not require the master to forward them to the API
+- input payload bytes do not enter the durable control event log
+- telemetry replay is not required for bootstrap
+- a node with an old or missing index hydrates from snapshot instead of replaying
+  ancient history
+- control replay is bounded by configured age and count
+- a full-fleet restart with large diagnostic history forms a cluster without
+  election churn
+- event-log growth under sustained generation is independent of generated token
+  count
+- per-token p50 and p99 stream latency improve or stay flat under concurrent
+  decode load
+
+## Compatibility Notes
+
+Mixed-version clusters need care because old nodes expect `ChunkGenerated` on
+`GLOBAL_EVENTS`.
+
+The rollout should use capability discovery:
+
+1. nodes advertise supported runtime-plane features in node identity or config
+   sync
+2. the master chooses the lowest common protocol for each task
+3. if any participant lacks data-stream support, the task falls back to the old
+   `ChunkGenerated` event path
+4. once all nodes advertise support, the master disables the legacy data-plane
+   event path for that task
+
+The fallback should be temporary and visible in diagnostics. Operators need to
+know when a single old node is keeping the cluster on the slower path.
+
+## Non-Goals
+
+This proposal does not require replacing the master election system, introducing
+consensus, or making generated token streams durable across API-node failure.
+
+It also does not remove event-sourced control state. The control plane still
+benefits from ordered decisions and pure state application. The change is that
+only durable control belongs in that ordered stream.
+
+## Implementation Checklist
+
+- define `ControlEvent`, `TelemetryMessage`, and `DataStreamMessage` type
+  families
+- add a runtime-plane capability advertisement
+- add target route fields to live task metadata
+- add `DATA_STREAM_MESSAGES` as an interim targeted transport
+- route runner output to data stream instead of `ChunkGenerated`
+- preserve terminal task outcome on the control plane
+- exclude data-plane and diagnostics events from disk logs
+- add `SnapshotRequired` handling to replay catch-up
+- add telemetry latest-value cache with TTL
+- update architecture docs once implementation begins
+- add stress tests for concurrent generation, stale replay requests, and
+  full-fleet restart after large historical traffic


### PR DESCRIPTION
First slice of #279 phase 1 (program #286). Stands up the **telemetry plane** — per-node readings gossiped last-write-wins, off the event log — and migrates `node_resources` onto it as the first, smallest-surface inhabitant (single reader: the planner), proving the full vertical before the harder `node_memory` slice.

## What this does
- New `TELEMETRY` topic + `NodeTelemetry` message + `TelemetryView` (latest-per-node, lives **outside** event-sourced `State`).
- `TelemetryView` is **Node-owned** and threaded into the Master (both construction sites, including election recreation) and the API. It survives a master flip, so a freshly promoted master keeps the cluster's `node_resources` instead of starting blind and risking a placement on a management node during repopulation — strictly better than today.
- `Worker._forward_info` forks: `NodeResources` → telemetry plane; every other `GatheredInfo` → `NodeGatheredInfo` event, unchanged.
- `node_resources` removed from `State` + `apply`; the planner and the three API placement previews read `TelemetryView.node_resources`.
- A Node-lifetime telemetry subscriber feeds the view, independent of election.

## Why node_resources first
One reader, no cross-rank determinism concern. `node_memory` (slice 2) has three readers and forces the admission-ceiling determinism fix (stamp the ceiling into the placement decision); proving the plane here de-risks that. All other `node_*` telemetry stays on the log until later slices.

## Validation
- Gauntlet: basedpyright 0, ruff clean, nix fmt clean, **1049 pytest passed**.
- New tests: topic-codec wire round-trip + view last-write-wins coalescing (applying the #287 round-trip lesson); election-reset Node construction updated.
- **Live smoke** (isolated single node, separate `SKULK_HOME`/namespace/port, zero model load, did not touch the running cluster):
  - management node → placement preview **refused** with the participation-ineligibility error (only fires when the view holds the role) → telemetry delivered `node_resources` into the view and the planner read it.
  - `node_resources` absent from `/state` → confirmed off the log.
  - full node → got **past** the participation filter → the refusal was specifically the role, not spurious.
  - Proves the key runtime unknown: the router delivers self-published gossip in-process, so a single node populates its own view.

Per the test-as-we-go policy: smoked live before the PR opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)