### PR TITLE
feat: GGUF model support — llama.cpp card creation + staging completeness (slice 3a)

### DIFF
--- a/src/skulk/download/download_utils.py
+++ b/src/skulk/download/download_utils.py
@@ -198,6 +198,7 @@ def companion_download_specs(
     base), while MTP sidecars and assistants degrade gracefully to
     run-without-speculation (best-effort).
     """
+
     def _bare_shard(repo: str) -> PipelineShardMetadata:
         return PipelineShardMetadata(
             model_card=ModelCard(
@@ -216,9 +217,7 @@ def companion_download_specs(
         )
 
     specs: list[tuple[PipelineShardMetadata, list[str], bool]] = []
-    if model_card.vision and model_card.vision.weights_repo != str(
-        model_card.model_id
-    ):
+    if model_card.vision and model_card.vision.weights_repo != str(model_card.model_id):
         specs.append(
             (
                 _bare_shard(model_card.vision.weights_repo),
@@ -273,9 +272,7 @@ def model_companions_present_on_disk(
     model complete after ensure_shard returns, so the gate cannot loop
     within a session.
     """
-    if model_card.vision and model_card.vision.weights_repo != str(
-        model_card.model_id
-    ):
+    if model_card.vision and model_card.vision.weights_repo != str(model_card.model_id):
         vision_repo = ModelId(model_card.vision.weights_repo)
         # Probe BOTH search roots: SKULK_MODELS_PATH (staging/store) and
         # SKULK_MODELS_DIR (where download_shard writes) — a vision repo
