### PR TITLE
feat(gguf): prefer a quant + download/load only the selected file (#334, #332)

### DIFF
--- a/src/skulk/download/download_utils.py
+++ b/src/skulk/download/download_utils.py
@@ -978,10 +978,17 @@ async def get_weight_map(model_id: ModelId, revision: str = "main") -> dict[str,
 
 
 async def resolve_allow_patterns(shard: ShardMetadata) -> list[str]:
-    # TODO: 'Smart' downloads are disabled because:
-    #  (i) We don't handle all kinds of files;
-    # (ii) We don't have sticky sessions.
-    # (iii) Tensor parallel requires all files.
+    # GGUF: the card pins the one quant to load (model_card.gguf_file), so fetch
+    # only that shard group + config.json instead of every quant the repo hosts
+    # (#332). Multi-quant repos otherwise download tens of GB of unused weights.
+    gguf_file = shard.model_card.gguf_file
+    if gguf_file:
+        from skulk.shared.models.model_cards import gguf_allow_patterns
+
+        return [*gguf_allow_patterns(gguf_file), "config.json"]
+    # Non-GGUF (safetensors/MLX): 'Smart' downloads stay disabled because
+    #  (i) we don't handle all kinds of files; (ii) no sticky sessions;
+    #  (iii) tensor parallel requires all files.
     return ["*"]
     try:
         weight_map = await get_weight_map(str(shard.model_card.model_id))

--- a/src/skulk/download/tests/test_gguf_completeness.py
+++ b/src/skulk/download/tests/test_gguf_completeness.py
@@ -49,3 +49,38 @@ def test_sharded_gguf_incomplete_missing_shard(tmp_path: Path) -> None:
     (tmp_path / "model-00001-of-00003.gguf").write_bytes(b"GGUF")
     assert not directory_has_gguf_weights(tmp_path)
     assert not is_model_directory_complete(tmp_path)
+
+
+async def test_resolve_allow_patterns_gguf_vs_safetensors() -> None:
+    """A GGUF card restricts the download to its pinned shard group + config.json;
+    a non-GGUF card keeps the broad ["*"] fetch (#332)."""
+    from skulk.download.download_utils import resolve_allow_patterns
+    from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
+    from skulk.shared.types.memory import Memory
+    from skulk.shared.types.worker.shards import PipelineShardMetadata
+
+    def _shard(card: ModelCard) -> PipelineShardMetadata:
+        return PipelineShardMetadata(
+            model_card=card,
+            device_rank=0,
+            world_size=1,
+            start_layer=0,
+            end_layer=card.n_layers,
+            n_layers=card.n_layers,
+        )
+
+    base = dict(
+        storage_size=Memory.from_gb(1),
+        n_layers=16,
+        hidden_size=2048,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+    )
+    gguf = ModelCard(model_id=ModelId("o/r"), gguf_file="m-Q4_K_M.gguf", **base)
+    assert await resolve_allow_patterns(_shard(gguf)) == [
+        "m-Q4_K_M.gguf",
+        "config.json",
+    ]
+
+    mlx = ModelCard(model_id=ModelId("o/r2"), **base)
+    assert await resolve_allow_patterns(_shard(mlx)) == ["*"]

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -815,7 +815,7 @@ _GGUF_RANK_UNRECOGNIZED: Final = 1_000  # unknown quant: after known quants
 _GGUF_RANK_UNQUANTIZED: Final = 10_000  # full precision: dead last
 
 
-def _gguf_quant_rank(name: str) -> int:
+def gguf_quant_rank(name: str) -> int:
     """Preference rank for a GGUF filename (lower is better); see #334."""
     low = name.rsplit("/", 1)[-1].lower()
     for index, marker in enumerate(_GGUF_QUANT_PREFERENCE):
@@ -849,7 +849,7 @@ def select_preferred_gguf(gguf_files: "list[tuple[str, int]]") -> str:
     """
     return min(
         (name for name, _ in gguf_files),
-        key=lambda name: (_gguf_quant_rank(name), name.rsplit("/", 1)[-1]),
+        key=lambda name: (gguf_quant_rank(name), name.rsplit("/", 1)[-1]),
     )
 
 

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Iterable
 from enum import Enum
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any, Final, Literal, cast
 
 import aiofiles
 import aiofiles.os as aios
@@ -430,6 +430,11 @@ class ModelCard(CamelCaseModel):
     family: str = ""
     quantization: str = ""
     base_model: str = ""
+    gguf_file: str | None = None
+    """For GGUF (llama.cpp) models: the repo-relative path of the weights file the
+    runner loads (the selected quant's first shard). Resolved once at card creation
+    (preferring a quant over BF16) so the download fetches only that quant and the
+    runner loads deterministically, instead of each layer re-globbing/guessing."""
     capabilities: list[str] = []
     context_length: int = 0
     uses_cfg: bool = False
@@ -544,7 +549,8 @@ class ModelCard(CamelCaseModel):
         tags so placement routes the model only to nodes with a llama.cpp engine
         and prefers a GPU backend.
         """
-        selected_size = _selected_gguf_shard_size(gguf_files)
+        selected = select_preferred_gguf(gguf_files)
+        selected_size = gguf_shard_group_size(selected, gguf_files)
 
         # Structural metadata comes from config.json, which most community GGUF
         # repos (bartowski, unsloth, mlx-community) ship alongside the weights.
@@ -586,6 +592,8 @@ class ModelCard(CamelCaseModel):
             num_key_value_heads=num_key_value_heads,
             context_length=context_length,
             tasks=[ModelTask.TextGeneration],
+            quantization=_gguf_quant_label(selected),
+            gguf_file=selected,
             trust_remote_code=False,
             is_custom=True,
             placement=PlacementCardConfig(
@@ -779,26 +787,96 @@ def gguf_weight_siblings(model_id: ModelId) -> "list[tuple[str, int]]":
     ]
 
 
-def _selected_gguf_shard_size(gguf_files: "list[tuple[str, int]]") -> Memory:
-    """Total bytes of the GGUF file the runner would load (with its shards).
+# Preferred GGUF quantizations, best first. Q4_K_M is the de-facto default
+# (good quality/size); unquantized (BF16/F16/F32) is deprioritized hard so a
+# multi-quant repo never defaults to the full-precision weights (#334).
+_GGUF_QUANT_PREFERENCE: Final[tuple[str, ...]] = (
+    "q4_k_m",
+    "q4_k_s",
+    "q5_k_m",
+    "q5_k_s",
+    "q6_k",
+    "q4_0",
+    "q5_0",
+    "q8_0",
+    "q3_k_m",
+    "q3_k_l",
+    "q3_k_s",
+    "q2_k",
+    "iq4_xs",
+    "iq4_nl",
+    "iq4",
+    "iq3",
+    "iq2",
+    "iq1",
+)
+_GGUF_UNQUANTIZED: Final[tuple[str, ...]] = ("bf16", "f16", "fp16", "f32", "fp32")
+_GGUF_RANK_UNRECOGNIZED: Final = 1_000  # unknown quant: after known quants
+_GGUF_RANK_UNQUANTIZED: Final = 10_000  # full precision: dead last
 
-    Mirrors ``llama_cpp.runner.select_gguf_file``: the first file in sorted
-    order is the one loaded. Sharded GGUFs are named ``<base>-00001-of-000NN.gguf``
-    and llama.cpp pulls the whole group from the first shard, so we sum the
-    sizes of all files sharing that shard base. A single-file quant sums to just
-    itself. This keeps the card's ``storage_size`` consistent with what actually
-    loads (rather than summing every quant a multi-quant repo happens to host).
+
+def _gguf_quant_rank(name: str) -> int:
+    """Preference rank for a GGUF filename (lower is better); see #334."""
+    low = name.rsplit("/", 1)[-1].lower()
+    for index, marker in enumerate(_GGUF_QUANT_PREFERENCE):
+        if marker in low:
+            return index
+    if any(token in low for token in _GGUF_UNQUANTIZED):
+        return _GGUF_RANK_UNQUANTIZED
+    return _GGUF_RANK_UNRECOGNIZED
+
+
+def _gguf_quant_label(name: str) -> str:
+    """Human quant label parsed from a GGUF filename (e.g. ``Q4_K_M``), or ``""``."""
+    low = name.rsplit("/", 1)[-1].lower()
+    for marker in _GGUF_QUANT_PREFERENCE:
+        if marker in low:
+            return marker.upper()
+    for token in _GGUF_UNQUANTIZED:
+        if token in low:
+            return token.upper()
+    return ""
+
+
+def select_preferred_gguf(gguf_files: "list[tuple[str, int]]") -> str:
+    """Pick the GGUF weights file to load: best quant, then basename order.
+
+    Prefers a real quantization (Q4_K_M first) over the unquantized BF16/F16 a
+    multi-quant repo also ships (#334). The basename tie-break makes the choice
+    deterministic and, for a shard group, picks the first shard. The runner's
+    ``select_gguf_file`` falls back to this same ranking when the card does not
+    pin a file, so download, sizing, and loading all agree.
     """
-    # Sort by basename to agree with select_gguf_file / directory_has_gguf_weights
-    # on which file is "first" (so sizing, completeness, and loading match).
-    names = sorted(
-        (name for name, _ in gguf_files), key=lambda name: name.rsplit("/", 1)[-1]
+    return min(
+        (name for name, _ in gguf_files),
+        key=lambda name: (_gguf_quant_rank(name), name.rsplit("/", 1)[-1]),
     )
-    selected = names[0]
-    sizes = dict(gguf_files)
+
+
+def gguf_allow_patterns(gguf_file: str) -> list[str]:
+    """Download allow-patterns for a card's selected GGUF (its shard group only).
+
+    A single-file quant downloads just itself; a sharded quant downloads its
+    whole ``<base>-NNNNN-of-NNNNN`` group via a glob. This is what lets the
+    downloader fetch only the chosen quant instead of every quant a multi-quant
+    repo hosts (#332). Caller adds non-weight files (e.g. ``config.json``).
+    """
+    base = _gguf_shard_base(gguf_file)
+    if base is None:
+        return [gguf_file]
+    return [f"{base}-*-of-*.gguf"]
+
+
+def gguf_shard_group_size(selected: str, gguf_files: "list[tuple[str, int]]") -> Memory:
+    """Total bytes of ``selected`` plus its sibling shards (its shard group).
+
+    A single-file quant sums to itself; a sharded quant sums every file sharing
+    its ``<base>-NNNNN-of-NNNNN`` group. Keeps ``storage_size`` consistent with
+    what actually loads, not the sum of every quant the repo hosts.
+    """
     base = _gguf_shard_base(selected)
     if base is None:
-        return Memory.from_bytes(sizes[selected])
+        return Memory.from_bytes(dict(gguf_files)[selected])
     return Memory.from_bytes(
         sum(size for name, size in gguf_files if _gguf_shard_base(name) == base)
     )

--- a/src/skulk/shared/models/tests/test_gguf_cards.py
+++ b/src/skulk/shared/models/tests/test_gguf_cards.py
@@ -96,3 +96,60 @@ async def test_fetch_gguf_card_without_config_fails_clearly(
 
     with pytest.raises(ValueError, match="#327"):
         await ModelCard.fetch_from_hf(ModelId("bare/gguf-repo"))
+
+
+def test_select_preferred_gguf_prefers_quant_over_bf16() -> None:
+    from skulk.shared.models.model_cards import (
+        gguf_allow_patterns,
+        gguf_shard_group_size,
+        select_preferred_gguf,
+    )
+
+    files = [
+        ("M-BF16.gguf", 2_000),
+        ("M-Q4_K_M.gguf", 800),
+        ("M-Q8_0.gguf", 1_300),
+    ]
+    sel = select_preferred_gguf(files)
+    assert sel == "M-Q4_K_M.gguf"  # quant beats BF16; Q4_K_M is top preference
+    assert gguf_shard_group_size(sel, files).in_bytes == 800
+    assert gguf_allow_patterns(sel) == ["M-Q4_K_M.gguf"]
+
+
+def test_select_preferred_gguf_sharded_group() -> None:
+    from skulk.shared.models.model_cards import (
+        gguf_allow_patterns,
+        gguf_shard_group_size,
+        select_preferred_gguf,
+    )
+
+    files = [
+        ("big-Q4_K_M-00001-of-00002.gguf", 500),
+        ("big-Q4_K_M-00002-of-00002.gguf", 600),
+        ("big-BF16.gguf", 4_000),
+    ]
+    sel = select_preferred_gguf(files)
+    assert sel == "big-Q4_K_M-00001-of-00002.gguf"
+    assert gguf_shard_group_size(sel, files).in_bytes == 1_100  # both shards
+    assert gguf_allow_patterns(sel) == ["big-Q4_K_M-*-of-*.gguf"]
+
+
+async def test_gguf_card_pins_selected_quant(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        model_cards,
+        "model_info",
+        _fake_model_info(["model-BF16.gguf", "model-Q4_K_M.gguf"]),
+    )
+
+    async def _cfg(_m: object) -> object:
+        return SimpleNamespace(
+            layer_count=16,
+            hidden_size=2048,
+            num_key_value_heads=8,
+            max_position_embeddings=8192,
+        )
+
+    monkeypatch.setattr(model_cards, "fetch_config_data", _cfg)
+    card = await ModelCard.fetch_from_hf(ModelId("some/gguf-repo"))
+    assert card.gguf_file == "model-Q4_K_M.gguf"
+    assert card.quantization == "Q4_K_M"

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -57,24 +57,23 @@ from skulk.worker.runner.bootstrap import logger
 def select_gguf_file(model_dir: Path) -> Path:
     """Pick the GGUF weights file to load from a staged model directory.
 
-    Returns the first ``*.gguf`` in sorted order, skipping multimodal projector
-    files (``mmproj*``). Sorted order puts the first shard (``*-00001-of-*``)
-    first, and llama.cpp discovers the remaining shards from it. Raises
-    ``FileNotFoundError`` when the directory contains no usable GGUF.
-
-    Searches recursively and sorts by file basename so the three GGUF-selection
-    sites agree on which file is "first": this runner, the card's
-    ``_selected_gguf_shard_size`` (sizing), and ``directory_has_gguf_weights``
-    (completeness) all use recursive discovery + basename order. Otherwise they
-    could disagree and a model would size/complete but fail to load.
+    Fallback for when the card does not pin a file (``gguf_file``): scans
+    recursively, skips ``mmproj*`` projectors, and ranks by the same
+    quant preference the card uses (``gguf_quant_rank``: a real quant over BF16),
+    then basename, so this fallback agrees with the card's sizing
+    (``gguf_shard_group_size``) and selection (``select_preferred_gguf``) and
+    never silently loads the full-precision BF16. Raises ``FileNotFoundError``
+    when the directory has no usable GGUF.
     """
+    from skulk.shared.models.model_cards import gguf_quant_rank
+
     candidates = sorted(
         (
             path
             for path in model_dir.glob("**/*.gguf")
             if "mmproj" not in path.name.lower()
         ),
-        key=lambda path: path.name,
+        key=lambda path: (gguf_quant_rank(path.name), path.name),
     )
     if not candidates:
         raise FileNotFoundError(f"no .gguf weights file found in {model_dir}")
@@ -264,11 +263,22 @@ class Runner:
         model_id = self.shard_metadata.model_card.model_id
         model_dir = build_model_path(ModelId(model_id))
         # Load the exact file the card pinned at creation (the selected quant);
-        # only fall back to scanning if it's somehow absent (older card / manual
-        # staging), so download, sizing, and loading stay in agreement.
+        # fall back to scanning if it's absent (older card / manual staging), so
+        # download, sizing, and loading stay in agreement.
         pinned = self.shard_metadata.model_card.gguf_file
-        gguf_path = model_dir / pinned if pinned else select_gguf_file(model_dir)
-        if not gguf_path.is_file():
+        gguf_path: Path | None = None
+        if pinned:
+            candidate = (model_dir / pinned).resolve()
+            # Reject a hand-edited card whose gguf_file is absolute or uses ".."
+            # to escape the model directory; fall back to the in-dir scan.
+            if candidate.is_file() and candidate.is_relative_to(model_dir.resolve()):
+                gguf_path = candidate
+            else:
+                logger.warning(
+                    f"card gguf_file {pinned!r} is missing or outside the model "
+                    f"dir; scanning {model_dir} instead"
+                )
+        if gguf_path is None:
             gguf_path = select_gguf_file(model_dir)
         logger.info(f"loading GGUF {gguf_path.name} for {model_id}")
         # n_gpu_layers=-1 offloads every layer to the GPU backend the binding was

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -263,7 +263,13 @@ class Runner:
 
         model_id = self.shard_metadata.model_card.model_id
         model_dir = build_model_path(ModelId(model_id))
-        gguf_path = select_gguf_file(model_dir)
+        # Load the exact file the card pinned at creation (the selected quant);
+        # only fall back to scanning if it's somehow absent (older card / manual
+        # staging), so download, sizing, and loading stay in agreement.
+        pinned = self.shard_metadata.model_card.gguf_file
+        gguf_path = model_dir / pinned if pinned else select_gguf_file(model_dir)
+        if not gguf_path.is_file():
+            gguf_path = select_gguf_file(model_dir)
         logger.info(f"loading GGUF {gguf_path.name} for {model_id}")
         # n_gpu_layers=-1 offloads every layer to the GPU backend the binding was
         # built with (Vulkan/ROCm/CUDA); n_ctx=0 uses the model's trained context.


### PR DESCRIPTION
First slice of the **Heterogeneous Compute Fabric** Epic 1 (#337) — making GGUF serving solid for real (multi-quant) repos.

GGUF repos almost always ship many quantizations. Before this, Skulk sized the card + the runner loaded the **first sorted** file (typically the unquantized **BF16**), and the downloader pulled **every quant** (`resolve_allow_patterns` returned `["*"]`). On a large model that's both the wrong file and tens of GB of wasted download.

## What
- **#334** — `ModelCard.fetch_from_hf` now selects a **preferred quant** (`select_preferred_gguf`: Q4_K_M first, … BF16/F16/F32 dead last) and pins it on a new `ModelCard.gguf_file` field (+ stamps `quantization`). `storage_size` is that quant's shard group only.
- **#332** — `resolve_allow_patterns` returns the pinned shard group (`gguf_allow_patterns`) + `config.json` for a GGUF card, so staging fetches **only the chosen quant**.
- The **runner** loads the pinned `gguf_file` (recursive-scan fallback only if absent), so download / sizing / loading all agree on one file.

## Tests
Quant preference (Q4_K_M over BF16), sharded-group sizing + allow-patterns, card pins the selected quant. basedpyright / ruff clean; 41 GGUF/runner tests pass. 0 em dashes.

## Scope / follow-ups (same Epic 1)
Deliberately **not** here, to keep this reviewable: **#327** (read metadata from the GGUF header when a repo has no config.json) and **#330** (persist the resolved engine/backend on the placement). Next PR. `#326` (embeddings status bug) is a separate-subsystem fix, its own small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)