### PR TITLE
ci(docs): publish stable (main) + next (dev) docs from one deploy (PR 3 of docs overhaul)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,71 +1,103 @@
 name: docs
 
+# The docs site is built and deployed from `dev`, but it serves TWO live sites
+# assembled into one GitHub Pages deploy:
+#   - the stable docs, built from `main`, at /Skulk/
+#   - the development ("next") docs, built from `dev`, at /Skulk/next/
+# Each is a normal full Docusaurus build of that branch's current content, so
+# there are no version snapshots to maintain or miss: a push to either branch
+# rebuilds both and redeploys. READMEs link per branch (main -> /Skulk/, dev ->
+# /Skulk/next/), and an announcement bar cross-links the two.
+
 on:
   pull_request:
   push:
     branches:
       - main
+      - dev
 
 permissions:
   contents: read
 
 jobs:
-  build-docs:
+  # PR validation: build the PR's own docs once (no deploy).
+  validate:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-          # Cache both the dashboard and the Docusaurus site together.
           cache-dependency-path: |
             dashboard-react/package-lock.json
             website/package-lock.json
-
-      - name: Install Python dependencies
-        run: uv sync --group dev
-
-      - name: Install dashboard dependencies
-        working-directory: dashboard-react
+      - run: uv sync --group dev
+      - working-directory: dashboard-react
         run: npm ci
-
-      - name: Install website dependencies
-        working-directory: website
+      - working-directory: website
         run: npm ci
-
-      - name: Build dashboard
-        working-directory: dashboard-react
+      - working-directory: dashboard-react
         run: npm run build
-
-      - name: Build docs site
-        run: uv run python scripts/build_docs.py
-
-      - name: Upload docs artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+      - run: uv run python scripts/build_docs.py
+      - uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: website/build
 
-      - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+  # Build the two live sites (stable from main, next from dev) on a push.
+  build:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - channel: stable
+            ref: main
+            base_url: /Skulk/
+          - channel: next
+            ref: dev
+            base_url: /Skulk/next/
+    steps:
+      - uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.ref }}
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            dashboard-react/package-lock.json
+            website/package-lock.json
+      - run: uv sync --group dev
+      - working-directory: dashboard-react
+        run: npm ci
+      - working-directory: website
+        run: npm ci
+      - working-directory: dashboard-react
+        run: npm run build
+      - name: Build docs site (${{ matrix.channel }})
+        env:
+          DOCS_BASE_URL: ${{ matrix.base_url }}
+          DOCS_CHANNEL: ${{ matrix.channel }}
+        run: uv run python scripts/build_docs.py
+      - uses: actions/upload-artifact@v4
+        with:
+          name: site-${{ matrix.channel }}
           path: website/build
 
-  deploy-docs:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build-docs
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       pages: write
@@ -74,6 +106,19 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Prepare site directory
+        run: mkdir -p site
+      - uses: actions/download-artifact@v4
+        with:
+          name: site-stable
+          path: site
+      - uses: actions/download-artifact@v4
+        with:
+          name: site-next
+          path: site/next
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,13 @@
 name: docs
 
-# The docs site is built and deployed from `dev`, but it serves TWO live sites
-# assembled into one GitHub Pages deploy:
+# The docs site serves TWO live sites assembled into one GitHub Pages deploy:
 #   - the stable docs, built from `main`, at /Skulk/
 #   - the development ("next") docs, built from `dev`, at /Skulk/next/
-# Each is a normal full Docusaurus build of that branch's current content, so
-# there are no version snapshots to maintain or miss: a push to either branch
-# rebuilds both and redeploys. READMEs link per branch (main -> /Skulk/, dev ->
-# /Skulk/next/), and an announcement bar cross-links the two.
+# A push to EITHER branch (main or dev) rebuilds both and redeploys: the build
+# matrix always builds stable from `main` and next from `dev`, regardless of
+# which branch triggered the run. Each is a normal full Docusaurus build of that
+# branch's current content, so there are no version snapshots to maintain or
+# miss. An announcement bar cross-links the two.
 
 on:
   pull_request:
@@ -100,6 +100,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      actions: read
       pages: write
       id-token: write
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,6 +99,12 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
+    # Serialize deploys: a main push and a dev push close together would both
+    # reach here and race the single Pages deployment. Queue them instead of
+    # cancelling, so neither branch's publish is lost.
+    concurrency:
+      group: pages-deploy
+      cancel-in-progress: false
     permissions:
       contents: read
       actions: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Docs source lives in `website/docs/`. Generated content:
 - `website/static/typedoc/` — TypeDoc HTML reference (gitignored)
 - `website/build/` — final Docusaurus output (gitignored)
 
