### PR TITLE
fix(state): round-trip last_seen datetimes through the disk event log (failover seed replay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **The failover-seed event round-trips through the disk event log again.** A
+  `StateSnapshotHydrated` (the failover seed, indexed as event 0) is read back
+  through the `Event` TypeAdapter, whose `TaggedModel` wrap validator unwraps the
+  `{ClassName: inner}` envelope by re-validating the inner payload as a *python*
+  object. Under `State`'s `strict=True` that path skips JSON-mode coercion, so
+  the ISO datetime strings JSON produced for `last_seen` were rejected
+  (`datetime_type`) and `DiskEventLog.read_range` halted at the seed. The phantom
+  -node fix (#291) had started re-stamping `last_seen` on the seed, so every
+  carried seed now hit this. `State` now coerces `last_seen` strings back to
+  `datetime` in a field-scoped `before` validator (it does not force the whole
+  model into python-mode validation, unlike a model-level validator). This
+  unblocks event-log replay across a failover and is a prerequisite for #279
+  Phase 3 snapshot/truncate (snapshots persist a full `State`, `last_seen`
+  included).
+
 - **Multi-node generation output is no longer silently reordered (#279 Phase 2b
   sequencing).** #279 Phase 2a moved per-token output (`ChunkGenerated`) off the
   master-indexed control plane (where the monotonic event `idx` gave every chunk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ This project records release notes here and mirrors public-facing notes in
   `{ClassName: inner}` envelope by re-validating the inner payload as a *python*
   object. Under `State`'s `strict=True` that path skips JSON-mode coercion, so
   the ISO datetime strings JSON produced for `last_seen` were rejected
-  (`datetime_type`) and `DiskEventLog.read_range` halted at the seed. The phantom
-  -node fix (#291) had started re-stamping `last_seen` on the seed, so every
-  carried seed now hit this. `State` now coerces `last_seen` strings back to
+  (`datetime_type`) and `DiskEventLog.read_range` halted at the seed. The
+  phantom-node fix (#291) had started re-stamping `last_seen` on the seed, so
+  every carried seed now hit this. `State` now coerces `last_seen` strings back to
   `datetime` in a field-scoped `before` validator (it does not force the whole
   model into python-mode validation, unlike a model-level validator). This
   unblocks event-log replay across a failover and is a prerequisite for #279

--- a/src/skulk/shared/types/state.py
+++ b/src/skulk/shared/types/state.py
@@ -93,3 +93,30 @@ class State(CamelCaseModel):
             return Topology.from_snapshot(snapshot)
 
         raise TypeError("Invalid representation for Topology field in State")
+
+    @field_validator("last_seen", mode="before")
+    @classmethod
+    def _coerce_last_seen(cls, value: object) -> object:
+        """Coerce ISO datetime strings in ``last_seen`` back to ``datetime``.
+
+        A ``StateSnapshotHydrated`` event persisted to the disk event log is
+        read back through the ``Event`` TypeAdapter, whose ``TaggedModel`` wrap
+        validator unwraps the ``{ClassName: inner}`` envelope by re-validating
+        the inner payload as a *python* object. Under ``strict=True`` that path
+        does not apply JSON-mode coercion to the nested ``State``, so the ISO
+        datetime strings that JSON serialization produced for ``last_seen`` are
+        rejected (``datetime_type``), halting event-log replay (#279 Phase 3 /
+        the failover-seed read). Coerce them here — scoped to this one field, so
+        unlike a model-level ``before`` validator it does not force the whole
+        model into python-mode validation (which previously broke state-sync,
+        see the note on ``last_seen`` above). Over-the-wire state-sync seeds
+        ``last_seen`` empty, so this only matters for the disk path.
+        """
+        if isinstance(value, Mapping):
+            return {
+                key: (
+                    datetime.fromisoformat(item) if isinstance(item, str) else item
+                )
+                for key, item in cast("Mapping[object, object]", value).items()
+            }
+        return value

--- a/src/skulk/utils/tests/test_event_log.py
+++ b/src/skulk/utils/tests/test_event_log.py
@@ -1,9 +1,12 @@
 # pyright: reportPrivateUsage=false
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
-from skulk.shared.types.events import TestEvent
+from skulk.shared.types.common import NodeId
+from skulk.shared.types.events import StateSnapshotHydrated, TestEvent
+from skulk.shared.types.state import State
 from skulk.utils.disk_event_log import DiskEventLog
 
 
@@ -26,6 +29,38 @@ def test_append_and_read_back(log_dir: Path):
         assert original.event_id == restored.event_id
 
     log.close()
+
+
+def test_state_snapshot_hydrated_with_last_seen_round_trips(log_dir: Path):
+    """A StateSnapshotHydrated with populated last_seen must replay from disk.
+
+    Regression: the disk-log Event adapter reads events through the TaggedModel
+    wrap validator, which re-validates the unwrapped payload as a python object;
+    under State's strict mode the ISO datetime strings JSON produced for
+    last_seen were rejected (datetime_type), halting replay at the seed event
+    (#279 failover-seed / Phase 3 replay). State now coerces last_seen strings
+    back to datetime, so the seed round-trips.
+    """
+    node = NodeId("node-a")
+    when = datetime.now(tz=timezone.utc)
+    seed = StateSnapshotHydrated(
+        state=State(
+            last_seen={node: when},
+            thunderbolt_bridge_cycles=[[node, NodeId("node-b")]],
+            last_event_applied_idx=0,
+        )
+    )
+
+    log = DiskEventLog(log_dir)
+    log.append(seed)
+    restored = list(log.read_all())
+    log.close()
+
+    assert len(restored) == 1
+    got = restored[0]
+    assert isinstance(got, StateSnapshotHydrated)
+    assert got.state.last_event_applied_idx == 0
+    assert got.state.last_seen[node] == when
 
 
 def test_read_range(log_dir: Path):


### PR DESCRIPTION
## Summary

First item of the post-#279 ordering (disk-log replay correctness → Phase 3 → Phase 2b unicast). Fixes a failover-seed disk-replay bug found during the #299 failover investigation, and a prerequisite for Phase 3 snapshot/truncate.

## The bug

The failover seed is a `StateSnapshotHydrated` event indexed as event 0 and written to the disk event log. Reading it back goes through the `Event` TypeAdapter, whose `TaggedModel` wrap validator unwraps the `{ClassName: inner}` envelope with `handler(v[ClassName])`, a **python object**. Under `State`'s `strict=True`, that re-validation skips JSON-mode coercion, so the ISO datetime strings JSON produced for `last_seen` (`Mapping[NodeId, datetime]`) are rejected with `datetime_type`, and `DiskEventLog.read_range` **halts at the seed** ("Stopping event log read because a record could not be decoded, idx=0").

It became reachable on the failover path because the phantom-node fix (#291) made `seed_state_for_new_session` **re-stamp `last_seen`** (instead of dropping it), so every carried seed now carries datetimes. `last_seen` is the only datetime-typed field in the entire `State` tree, which is why only `StateSnapshotHydrated` tripped it.

Confirmed on current `dev`: a `StateSnapshotHydrated` with populated `last_seen` does not round-trip through `_serialize_event`/`_deserialize_event` (fails); with the fix it round-trips cleanly.

## Fix

`State` coerces `last_seen` ISO strings back to `datetime` in a **field-scoped** `before` validator. Scoping to one field (mirroring the existing `topology` field validator) avoids the trap the inline note on `last_seen` warns about: a **model-level** `before` validator forces the whole model into python-mode validation, which previously broke state-sync. Over-the-wire state-sync isn't affected (it validates JSON directly); this only matters for the disk-log adapter path.

## Why it matters / Phase 3

- Unblocks event-log replay across a failover (a restarting/joining node reading the seed from disk).
- Prerequisite for **#279 Phase 3 (snapshot/truncate)**: snapshots persist a full `State` (`last_seen` included), so the joiner-replay path would hit the identical wall.

## Tests
- `test_state_snapshot_hydrated_with_last_seen_round_trips`: append a seed with populated `last_seen` to a `DiskEventLog`, read it back, assert the datetime survives. Fails without the fix.
- Full gauntlet green: basedpyright 0, ruff clean, 1089 pytest passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
