### PR TITLE
feat(deploy): headless mode so non-Mac nodes run under the managed service

### DIFF
--- a/deployment/install/skulk-startup.sh
+++ b/deployment/install/skulk-startup.sh
@@ -56,6 +56,8 @@ unset _d
 
 AUTO_UPDATE="${SKULK_AUTO_UPDATE:-1}"
 VERBOSITY="${SKULK_VERBOSITY:--v}"
+# Headless nodes serve the API without the web UI (no dashboard build).
+HEADLESS="${SKULK_HEADLESS:-0}"
 
 run_prep() {
     # `git pull` — non-fatal. Common failure modes (offline at boot,
@@ -78,6 +80,16 @@ run_prep() {
         log "warning: uv sync failed (continuing with current venv)"
     fi
 
+    # Headless nodes (e.g. a non-Mac worker like a Strix Halo / ROCm box)
+    # intentionally serve the API without the web UI: the node sets
+    # DASHBOARD_DIR=None and skips the mount when assets are absent (#333).
+    # For those, skip the dashboard build and its fatal dist/ check entirely
+    # so the service can run without Node/npm installed.
+    if [[ "$HEADLESS" == "1" ]]; then
+        log "SKULK_HEADLESS=1: skipping dashboard build; API serves without the web UI"
+        return
+    fi
+
     # Dashboard build — non-fatal on success path (we boot with the
     # previously built dist/), fatal only if dist/ ends up missing.
     if [[ -d dashboard-react ]]; then
@@ -94,6 +106,7 @@ run_prep() {
     if [[ ! -d dashboard-react/dist ]]; then
         log "ERROR: dashboard-react/dist is missing — cannot start without a built dashboard."
         log "fix: run 'cd dashboard-react && npm install && npm run build' manually, then restart the service."
+        log "     (headless nodes that serve the API without the UI: set SKULK_HEADLESS=1 in $ENV_FILE)"
         exit 1
     fi
 }
@@ -102,9 +115,10 @@ if [[ "$AUTO_UPDATE" == "1" ]]; then
     run_prep
 else
     log "SKULK_AUTO_UPDATE=$AUTO_UPDATE — skipping boot-time update"
-    if [[ ! -d dashboard-react/dist ]]; then
+    if [[ "$HEADLESS" != "1" && ! -d dashboard-react/dist ]]; then
         log "ERROR: dashboard-react/dist is missing and auto-update is off."
         log "fix: build the dashboard once, or set SKULK_AUTO_UPDATE=1 in $ENV_FILE."
+        log "     (headless nodes that serve the API without the UI: set SKULK_HEADLESS=1 in $ENV_FILE)"
         exit 1
     fi
 fi

--- a/deployment/install/skulk.env.example
+++ b/deployment/install/skulk.env.example
@@ -30,6 +30,14 @@ SKULK_AUTO_UPDATE=1
 # for debug. Empty string = default (info level).
 SKULK_VERBOSITY=-v
 
+# Headless node: serve the API without the web dashboard. Set to 1 on
+# nodes that don't build the React UI (e.g. a non-Mac worker such as a
+# Strix Halo / ROCm box without Node/npm). The boot-time prep then skips
+# the dashboard build and its otherwise-fatal "dist/ missing" check, and
+# the node serves the API with DASHBOARD_DIR unset. Default 0 keeps the
+# fail-loud behavior so a Mac with an accidentally-missing build is caught.
+# SKULK_HEADLESS=0
+
 # Cluster namespace — nodes only join clusters with the same namespace.
 # Use a unique value per cluster (e.g. per home, per project).
 SKULK_LIBP2P_NAMESPACE=foxlight-main

--- a/deployment/rocm/README.md
+++ b/deployment/rocm/README.md
@@ -56,9 +56,50 @@ cp deployment/rocm/launch-skulk.sh.example ~/launch-skulk.sh
 chmod +x ~/launch-skulk.sh
 ~/launch-skulk.sh           # foreground, to watch the first boot
 
-# 4. Once it joins cleanly, run it detached so it survives the SSH session:
-setsid bash -c 'exec ~/launch-skulk.sh > ~/skulk.log 2>&1' </dev/null >/dev/null 2>&1 &
+# 4. Once it joins cleanly, run it detached so it survives the SSH session.
+#    nohup + disown matter: a bare `setsid ... &` inside an SSH command can be
+#    SIGHUP'd during session teardown before it fully detaches.
+nohup setsid bash ~/launch-skulk.sh > ~/skulk.log 2>&1 < /dev/null & disown
 ```
+
+The detached launcher above is fine for first-boot watching, but it does **not**
+restart skulk after a crash or reboot. For a permanent node, install the managed
+service instead (next section).
+
+## Running as a managed service (recommended)
+
+For a node that should rejoin the cluster automatically after a crash or reboot,
+run Skulk under the same systemd user service the rest of the fleet uses, rather
+than the detached launcher. This mirrors the macOS LaunchAgent on Apple Silicon
+nodes: start-on-boot (via linger), restart-on-failure, and boot-time `git pull` /
+`uv sync` through `deployment/install/skulk-startup.sh`.
+
+```bash
+# 1. Put this node's cluster env in the service env file. Headless is required
+#    so the boot-time prep skips the (absent) dashboard build. Add the same
+#    backend/namespace/Zenoh knobs you'd otherwise set in launch-skulk.sh.
+mkdir -p ~/.skulk
+cat >> ~/.skulk/skulk.env <<'ENV'
+SKULK_HEADLESS=1
+SKULK_LLAMA_CPP_BACKENDS=vulkan
+# Skip boot-time `uv sync`: it reinstalls the CPU llama-cpp-python wheel and
+# clobbers the Vulkan build below. Pin the revision and update manually instead.
+SKULK_AUTO_UPDATE=0
+# SKULK_LIBP2P_NAMESPACE=...   # match the rest of the fleet
+# SKULK_ZENOH_DATA_PLANE / SKULK_ZENOH_LISTEN / SKULK_ZENOH_CONNECT as needed
+ENV
+
+# 2. Install + enable the user service (enables linger for boot autostart).
+deployment/install/install-systemd.sh
+```
+
+The Vulkan `llama-cpp-python` build from Quick-start step 2 must already be in the
+`.venv` before you start the service. With `SKULK_AUTO_UPDATE=0` the service runs
+whatever is on disk, so the Vulkan wheel survives restarts; to update the node,
+`git pull` and re-run the `uv sync` + `--no-binary` Vulkan install by hand, then
+`systemctl --user restart skulk`. Manage the service with
+`systemctl --user {status,restart,stop} skulk` and follow logs via
+`journalctl --user -u skulk -f`.
 
 The node advertises `llama_cpp` + `llama_cpp-vulkan` backends (because
 `SKULK_LLAMA_CPP_BACKENDS=vulkan` is set and `llama_cpp` imports), and the

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -432,7 +432,7 @@ Selection logic: `src/skulk/worker/engines/mlx/cache.py::make_kv_cache`. Some ba
 
 ### Environment variables
 
-`SKULK_*` is preferred; `SKULK_*` accepted as legacy. Migration tracked under #110.
+Only `SKULK_*` names are read. The legacy `EXO_*` deprecation runway was removed in #324; typed-config migration is tracked under #110. (Some rows below still show a duplicated `SKULK_X / SKULK_X` artifact from that rename and will be de-duplicated in the #110 sweep.)
 
 | Var | What |
 |---|---|
@@ -457,6 +457,7 @@ Selection logic: `src/skulk/worker/engines/mlx/cache.py::make_kv_cache`. Some ba
 | `SKULK_VISION_DEBUG_SAVE_DIR` | Save debug image artifacts |
 | `SKULK_NATIVE_VISION_REFERENCE_PATH` | Force native-vision reference path (Gemma 4) |
 | `SKULK_OFFLINE` | Run without internet checks (no model fetching) |
+| `SKULK_HEADLESS` | Deploy knob read by `deployment/install/skulk-startup.sh` (the LaunchAgent/systemd entrypoint). `1` on a node that serves the API without the web UI (e.g. a non-Mac worker like a Strix Halo/ROCm box with no Node/npm): boot-time prep skips the dashboard build and its otherwise-fatal `dashboard-react/dist` missing check, and the node runs with `DASHBOARD_DIR` unset (#333). Default `0` keeps the fail-loud behavior so a Mac with an accidentally-absent build is caught. |
 | `SKULK_TEST_DISTRIBUTED_MODEL` | Tests only: force the distributed/prefix-cache slow-test model (`gpt-oss-20b` or `llama-3.2-1b`); default auto-selects by Metal working-set size |
 | `MLX_METAL_FAST_SYNCH` | Set by Skulk based on resolved card preference; not for direct operator use |
 | `MLX_HOSTFILE`, `MLX_RANK`, `MLX_RING_VERBOSE`, `MLX_IBV_DEVICES`, `MLX_JACCL_COORDINATOR` | MLX upstream env vars; auto-set by Skulk during distributed init. Ring hostfile addresses are chosen per neighbor pair from OBSERVED libp2p connections, ranked thunderbolt > maybe_ethernet > ethernet > wifi > unknown > VPN/overlay — Tailscale CGNAT (100.64/10, fd7a:115c:a1e0::/48) addresses are detected by ADDRESS (utun types don't gossip) and rank strictly last: the overlay exists for external reachability and may be DERP-relayed, so it is only used when a pair has no local candidate (#265). Selection lives in `_find_ip_prioritised` / `get_mlx_ring_hosts_by_node` (`src/skulk/master/placement_utils.py`) |


### PR DESCRIPTION
## Problem

A node that serves the API without the web UI (e.g. a Strix Halo / ROCm worker with no Node/npm) could not run under the existing launchd/systemd service. `deployment/install/skulk-startup.sh` unconditionally builds the dashboard and `exit 1`s if `dashboard-react/dist` is missing. So such nodes (kite4) were stuck on an ad-hoc detached `launch-skulk.sh` with **no crash/reboot recovery** — if the box rebooted or the process died, it silently dropped out of the fabric and nothing brought it back. The Macs get all of that from launchd; the Linux node got none of it.

The runtime already supports headless nodes (`DASHBOARD_DIR` unset, API served without the UI, #333) — the startup script just hadn't caught up.

## Change

- **`SKULK_HEADLESS=1`** in `skulk-startup.sh`: skip the dashboard build and its otherwise-fatal `dist/` check; the node serves the API with no UI. Default `0` keeps the fail-loud behavior so a Mac with an accidentally-missing build is still caught (covers both the auto-update and `SKULK_AUTO_UPDATE=0` paths).
- Document the var in `skulk.env.example` and the architecture reference; correct the reference's now-stale `EXO_`-legacy env note (#324).
- `deployment/rocm/README.md`: add a "Running as a managed service" section (install the existing systemd user service with `SKULK_HEADLESS=1` + `SKULK_AUTO_UPDATE=0` so boot-time `uv sync` doesn't clobber the Vulkan `llama-cpp-python` build), and fix the fragile detached-launch incantation (`nohup … & disown`, since a bare `setsid … &` inside an SSH command gets SIGHUP'd during session teardown).

## Validation

Installed live on kite4 (Strix Halo, no Node/npm): the systemd user service starts headless, kite4 rejoins as the 4th cluster node, and `systemctl --user restart skulk` cleanly cycles it (new ExecMainPID, service stays active). No Python changed (shell + docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)