-Deploy (`.github/workflows/docs.yml`): a push to `main` OR `dev` publishes TWO live sites in one GitHub Pages deploy — the **stable** docs built from `main` at `/Skulk/` and the **next** docs built from `dev` at `/Skulk/next/`. A build matrix builds each branch's current content (baseUrl set via `DOCS_BASE_URL`, channel banner via `DOCS_CHANNEL`), and the deploy job assembles them (stable at root, next under `/next/`). There are no Docusaurus version snapshots to maintain: each site is rebuilt live from its branch, so a push to either rebuilds and redeploys both. PRs build the PR's own docs as a validation artifact only.
+Deploy (`.github/workflows/docs.yml`): a push to `main` OR `dev` publishes TWO live sites in one GitHub Pages deploy: the **stable** docs built from `main` at `/Skulk/` and the **next** docs built from `dev` at `/Skulk/next/`. A build matrix builds each branch's current content (baseUrl set via `DOCS_BASE_URL`, channel banner via `DOCS_CHANNEL`), and the deploy job assembles them (stable at root, next under `/next/`). There are no Docusaurus version snapshots to maintain: each site is rebuilt live from its branch, so a push to either rebuilds and redeploys both. PRs build the PR's own docs as a validation artifact only.
 
 ## Pre-Commit Checks (REQUIRED)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ Docs source lives in `website/docs/`. Generated content:
 - `website/static/typedoc/` — TypeDoc HTML reference (gitignored)
 - `website/build/` — final Docusaurus output (gitignored)
 
+Deploy (`.github/workflows/docs.yml`): a push to `main` OR `dev` publishes TWO live sites in one GitHub Pages deploy — the **stable** docs built from `main` at `/Skulk/` and the **next** docs built from `dev` at `/Skulk/next/`. A build matrix builds each branch's current content (baseUrl set via `DOCS_BASE_URL`, channel banner via `DOCS_CHANNEL`), and the deploy job assembles them (stable at root, next under `/next/`). There are no Docusaurus version snapshots to maintain: each site is rebuilt live from its branch, so a push to either rebuilds and redeploys both. PRs build the PR's own docs as a validation artifact only.
+
 ## Pre-Commit Checks (REQUIRED)
 
 **IMPORTANT: Always run these checks before committing code. CI will fail if these don't pass.**

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,17 +4,21 @@ import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 import type { PluginOptions as OpenApiPluginOptions } from "docusaurus-plugin-openapi-docs";
 
+// baseUrl is env-overridable so one config can build two live sites from one
+// deploy job: the stable site (from `main`) at /Skulk/ and the "next" site
+// (from `dev`) at /Skulk/next/. Each is a normal full build of that branch's
+// current docs, so there are no version snapshots to maintain or miss. Anything
+// pointing at the site root (e.g. the TypeDoc static dir) is derived from this
+// so it stays correct on whichever channel is being built.
+const baseUrl = process.env.DOCS_BASE_URL ?? "/Skulk/";
+
 const config: Config = {
   title: "Skulk Developer Docs",
   tagline: "Distributed AI inference, edge-to-edge",
   favicon: "img/skulk-logo.svg",
 
   url: "https://foxlight-foundation.github.io",
-  // baseUrl is env-overridable so one config can build two live sites from one
-  // deploy job: the stable site (from `main`) at /Skulk/ and the "next" site
-  // (from `dev`) at /Skulk/next/. Each is a normal full build of that branch's
-  // current docs, so there are no version snapshots to maintain or miss.
-  baseUrl: process.env.DOCS_BASE_URL ?? "/Skulk/",
+  baseUrl,
 
   organizationName: "foxlight-foundation",
   projectName: "Skulk",
@@ -146,11 +150,11 @@ const config: Config = {
           label: "API Reference",
         },
         {
-          // TypeDoc HTML is served from website/static/typedoc/ at /typedoc/.
-          // Uses the full URL so Docusaurus doesn't treat it as an internal
-          // link and fail the broken-link check (static files are invisible
-          // to the link checker).
-          href: "https://foxlight-foundation.github.io/Skulk/typedoc/",
+          // TypeDoc HTML is served from website/static/typedoc/ under the
+          // site baseUrl. Built as a full URL (channel-aware via baseUrl) so
+          // Docusaurus doesn't treat it as an internal link and fail the
+          // broken-link check (static files are invisible to the link checker).
+          href: `https://foxlight-foundation.github.io${baseUrl}typedoc/`,
           label: "TypeScript API",
           position: "left",
         },
@@ -179,7 +183,7 @@ const config: Config = {
             { label: "API Reference", to: "/api/skulk-api" },
             {
               label: "TypeScript API",
-              href: "https://foxlight-foundation.github.io/Skulk/typedoc/",
+              href: `https://foxlight-foundation.github.io${baseUrl}typedoc/`,
             },
           ],
         },

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -10,7 +10,11 @@ import type { PluginOptions as OpenApiPluginOptions } from "docusaurus-plugin-op
 // current docs, so there are no version snapshots to maintain or miss. Anything
 // pointing at the site root (e.g. the TypeDoc static dir) is derived from this
 // so it stays correct on whichever channel is being built.
