### PR TITLE
docs: fabric identity + user-job focus + de-lore (PR 1 of docs overhaul)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 This site combines practical guides with generated reference material for Skulk.
 
-Skulk is a distributed inference platform, so these docs try to serve both of the audiences that show up most often:
+Skulk is an interconnect fabric for multi-node AI compute (distributed inference is its headline use), so these docs try to serve both of the audiences that show up most often:
 
 - people who are new and want a clear path to a first working setup
 - developers who want exact API, type, and integration reference material

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -13,35 +13,10 @@ That API has two jobs:
 - compatibility endpoints for tools that already speak OpenAI, Claude, or Ollama-style APIs
 - Skulk-specific control endpoints for placement, downloads, config, tracing, and model-store workflows
 
-## The Most Important Rule
-
-For text generation, Skulk is not just a stateless HTTP server.
-
-**A model has to be placed and running before chat-style requests will work.**
-
-The dashboard enforces this too: it will not let you chat until a model is placed and ready.
-
-If you call `/v1/chat/completions` too early, Skulk will usually return something like:
-
-```json
-{
-  "error": {
-    "message": "No instance found for model mlx-community/...",
-    "type": "Not Found",
-    "code": 404
-  }
-}
-```
-
-## Start Here
-
-If you want your first successful API call, use this flow:
-
-1. Start Skulk with `uv run skulk`.
-2. Preview valid placements for a model.
-3. Launch a placement.
-4. Wait for the model to be ready.
-5. Send a chat request.
+A model must be placed and running before chat requests for it succeed; calling
+`/v1/chat/completions` for an unplaced model returns a 404 `No instance found`.
+The [First Success Flow](#first-success-flow) below walks from placement to first
+token.
 
 ## Quick Navigation
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -10,7 +10,7 @@ This is the long-form mental model for how Skulk is put together end to end. Rea
 
 ## What Skulk is
 
-Skulk is a distributed inference system that connects multiple Apple Silicon (and increasingly Linux/CUDA) nodes into one logical inference cluster. Models are sharded across nodes; any node's API can serve cluster-wide requests; the cluster keeps running through node arrivals, departures, and master failures. One Python binary (`uv run skulk`) is everything you need on each node — the same process is router, worker, master-eligible coordinator, election participant, API server, and dashboard host.
+Skulk is an interconnect fabric for multi-node AI compute: it connects multiple Apple Silicon (and increasingly Linux/CUDA) nodes into one cluster and moves work across them. Its headline use is distributed inference, where models are sharded across nodes, any node's API can serve cluster-wide requests, and the cluster keeps running through node arrivals, departures, and master failures. One Python binary (`uv run skulk`) is everything you need on each node: the same process is router, worker, master-eligible coordinator, election participant, API server, and dashboard host.
 
 The design choices that shape almost everything else:
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -31,8 +31,8 @@ For the runtime details, see [build and runtime paths](build-and-runtime) and
 
 ## Why Skulk
 
-**Run models that don't fit on one machine.** Skulk splits a model across every
-device in the cluster and routes the work through the pipeline automatically. A
+**Run models that don't fit on one machine.** Skulk splits a model across as many
+machines as it needs and routes the work through the pipeline automatically. A
 70B model that won't fit in one Mac's unified memory can run across two.
 
 **Every device counts.** MacBooks, Mac Studios, Mac Pros, and Linux boxes all
@@ -41,8 +41,9 @@ nodes, and rebalances when a node leaves or rejoins.
 
 **Always on, self-healing.** Skulk runs as a supervised service on macOS and
 Linux: it starts at boot, restarts on crash, and rebuilds cluster state on
-recovery. If the master node dies mid-request, a new one is elected and serving
-continues.
+recovery. If the master node dies, a new one is elected and the models already
+placed keep running, so the cluster stays available (an in-flight request at the
+moment of failover may need to be retried).
 
 **Manage it from anywhere.** Put your nodes on a Tailscale network and the
 mobile-friendly operator panel gives you live memory, GPU, and temperature for

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,58 +1,85 @@
 ---
 id: intro
-title: Skulk Developer Docs
+title: Skulk
 sidebar_position: 1
 slug: /
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->
 
+**Skulk is an interconnect fabric for multi-node AI compute.** It joins several
+machines into one cluster and moves work across them as if they were a single
+device.
+
+Its headline use today is **distributed inference**: point Skulk at a few
+machines and it pools their memory and GPUs behind one OpenAI-compatible
+endpoint, so you can run models far larger than any single machine could hold.
+
+## Get started
+
+1. Install and start Skulk on each machine. The
+   [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md)
+   covers installation and the first run.
+2. Open the dashboard (default `http://localhost:52415`), pick a model, and
+   launch it. Skulk places it across the cluster and starts serving when it is
+   ready.
+3. Call the OpenAI-compatible endpoint at `/v1/chat/completions` with any client
+   that speaks that format.
+
+For the runtime details, see [build and runtime paths](build-and-runtime) and
+[run as a service](run-skulk-as-a-service).
+
 ## Why Skulk
 
-Most inference tools assume a single machine. Skulk assumes a cluster.
+**Run models that don't fit on one machine.** Skulk splits a model across every
+device in the cluster and routes the work through the pipeline automatically. A
+70B model that won't fit in one Mac's unified memory can run across two.
 
-**Run models that don't fit on one machine.** Skulk splits a model across every device in your cluster and routes inference through the pipeline automatically. A 70B model that won't fit in your Mac's unified memory might fit across two.
+**Every device counts.** MacBooks, Mac Studios, Mac Pros, and Linux boxes all
+join the same cluster. Skulk elects a master, places models across the available
+nodes, and rebalances when a node leaves or rejoins.
 
-**Every device counts.** MacBooks, Mac Studios, Mac Pros, Linux boxes — if it runs MLX, it joins the cluster. Skulk elects a master, places model instances across available nodes, and rebalances when a node goes down or comes back.
+**Always on, self-healing.** Skulk runs as a supervised service on macOS and
+Linux: it starts at boot, restarts on crash, and rebuilds cluster state on
+recovery. If the master node dies mid-request, a new one is elected and serving
+continues.
 
-**Always on, self-healing.** Skulk runs as a supervised service on macOS and Linux. It starts at boot, restarts on crash, and recovers cluster state from its event log — no babysitting required. A startup preflight detects port conflicts and tells the supervisor to back off and retry rather than failing silently.
+**Manage it from anywhere.** Put your nodes on a Tailscale network and the
+mobile-friendly operator panel gives you live memory, GPU, and temperature for
+every node, plus one-tap node restarts, over plain HTTP. No SSH required.
 
-**Manage it from anywhere.** Add Tailscale to your nodes and your phone and you have a private overlay network to your cluster. The dashboard works over plain HTTP on the Tailscale address. The built-in operator panel is mobile-optimized — it shows memory, GPU, and temperature for every node and lets you restart any node with a two-tap confirmation. You don't need SSH.
+**OpenAI-compatible.** Any client that speaks the OpenAI chat-completions format
+works out of the box. No SDK changes, no custom client.
 
-**OpenAI-compatible API.** Any client that speaks the OpenAI chat completions format works with Skulk out of the box — no SDK changes, no custom clients.
+**Observable by default.** Runtime tracing, a cross-cluster flight recorder,
+per-node diagnostics, and structured logs you can ship to VictoriaLogs let you
+see exactly what each node is doing during a request.
 
-**Observable by default.** Runtime tracing, a cross-cluster flight recorder, per-node diagnostics, and structured JSON logging that ships to VictoriaLogs via Vector. You can see exactly what's happening across every rank during an inference request.
+## Common tasks
 
----
+- **Use the API** to run inference: [API guide](api-guide), and the browsable
+  [API reference](/api/skulk-api).
+- **Manage the cluster** (place models, watch nodes, recover): the
+  [dashboard and operations guide](operations), and
+  [remote access via Tailscale](tailscale).
+- **Debug the cluster** during a request: [tracing and debugging](tracing).
+- **Add models to the model store**: [model store guide](model-store).
+- **Span locations or networks** with one cluster:
+  [multi-network clustering](tailscale-clustering).
 
-## Start Here
+## What Skulk is, and where it's going
 
-If you are getting oriented, start with these pages:
+Skulk separates cluster traffic into three planes: a **compute** plane (the
+high-speed interconnect that exchanges model activations between nodes), a
+**control** plane (cluster decisions, task lifecycle, and node health), and a
+**data** plane (generated output streamed back to the requesting node). Keeping
+these separate is what makes Skulk a general fabric rather than a single-purpose
+inference server: inference is the first workload to ride it, not the limit of
+what it can carry.
 
-- [README](https://github.com/Foxlight-Foundation/Skulk/blob/main/README.md) — installation, first run, quick-start
-- [Build and runtime paths](build-and-runtime) — how `uv` and Nix fit together
-- [Run as a service](run-skulk-as-a-service) — autostart and crash recovery for macOS and Linux
-- [Remote access](tailscale) — reach your dashboard and operator panel from anywhere via Tailscale
-- [API guide](api-guide) — place a model, then call the API
-- [Model store guide](model-store) — shared model storage and download workflows
-- [Tracing and debugging](tracing) — runtime tracing, cluster browsing, and operator workflow
-- [Architecture overview](architecture) — how the node, cluster, and event model fit together
-
-## Common Jobs
-
-- I want to browse the backend API: [API Reference](/api/skulk-api)
-- I want frontend and TypeScript symbols: [TypeScript API](https://foxlight-foundation.github.io/Skulk/typedoc/)
-- I want implementation context before I integrate: [Architecture overview](architecture)
-- I want to debug live inference: [Tracing and debugging](tracing)
-- I want to manage my cluster remotely: [Remote access via Tailscale](tailscale)
-- I want nodes in different locations in one cluster: [Multi-network clustering](tailscale-clustering)
-
-## What Lives Here
-
-- Hand-written guides for setup, architecture, and operational workflows
-- Generated OpenAPI output for the FastAPI backend, browsable per-endpoint with a try-it-out console
-- Generated TypeDoc output for selected TypeScript modules in `dashboard-react`
-
-## Keep In Mind
-
-For text generation, Skulk is not just a stateless HTTP API. A model generally needs to be placed and running before chat-style requests succeed. The dashboard enforces this, and the compatibility APIs reflect the same runtime reality.
+That foundation opens up more than running one model across machines. The same
+interconnect is built to support disaggregating a model so different nodes handle
+different parts of it, treating memory as its own kind of node, mixing inference
+backends, and composing clusters out of smaller ones. The
+[architecture overview](architecture) explains how the pieces fit together
+today.

--- a/website/docs/model-behaviors/deepseek-v32.md
+++ b/website/docs/model-behaviors/deepseek-v32.md
@@ -6,8 +6,7 @@ sidebar_position: 3
 
 <!-- Copyright 2025 Foxlight Foundation -->
 
-DeepSeek V3.2 is the Phase 1 reference point for DSML-based prompt and parsing
-behavior.
+DeepSeek V3.2 is the reference point for DSML-based prompt and parsing behavior.
 
 ## Why DeepSeek V3.2 Is Special
 
@@ -23,7 +22,7 @@ That means the runtime needs to know:
 
 ## Current Capability Handling
 
-Phase 1 supports DeepSeek V3.2 through resolved family defaults:
+Skulk supports DeepSeek V3.2 through resolved family defaults:
 
 - DSML prompt renderer
 - DeepSeek V3.2 output parser

--- a/website/docs/model-behaviors/gemma4.md
+++ b/website/docs/model-behaviors/gemma4.md
@@ -73,7 +73,7 @@ Today that includes declarations for:
 
 ## Current Gaps
 
-Phase 1 does **not** mean Gemma 4 is fully feature-complete yet.
+Current support does **not** mean Gemma 4 is fully feature-complete yet.
 
 Some follow-up work is intentionally tracked separately, including:
 

--- a/website/docs/model-behaviors/gpt-oss.md
+++ b/website/docs/model-behaviors/gpt-oss.md
@@ -6,8 +6,8 @@ sidebar_position: 2
 
 <!-- Copyright 2025 Foxlight Foundation -->
 
-GPT-OSS is one of the first non-Gemma families that Phase 1 treats as a
-first-class capability-system consumer.
+GPT-OSS is one of the first non-Gemma families treated as a first-class
+capability-system consumer.
 
 ## Why GPT-OSS Is Special
 

--- a/website/docs/model-capabilities.md
+++ b/website/docs/model-capabilities.md
@@ -58,26 +58,24 @@ The combined approach gives us:
 - one declarative source of truth
 - one normalized execution contract
 
-## Current Phase 1 Goal
+## The capability spine
 
-Phase 1 is about building the capability spine that UI and API work can depend on.
-
-That means:
+The capability system is the spine that UI and API behavior depend on:
 
 - cards can declare advanced capability sections
-- old cards still work
+- older cards without those sections still work
 - runtime behavior for key decisions is capability-driven
-- model metadata exposed by the API can begin surfacing refined behavior to clients
+- model metadata exposed by the API surfaces refined behavior to clients
 
-Phase 1 specifically focuses on:
+The decisions it drives today are:
 
 - reasoning/thinking defaults
 - prompt renderer selection
 - output parser selection
 
-## Phase 2 Thinking Contract
+## Thinking contract
 
-Phase 2 keeps the existing public controls:
+The existing public controls are preserved:
 
 - `enable_thinking`
 - `reasoning_effort`
@@ -124,7 +122,7 @@ The resolved runtime profile follows a simple precedence model:
 2. model-family defaults fill in known behavior for important families
 3. generic fallback preserves compatibility for everything else
 
-Phase 1 intentionally keeps those heuristics conservative. The goal is not to
+The runtime intentionally keeps those heuristics conservative. The goal is not to
 guess every possible advanced feature, but to preserve current behavior while
 letting extended cards make support more precise.
 

--- a/website/docs/model-cards.md
+++ b/website/docs/model-cards.md
@@ -173,7 +173,7 @@ When a model card declares `mtp_heads = true` and `mtp_sidecar_repo`, Skulk:
 
 1. Downloads `mtp.safetensors` from the sidecar repo alongside the base model weights.
 2. Loads the sidecar at model load time and makes the weights available to the runner.
-3. Uses the MTP heads during generation for speculative decoding (requires runner support — see issue #152).
+3. Uses the MTP heads during generation for speculative decoding (on runners that support it).
 
 If the sidecar is declared but the file is not found locally, Skulk logs a warning and continues with standard autoregressive generation.
 


### PR DESCRIPTION
First PR of the docs overhaul. Reframes Skulk's identity and removes internal roadmap lore from user-facing pages.

## What changed
- **intro.md** ground-up rewrite: opens with **"Skulk is an interconnect fabric for multi-node AI compute"** and a 3-step distributed-inference on-ramp. Cuts the condescending placement-rule filler and the TypeScript/TypeDoc links. "Common tasks" now targets user jobs (use the API, manage the cluster, debug the cluster, add models to the store). Adds a short "what Skulk is, and where it's going" section (three planes; direction toward disaggregation, memory-as-nodes, heterogeneous backends, sub-clusters).
- **Positioning**: `architecture.md` and the stale `docs/index.md` landing no longer call Skulk a "distributed inference system/platform"; it's the fabric, with inference as the headline use.
- **De-lore** (user-facing pages only): `model-capabilities.md` ("Phase 1/2" to plain feature language), `model-behaviors/*` + `model-cards.md` (drop "Phase 1" / a bare issue ref), `api-guide.md` (trim the "Most Important Rule" + 5-step preamble to one sentence + a link to the worked example).

## Scope notes
- `architecture-reference.md` (the LLM fact-sheet) is intentionally left as-is.
- The deeper `architecture.md` issue-ref de-lore and the new **cluster-communication** doc land in the next PR (they restructure the same telemetry/data-plane paragraphs, so editing them twice is avoided here).
- README reframe and Docusaurus versioning are their own later PRs.

## Verification
- All intra-doc links in the new intro resolve to existing pages.
- 0 em dashes added (`git diff origin/dev | grep -cE '^\+.*—'` == 0).
- Relying on the `build-docs` CI job to validate the Docusaurus build (pure prose change, no sidebar/frontmatter/structural edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)