### PR TITLE
feat(gguf): build card from GGUF header when config.json is absent (#327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Added
 
+- **GGUF cards can be built from the binary header when no `config.json` is
+  present (#327).** A GGUF repo that ships only the `.gguf` weights (no
+  `config.json`) now has its structural fields (layer count, hidden size,
+  KV-head count, context length) read directly from the selected file's GGUF
+  metadata header via a ranged read of the file start, instead of failing the
+  card build. Repos that ship `config.json` (most community GGUF repos) still
+  use it; the header read is the fallback. Completes the selective-quant GGUF
+  download/load path so more llama.cpp repos work without a hand-written card.
+
 - **Zenoh data-plane hardening toward default-on (#308 + #309).** Security
   (#308): the Zenoh session now sets a **namespace** (a collision-resistant
   SHA-256 hash of the exact token libp2p isolates on: `SKULK_LIBP2P_NAMESPACE`

--- a/src/skulk/download/download_utils.py
+++ b/src/skulk/download/download_utils.py
@@ -319,14 +319,23 @@ def build_model_path(model_id: ModelId) -> Path:
     found = resolve_model_in_path(model_id)
     if found is not None:
         return found
+    # A safetensors/MLX repo is identified by its config.json; a bare GGUF repo
+    # (no config.json) is identified by a complete GGUF shard group on disk. Both
+    # must be accepted here or a bare GGUF model that downloaded fine would fail
+    # to load with FileNotFoundError (#327).
     default = SKULK_MODELS_DIR / model_id.normalize()
-    if default.is_dir() and (default / "config.json").exists():
+    if default.is_dir() and (
+        (default / "config.json").exists() or directory_has_gguf_weights(default)
+    ):
         return default
     # Fallback: check the default staging directory directly.
     # This covers cases where the staging path wasn't registered in
     # SKULK_MODELS_PATH (e.g., config not yet synced) but files exist.
     staging_fallback = Path.home() / ".exo" / "staging" / model_id.normalize()
-    if staging_fallback.is_dir() and (staging_fallback / "config.json").exists():
+    if staging_fallback.is_dir() and (
+        (staging_fallback / "config.json").exists()
+        or directory_has_gguf_weights(staging_fallback)
+    ):
         return staging_fallback
     raise FileNotFoundError(
         f"Model {model_id} not found on disk. "

--- a/src/skulk/download/download_utils.py
+++ b/src/skulk/download/download_utils.py
@@ -766,6 +766,61 @@ async def file_meta(
         return content_length, etag
 
 
+async def range_read(
+    model_id: ModelId, revision: str, path: str, start: int, length: int
+) -> bytes:
+    """Read a byte range ``[start, start + length)`` of a repo file over HTTP.
+
+    Used to read a file's header (for example, a GGUF metadata block) without
+    downloading the whole multi-gigabyte weights file. Reuses the download
+    auth/SSL/proxy session and follows Hugging Face's ``resolve`` to CDN
+    redirect (the CDN serves range requests, which the resumable downloader
+    already depends on).
+
+    Args:
+        model_id: The Hugging Face repo id.
+        revision: The git revision to read (for example, ``"main"``).
+        path: The repo-relative file path.
+        start: The first byte offset to read (0-based, inclusive).
+        length: The number of bytes to read.
+
+    Returns:
+        The bytes the server returned for the range. This may be shorter than
+        ``length`` when the range runs past the end of the file.
+
+    Raises:
+        HuggingFaceAuthenticationError: The repo requires auth the caller lacks.
+        FileNotFoundError: The file does not exist in the repo at ``revision``.
+    """
+    url = urljoin(f"{get_hf_endpoint()}/{model_id}/resolve/{revision}/", path)
+    headers = {
+        **(await get_download_headers()),
+        "Range": f"bytes={start}-{start + length - 1}",
+    }
+    async with (
+        create_http_session(timeout_profile="short") as session,
+        session.get(url, headers=headers) as r,
+    ):
+        if r.status in (401, 403):
+            raise HuggingFaceAuthenticationError(
+                await _build_auth_error_message(r.status, model_id)
+            )
+        if r.status == 404:
+            raise FileNotFoundError(
+                f"File {path} not found in {model_id}@{revision}"
+            )
+        # A range starting at/after EOF yields 416; surface it as an empty read
+        # so callers see a clean end-of-file instead of an HTTP error.
+        if r.status == 416:
+            return b""
+        r.raise_for_status()
+        # Read at most ``length`` bytes from the body. With a 206 Partial Content
+        # response this is the requested range; if the CDN ever ignored the
+        # Range header (returning 200), capping the read still bounds memory to
+        # the header window instead of pulling the whole weights file.
+        return await r.content.read(length)
+
+
 async def download_file_with_retry(
     model_id: ModelId,
     revision: str,

--- a/src/skulk/download/tests/test_gguf_completeness.py
+++ b/src/skulk/download/tests/test_gguf_completeness.py
@@ -2,10 +2,15 @@
 
 from pathlib import Path
 
+import pytest
+
+from skulk.download import download_utils
 from skulk.download.download_utils import (
+    build_model_path,
     directory_has_gguf_weights,
     is_model_directory_complete,
 )
+from skulk.shared.types.common import ModelId
 
 
 def test_gguf_dir_recognized_complete(tmp_path: Path) -> None:
@@ -51,6 +56,38 @@ def test_sharded_gguf_incomplete_missing_shard(tmp_path: Path) -> None:
     assert not is_model_directory_complete(tmp_path)
 
 
+def _no_path_match(_model_id: ModelId) -> Path | None:
+    """A resolve_model_in_path stub: no SKULK_MODELS_PATH hit."""
+    return None
+
+
+def test_build_model_path_accepts_bare_gguf_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare GGUF repo (no config.json) downloaded to the default models dir is
+    resolvable at load time, not just when it lands in SKULK_MODELS_PATH (#327).
+    """
+    model_id = ModelId("org/bare-gguf-repo")
+    model_dir = tmp_path / model_id.normalize()
+    model_dir.mkdir(parents=True)
+    (model_dir / "model-Q4_K_M.gguf").write_bytes(b"GGUF")  # no config.json
+
+    # No SKULK_MODELS_PATH match, default dir is the tmp models dir.
+    monkeypatch.setattr(download_utils, "SKULK_MODELS_DIR", tmp_path)
+    monkeypatch.setattr(download_utils, "resolve_model_in_path", _no_path_match)
+
+    assert build_model_path(model_id) == model_dir
+
+
+def test_build_model_path_missing_is_filenotfound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(download_utils, "SKULK_MODELS_DIR", tmp_path)
+    monkeypatch.setattr(download_utils, "resolve_model_in_path", _no_path_match)
+    with pytest.raises(FileNotFoundError):
+        build_model_path(ModelId("org/not-on-disk"))
+
+
 async def test_resolve_allow_patterns_gguf_vs_safetensors() -> None:
     """A GGUF card restricts the download to its pinned shard group + config.json;
     a non-GGUF card keeps the broad ["*"] fetch (#332)."""
@@ -69,18 +106,22 @@ async def test_resolve_allow_patterns_gguf_vs_safetensors() -> None:
             n_layers=card.n_layers,
         )
 
-    base = dict(
-        storage_size=Memory.from_gb(1),
-        n_layers=16,
-        hidden_size=2048,
-        supports_tensor=False,
-        tasks=[ModelTask.TextGeneration],
-    )
-    gguf = ModelCard(model_id=ModelId("o/r"), gguf_file="m-Q4_K_M.gguf", **base)
+    def _card(model_id: str, gguf_file: str | None = None) -> ModelCard:
+        return ModelCard(
+            model_id=ModelId(model_id),
+            storage_size=Memory.from_gb(1),
+            n_layers=16,
+            hidden_size=2048,
+            supports_tensor=False,
+            tasks=[ModelTask.TextGeneration],
+            gguf_file=gguf_file,
+        )
+
+    gguf = _card("o/r", gguf_file="m-Q4_K_M.gguf")
     assert await resolve_allow_patterns(_shard(gguf)) == [
         "m-Q4_K_M.gguf",
         "config.json",
     ]
 
-    mlx = ModelCard(model_id=ModelId("o/r2"), **base)
+    mlx = _card("o/r2")
     assert await resolve_allow_patterns(_shard(mlx)) == ["*"]

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -1,7 +1,8 @@
 import json
-from collections.abc import Iterable
+import struct
+from collections.abc import Awaitable, Callable, Iterable
 from enum import Enum
-from typing import Annotated, Any, Final, Literal, cast
+from typing import Annotated, Any, Final, Literal, NamedTuple, cast
 
 import aiofiles
 import aiofiles.os as aios
@@ -542,45 +543,52 @@ class ModelCard(CamelCaseModel):
         Sizes the weights from the GGUF file the runner would actually load
         (`select_gguf_file` picks the first sorted file + its shard group).
         Structural fields come from `config.json` when the repo ships one (most
-        community GGUF repos do). A bare repo with no config.json **raises a
-        clear error** pointing at the GGUF-header-parse follow-up (#327) rather
-        than fabricating metadata (a `ModelCard` also cannot be constructed with
-        0 for its `PositiveInt` layer/hidden fields). Stamps the llama.cpp backend
-        tags so placement routes the model only to nodes with a llama.cpp engine
-        and prefers a GPU backend.
+        community GGUF repos do); a bare repo with no usable config.json has its
+        metadata read straight from the selected GGUF file's binary header via a
+        ranged read of the file start (#327), so neither path fabricates the
+        layer/hidden sizes placement's memory and KV-budget math depend on.
+        Stamps the llama.cpp backend tags so placement routes the model only to
+        nodes with a llama.cpp engine and prefers a GPU backend.
         """
         selected = select_preferred_gguf(gguf_files)
         selected_size = gguf_shard_group_size(selected, gguf_files)
 
         # Structural metadata comes from config.json, which most community GGUF
         # repos (bartowski, unsloth, mlx-community) ship alongside the weights.
-        # A bare GGUF repo with no config.json needs the metadata read from the
-        # GGUF header instead (#327); until that lands, fail clearly rather than
-        # fabricate placeholder layer/hidden sizes that would skew placement's
-        # memory and KV-budget math. Catch only the missing-file case so HF
-        # auth / rate-limit / transient network errors propagate unchanged
-        # instead of being mislabeled as "no config.json".
+        # Catch only the missing-file case so HF auth / rate-limit / transient
+        # network errors propagate unchanged instead of being mislabeled as
+        # "no config.json".
         try:
             config_data = await fetch_config_data(model_id)
-        except FileNotFoundError as exc:
-            raise ValueError(
-                f"GGUF repo {model_id} has no usable config.json ({exc}); "
-                "reading model metadata from the GGUF header is not yet "
-                "supported (#327). Use a GGUF repo that ships config.json."
-            ) from exc
-        # ModelCard requires positive n_layers/hidden_size (PositiveInt). If the
-        # config.json is present but lacks usable values, fail with the same clear
-        # error rather than a raw pydantic ValidationError.
-        if not config_data.layer_count or not config_data.hidden_size:
-            raise ValueError(
-                f"GGUF repo {model_id} config.json is missing usable layer/hidden "
-                "sizes; reading model metadata from the GGUF header is not yet "
-                "supported (#327)."
+        except FileNotFoundError:
+            config_data = None
+
+        if config_data is not None and config_data.layer_count and (
+            config_data.hidden_size
+        ):
+            n_layers = config_data.layer_count
+            hidden_size = config_data.hidden_size
+            num_key_value_heads = config_data.num_key_value_heads
+            context_length = config_data.max_position_embeddings or 0
+        else:
+            # No usable config.json: read the structural fields from the GGUF
+            # binary header. ``selected`` is the first shard, which carries the
+            # metadata block, so a ranged read of its start is enough.
+            reason = "absent" if config_data is None else "missing layer/hidden sizes"
+            logger.info(
+                f"GGUF repo {model_id} config.json {reason}; reading model "
+                f"metadata from the GGUF header of {selected}"
             )
-        n_layers = config_data.layer_count
-        hidden_size = config_data.hidden_size
-        num_key_value_heads = config_data.num_key_value_heads
-        context_length = config_data.max_position_embeddings or 0
+            from skulk.download.download_utils import range_read
+
+            async def _fetch(offset: int, length: int) -> bytes:
+                return await range_read(model_id, "main", selected, offset, length)
+
+            fields = await read_gguf_structural_fields(_fetch)
+            n_layers = fields.n_layers
+            hidden_size = fields.hidden_size
+            num_key_value_heads = fields.num_key_value_heads
+            context_length = fields.context_length
 
         return ModelCard(
             model_id=ModelId(model_id),
@@ -900,3 +908,224 @@ def _gguf_shard_base(name: str) -> str | None:
     ):
         return parts[0]
     return None
+
+
+# --- GGUF binary header parsing (#327) -------------------------------------
+#
+# A GGUF file begins with a metadata block (magic, version, tensor count, then
+# a list of typed key/value pairs) followed by the tensor data. The structural
+# fields a model card needs (layer count, hidden size, KV-head count, context
+# length) live in that block under arch-prefixed keys, so they can be read from
+# the start of the file via a ranged HTTP read instead of pulling the multi-GB
+# weights. This is the fallback for GGUF repos that ship no ``config.json``.
+#
+# Spec: https://github.com/ggml-org/ggml/blob/master/docs/gguf.md
+
+_GGUF_MAGIC: Final = b"GGUF"
+# Lengths/counts are 64-bit in GGUF v2/v3; v1 used 32-bit and is obsolete.
+_GGUF_SUPPORTED_VERSIONS: Final = frozenset({2, 3})
+
+# GGUF metadata value type tags.
+_GGUF_TYPE_STRING: Final = 8
+_GGUF_TYPE_ARRAY: Final = 9
+# Scalar value type tag -> struct format. ``bool`` (tag 7) is read as a byte;
+# we deliberately do not store it as an int field (see the parse loop).
+_GGUF_SCALAR_FMT: Final[dict[int, str]] = {
+    0: "<B",  # uint8
+    1: "<b",  # int8
+    2: "<H",  # uint16
+    3: "<h",  # int16
+    4: "<I",  # uint32
+    5: "<i",  # int32
+    6: "<f",  # float32
+    7: "<B",  # bool (stored as one byte)
+    10: "<Q",  # uint64
+    11: "<q",  # int64
+    12: "<d",  # float64
+}
+_GGUF_SCALAR_SIZE: Final[dict[int, int]] = {
+    tag: struct.calcsize(fmt) for tag, fmt in _GGUF_SCALAR_FMT.items()
+}
+
+# Structural keys we read, relative to ``general.architecture`` (e.g. for arch
+# ``llama`` we read ``llama.block_count``). These mirror config.json's
+# layer_count / hidden_size / num_key_value_heads / max_position_embeddings.
+_GGUF_KEY_BLOCK_COUNT: Final = "block_count"
+_GGUF_KEY_EMBEDDING_LENGTH: Final = "embedding_length"
+_GGUF_KEY_HEAD_COUNT_KV: Final = "attention.head_count_kv"
+_GGUF_KEY_CONTEXT_LENGTH: Final = "context_length"
+_GGUF_WANTED_SUFFIXES: Final = (
+    _GGUF_KEY_BLOCK_COUNT,
+    _GGUF_KEY_EMBEDDING_LENGTH,
+    _GGUF_KEY_HEAD_COUNT_KV,
+    _GGUF_KEY_CONTEXT_LENGTH,
+)
+
+
+class GgufStructuralFields(NamedTuple):
+    """Structural model dimensions read from a GGUF metadata header (#327)."""
+
+    n_layers: int
+    hidden_size: int
+    num_key_value_heads: int | None
+    context_length: int
+
+
+class _GgufHeaderReader:
+    """Sequential cursor over a GGUF metadata header fetched on demand.
+
+    Bytes are pulled through an injected ``fetch(offset, length)`` coroutine
+    (HTTP range in production, an in-memory blob in tests) into a growing buffer
+    and cached, so the header is read in a few windows rather than one giant
+    request. The cursor advances as typed values are read; large arrays (e.g. a
+    tokenizer vocabulary) are skipped by advancing the cursor, fetching more
+    only if a wanted key happens to sit past them.
+    """
+
+    _WINDOW: Final = 1 << 20  # 1 MiB per fetch; structural keys sit well inside.
+
+    def __init__(self, fetch: "Callable[[int, int], Awaitable[bytes]]") -> None:
+        self._fetch = fetch
+        self._buf = bytearray()
+        self._eof = False
+        self.pos = 0
+
+    async def _ensure(self, end: int) -> None:
+        """Fetch until the buffer holds at least ``end`` bytes (or EOF)."""
+        while len(self._buf) < end and not self._eof:
+            start = len(self._buf)
+            length = max(self._WINDOW, end - start)
+            chunk = await self._fetch(start, length)
+            # Only an empty read is EOF; a short read is a partial transport
+            # chunk, so keep fetching from the new offset rather than stopping.
+            if not chunk:
+                self._eof = True
+                return
+            self._buf.extend(chunk)
+
+    async def _take(self, n: int) -> bytes:
+        await self._ensure(self.pos + n)
+        if self.pos + n > len(self._buf):
+            raise ValueError("GGUF header truncated before the wanted metadata")
+        data = bytes(self._buf[self.pos : self.pos + n])
+        self.pos += n
+        return data
+
+    async def _u32(self) -> int:
+        return cast(int, struct.unpack("<I", await self._take(4))[0])
+
+    async def _u64(self) -> int:
+        return cast(int, struct.unpack("<Q", await self._take(8))[0])
+
+    async def read_string(self) -> str:
+        length = await self._u64()
+        return (await self._take(length)).decode("utf-8", errors="replace")
+
+    async def read_value(self, value_type: int) -> "int | str | None":
+        """Read one metadata value; return ints/strings, skip everything else.
+
+        Returns the value for integer and string scalars (the only kinds the
+        wanted keys use), and ``None`` for floats, bools, and arrays after
+        advancing past them.
+        """
+        if value_type == _GGUF_TYPE_STRING:
+            return await self.read_string()
+        if value_type == _GGUF_TYPE_ARRAY:
+            await self._skip_array()
+            return None
+        fmt = _GGUF_SCALAR_FMT.get(value_type)
+        if fmt is None:
+            raise ValueError(f"unknown GGUF metadata value type {value_type}")
+        raw = await self._take(_GGUF_SCALAR_SIZE[value_type])
+        # Floats and bools are not structural fields we read; only surface ints.
+        if value_type in (6, 12, 7):  # float32, float64, bool
+            return None
+        return cast(int, struct.unpack(fmt, raw)[0])
+
+    async def _skip_array(self) -> None:
+        element_type = await self._u32()
+        count = await self._u64()
+        if element_type in _GGUF_SCALAR_SIZE:
+            # Bulk-skip fixed-width elements (e.g. a token-score float array).
+            self.pos += _GGUF_SCALAR_SIZE[element_type] * count
+        elif element_type == _GGUF_TYPE_STRING:
+            for _ in range(count):
+                _ = await self.read_string()
+        elif element_type == _GGUF_TYPE_ARRAY:
+            for _ in range(count):
+                await self._skip_array()
+        else:
+            raise ValueError(f"unknown GGUF array element type {element_type}")
+
+    async def parse_structural_fields(self) -> GgufStructuralFields:
+        """Read the structural model dimensions from this GGUF header.
+
+        Reads ``general.architecture`` and the arch-prefixed ``block_count`` /
+        ``embedding_length`` / ``attention.head_count_kv`` / ``context_length``
+        keys, stopping as soon as all are seen (so a trailing multi-megabyte
+        tokenizer array is never fetched).
+
+        Raises:
+            ValueError: The bytes are not a supported GGUF header, or the header
+                lacks the architecture / layer / hidden-size keys needed to
+                build a card.
+        """
+        if (await self._take(4)) != _GGUF_MAGIC:
+            raise ValueError("not a GGUF file (bad magic)")
+        version = await self._u32()
+        if version not in _GGUF_SUPPORTED_VERSIONS:
+            raise ValueError(f"unsupported GGUF version {version}")
+        _ = await self._u64()  # tensor_count
+        kv_count = await self._u64()
+
+        architecture: str | None = None
+        collected: dict[str, int] = {}
+        for _ in range(kv_count):
+            key = await self.read_string()
+            value = await self.read_value(await self._u32())
+            if key == "general.architecture" and isinstance(value, str):
+                architecture = value
+            elif isinstance(value, int):
+                collected[key] = value
+            if architecture is not None and all(
+                f"{architecture}.{suffix}" in collected
+                for suffix in _GGUF_WANTED_SUFFIXES
+            ):
+                break
+
+        if architecture is None:
+            raise ValueError("GGUF header missing general.architecture")
+
+        def field(suffix: str) -> int | None:
+            return collected.get(f"{architecture}.{suffix}")
+
+        n_layers = field(_GGUF_KEY_BLOCK_COUNT)
+        hidden_size = field(_GGUF_KEY_EMBEDDING_LENGTH)
+        if not n_layers or not hidden_size:
+            raise ValueError(
+                f"GGUF header for arch {architecture!r} is missing block_count / "
+                "embedding_length"
+            )
+        return GgufStructuralFields(
+            n_layers=n_layers,
+            hidden_size=hidden_size,
+            num_key_value_heads=field(_GGUF_KEY_HEAD_COUNT_KV) or None,
+            context_length=field(_GGUF_KEY_CONTEXT_LENGTH) or 0,
+        )
+
+
+async def read_gguf_structural_fields(
+    fetch: "Callable[[int, int], Awaitable[bytes]]",
+) -> GgufStructuralFields:
+    """Parse structural model dimensions from a GGUF metadata header.
+
+    ``fetch(offset, length)`` supplies bytes from the start of the GGUF file
+    (an HTTP range read in production, an in-memory blob in tests). See
+    :meth:`_GgufHeaderReader.parse_structural_fields` for what is read.
+
+    Raises:
+        ValueError: The bytes are not a supported GGUF header, or the header
+            lacks the architecture / layer / hidden-size keys needed to build a
+            card.
+    """
+    return await _GgufHeaderReader(fetch).parse_structural_fields()

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -555,12 +555,14 @@ class ModelCard(CamelCaseModel):
 
         # Structural metadata comes from config.json, which most community GGUF
         # repos (bartowski, unsloth, mlx-community) ship alongside the weights.
-        # Catch only the missing-file case so HF auth / rate-limit / transient
-        # network errors propagate unchanged instead of being mislabeled as
-        # "no config.json".
+        # Treat a missing config.json (FileNotFoundError) OR a present-but-unusable
+        # one (ValidationError, e.g. no num_hidden_layers, which ConfigData
+        # requires) as "no usable config" and fall back to the GGUF header. HF
+        # auth / rate-limit / transient network errors are neither and propagate
+        # unchanged instead of being mislabeled as "no config.json".
         try:
             config_data = await fetch_config_data(model_id)
-        except FileNotFoundError:
+        except (FileNotFoundError, ValidationError):
             config_data = None
 
         if config_data is not None and config_data.layer_count and (
@@ -960,6 +962,13 @@ _GGUF_WANTED_SUFFIXES: Final = (
     _GGUF_KEY_HEAD_COUNT_KV,
     _GGUF_KEY_CONTEXT_LENGTH,
 )
+# The keys a card cannot be built without; head_count_kv and context_length are
+# best-effort (default to None / 0). Used to decide the early stop at the start
+# of the tokenizer section when a best-effort key is simply absent.
+_GGUF_REQUIRED_SUFFIXES: Final = (
+    _GGUF_KEY_BLOCK_COUNT,
+    _GGUF_KEY_EMBEDDING_LENGTH,
+)
 
 
 class GgufStructuralFields(NamedTuple):
@@ -994,8 +1003,10 @@ class _GgufHeaderReader:
         """Fetch until the buffer holds at least ``end`` bytes (or EOF)."""
         while len(self._buf) < end and not self._eof:
             start = len(self._buf)
-            length = max(self._WINDOW, end - start)
-            chunk = await self._fetch(start, length)
+            # Cap each fetch at one window and loop, so a large forward jump (a
+            # bulk array skip past ``end``) never balloons into a single huge
+            # range request; the loop keeps memory/request size window-bounded.
+            chunk = await self._fetch(start, self._WINDOW)
             # Only an empty read is EOF; a short read is a partial transport
             # chunk, so keep fetching from the new offset rather than stopping.
             if not chunk:
@@ -1062,8 +1073,9 @@ class _GgufHeaderReader:
 
         Reads ``general.architecture`` and the arch-prefixed ``block_count`` /
         ``embedding_length`` / ``attention.head_count_kv`` / ``context_length``
-        keys, stopping as soon as all are seen (so a trailing multi-megabyte
-        tokenizer array is never fetched).
+        keys. Stops as soon as all are seen, or, if a best-effort key is absent,
+        at the start of the tokenizer section (the arch scalars always precede
+        it), so a trailing multi-megabyte tokenizer array is never fetched.
 
         Raises:
             ValueError: The bytes are not a supported GGUF header, or the header
@@ -1080,17 +1092,28 @@ class _GgufHeaderReader:
 
         architecture: str | None = None
         collected: dict[str, int] = {}
+
+        def _has(suffixes: "tuple[str, ...]") -> bool:
+            return architecture is not None and all(
+                f"{architecture}.{suffix}" in collected for suffix in suffixes
+            )
+
         for _ in range(kv_count):
             key = await self.read_string()
+            # The arch-prefixed scalar keys precede the tokenizer section; once a
+            # tokenizer key appears no more arch scalars follow, so if the
+            # required fields are known, stop before reading a potentially huge
+            # tokenizer array for best-effort fields that are simply absent.
+            if key.startswith("tokenizer.") and _has(_GGUF_REQUIRED_SUFFIXES):
+                break
             value = await self.read_value(await self._u32())
             if key == "general.architecture" and isinstance(value, str):
                 architecture = value
             elif isinstance(value, int):
                 collected[key] = value
-            if architecture is not None and all(
-                f"{architecture}.{suffix}" in collected
-                for suffix in _GGUF_WANTED_SUFFIXES
-            ):
+            # Fast path: every wanted key (including best-effort ones) is in,
+            # before any tokenizer array.
+            if _has(_GGUF_WANTED_SUFFIXES):
                 break
 
         if architecture is None:

--- a/src/skulk/shared/models/tests/test_gguf_cards.py
+++ b/src/skulk/shared/models/tests/test_gguf_cards.py
@@ -1,6 +1,8 @@
 # pyright: reportPrivateUsage=false
 """Tests for GGUF-repo detection and llama.cpp card creation (slice 3a)."""
 
+import struct
+from collections.abc import Awaitable, Callable
 from types import SimpleNamespace
 
 import pytest
@@ -12,6 +14,61 @@ from skulk.shared.models.model_cards import (
     _gguf_shard_base,
     gguf_weight_siblings,
 )
+
+# --- GGUF binary header builders (for #327 header-parse tests) --------------
+#
+# Minimal encoders for the GGUF metadata block: magic, version, tensor count,
+# kv count, then typed key/value pairs. Mirrors the spec well enough to exercise
+# read_gguf_structural_fields without a real multi-GB weights file.
+
+_GGUF_T_FLOAT32 = 6
+_GGUF_T_UINT32 = 4
+_GGUF_T_STRING = 8
+_GGUF_T_ARRAY = 9
+
+
+def _g_str(value: str) -> bytes:
+    encoded = value.encode("utf-8")
+    return struct.pack("<Q", len(encoded)) + encoded
+
+
+def _kv_string(key: str, value: str) -> bytes:
+    return _g_str(key) + struct.pack("<I", _GGUF_T_STRING) + _g_str(value)
+
+
+def _kv_u32(key: str, value: int) -> bytes:
+    return _g_str(key) + struct.pack("<I", _GGUF_T_UINT32) + struct.pack("<I", value)
+
+
+def _kv_string_array(key: str, values: list[str]) -> bytes:
+    body = struct.pack("<I", _GGUF_T_STRING) + struct.pack("<Q", len(values))
+    for value in values:
+        body += _g_str(value)
+    return _g_str(key) + struct.pack("<I", _GGUF_T_ARRAY) + body
+
+
+def _kv_f32_array(key: str, values: list[float]) -> bytes:
+    body = struct.pack("<I", _GGUF_T_FLOAT32) + struct.pack("<Q", len(values))
+    for value in values:
+        body += struct.pack("<f", value)
+    return _g_str(key) + struct.pack("<I", _GGUF_T_ARRAY) + body
+
+
+def _build_gguf(kvs: list[bytes], *, version: int = 3, tensor_count: int = 0) -> bytes:
+    return (
+        model_cards._GGUF_MAGIC
+        + struct.pack("<I", version)
+        + struct.pack("<Q", tensor_count)
+        + struct.pack("<Q", len(kvs))
+        + b"".join(kvs)
+    )
+
+
+def _mem_fetch(blob: bytes) -> "Callable[[int, int], Awaitable[bytes]]":
+    async def _fetch(offset: int, length: int) -> bytes:
+        return blob[offset : offset + length]
+
+    return _fetch
 
 
 def _fake_model_info(filenames: list[str]):
@@ -82,11 +139,11 @@ async def test_fetch_gguf_card_stamps_llama_cpp_backends(
     assert card.storage_size.in_bytes == 100  # the single selected gguf
 
 
-async def test_fetch_gguf_card_without_config_fails_clearly(
+async def test_fetch_gguf_card_reads_header_when_no_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # A bare GGUF repo (no config.json) needs the GGUF-header parse (#327); until
-    # then we fail with a clear, actionable error rather than fabricate metadata.
+    # A bare GGUF repo (no config.json) has its structural fields read from the
+    # GGUF binary header instead (#327), rather than failing or fabricating them.
     monkeypatch.setattr(model_cards, "model_info", _fake_model_info(["model-q4.gguf"]))
 
     async def _raises(_model_id: object) -> object:
@@ -94,8 +151,122 @@ async def test_fetch_gguf_card_without_config_fails_clearly(
 
     monkeypatch.setattr(model_cards, "fetch_config_data", _raises)
 
-    with pytest.raises(ValueError, match="#327"):
-        await ModelCard.fetch_from_hf(ModelId("bare/gguf-repo"))
+    blob = _build_gguf(
+        [
+            _kv_string("general.architecture", "llama"),
+            _kv_u32("llama.block_count", 24),
+            _kv_u32("llama.embedding_length", 3072),
+            _kv_u32("llama.attention.head_count_kv", 6),
+            _kv_u32("llama.context_length", 16384),
+        ]
+    )
+
+    from skulk.download import download_utils
+
+    async def _range(
+        _model_id: object, _revision: str, _path: str, start: int, length: int
+    ) -> bytes:
+        return blob[start : start + length]
+
+    monkeypatch.setattr(download_utils, "range_read", _range)
+
+    card = await ModelCard.fetch_from_hf(ModelId("bare/gguf-repo"))
+    assert card.n_layers == 24 and card.hidden_size == 3072
+    assert card.num_key_value_heads == 6 and card.context_length == 16384
+    assert card.gguf_file == "model-q4.gguf"
+
+
+async def test_read_gguf_structural_fields_basic() -> None:
+    blob = _build_gguf(
+        [
+            _kv_string("general.architecture", "llama"),
+            _kv_u32("llama.block_count", 32),
+            _kv_u32("llama.embedding_length", 4096),
+            _kv_u32("llama.attention.head_count_kv", 8),
+            _kv_u32("llama.context_length", 8192),
+        ]
+    )
+    fields = await model_cards.read_gguf_structural_fields(_mem_fetch(blob))
+    assert fields == model_cards.GgufStructuralFields(32, 4096, 8, 8192)
+
+
+async def test_read_gguf_skips_arrays_before_structural_keys() -> None:
+    # A multi-thousand-entry tokenizer array sitting before the structural keys
+    # must be skipped, not parsed into the metadata, and not block the read.
+    blob = _build_gguf(
+        [
+            _kv_string("general.architecture", "qwen2"),
+            _kv_string_array("tokenizer.ggml.tokens", [f"t{i}" for i in range(5000)]),
+            _kv_f32_array("tokenizer.ggml.scores", [0.1] * 5000),
+            _kv_u32("qwen2.block_count", 28),
+            _kv_u32("qwen2.embedding_length", 3584),
+            _kv_u32("qwen2.attention.head_count_kv", 4),
+            _kv_u32("qwen2.context_length", 32768),
+        ]
+    )
+    fields = await model_cards.read_gguf_structural_fields(_mem_fetch(blob))
+    assert fields.n_layers == 28 and fields.hidden_size == 3584
+    assert fields.num_key_value_heads == 4 and fields.context_length == 32768
+
+
+async def test_read_gguf_missing_kv_heads_is_none() -> None:
+    blob = _build_gguf(
+        [
+            _kv_string("general.architecture", "llama"),
+            _kv_u32("llama.block_count", 16),
+            _kv_u32("llama.embedding_length", 2048),
+            _kv_u32("llama.context_length", 4096),
+        ]
+    )
+    fields = await model_cards.read_gguf_structural_fields(_mem_fetch(blob))
+    assert fields.num_key_value_heads is None
+    assert fields.n_layers == 16 and fields.context_length == 4096
+
+
+async def test_read_gguf_bad_magic_raises() -> None:
+    with pytest.raises(ValueError, match="not a GGUF"):
+        await model_cards.read_gguf_structural_fields(_mem_fetch(b"XXXX" + b"\x00" * 64))
+
+
+async def test_read_gguf_unsupported_version_raises() -> None:
+    blob = (
+        model_cards._GGUF_MAGIC
+        + struct.pack("<I", 1)  # v1: 32-bit lengths, obsolete
+        + struct.pack("<Q", 0)
+        + struct.pack("<Q", 0)
+    )
+    with pytest.raises(ValueError, match="version"):
+        await model_cards.read_gguf_structural_fields(_mem_fetch(blob))
+
+
+async def test_read_gguf_missing_architecture_raises() -> None:
+    blob = _build_gguf([_kv_u32("llama.block_count", 8)])
+    with pytest.raises(ValueError, match="architecture"):
+        await model_cards.read_gguf_structural_fields(_mem_fetch(blob))
+
+
+async def test_read_gguf_windowed_fetch() -> None:
+    # A transport that returns only a few bytes per call must be reassembled,
+    # not mistaken for EOF after the first short read.
+    blob = _build_gguf(
+        [
+            _kv_string("general.architecture", "llama"),
+            _kv_u32("llama.block_count", 10),
+            _kv_u32("llama.embedding_length", 100),
+            _kv_u32("llama.attention.head_count_kv", 2),
+            _kv_u32("llama.context_length", 2048),
+        ]
+    )
+    calls = 0
+
+    async def _chunked(offset: int, length: int) -> bytes:
+        nonlocal calls
+        calls += 1
+        return blob[offset : offset + min(length, 7)]
+
+    fields = await model_cards.read_gguf_structural_fields(_chunked)
+    assert fields.n_layers == 10 and fields.hidden_size == 100
+    assert calls > 1  # required multiple fetches to assemble the header
 
 
 def test_select_preferred_gguf_prefers_quant_over_bf16() -> None:

--- a/src/skulk/shared/models/tests/test_gguf_cards.py
+++ b/src/skulk/shared/models/tests/test_gguf_cards.py
@@ -176,6 +176,74 @@ async def test_fetch_gguf_card_reads_header_when_no_config(
     assert card.gguf_file == "model-q4.gguf"
 
 
+async def test_fetch_gguf_card_reads_header_when_config_unusable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A config.json that is present but missing num_hidden_layers fails ConfigData
+    # validation; that is "config present but unusable", so the header fallback
+    # must still kick in rather than letting the ValidationError abort the build.
+    monkeypatch.setattr(model_cards, "model_info", _fake_model_info(["model-q4.gguf"]))
+
+    async def _bad_config(_model_id: object) -> object:
+        # Raises a genuine pydantic ValidationError (layer_count is required).
+        model_cards.ConfigData.model_validate({"hidden_size": 1})
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(model_cards, "fetch_config_data", _bad_config)
+
+    blob = _build_gguf(
+        [
+            _kv_string("general.architecture", "qwen2"),
+            _kv_u32("qwen2.block_count", 12),
+            _kv_u32("qwen2.embedding_length", 1536),
+            _kv_u32("qwen2.attention.head_count_kv", 2),
+            _kv_u32("qwen2.context_length", 8192),
+        ]
+    )
+
+    from skulk.download import download_utils
+
+    async def _range(
+        _model_id: object, _revision: str, _path: str, start: int, length: int
+    ) -> bytes:
+        return blob[start : start + length]
+
+    monkeypatch.setattr(download_utils, "range_read", _range)
+
+    card = await ModelCard.fetch_from_hf(ModelId("partial-config/gguf-repo"))
+    assert card.n_layers == 12 and card.hidden_size == 1536
+
+
+async def test_read_gguf_stops_at_tokenizer_when_kv_heads_absent() -> None:
+    # head_count_kv is best-effort: when it is absent, the reader must stop at the
+    # tokenizer section once the required fields are known, NOT scan the whole KV
+    # block. The blob is truncated right after the first tokenizer key, so any
+    # attempt to read past it raises; a correct early stop returns cleanly (#327).
+    import struct as _struct
+
+    kvs = b"".join(
+        [
+            _kv_string("general.architecture", "llama"),
+            _kv_u32("llama.block_count", 8),
+            _kv_u32("llama.embedding_length", 512),
+            _kv_u32("llama.context_length", 2048),
+        ]
+    )
+    # Claim more keys than are fully present; the next key is a tokenizer key with
+    # no value bytes after it (truncated), which would fail if actually read.
+    header = (
+        model_cards._GGUF_MAGIC
+        + _struct.pack("<I", 3)
+        + _struct.pack("<Q", 0)
+        + _struct.pack("<Q", 5)
+    )
+    truncated = header + kvs + _g_str("tokenizer.ggml.model")
+
+    fields = await model_cards.read_gguf_structural_fields(_mem_fetch(truncated))
+    assert fields.n_layers == 8 and fields.hidden_size == 512
+    assert fields.num_key_value_heads is None and fields.context_length == 2048
+
+
 async def test_read_gguf_structural_fields_basic() -> None:
     blob = _build_gguf(
         [


### PR DESCRIPTION
## What

Completes the selective-quant GGUF work (Epic 1, follows #338) by handling GGUF repos that ship **only** the `.gguf` weights with no `config.json`.

Previously such a repo failed card creation with a "GGUF-header parse not yet supported (#327)" error. Now Skulk reads the structural model dimensions (layer count, hidden size, KV-head count, context length) straight from the selected GGUF file's binary metadata header, via a **ranged read of the file start** so the multi-GB tensor data is never downloaded just to build the card.

Repos that ship `config.json` (most community GGUF repos: bartowski, unsloth, mlx-community) are unchanged; the header read is the fallback.

## How

- **`download_utils.range_read`** — ranged HTTP read of a repo file. Reuses the existing download auth/SSL/proxy session, follows HF's `resolve` to CDN redirect (the CDN serves ranges, which the resumable downloader already relies on), and maps HTTP 416 to a clean empty read (EOF).
- **`model_cards`** — a minimal in-house GGUF header parser (`_GgufHeaderReader` + `read_gguf_structural_fields`). It walks the metadata KV block, reads `general.architecture` plus the four arch-prefixed structural keys (`block_count`, `embedding_length`, `attention.head_count_kv`, `context_length`), **stops as soon as all are found** (so a trailing multi-megabyte tokenizer array is never fetched), and skips arrays in bulk. No new dependency (the `gguf` PyPI reader needs a local mmap'd file; we want a ranged remote read).
- **`_fetch_gguf_from_hf`** falls back to the header read when `config.json` is absent (`FileNotFoundError`) or lacks usable layer/hidden sizes.

## Tests

Synthetic GGUF-header builders covering: basic parse, array-skip-before-structural-keys, missing KV-heads, bad magic, unsupported version, missing architecture, windowed/short-read transport reassembly, and the end-to-end no-`config.json` card build (via mocked `range_read`).

```
uv run pytest src/skulk/shared/models/tests/test_gguf_cards.py src/skulk/download/tests/ -q   # 60 passed
uv run basedpyright <changed files>   # 0 errors
uv run ruff check   # clean
```

Closes #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)