### PR TITLE
fix(api): boot headless/non-Mac nodes without built dashboard assets (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,16 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Headless/non-Mac nodes boot without the built dashboard (#333).** A worker
+  node with no `dashboard-react/dist` (for example a Linux node with no node/npm
+  to build the UI) previously failed to start: `constants.py` resolved
+  `DASHBOARD_DIR` at import and raised `FileNotFoundError`, and the API's
+  `StaticFiles` mount raised when the directory was absent. `DASHBOARD_DIR` is
+  now `None` when the assets are absent and no `SKULK_DASHBOARD_DIR` override is
+  set, and the API skips serving the dashboard (logging a notice) while serving
+  the full API. Nodes that have the assets, or set `SKULK_DASHBOARD_DIR`, serve
+  the UI unchanged.
+
 - **Embedding tasks reach a clean terminal state (#326).** The embedding runner
   held `RunnerReady` across the `TextEmbedding` forward pass, but the supervisor
   asserts the runner is in an active state when it forwards a task's terminal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ Skulk is a distributed AI inference system that connects multiple devices into o
 ## Build & Run Commands
 
 ```bash
-# Build the dashboard (required before running skulk)
+# Build the dashboard (needed to serve the web UI; a headless node can run
+# without it, in which case the API serves without the dashboard)
 cd dashboard-react && npm install && npm run build && cd ..
 
 # Run skulk (starts both master and worker with API at http://localhost:52415)
@@ -142,7 +143,7 @@ Rust code in `rust/` provides:
 - `system_custodian`: System-level operations
 
 ### Dashboard
-React + TypeScript + styled-components frontend in `dashboard-react/`. Build output goes to `dashboard-react/dist/` and is served by the API.
+React + TypeScript + styled-components frontend in `dashboard-react/`. Build output goes to `dashboard-react/dist/` and is served by the API when present. A node without the built assets (a headless/non-Mac worker, or with no `SKULK_DASHBOARD_DIR`) sets `DASHBOARD_DIR=None`, skips the mount, and serves the API without the UI.
 
 ### Model Capability System
 Skulk now treats model capability handling as two layers:

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -736,7 +736,13 @@ class API:
         self._setup_cors()
         self._setup_routes()
 
-        if mount_dashboard:
+        # A headless/worker node may have no built dashboard assets
+        # (DASHBOARD_DIR is None); serving the UI is then skipped so the node
+        # still boots and serves the API (#333). The control/data planes and
+        # all API routes are unaffected.
+        if mount_dashboard and DASHBOARD_DIR is not None:
+            dashboard_dir = DASHBOARD_DIR
+
             # The dashboard is a SPA that restores its active view from the
             # URL path (App.tsx reads location.pathname), so deep links and
             # browser refreshes hit these paths directly. StaticFiles only
@@ -746,7 +752,7 @@ class API:
             # dashboard-react/src/components/layout/HeaderNav.tsx.
             async def _spa_index() -> FileResponse:
                 """Serve the dashboard SPA shell for client-routed paths."""
-                return FileResponse(os.path.join(DASHBOARD_DIR, "index.html"))
+                return FileResponse(os.path.join(dashboard_dir, "index.html"))
 
             # Both slash forms: the StaticFiles mount at "/" swallows
             # unmatched paths before FastAPI's redirect-slashes logic can
@@ -758,10 +764,16 @@ class API:
             self.app.mount(
                 "/",
                 StaticFiles(
-                    directory=DASHBOARD_DIR,
+                    directory=dashboard_dir,
                     html=True,
                 ),
                 name="dashboard",
+            )
+        elif mount_dashboard:
+            logger.info(
+                "Dashboard assets not found (DASHBOARD_DIR is unset); serving the "
+                "API without the dashboard UI. Build it with `cd dashboard-react "
+                "&& npm run build` or set SKULK_DASHBOARD_DIR to serve the UI."
             )
 
         self._text_generation_queues: dict[

--- a/src/skulk/api/tests/test_spa_routes.py
+++ b/src/skulk/api/tests/test_spa_routes.py
@@ -68,3 +68,31 @@ def test_unknown_path_still_404s(tmp_path: Path) -> None:
     # must keep 404ing so typos and probes don't silently render the app.
     with _client_with_dashboard(tmp_path) as client:
         assert client.get("/definitely-not-a-route").status_code == 404
+
+
+def test_headless_api_boots_without_dashboard_assets() -> None:
+    # A headless/non-Mac node has no built dashboard (DASHBOARD_DIR is None).
+    # mount_dashboard=True must then NOT register the StaticFiles mount or the
+    # SPA fallbacks, and the API must still boot and serve (#333).
+    command_sender, _ = channel[ForwarderCommand]()
+    download_sender, _ = channel[ForwarderDownloadCommand]()
+    _, event_receiver = channel[IndexedEvent]()
+    _, election_receiver = channel[ElectionMessage]()
+    with patch("skulk.api.main.DASHBOARD_DIR", None):
+        api = API(
+            NodeId("test-node"),
+            port=52415,
+            event_receiver=event_receiver,
+            command_sender=command_sender,
+            download_command_sender=download_sender,
+            election_receiver=election_receiver,
+            enable_event_log=False,
+            mount_dashboard=True,
+        )
+        # The dashboard StaticFiles mount is absent.
+        assert "dashboard" not in {
+            getattr(route, "name", None) for route in api.app.routes
+        }
+        client = TestClient(api.app)
+        # No SPA fallback and no "/" mount when assets are missing.
+        assert client.get("/cluster").status_code == 404

--- a/src/skulk/shared/constants.py
+++ b/src/skulk/shared/constants.py
@@ -2,7 +2,7 @@ import os
 import sys
 from pathlib import Path
 
-from skulk.utils.dashboard_path import find_dashboard, find_resources
+from skulk.utils.dashboard_path import find_dashboard_optional, find_resources
 
 
 def _env(skulk_key: str, legacy_key: str, default: str | None = None) -> str | None:
@@ -125,8 +125,14 @@ RESOURCES_DIR = (
     find_resources() if _RESOURCES_DIR_ENV is None else Path.home() / _RESOURCES_DIR_ENV
 )
 _DASHBOARD_DIR_ENV = _env("SKULK_DASHBOARD_DIR", "EXO_DASHBOARD_DIR")
-DASHBOARD_DIR = (
-    find_dashboard() if _DASHBOARD_DIR_ENV is None else Path.home() / _DASHBOARD_DIR_ENV
+# ``None`` on a headless/worker node that has no built dashboard assets and no
+# explicit override: importing constants (a boot-path module) must not fail just
+# because the UI was never built. The API skips serving the dashboard when this
+# is None; an explicit SKULK_DASHBOARD_DIR is honored as-is (#333).
+DASHBOARD_DIR: Path | None = (
+    find_dashboard_optional()
+    if _DASHBOARD_DIR_ENV is None
+    else Path.home() / _DASHBOARD_DIR_ENV
 )
 
 # Log files (data/logs or cache)

--- a/src/skulk/shared/constants.py
+++ b/src/skulk/shared/constants.py
@@ -128,7 +128,10 @@ _DASHBOARD_DIR_ENV = _env("SKULK_DASHBOARD_DIR", "EXO_DASHBOARD_DIR")
 # ``None`` on a headless/worker node that has no built dashboard assets and no
 # explicit override: importing constants (a boot-path module) must not fail just
 # because the UI was never built. The API skips serving the dashboard when this
-# is None; an explicit SKULK_DASHBOARD_DIR is honored as-is (#333).
+# is None. An explicit SKULK_DASHBOARD_DIR is resolved under the home directory
+# with the same ``Path.home() / value`` convention as the other ``*_DIR`` env
+# vars (so a relative value is home-relative and an absolute value is used as
+# given), matching prior behavior (#333).
 DASHBOARD_DIR: Path | None = (
     find_dashboard_optional()
     if _DASHBOARD_DIR_ENV is None

--- a/src/skulk/utils/dashboard_path.py
+++ b/src/skulk/utils/dashboard_path.py
@@ -31,8 +31,19 @@ def _find_resources_in_bundle() -> Path | None:
     return None
 
 
+def find_dashboard_optional() -> Path | None:
+    """Locate the built dashboard assets, or ``None`` if they are absent.
+
+    A headless/worker node (e.g. a Linux node with no node/npm to build the
+    dashboard) is a first-class deployment, so a missing ``dashboard-react/dist``
+    must not be fatal. Callers that can run without the UI use this and skip
+    serving it; callers that require the UI use :func:`find_dashboard`.
+    """
+    return _find_react_dashboard_in_repo() or _find_dashboard_in_bundle()
+
+
 def find_dashboard() -> Path:
-    dashboard = _find_react_dashboard_in_repo() or _find_dashboard_in_bundle()
+    dashboard = find_dashboard_optional()
     if not dashboard:
         raise FileNotFoundError(
             "Unable to locate dashboard assets — run: cd dashboard-react && npm install && npm run build && cd .."

--- a/src/skulk/utils/tests/test_dashboard_path.py
+++ b/src/skulk/utils/tests/test_dashboard_path.py
@@ -1,0 +1,37 @@
+# pyright: reportPrivateUsage=false
+"""Dashboard-asset resolution for headless/worker nodes (#333)."""
+
+from pathlib import Path
+
+import pytest
+
+from skulk.utils import dashboard_path
+
+
+def test_find_dashboard_optional_returns_none_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A headless node with no built assets and no bundle: resolution must yield
+    # None rather than raising, so importing constants does not fail on boot.
+    monkeypatch.setattr(dashboard_path, "_find_react_dashboard_in_repo", lambda: None)
+    monkeypatch.setattr(dashboard_path, "_find_dashboard_in_bundle", lambda: None)
+    assert dashboard_path.find_dashboard_optional() is None
+
+
+def test_find_dashboard_raises_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The strict variant still raises for callers that require the UI.
+    monkeypatch.setattr(dashboard_path, "_find_react_dashboard_in_repo", lambda: None)
+    monkeypatch.setattr(dashboard_path, "_find_dashboard_in_bundle", lambda: None)
+    with pytest.raises(FileNotFoundError):
+        dashboard_path.find_dashboard()
+
+
+def test_find_dashboard_optional_returns_found_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(dashboard_path, "_find_react_dashboard_in_repo", lambda: tmp_path)
+    monkeypatch.setattr(dashboard_path, "_find_dashboard_in_bundle", lambda: None)
+    assert dashboard_path.find_dashboard_optional() == tmp_path
+    assert dashboard_path.find_dashboard() == tmp_path

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -76,7 +76,7 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 - **Role:** HTTP entry point; FastAPI app; OpenAI / Ollama / Claude / Responses / Skulk-native adapters; serves dashboard
 - **Lives in:** `src/skulk/api/main.py`; adapters at `src/skulk/api/adapters/`
 - **Default port:** 52415
-- **Mounts:** dashboard at `/`; OpenAPI at `/api/openapi.json`
+- **Mounts:** dashboard at `/` (skipped when the built assets are absent, e.g. a headless/non-Mac worker node with no `dashboard-react/dist`; `DASHBOARD_DIR` is then `None` and the API serves without the UI, #333); OpenAPI at `/api/openapi.json`
 - **Background tasks:** `_apply_state` (consumes `GLOBAL_EVENTS` and persists merged traces), `_pause_on_new_election`, `_cleanup_expired_images` (image-store TTL), `_prune_old_traces` (hourly trace janitor backed by `prune_old_trace_files`; retention via `tracing.retention_days`)
 
 ### Dashboard

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -10,7 +10,7 @@ This is the long-form mental model for how Skulk is put together end to end. Rea
 
 ## What Skulk is
 
-Skulk is an interconnect fabric for multi-node AI compute: it connects multiple Apple Silicon (and increasingly Linux/CUDA) nodes into one cluster and moves work across them. Its headline use is distributed inference, where models are sharded across nodes, any node's API can serve cluster-wide requests, and the cluster keeps running through node arrivals, departures, and master failures. One Python binary (`uv run skulk`) is everything you need on each node: the same process is router, worker, master-eligible coordinator, election participant, API server, and dashboard host.
+Skulk is an interconnect fabric for multi-node AI compute: it connects multiple Apple Silicon (and increasingly Linux/CUDA) nodes into one cluster and moves work across them. Its headline use is distributed inference, where models are sharded across nodes, any node's API can serve cluster-wide requests, and the cluster keeps running through node arrivals, departures, and master failures. One Python binary (`uv run skulk`) is everything you need on each node: the same process is router, worker, master-eligible coordinator, election participant, API server, and, when its built assets are present, dashboard host. A headless node (for example a Linux worker with no built dashboard) runs as a full node and serves the API without the UI.
 
 The design choices that shape almost everything else:
 
@@ -58,7 +58,7 @@ Each subsystem has its own concern:
 - **Master** indexes incoming events into the event log (writing them to disk via `DiskEventLog`), publishes indexed events on `GLOBAL_EVENTS` for followers, and decides instance placements when a model is launched.
 - **Worker** receives indexed events, applies them to its local view of `State`, downloads model weights to disk when assigned a placement, and spawns / supervises runner subprocesses. Before spawning, it refuses a shard that won't fit local memory (a last-resort guard below the master's admission check, using the same shared estimator), and a crash circuit breaker gives up on a runner that keeps failing rather than relaunching it into another GPU-memory leak. When the give-up is driven by that *memory* guard (not a crash) the worker asks the master to re-place the model one node wider via `RefuseInstancePlacement` instead of letting the placement silently disappear (see "Placement memory admission" below).
 - **Runner** is *not* in the same process — it's a `mp.Process` daemon spawned by the worker. It owns one model and serves inference tasks for it. Multiple runners (one per pipeline rank) coordinate via `mlx.distributed` collectives.
-- **API** is a FastAPI app that exposes inference endpoints in four wire formats (OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, Ollama) and Skulk-native control endpoints (placements, diagnostics, traces, config). It also serves the dashboard build at `/`.
+- **API** is a FastAPI app that exposes inference endpoints in four wire formats (OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, Ollama) and Skulk-native control endpoints (placements, diagnostics, traces, config). It also serves the dashboard build at `/` when those assets are present; a headless node built without the UI skips that mount and serves the API alone.
 - **Storage** is a collection of on-disk responsibilities: the event log (msgpack + zstd), the model cache directory, custom model cards (per-user TOML files), and the optional shared model store.
 
 ## The shape of a cluster
@@ -318,7 +318,7 @@ The adapters live in `src/skulk/api/adapters/`. Each one handles request normali
 
 ## The dashboard
 
-The dashboard is the operator-facing UI for the same Skulk runtime. It's a React + TypeScript + styled-components SPA, built with Vite, served by the API at `/` (the API's static-files mount).
+The dashboard is the operator-facing UI for the same Skulk runtime. It's a React + TypeScript + styled-components SPA, built with Vite, served by the API at `/` (the API's static-files mount) on nodes where the built assets are present. A node without them (a headless or non-Mac worker built without the UI) still runs the full API; operators reach the dashboard from any node that has it.
 
 Architecture decisions:
 


### PR DESCRIPTION
## What

Opens **Epic 2 (non-Mac nodes first-class, #337)**. A worker node with no `dashboard-react/dist` — for example a Linux/Strix Halo node with no node/npm to build the UI — could not start at all:

1. `constants.py` resolved `DASHBOARD_DIR` at **import** via `find_dashboard()`, which raised `FileNotFoundError` when the assets were absent (and `constants` is on the boot path).
2. The API's `StaticFiles(directory=DASHBOARD_DIR)` mount raised `RuntimeError` when the directory did not exist.

The workaround was a stub directory + an explicit `SKULK_DASHBOARD_DIR` (used during the kite4 bring-up). This makes a headless node a first-class deployment instead.

## How

- **`dashboard_path.find_dashboard_optional()`** returns `None` instead of raising; `find_dashboard()` keeps the strict contract (still raises) for callers that require the UI.
- **`DASHBOARD_DIR` is now `Path | None`** — `None` on a headless node with no assets and no `SKULK_DASHBOARD_DIR` override, so importing `constants` no longer fails on boot. An explicit `SKULK_DASHBOARD_DIR` is honored unchanged.
- **The API skips** the SPA fallback routes + the `StaticFiles` mount when `DASHBOARD_DIR is None`, logging a one-line notice, and serves the full API. Nodes that have the assets (or set `SKULK_DASHBOARD_DIR`) serve the UI exactly as before.

`DASHBOARD_DIR` is only referenced in `constants.py` (definition) and these two API spots, so the `Path | None` change is contained.

## Tests / validation

- `test_dashboard_path.py`: optional resolver returns `None` when absent, strict resolver raises, both return the found path when present.
- Verified the headless boot path locally: with the finders returning `None`, `import skulk.shared.constants` yields `DASHBOARD_DIR = None` and `import skulk.api.main` both succeed.

```
uv run basedpyright    # 0 errors (whole project)
uv run ruff check      # clean
uv run pytest src/skulk/utils/tests/test_dashboard_path.py -q   # 3 passed
```

Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)