### PR TITLE
docs: add navbar Stable/Next channel selector

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -170,6 +170,13 @@ const config: Config = {
           type: "dropdown",
           label: process.env.DOCS_CHANNEL === "next" ? "Next (dev)" : "Stable",
           position: "right",
+          // Full URLs (not root-relative) for the same reason as the TypeDoc
+          // link above: a navbar `href` that looks internal is run through the
+          // broken-link checker, and a cross-channel path like /Skulk/next/ is
+          // not a routable page on the stable build (and vice versa), so it
+          // would fail the build. Full URLs are treated as external and skipped.
+          // (The announcementBar can use root-relative paths because its raw
+          // HTML string is not parsed by the link checker.)
           items: [
             {
               label: "Stable",

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -163,6 +163,25 @@ const config: Config = {
           position: "left",
         },
         {
+          // Always-visible switch between the two live sites. The label shows
+          // the channel you're currently on (driven by DOCS_CHANNEL, the same
+          // env that drives the cross-link banner), and both destinations are
+          // listed so you can jump either way from anywhere in the docs.
+          type: "dropdown",
+          label: process.env.DOCS_CHANNEL === "next" ? "Next (dev)" : "Stable",
+          position: "right",
+          items: [
+            {
+              label: "Stable",
+              href: "https://foxlight-foundation.github.io/Skulk/",
+            },
+            {
+              label: "Next (dev)",
+              href: "https://foxlight-foundation.github.io/Skulk/next/",
+            },
+          ],
+        },
+        {
           href: "https://github.com/Foxlight-Foundation/Skulk",
           label: "GitHub",
           position: "right",


### PR DESCRIPTION
## What

Adds an always-visible navbar dropdown to switch between the two live docs sites:

- **Stable** — built from \`main\` at \`/Skulk/\`
- **Next (dev)** — built from \`dev\` at \`/Skulk/next/\`

The dropdown label reflects the channel you're currently on (driven by \`DOCS_CHANNEL\`, the same env that drives the existing cross-link announcement bar), and both destinations are always listed so readers can jump either direction from any page.

## Why

The cross-link banner only told you the *other* site existed; there was no persistent, always-reachable switch. This makes the stable/next relationship a first-class, one-click affordance in the chrome.

## Caveat

Same as the banner: this is config-driven, so it renders on \`/Skulk/next/\` immediately on merge to \`dev\`, and on the stable root only after a \`dev\`→\`main\` release promotion.

## Validation

- \`npm run build\` clean for both channels (\`DOCS_CHANNEL=next\` and \`stable\`).
- 0 em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)