### PR TITLE
fix(mlx): stop Moonlight on <|im_end|> so the turn token doesn't leak (#304)

### DIFF
--- a/src/skulk/worker/engines/mlx/utils_mlx.py
+++ b/src/skulk/worker/engines/mlx/utils_mlx.py
@@ -946,6 +946,15 @@ def get_eos_token_ids_for_model(model_id: ModelId) -> list[int] | None:
     elif "qwen3.5" in model_id_lower or "qwen-3.5" in model_id_lower:
         # For Qwen3.5: 248046 (<|im_end|>), 248044 (<|endoftext|>)
         return [248046, 248044]
+    elif "moonlight" in model_id_lower:
+        # Moonlight's tokenizer eos_token is [EOS] (163585), but its chat
+        # template ends assistant turns with <|im_end|> (163586). Without the
+        # latter in the eos set, <|im_end|> is generated as an ordinary token,
+        # leaks into the output, and generation runs past the turn boundary
+        # into hallucinated follow-on turns (Skulk #304). Moonlight shares the
+        # Kimi tokenizer family, so 163586 is the same <|im_end|> id used for
+        # kimi-k2 above. Keep [EOS] too so the model's own stop token still works.
+        return [163585, 163586]
     return None
 
 

--- a/src/skulk/worker/tests/unittests/test_mlx/test_eos_token_ids.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_eos_token_ids.py
@@ -1,0 +1,49 @@
+"""Pure-mapping tests for ``get_eos_token_ids_for_model``.
+
+These assert the per-model EOS overrides without loading or downloading any
+tokenizer, so they run in normal CI. They deliberately live in their own module
+(no ``pytestmark = pytest.mark.slow``) because the tokenizer tests in
+``test_tokenizers.py`` are marked slow and CI runs ``pytest -m "not slow"`` — a
+regression test placed there would be silently deselected and protect nothing.
+"""
+
+from skulk.shared.models.model_cards import ModelId
+from skulk.worker.engines.mlx.utils_mlx import get_eos_token_ids_for_model
+
+
+def test_moonlight_eos_includes_im_end() -> None:
+    """Moonlight must stop on <|im_end|> (163586), not just its [EOS] (163585).
+
+    Moonlight's tokenizer eos_token is [EOS] but its chat template ends assistant
+    turns with <|im_end|>. Without 163586 in the eos set the turn token leaks into
+    output and generation runs past the turn boundary (Skulk #304).
+    """
+    eos = get_eos_token_ids_for_model(
+        ModelId("mlx-community/Moonlight-16B-A3B-Instruct-4-bit")
+    )
+    assert eos is not None, "Moonlight should have explicit eos token ids"
+    assert 163586 in eos, "Moonlight eos must include <|im_end|> (163586)"
+    assert 163585 in eos, "Moonlight eos should retain [EOS] (163585)"
+
+
+def test_known_family_eos_overrides() -> None:
+    """The other explicit-EOS families keep their documented token ids."""
+    assert get_eos_token_ids_for_model(ModelId("moonshotai/Kimi-K2-Instruct")) == [
+        163586
+    ]
+    assert get_eos_token_ids_for_model(ModelId("mlx-community/gpt-oss-20b-MXFP4-Q8")) == [
+        200002,
+        200012,
+    ]
+    assert get_eos_token_ids_for_model(ModelId("mlx-community/Qwen3.5-27B-4bit")) == [
+        248046,
+        248044,
+    ]
+
+
+def test_unknown_model_uses_tokenizer_config() -> None:
+    """Models without an explicit override return None (use tokenizer config)."""
+    assert (
+        get_eos_token_ids_for_model(ModelId("mlx-community/Meta-Llama-3.1-8B-Instruct-4bit"))
+        is None
+    )

--- a/src/skulk/worker/tests/unittests/test_mlx/test_tokenizers.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_tokenizers.py
@@ -348,20 +348,6 @@ async def test_kimi_tokenizer_specifically():
     assert eos_token_ids == [163586], "Kimi EOS token should be [163586]"
 
 
-def test_moonlight_eos_includes_im_end() -> None:
-    """Moonlight must stop on <|im_end|> (163586), not just its [EOS] (163585).
-
-    Moonlight's tokenizer eos_token is [EOS] but its chat template ends assistant
-    turns with <|im_end|>. Without 163586 in the eos set the turn token leaks into
-    output and generation runs past the turn boundary (Skulk #304). Pure mapping
-    test (no tokenizer download needed).
-    """
-    eos = get_eos_token_ids_for_model("mlx-community/Moonlight-16B-A3B-Instruct-4-bit")
-    assert eos is not None, "Moonlight should have explicit eos token ids"
-    assert 163586 in eos, "Moonlight eos must include <|im_end|> (163586)"
-    assert 163585 in eos, "Moonlight eos should retain [EOS] (163585)"
-
-
 # Test GLM tokenizer since it also has special handling
 @pytest.mark.asyncio
 async def test_glm_tokenizer_specifically():

--- a/src/skulk/worker/tests/unittests/test_mlx/test_tokenizers.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_tokenizers.py
@@ -348,6 +348,20 @@ async def test_kimi_tokenizer_specifically():
     assert eos_token_ids == [163586], "Kimi EOS token should be [163586]"
 
 
+def test_moonlight_eos_includes_im_end() -> None:
+    """Moonlight must stop on <|im_end|> (163586), not just its [EOS] (163585).
+
+    Moonlight's tokenizer eos_token is [EOS] but its chat template ends assistant
+    turns with <|im_end|>. Without 163586 in the eos set the turn token leaks into
+    output and generation runs past the turn boundary (Skulk #304). Pure mapping
+    test (no tokenizer download needed).
+    """
+    eos = get_eos_token_ids_for_model("mlx-community/Moonlight-16B-A3B-Instruct-4-bit")
+    assert eos is not None, "Moonlight should have explicit eos token ids"
+    assert 163586 in eos, "Moonlight eos must include <|im_end|> (163586)"
+    assert 163585 in eos, "Moonlight eos should retain [EOS] (163585)"
+
+
 # Test GLM tokenizer since it also has special handling
 @pytest.mark.asyncio
 async def test_glm_tokenizer_specifically():


### PR DESCRIPTION
## What
`get_eos_token_ids_for_model` now returns `[163585, 163586]` for Moonlight, adding `<|im_end|>` (163586) to its eos set alongside `[EOS]` (163585).

## Why
`mlx-community/Moonlight-16B-A3B-Instruct-4-bit` generated its `<|im_end|>` turn terminator as a normal token and ran past the assistant turn (e.g. `Paris<|im_end|><|im_end|> What is the capital of Germany?...`). Its tokenizer eos is `[EOS]`, but the chat template ends turns with `<|im_end|>`; the function returned `None` so `<|im_end|>` was never a stop token. Found via the skulk-test-harness model matrix on dev (2026-06-15).

Closes #304.

## Test
`test_moonlight_eos_includes_im_end` (pure mapping, no download): asserts 163586 and 163585 are both in the eos set. Passes. ruff + basedpyright clean on the changed files.

## Note
Per-model hardcoding here is the #186 anti-pattern; the general fix (derive the chat-template turn terminator into the eos set automatically) is noted in #304 as follow-up, out of scope for this minimal fix.

## Live verification
Unit-verified; not yet run against a live Moonlight placement (would need this branch deployed to a worker). Happy to live-verify before merge if wanted, or let the standard post-merge cluster regression cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)