-const baseUrl = process.env.DOCS_BASE_URL ?? "/Skulk/";
+// Normalize to exactly one leading and trailing slash (Docusaurus requires both)
+// so a fat-fingered DOCS_BASE_URL (e.g. "Skulk/next") still builds.
+const rawBaseUrl = process.env.DOCS_BASE_URL ?? "/Skulk/";
+const strippedBaseUrl = rawBaseUrl.replace(/^\/+|\/+$/g, "");
+const baseUrl = strippedBaseUrl ? `/${strippedBaseUrl}/` : "/";
 
 const config: Config = {
   title: "Skulk Developer Docs",

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -10,7 +10,11 @@ const config: Config = {
   favicon: "img/skulk-logo.svg",
 
   url: "https://foxlight-foundation.github.io",
-  baseUrl: "/Skulk/",
+  // baseUrl is env-overridable so one config can build two live sites from one
+  // deploy job: the stable site (from `main`) at /Skulk/ and the "next" site
+  // (from `dev`) at /Skulk/next/. Each is a normal full build of that branch's
+  // current docs, so there are no version snapshots to maintain or miss.
+  baseUrl: process.env.DOCS_BASE_URL ?? "/Skulk/",
 
   organizationName: "foxlight-foundation",
   projectName: "Skulk",
@@ -105,6 +109,23 @@ const config: Config = {
   themes: ["docusaurus-theme-openapi-docs"],
 
   themeConfig: {
+    // Cross-link the two live sites. On the "next" (dev) build this points back
+    // to the stable docs; on the stable build it points to the dev docs. Driven
+    // by DOCS_CHANNEL so the same config produces the right banner for each build.
+    announcementBar:
+      process.env.DOCS_CHANNEL === "next"
+        ? {
+            id: "channel-next",
+            content:
+              'You are viewing the <b>development (next)</b> docs. For the latest release, see the <a href="/Skulk/">stable docs</a>.',
+            isCloseable: false,
+          }
+        : {
+            id: "channel-stable",
+            content:
+              'You are viewing the <b>stable</b> docs. For unreleased changes, see the <a href="/Skulk/next/">development docs</a>.',
+            isCloseable: true,
+          },
     navbar: {
       title: "Skulk",
       logo: {


### PR DESCRIPTION
Final PR of the docs overhaul. Makes the docs site serve **two live sites** from one GitHub Pages deploy, so readers can see docs for both the released and in-development branches.

## How it works
- **`docs.yml`**: on a push to `main` or `dev`, a matrix builds **`stable`** from `main` (`/Skulk/`) and **`next`** from `dev` (`/Skulk/next/`); the deploy job assembles them (stable at root, next under `/next/`) into one Pages artifact. PRs still build the PR's own docs as a validation artifact (no deploy).
- **`docusaurus.config.ts`**: `baseUrl` is env-driven (`DOCS_BASE_URL`) so one config builds both sites, plus an `announcementBar` (`DOCS_CHANNEL`) that cross-links stable ⇄ next.

## Why this shape (no Docusaurus versioning)
Each site is a normal full build of its branch's **current** content. So there are **no version snapshots to take or miss** — a push to either branch rebuilds and redeploys both. This was a deliberate choice over Docusaurus's `docs:version` mechanism, which would require a manual snapshot at every release (miss-prone) and entangles the auto-generated OpenAPI reference per version. It also avoids a per-branch README link flip at release: the two sites cross-link via the banner instead.

## Validation
Ran the full `next`-channel pipeline locally (`DOCS_BASE_URL=/Skulk/next/ DOCS_CHANNEL=next uv run python scripts/build_docs.py`): build succeeds, output carries `/Skulk/next/` URLs and the "development (next)" banner, the new `cluster-communication` page builds, and the retired `runtime-plane-separation` page is absent. 0 em dashes.

## Note
This changes the **deploy workflow**, so unlike the prose PRs I'm holding this one for your explicit merge. After it lands, the only remaining item is the gated final step (detach the GitHub fork + remove the local exo clone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)