### PR TITLE
fix(master): re-stamp last_seen for carried identities to prevent phantom-node leak (#289)

### DIFF
--- a/src/skulk/shared/session_carryover.py
+++ b/src/skulk/shared/session_carryover.py
@@ -97,13 +97,19 @@ def seed_state_for_new_session(prior: State, now: datetime | None = None) -> Sta
     stamp = now if now is not None else datetime.now(tz=timezone.utc)
     # Arm the liveness clock for every node the seed still carries info about.
     # The prune loop only reaps via last_seen, so a carried identity with no
-    # last_seen entry is immortal (the phantom-node leak, #218 family).
+    # last_seen entry is immortal (the phantom-node leak, #218 family). This
+    # MUST cover every node_* map copied into the seed below — a node present
+    # only in node_thunderbolt/node_thunderbolt_bridge/node_rdma_ctl (not in
+    # identities/memory) would otherwise still leak (review catch on #291).
     carried_node_ids = (
         prior.node_identities.keys()
         | prior.node_memory.keys()
         | prior.node_disk.keys()
         | prior.node_system.keys()
         | prior.node_network.keys()
+        | prior.node_thunderbolt.keys()
+        | prior.node_thunderbolt_bridge.keys()
+        | prior.node_rdma_ctl.keys()
     )
     last_seen = {node_id: stamp for node_id in carried_node_ids}
     return State(

--- a/src/skulk/shared/session_carryover.py
+++ b/src/skulk/shared/session_carryover.py
@@ -12,6 +12,7 @@ safe starting state for the new session.
 """
 
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
 
 from skulk.shared.types.common import NodeId
 from skulk.shared.types.state import State
@@ -37,7 +38,7 @@ def _completed_downloads_only(
     }
 
 
-def seed_state_for_new_session(prior: State) -> State:
+def seed_state_for_new_session(prior: State, now: datetime | None = None) -> State:
     """Build the new session's initial state from the prior replicated view.
 
     Carried (the durable facts the new session should preserve):
@@ -59,6 +60,20 @@ def seed_state_for_new_session(prior: State) -> State:
     - ``thunderbolt_bridge_cycles`` and ``tracing_enabled`` — cluster
       configuration facts that have no session affinity.
 
+    - ``last_seen`` — carried, but re-stamped to ``now`` for every node the
+      seed still knows about (the union of the carried ``node_*`` maps) rather
+      than copied from the prior snapshot. This arms the master's 30s
+      liveness clock for each carried identity: a node that re-gossips (under
+      the same id) keeps refreshing normally, while a carried identity that
+      never returns is reaped by the ordinary ``NodeTimedOut`` prune after the
+      settle grace. Dropping ``last_seen`` entirely (the pre-fix behavior)
+      left carried identities with NO liveness anchor, and the prune loop only
+      reaps via ``last_seen`` — so a node that restarted under a new id around
+      a session transition leaked its prior identity into ``node_identities``/
+      ``node_memory`` permanently, surfacing as a phantom node in ``/state``
+      (#218 family). Re-stamping to ``now`` (not the stale prior timestamp)
+      avoids admitting a long-dead node onto the live clock as already-fresh.
+
     Deliberately dropped (session-scoped or liveness-derived):
     - ``tasks`` — in-flight commands/streams died with the old session's
       router plumbing; carrying them would spawn cancel loops against
@@ -67,20 +82,35 @@ def seed_state_for_new_session(prior: State) -> State:
       tears down (each node's worker is re-created and shuts its supervisors
       down); stale ``RunnerReady`` entries would confuse the ConnectToGroup
       readiness gates. Fresh CreateRunner cycles repopulate them.
-    - ``topology`` and ``last_seen`` — liveness must come from the live
-      router's connection gossip, not a snapshot that still shows the dead
-      master as connected; a stale edge here would delay dead-node instance
-      cleanup or admit placements onto a corpse.
+    - ``topology`` — liveness must come from the live router's connection
+      gossip, not a snapshot that still shows the dead master as connected; a
+      stale edge here would delay dead-node instance cleanup or admit
+      placements onto a corpse. (Placement eligibility and instance cleanup
+      both key off ``topology``, not ``last_seen``, so re-stamping the latter
+      above does neither.)
     - ``last_event_applied_idx`` — the master indexes this seed as the FIRST
       EVENT of the new session (a logged ``StateSnapshotHydrated``), setting
       the index at that point; followers receive it inside the snapshot if
       they bootstrap later, or as live event 0 if they bootstrapped against
       the momentarily-empty pre-seed state (the promotion race).
     """
+    stamp = now if now is not None else datetime.now(tz=timezone.utc)
+    # Arm the liveness clock for every node the seed still carries info about.
+    # The prune loop only reaps via last_seen, so a carried identity with no
+    # last_seen entry is immortal (the phantom-node leak, #218 family).
+    carried_node_ids = (
+        prior.node_identities.keys()
+        | prior.node_memory.keys()
+        | prior.node_disk.keys()
+        | prior.node_system.keys()
+        | prior.node_network.keys()
+    )
+    last_seen = {node_id: stamp for node_id in carried_node_ids}
     return State(
         instances=prior.instances,
         downloads=_completed_downloads_only(prior.downloads),
         tracing_enabled=prior.tracing_enabled,
+        last_seen=last_seen,
         node_identities=prior.node_identities,
         node_memory=prior.node_memory,
         node_disk=prior.node_disk,

--- a/src/skulk/shared/tests/test_session_carryover.py
+++ b/src/skulk/shared/tests/test_session_carryover.py
@@ -103,7 +103,7 @@ def test_carries_only_completed_downloads():
 
 
 def test_drops_session_scoped_state():
-    prior, node = _prior_state()
+    prior, _node = _prior_state()
     seed = seed_state_for_new_session(prior)
     # In-flight tasks died with the old session's plumbing.
     assert seed.tasks == {}
@@ -112,7 +112,21 @@ def test_drops_session_scoped_state():
     # Liveness must come from live gossip — a carried topology would keep a
     # dead master's out-edges forever (only their source node deletes them).
     assert seed.topology.list_nodes() == []
-    assert seed.last_seen == {}
     # The new session's event log starts at the beginning.
     assert seed.last_event_applied_idx == -1
-    assert node not in seed.last_seen
+
+
+def test_seeds_last_seen_for_carried_identities():
+    # last_seen is re-stamped (not dropped) for every carried node so the
+    # master's 30s prune clock is armed: a carried identity that never
+    # re-gossips is reaped instead of leaking as a phantom node (#218 family).
+    # Pre-fix this was dropped entirely, leaving carried identities with no
+    # liveness anchor — and the prune loop only reaps via last_seen.
+    prior, node = _prior_state()
+    stamp = datetime(2026, 6, 13, 12, 0, 0, tzinfo=timezone.utc)
+    seed = seed_state_for_new_session(prior, now=stamp)
+    # Every carried node identity gets a fresh last_seen anchor...
+    assert seed.last_seen == {node: stamp}
+    # ...re-stamped to `now`, NOT copied from the prior (possibly stale) view,
+    # so a long-dead node is not admitted to the live clock as already-fresh.
+    assert seed.last_seen[node] != prior.last_seen[node]

--- a/src/skulk/shared/tests/test_session_carryover.py
+++ b/src/skulk/shared/tests/test_session_carryover.py
@@ -30,7 +30,9 @@ def _prior_state() -> tuple[State, NodeId]:
         runners={},
         tasks={},
         downloads={node: []},
-        last_seen={node: datetime.now(tz=timezone.utc)},
+        # Deterministically stale so the "re-stamped to now, not copied from
+        # prior" assertion can never collide with the test's stamp.
+        last_seen={node: datetime(2020, 1, 1, tzinfo=timezone.utc)},
         topology=topology,
         tracing_enabled=True,
         last_event_applied_idx=4242,
@@ -130,3 +132,20 @@ def test_seeds_last_seen_for_carried_identities():
     # ...re-stamped to `now`, NOT copied from the prior (possibly stale) view,
     # so a long-dead node is not admitted to the live clock as already-fresh.
     assert seed.last_seen[node] != prior.last_seen[node]
+
+
+def test_seeds_last_seen_for_node_in_only_thunderbolt_map():
+    # A node carried ONLY in a TB/RDMA map (not identities/memory) must still
+    # get a last_seen anchor — otherwise it evades the prune loop and leaks as
+    # a phantom after a session transition (review catch on #291). The carried
+    # set must cover every node_* map copied into the seed, not just the common
+    # identity/memory ones.
+    from skulk.shared.types.profiling import NodeThunderboltInfo
+
+    tb_only = NodeId()
+    prior = State(node_thunderbolt={tb_only: NodeThunderboltInfo(interfaces=[])})
+    stamp = datetime(2026, 6, 13, 12, 0, 0, tzinfo=timezone.utc)
+    seed = seed_state_for_new_session(prior, now=stamp)
+    assert seed.node_thunderbolt[tb_only].interfaces == []
+    # The TB-only node is armed for the prune loop.
+    assert seed.last_seen.get(tb_only) == stamp


### PR DESCRIPTION
## Problem

Phantom nodes accumulate in `/state` — extra entries in `nodeIdentities`/`nodeMemory` that never clear (the #218 family). Diagnosed live on the kite fleet: a restarted node leaves its prior identity behind permanently.

## Root cause

Two compounding factors:

1. **Ephemeral node IDs (#289):** `get_node_id_keypair` short-circuits with `Keypair.generate()`, so every process start mints a new node_id and orphans the old one.
2. **The leak:** `seed_state_for_new_session` carries `node_identities`/`node_memory` across a master session transition but **drops `last_seen` entirely**. The master prune loop (`master/main.py`) reaps timed-out nodes by iterating **only** `state.last_seen`:
   ```python
   timed_out = {nid for nid, seen in state.last_seen.items() if now - seen > 30s}
   ```
   An identity carried with **no `last_seen` entry** can never have its age computed → never times out → immortal. `apply_node_gathered_info` always writes `last_seen` alongside identity/memory, so this seed path is the only way to produce identity-without-`last_seen`.

Combined: any node that restarts around a master election leaks its prior identity forever.

## Fix

Re-stamp `last_seen` to the seed-build time for every node the seed still carries info about (union of the carried `node_*` map keys). This arms the existing 30s liveness clock:
- a node that re-gossips refreshes normally;
- a carried identity that never returns is reaped by the ordinary `NodeTimedOut` prune after the settle grace.

Re-stamping to `now` (not the stale prior timestamp) avoids admitting a long-dead node as already-fresh. Placement eligibility and instance cleanup key off `topology`, not `last_seen`, so this neither admits placements onto a corpse nor delays dead-node cleanup.

## Tests

`test_session_carryover.py`: added `test_seeds_last_seen_for_carried_identities` (carried IDs get a fresh `now` anchor, not the prior timestamp) and updated `test_drops_session_scoped_state` (topology still dropped; `last_seen` now armed). basedpyright/ruff/pytest green.

## Validation

Diagnosed against the live fleet where `/state` showed 5 then 9 identities for 3-4 real nodes (each restart leaking one). After a clean full-fleet restart the count returns to 0 phantoms; this fix keeps it at 0 across session transitions.

Related: #289 (ephemeral node_id — the trigger), #218 (stale-identity family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)