@@ -441,10 +438,28 @@ def _scan_model_directory(
     return list(entries_by_path.values())
 
 
+def directory_has_gguf_weights(model_dir: Path) -> bool:
+    """True if the directory holds a llama.cpp GGUF weights file.
+
+    Recognizes a staged GGUF model, which has no ``*.safetensors.index.json``
+    (the completeness probe used for MLX/safetensors repos). Excludes ``mmproj*``
+    multimodal projector files, which are not the LM weights. An in-progress
+    download is named ``*.gguf.partial`` and is not matched here, so this is true
+    only once at least one GGUF weight file has finished downloading.
+    """
+    return any(
+        "mmproj" not in path.name.lower() for path in model_dir.glob("**/*.gguf")
+    )
+
+
 def is_model_directory_complete(model_dir: Path) -> bool:
     """Check if a model directory contains all required weight files."""
     file_list = _scan_model_directory(model_dir, recursive=True)
-    return file_list is not None and all(f.size is not None for f in file_list)
+    if file_list is not None and all(f.size is not None for f in file_list):
+        return True
+    # GGUF repos have no safetensors index, so _scan_model_directory returns
+    # None; treat the directory as complete once the GGUF weights are present.
+    return directory_has_gguf_weights(model_dir)
 
 
 async def _build_file_list_from_local_directory(

--- a/src/skulk/download/download_utils.py
+++ b/src/skulk/download/download_utils.py
@@ -444,21 +444,60 @@ def directory_has_gguf_weights(model_dir: Path) -> bool:
     Recognizes a staged GGUF model, which has no ``*.safetensors.index.json``
     (the completeness probe used for MLX/safetensors repos). Excludes ``mmproj*``
     multimodal projector files, which are not the LM weights. An in-progress
-    download is named ``*.gguf.partial`` and is not matched here, so this is true
-    only once at least one GGUF weight file has finished downloading.
+    download is named ``*.gguf.partial`` and is not matched here.
+
+    For a **sharded** GGUF (``<base>-00001-of-000NN.gguf``) the llama.cpp runner
+    opens the first shard and needs the rest beside it, so a directory counts as
+    complete only when the whole shard group of the file the runner would load
+    (the first sorted one, matching ``select_gguf_file``) is present; otherwise
+    an interrupted stage that left only some shards would falsely look complete.
     """
-    return any(
-        "mmproj" not in path.name.lower() for path in model_dir.glob("**/*.gguf")
+    names = sorted(
+        path.name
+        for path in model_dir.glob("**/*.gguf")
+        if "mmproj" not in path.name.lower()
     )
+    if not names:
+        return False
+    shard_info = _gguf_shard_info(names[0])
+    if shard_info is None:
+        return True  # single-file quant present
+    base, total = shard_info
+    present = set(names)
+    return all(
+        f"{base}-{index:05d}-of-{total:05d}.gguf" in present
+        for index in range(1, total + 1)
+    )
+
+
+def _gguf_shard_info(name: str) -> "tuple[str, int] | None":
+    """Parse a GGUF shard filename into ``(base, total_shards)``, or ``None``.
+
+    ``foo-00001-of-00003.gguf`` -> ``("foo", 3)``; ``foo.gguf`` -> ``None``. The
+    base may contain dashes, so only the trailing three ``-`` tokens are split.
+    """
+    if not name.endswith(".gguf"):
+        return None
+    parts = name[: -len(".gguf")].rsplit("-", 3)
+    if (
+        len(parts) == 4
+        and parts[1].isdigit()
+        and parts[2] == "of"
+        and parts[3].isdigit()
+    ):
+        return parts[0], int(parts[3])
+    return None
 
 
 def is_model_directory_complete(model_dir: Path) -> bool:
     """Check if a model directory contains all required weight files."""
     file_list = _scan_model_directory(model_dir, recursive=True)
-    if file_list is not None and all(f.size is not None for f in file_list):
-        return True
-    # GGUF repos have no safetensors index, so _scan_model_directory returns
-    # None; treat the directory as complete once the GGUF weights are present.
+    if file_list is not None:
+        # A safetensors index is present: completeness is governed entirely by it
+        # (do NOT let a stray .gguf mask a partially-downloaded safetensors set).
+        return all(f.size is not None for f in file_list)
+    # No safetensors index -> this may be a GGUF repo; complete once its weights
+    # (the full shard group) are present.
     return directory_has_gguf_weights(model_dir)
 
 
@@ -468,18 +507,48 @@ async def _build_file_list_from_local_directory(
 ) -> list[FileListEntry] | None:
     """Build a file list from locally existing model files.
 
-    We can only figure out the files we need from safetensors index, so
-    a local directory must contain a *.safetensors.index.json and
-    safetensors listed there.
+    Safetensors repos are resolved from their ``*.safetensors.index.json``. GGUF
+    repos have no index, so when the scanner finds none we fall back to listing
+    the files on disk directly, which lets a pre-staged GGUF serve under
+    ``--offline`` (no cached HF file-list), where the remote fetch would
+    otherwise report ``not_started``.
     """
     model_dir = (await ensure_models_dir()) / model_id.normalize()
     if not await aios.path.exists(model_dir):
         return None
 
     file_list = await asyncio.to_thread(_scan_model_directory, model_dir, recursive)
-    if not file_list:
-        return None
-    return file_list
+    if file_list:
+        return file_list
+    # No safetensors index: serve a complete GGUF directory from the local files.
+    if await asyncio.to_thread(directory_has_gguf_weights, model_dir):
+        return await asyncio.to_thread(_list_local_files, model_dir, recursive)
+    return None
+
+
+def _list_local_files(model_dir: Path, recursive: bool) -> list[FileListEntry]:
+    """List on-disk files as FileListEntry (skipping ``.partial`` temporaries)."""
+    entries: list[FileListEntry] = []
+    if recursive:
+        for dirpath, _, filenames in os.walk(model_dir):
+            for filename in filenames:
+                if filename.endswith(".partial"):
+                    continue
+                full_path = Path(dirpath) / filename
+                entries.append(
+                    FileListEntry(
+                        type="file",
+                        path=str(full_path.relative_to(model_dir)),
+                        size=full_path.stat().st_size,
+                    )
+                )
+    else:
+        for item in model_dir.iterdir():
+            if item.is_file() and not item.name.endswith(".partial"):
+                entries.append(
+                    FileListEntry(type="file", path=item.name, size=item.stat().st_size)
+                )
+    return entries
 
 
 _fetched_file_lists_this_session: set[str] = set()

--- a/src/skulk/download/tests/test_gguf_completeness.py
+++ b/src/skulk/download/tests/test_gguf_completeness.py
@@ -33,3 +33,19 @@ def test_in_progress_gguf_partial_is_not_complete(tmp_path: Path) -> None:
 
 def test_empty_dir_not_complete(tmp_path: Path) -> None:
     assert not is_model_directory_complete(tmp_path)
+
+
+def test_sharded_gguf_complete_only_with_all_shards(tmp_path: Path) -> None:
+    # All shards present -> complete.
+    for i in (1, 2, 3):
+        (tmp_path / f"model-{i:05d}-of-00003.gguf").write_bytes(b"GGUF")
+    assert directory_has_gguf_weights(tmp_path)
+    assert is_model_directory_complete(tmp_path)
+
+
+def test_sharded_gguf_incomplete_missing_shard(tmp_path: Path) -> None:
+    # Only the first shard finalized (no .partial) -> NOT complete; otherwise the
+    # store would skip restaging and llama.cpp would fail to find the rest.
+    (tmp_path / "model-00001-of-00003.gguf").write_bytes(b"GGUF")
+    assert not directory_has_gguf_weights(tmp_path)
+    assert not is_model_directory_complete(tmp_path)

--- a/src/skulk/download/tests/test_gguf_completeness.py
+++ b/src/skulk/download/tests/test_gguf_completeness.py
@@ -1,0 +1,35 @@
+"""GGUF staged-directory completeness recognition (slice 3a, downloader side)."""
+
+from pathlib import Path
+
+from skulk.download.download_utils import (
+    directory_has_gguf_weights,
+    is_model_directory_complete,
+)
+
+
+def test_gguf_dir_recognized_complete(tmp_path: Path) -> None:
+    # A GGUF repo has no *.safetensors.index.json, so the safetensors probe
+    # returns None; the directory must still be recognized as complete.
+    (tmp_path / "model-q4.gguf").write_bytes(b"GGUF")
+    (tmp_path / "config.json").write_text("{}")
+    assert directory_has_gguf_weights(tmp_path)
+    assert is_model_directory_complete(tmp_path)
+
+
+def test_mmproj_only_is_not_complete(tmp_path: Path) -> None:
+    # An mmproj projector is not the LM weights; on its own the dir is not done.
+    (tmp_path / "mmproj-model.gguf").write_bytes(b"GGUF")
+    assert not directory_has_gguf_weights(tmp_path)
+    assert not is_model_directory_complete(tmp_path)
+
+
+def test_in_progress_gguf_partial_is_not_complete(tmp_path: Path) -> None:
+    # An in-progress download is *.gguf.partial and must not count as complete.
+    (tmp_path / "model-q4.gguf.partial").write_bytes(b"GG")
+    assert not directory_has_gguf_weights(tmp_path)
+    assert not is_model_directory_complete(tmp_path)
+
+
+def test_empty_dir_not_complete(tmp_path: Path) -> None:
+    assert not is_model_directory_complete(tmp_path)

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -492,7 +492,14 @@ class ModelCard(CamelCaseModel):
 
         This is a pure fetch — it does NOT save to disk or update the cache.
         Persistence is handled by the event-sourcing layer (worker event handler).
+
+        Detects GGUF repos (which `mlx-lm` cannot load) and builds a llama.cpp
+        card for them instead of the default MLX/safetensors card.
         """
+        gguf_files = gguf_weight_siblings(model_id)
+        if gguf_files:
+            return await ModelCard._fetch_gguf_from_hf(model_id, gguf_files)
+
         # TODO: failure if files do not exist
         config_data = await fetch_config_data(model_id)
         num_layers = config_data.layer_count
@@ -510,6 +517,74 @@ class ModelCard(CamelCaseModel):
             trust_remote_code=True,
             is_custom=True,
             vision=config_data.vision,
+        )
+
+    @staticmethod
+    async def _fetch_gguf_from_hf(
+        model_id: ModelId, gguf_files: "list[tuple[str, int]]"
+    ) -> "ModelCard":
+        """Build a llama.cpp model card for a GGUF repo.
+
+        Sizes the weights from the GGUF file the runner would actually load
+        (`select_gguf_file` picks the first sorted file + its shard group).
+        Structural fields come from `config.json` when the repo ships one (most
+        community GGUF repos do); when it does not they default to 0 and a
+        follow-up (GGUF-header parse, #327) can fill them in. Stamps the
+        llama.cpp backend tags so placement routes the model only to nodes with a
+        llama.cpp engine and prefers a GPU backend.
+        """
+        selected_size = _selected_gguf_shard_size(gguf_files)
+
+        # Structural metadata comes from config.json, which most community GGUF
+        # repos (bartowski, unsloth, mlx-community) ship alongside the weights.
+        # A bare GGUF repo with no config.json needs the metadata read from the
+        # GGUF header instead (#327); until that lands, fail clearly rather than
+        # fabricate placeholder layer/hidden sizes that would skew placement's
+        # memory and KV-budget math.
+        try:
+            config_data = await fetch_config_data(model_id)
+        except Exception as exc:
+            raise ValueError(
+                f"GGUF repo {model_id} has no usable config.json ({exc}); "
+                "reading model metadata from the GGUF header is not yet "
+                "supported (#327). Use a GGUF repo that ships config.json."
+            ) from exc
+        n_layers = config_data.layer_count
+        hidden_size = config_data.hidden_size or 0
+        num_key_value_heads = config_data.num_key_value_heads
+        context_length = config_data.max_position_embeddings or 0
+
+        return ModelCard(
+            model_id=ModelId(model_id),
+            storage_size=selected_size,
+            n_layers=n_layers,
+            hidden_size=hidden_size,
+            # llama.cpp runs single-node in Skulk (no tensor parallelism).
+            supports_tensor=False,
+            num_key_value_heads=num_key_value_heads,
+            context_length=context_length,
+            tasks=[ModelTask.TextGeneration],
+            trust_remote_code=False,
+            is_custom=True,
+            placement=PlacementCardConfig(
+                compatible_backends=frozenset(
+                    {
+                        "llama_cpp-vulkan",
+                        "llama_cpp-rocm",
+                        "llama_cpp-cuda",
+                        "llama_cpp-cpu",
+                    }
+                ),
+                # Prefer a GPU backend over CPU; the GPU ordering is a sensible
+                # default a card author can tune per model (Vulkan vs ROCm
+                # performance is model-dependent).
+                backend_preference=(
+                    "llama_cpp-vulkan",
+                    "llama_cpp-rocm",
+                    "llama_cpp-cuda",
+                    "llama_cpp-cpu",
+                ),
+            ),
         )
 
 
@@ -663,3 +738,61 @@ async def fetch_safetensors_size(model_id: ModelId) -> Memory:
     if info.safetensors is None:
         raise ValueError(f"No safetensors info found for {model_id}")
     return Memory.from_bytes(info.safetensors.total)
+
+
+def gguf_weight_siblings(model_id: ModelId) -> "list[tuple[str, int]]":
+    """List a repo's GGUF weight files (filename, size) via the HF API.
+
+    Excludes multimodal projector files (``mmproj*``), which are not the LM
+    weights. Returns an empty list for a non-GGUF repo, so callers use this as a
+    "is this a GGUF model?" probe. Sizes are bytes (0 when HF omits the size).
+    """
+    info = model_info(model_id, files_metadata=True)
+    siblings = info.siblings or []
+    return [
+        (sibling.rfilename, sibling.size or 0)
+        for sibling in siblings
+        if sibling.rfilename.endswith(".gguf")
+        and "mmproj" not in sibling.rfilename.lower()
+    ]
+
+
+def _selected_gguf_shard_size(gguf_files: "list[tuple[str, int]]") -> Memory:
+    """Total bytes of the GGUF file the runner would load (with its shards).
+
+    Mirrors ``llama_cpp.runner.select_gguf_file``: the first file in sorted
+    order is the one loaded. Sharded GGUFs are named ``<base>-00001-of-000NN.gguf``
+    and llama.cpp pulls the whole group from the first shard, so we sum the
+    sizes of all files sharing that shard base. A single-file quant sums to just
+    itself. This keeps the card's ``storage_size`` consistent with what actually
+    loads (rather than summing every quant a multi-quant repo happens to host).
+    """
+    names = sorted(name for name, _ in gguf_files)
+    selected = names[0]
+    sizes = dict(gguf_files)
+    base = _gguf_shard_base(selected)
+    if base is None:
+        return Memory.from_bytes(sizes[selected])
+    return Memory.from_bytes(
+        sum(size for name, size in gguf_files if _gguf_shard_base(name) == base)
+    )
+
+
+def _gguf_shard_base(name: str) -> str | None:
+    """Return the shard-group base of a GGUF filename, or ``None`` if unsharded.
+
+    ``foo-00001-of-00003.gguf`` -> ``foo``; ``foo.gguf`` -> ``None``. Detects the
+    ``-NNNNN-of-NNNNN.gguf`` suffix without a regex (re is not imported here).
+    The base itself may contain dashes (e.g. ``Qwen2.5-7B-Instruct-Q4_K_M``), so
+    we split only the trailing three ``-`` tokens.
+    """
+    stem = name[: -len(".gguf")] if name.endswith(".gguf") else name
+    parts = stem.rsplit("-", 3)
+    if (
+        len(parts) == 4
+        and parts[1].isdigit()
+        and parts[2] == "of"
+        and parts[3].isdigit()
+    ):
+        return parts[0]
+    return None

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -528,10 +528,12 @@ class ModelCard(CamelCaseModel):
         Sizes the weights from the GGUF file the runner would actually load
         (`select_gguf_file` picks the first sorted file + its shard group).
         Structural fields come from `config.json` when the repo ships one (most
-        community GGUF repos do); when it does not they default to 0 and a
-        follow-up (GGUF-header parse, #327) can fill them in. Stamps the
-        llama.cpp backend tags so placement routes the model only to nodes with a
-        llama.cpp engine and prefers a GPU backend.
+        community GGUF repos do). A bare repo with no config.json **raises a
+        clear error** pointing at the GGUF-header-parse follow-up (#327) rather
+        than fabricating metadata (a `ModelCard` also cannot be constructed with
+        0 for its `PositiveInt` layer/hidden fields). Stamps the llama.cpp backend
+        tags so placement routes the model only to nodes with a llama.cpp engine
+        and prefers a GPU backend.
         """
         selected_size = _selected_gguf_shard_size(gguf_files)
 
@@ -540,10 +542,12 @@ class ModelCard(CamelCaseModel):
         # A bare GGUF repo with no config.json needs the metadata read from the
         # GGUF header instead (#327); until that lands, fail clearly rather than
         # fabricate placeholder layer/hidden sizes that would skew placement's
-        # memory and KV-budget math.
+        # memory and KV-budget math. Catch only the missing-file case so HF
+        # auth / rate-limit / transient network errors propagate unchanged
+        # instead of being mislabeled as "no config.json".
         try:
             config_data = await fetch_config_data(model_id)
-        except Exception as exc:
+        except FileNotFoundError as exc:
             raise ValueError(
                 f"GGUF repo {model_id} has no usable config.json ({exc}); "
                 "reading model metadata from the GGUF header is not yet "

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -496,7 +496,16 @@ class ModelCard(CamelCaseModel):
         Detects GGUF repos (which `mlx-lm` cannot load) and builds a llama.cpp
         card for them instead of the default MLX/safetensors card.
         """
-        gguf_files = gguf_weight_siblings(model_id)
+        # GGUF detection is a best-effort probe: it hits the HF model-info API,
+        # which the safetensors path below does NOT require (it has its own retry
+        # and local-file fallback). A transient/offline/rate-limited probe must
+        # therefore NOT block a safetensors card that could otherwise load from
+        # cache: treat any probe failure as "not proven GGUF" and fall through.
+        try:
+            gguf_files = gguf_weight_siblings(model_id)
+        except Exception as exc:  # noqa: BLE001  (best-effort probe, see above)
+            logger.debug(f"GGUF probe for {model_id} failed ({exc}); assuming non-GGUF")
+            gguf_files = []
         if gguf_files:
             return await ModelCard._fetch_gguf_from_hf(model_id, gguf_files)
 

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -553,8 +553,17 @@ class ModelCard(CamelCaseModel):
                 "reading model metadata from the GGUF header is not yet "
                 "supported (#327). Use a GGUF repo that ships config.json."
             ) from exc
+        # ModelCard requires positive n_layers/hidden_size (PositiveInt). If the
+        # config.json is present but lacks usable values, fail with the same clear
+        # error rather than a raw pydantic ValidationError.
+        if not config_data.layer_count or not config_data.hidden_size:
+            raise ValueError(
+                f"GGUF repo {model_id} config.json is missing usable layer/hidden "
+                "sizes; reading model metadata from the GGUF header is not yet "
+                "supported (#327)."
+            )
         n_layers = config_data.layer_count
-        hidden_size = config_data.hidden_size or 0
+        hidden_size = config_data.hidden_size
         num_key_value_heads = config_data.num_key_value_heads
         context_length = config_data.max_position_embeddings or 0
 
@@ -771,7 +780,11 @@ def _selected_gguf_shard_size(gguf_files: "list[tuple[str, int]]") -> Memory:
     itself. This keeps the card's ``storage_size`` consistent with what actually
     loads (rather than summing every quant a multi-quant repo happens to host).
     """
-    names = sorted(name for name, _ in gguf_files)
+    # Sort by basename to agree with select_gguf_file / directory_has_gguf_weights
+    # on which file is "first" (so sizing, completeness, and loading match).
+    names = sorted(
+        (name for name, _ in gguf_files), key=lambda name: name.rsplit("/", 1)[-1]
+    )
     selected = names[0]
     sizes = dict(gguf_files)
     base = _gguf_shard_base(selected)

--- a/src/skulk/shared/models/tests/test_gguf_cards.py
+++ b/src/skulk/shared/models/tests/test_gguf_cards.py
@@ -1,0 +1,98 @@
+# pyright: reportPrivateUsage=false
+"""Tests for GGUF-repo detection and llama.cpp card creation (slice 3a)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from skulk.shared.models import model_cards
+from skulk.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    _gguf_shard_base,
+    gguf_weight_siblings,
+)
+
+
+def _fake_model_info(filenames: list[str]):
+    """A stand-in for huggingface_hub.model_info with files_metadata=True."""
+
+    def _factory(_model_id: object, files_metadata: bool = False) -> object:
+        siblings = [SimpleNamespace(rfilename=name, size=100) for name in filenames]
+        return SimpleNamespace(siblings=siblings, safetensors=None)
+
+    return _factory
+
+
+def test_gguf_weight_siblings_filters_gguf_and_mmproj(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        model_cards,
+        "model_info",
+        _fake_model_info(
+            ["model.gguf", "mmproj-model.gguf", "config.json", "README.md"]
+        ),
+    )
+    siblings = gguf_weight_siblings(ModelId("some/gguf-repo"))
+    names = {name for name, _ in siblings}
+    assert names == {"model.gguf"}  # .gguf only, mmproj excluded
+
+
+def test_non_gguf_repo_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        model_cards,
+        "model_info",
+        _fake_model_info(["model.safetensors", "config.json"]),
+    )
+    assert gguf_weight_siblings(ModelId("some/mlx-repo")) == []
+
+
+def test_shard_base_detection() -> None:
+    assert _gguf_shard_base("model.gguf") is None
+    assert _gguf_shard_base("model-00001-of-00003.gguf") == "model"
+    assert (
+        _gguf_shard_base("Qwen2.5-7B-Instruct-Q4_K_M-00001-of-00003.gguf")
+        == "Qwen2.5-7B-Instruct-Q4_K_M"
+    )
+
+
+async def test_fetch_gguf_card_stamps_llama_cpp_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(model_cards, "model_info", _fake_model_info(["model-q4.gguf"]))
+
+    async def _fake_config(_model_id: object) -> object:
+        return SimpleNamespace(
+            layer_count=32,
+            hidden_size=4096,
+            num_key_value_heads=8,
+            max_position_embeddings=8192,
+        )
+
+    monkeypatch.setattr(model_cards, "fetch_config_data", _fake_config)
+
+    card = await ModelCard.fetch_from_hf(ModelId("some/gguf-repo"))
+    assert card.placement.compatible_backends == frozenset(
+        {"llama_cpp-vulkan", "llama_cpp-rocm", "llama_cpp-cuda", "llama_cpp-cpu"}
+    )
+    assert card.placement.backend_preference[0] == "llama_cpp-vulkan"
+    assert card.supports_tensor is False  # single-node engine
+    assert card.n_layers == 32 and card.hidden_size == 4096
+    assert card.storage_size.in_bytes == 100  # the single selected gguf
+
+
+async def test_fetch_gguf_card_without_config_fails_clearly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A bare GGUF repo (no config.json) needs the GGUF-header parse (#327); until
+    # then we fail with a clear, actionable error rather than fabricate metadata.
+    monkeypatch.setattr(model_cards, "model_info", _fake_model_info(["model-q4.gguf"]))
+
+    async def _raises(_model_id: object) -> object:
+        raise FileNotFoundError("no config.json in this bare GGUF repo")
+
+    monkeypatch.setattr(model_cards, "fetch_config_data", _raises)
+
+    with pytest.raises(ValueError, match="#327"):
+        await ModelCard.fetch_from_hf(ModelId("bare/gguf-repo"))

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -62,10 +62,11 @@ def select_gguf_file(model_dir: Path) -> Path:
     first, and llama.cpp discovers the remaining shards from it. Raises
     ``FileNotFoundError`` when the directory contains no usable GGUF.
 
-    Searches recursively and sorts by the directory-relative path so it selects
-    the SAME file the card sized and the completeness check recognized
-    (``gguf_weight_siblings`` / ``_selected_gguf_shard_size`` use repo-relative
-    names); otherwise a nested-layout repo could size/complete but fail to load.
+    Searches recursively and sorts by file basename so the three GGUF-selection
+    sites agree on which file is "first": this runner, the card's
+    ``_selected_gguf_shard_size`` (sizing), and ``directory_has_gguf_weights``
+    (completeness) all use recursive discovery + basename order. Otherwise they
+    could disagree and a model would size/complete but fail to load.
     """
     candidates = sorted(
         (
@@ -73,7 +74,7 @@ def select_gguf_file(model_dir: Path) -> Path:
             for path in model_dir.glob("**/*.gguf")
             if "mmproj" not in path.name.lower()
         ),
-        key=lambda path: str(path.relative_to(model_dir)),
+        key=lambda path: path.name,
     )
     if not candidates:
         raise FileNotFoundError(f"no .gguf weights file found in {model_dir}")

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -61,9 +61,19 @@ def select_gguf_file(model_dir: Path) -> Path:
     files (``mmproj*``). Sorted order puts the first shard (``*-00001-of-*``)
     first, and llama.cpp discovers the remaining shards from it. Raises
     ``FileNotFoundError`` when the directory contains no usable GGUF.
+
+    Searches recursively and sorts by the directory-relative path so it selects
+    the SAME file the card sized and the completeness check recognized
+    (``gguf_weight_siblings`` / ``_selected_gguf_shard_size`` use repo-relative
+    names); otherwise a nested-layout repo could size/complete but fail to load.
     """
     candidates = sorted(
-        path for path in model_dir.glob("*.gguf") if "mmproj" not in path.name.lower()
+        (
+            path
+            for path in model_dir.glob("**/*.gguf")
+            if "mmproj" not in path.name.lower()
+        ),
+        key=lambda path: str(path.relative_to(model_dir)),
     )
     if not candidates:
         raise FileNotFoundError(f"no .gguf weights file found in {model_dir}")


### PR DESCRIPTION
Slice 3a of separable engines: make a GGUF model card-able and stage-able, so the in-process llama.cpp runner (merged in #325) can actually be fed a model. Two commits.

## Commit 1 — GGUF card creation (`model_cards.py`)
`ModelCard.fetch_from_hf` detects a GGUF repo (`gguf_weight_siblings`, via the HF API) and builds a **llama.cpp** card instead of the MLX/safetensors one:
- `storage_size` from the GGUF file the runner actually loads — the first sorted file + its shard group (`_selected_gguf_shard_size`/`_gguf_shard_base`, mirroring the runner's `select_gguf_file`) — **not** the sum of every quant a multi-quant repo hosts.
- Structural fields from `config.json` (which bartowski / unsloth / mlx-community GGUF repos ship). A bare repo with no `config.json` fails with a clear, actionable error pointing at the GGUF-header-parse follow-up (#327), rather than fabricating layer/hidden sizes that would skew placement math.
- Stamps `placement.compatible_backends` + `backend_preference` with the llama_cpp tags (GPU-preferred). `supports_tensor=False`. So placement routes the model only to llama.cpp nodes and the single-node guard (from #325) applies.

## Commit 2 — GGUF staging completeness (`download_utils.py`)
The fetch already pulls `.gguf` (`resolve_allow_patterns` returns `"*"`), but completeness detection was safetensors-only: `is_model_directory_complete` required a `*.safetensors.index.json`, so a staged GGUF directory was **never** recognized as complete → the store would re-stage every launch / never mark it available. Adds `directory_has_gguf_weights()` and a fallback in `is_model_directory_complete()` (which `_staged_directory_looks_complete` and `resolve_model_in_path` both call, so they pick it up for free). In-progress `*.gguf.partial` and `mmproj` projectors are excluded.

## Known follow-up (not this PR)
`resolve_allow_patterns` returns `"*"`, so a **multi-quant** GGUF repo downloads every quant (big disk). Use a single-quant repo for now; selective-quant download is a separate change (will file).

## Not in this PR
**Slice 3b (live):** build llama-cpp-python (Vulkan) into kite4's skulk venv, stage a GGUF, place + generate over the cluster. That's the end-to-end live validation; this PR is the code, with 9 unit tests covering card creation, sizing/shard-grouping, config-absent handling, and GGUF completeness recognition.

## Validation
`basedpyright` / `ruff` clean, 0 em dashes, 9 new tests pass; broader download + models suites (67 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)