### PR TITLE
chore(net): seed libp2p PNET key with skulk_discovery_network (#324, wire break)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Changed
 
+- **The libp2p private-network key seed is now `skulk_discovery_network` (#324).**
+  `swarm.rs` derived the PNET pre-shared key from the literal
+  `exo_discovery_network` (an exo-rename residue). The seed is now
+  `skulk_discovery_network`. **This is a wire-compatibility break**: a node built
+  with the new seed cannot form a libp2p cluster with a node built on the old
+  seed, so it must roll out as a single coordinated whole-fleet rebuild and
+  restart (do not roll nodes one at a time). The Zenoh data-plane namespace is
+  unaffected (it derives from `NETWORK_VERSION` / `SKULK_LIBP2P_NAMESPACE`, not
+  this seed).
+
 - **Zenoh data plane is now soft default-on (#315).** The `DATA` topic (per-token
   generation output) uses the Eclipse Zenoh transport by default when a node is
   configured for it. `SKULK_ZENOH_DATA_PLANE` is now tri-state

--- a/rust/networking/src/swarm.rs
+++ b/rust/networking/src/swarm.rs
@@ -182,7 +182,10 @@ mod transport {
     /// Key used for networking's private network; parametrized on the [`NETWORK_VERSION`].
     /// See [`pnet_upgrade`] for more.
     static PNET_PRESHARED_KEY: LazyLock<[u8; 32]> = LazyLock::new(|| {
-        let builder = Sha3_256::new().update(b"exo_discovery_network");
+        // Seed for the libp2p private-network pre-shared key. Changing this is a
+        // wire-compatibility break (nodes with a different seed cannot form a
+        // cluster), so it lands only as a coordinated whole-fleet upgrade (#324).
+        let builder = Sha3_256::new().update(b"skulk_discovery_network");
 
         if let Ok(var) = env::var(OVERRIDE_VERSION_ENV_VAR) {
             let bytes = var.into_bytes();


### PR DESCRIPTION
## What

The final piece of the EXO expunge (#324). `rust/networking/src/swarm.rs` derived the libp2p private-network pre-shared key from the literal `b"exo_discovery_network"` — an exo-rename residue. Reseed it to `b"skulk_discovery_network"`.

## ⚠️ Wire-compatibility break

A node built with the new seed **cannot form a libp2p cluster** with a node built on the old seed (the PNET handshake fails). This must roll out as a **single coordinated whole-fleet rebuild + restart**, not a rolling upgrade. Tom has authorized tearing down and rebuilding the fleet.

The **Zenoh data-plane namespace is unaffected** — it derives from `NETWORK_VERSION` / `SKULK_LIBP2P_NAMESPACE` (`_libp2p_namespace_token`), not this seed.

## Scope

One-line seed change in `swarm.rs` (plus the comment + CHANGELOG). `cargo check -p networking` passes; no test hardcodes the derived key. This is the rust counterpart to #347 (the Python EXO expunge); both together finish #324.

Closes #324 (with #347).

🤖 Generated with [Claude Code](https://claude.com/claude-code)