### PR TITLE
feat(dashboard): normalized accelerator panel (cross-vendor GPU card)

### DIFF
--- a/dashboard-react/src/components/observability/AcceleratorPanel.stories.tsx
+++ b/dashboard-react/src/components/observability/AcceleratorPanel.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AcceleratorPanel } from './AcceleratorPanel';
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      width: 260,
+      padding: 16,
+      background: '#0b0b0d',
+      border: '1px solid #2a2a2e',
+      borderRadius: 8,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const meta: Meta<typeof AcceleratorPanel> = {
+  title: 'Observability/AcceleratorPanel',
+  component: AcceleratorPanel,
+  parameters: { layout: 'centered' },
+  decorators: [(Story) => <Frame><Story /></Frame>],
+};
+
+export default meta;
+type Story = StoryObj<typeof AcceleratorPanel>;
+
+/** Apple Silicon: unified memory, so VRAM is "not reported" (no discrete pool). */
+export const Apple: Story = {
+  args: {
+    accelerator: {
+      vendor: 'apple',
+      name: 'Apple GPU',
+      utilizationRatio: 0.07,
+      vramTotalBytes: null,
+      vramUsedBytes: null,
+      powerWatts: 0.07,
+      temperatureCelsius: 39,
+      clockMhz: null,
+    },
+  },
+};
+
+/** AMD Strix Halo: a discrete 64 GiB GPU VRAM pool carved from unified memory. */
+export const AmdStrixHalo: Story = {
+  name: 'AMD (Strix Halo)',
+  args: {
+    accelerator: {
+      vendor: 'amd',
+      name: 'AMD GPU',
+      utilizationRatio: 0.0,
+      vramTotalBytes: 68719476736,
+      vramUsedBytes: 163233792,
+      powerWatts: 7.05,
+      temperatureCelsius: 35,
+      clockMhz: 600,
+    },
+  },
+};
+
+/** AMD under load, to show the VRAM bar filled. */
+export const AmdBusy: Story = {
+  name: 'AMD (busy)',
+  args: {
+    accelerator: {
+      vendor: 'amd',
+      name: 'AMD GPU',
+      utilizationRatio: 0.93,
+      vramTotalBytes: 68719476736,
+      vramUsedBytes: 41231686041,
+      powerWatts: 96.4,
+      temperatureCelsius: 71,
+      clockMhz: 2900,
+    },
+  },
+};

--- a/dashboard-react/src/components/observability/AcceleratorPanel.tsx
+++ b/dashboard-react/src/components/observability/AcceleratorPanel.tsx
@@ -142,7 +142,9 @@ export function AcceleratorPanel({ accelerator }: AcceleratorPanelProps) {
       <Row>
         <Key>VRAM</Key>
         <Value>
-          {total == null ? NOT_REPORTED : `${gib(used)} / ${gib(total)}`}
+          {/* Collapse to a single "not reported" only when BOTH are absent;
+              otherwise show each side via gib() so a partial reading isn't lost. */}
+          {used == null && total == null ? NOT_REPORTED : `${gib(used)} / ${gib(total)}`}
         </Value>
       </Row>
       {vramRatio != null && (

--- a/dashboard-react/src/components/observability/AcceleratorPanel.tsx
+++ b/dashboard-react/src/components/observability/AcceleratorPanel.tsx
@@ -1,0 +1,167 @@
+import styled from 'styled-components';
+
+/**
+ * Normalized accelerator metrics as they arrive from the API (camelCase).
+ * Mirrors the backend `AcceleratorMetrics`: any field a collector cannot measure
+ * is `null`, which renders as "not reported" rather than a misleading zero.
+ */
+export interface AcceleratorMetrics {
+  vendor?: string;
+  name?: string;
+  utilizationRatio?: number | null;
+  vramTotalBytes?: number | null;
+  vramUsedBytes?: number | null;
+  powerWatts?: number | null;
+  temperatureCelsius?: number | null;
+  clockMhz?: number | null;
+}
+
+/** Props for {@link AcceleratorPanel}. */
+export interface AcceleratorPanelProps {
+  /** The node's normalized accelerator block, or undefined if none reported. */
+  accelerator?: AcceleratorMetrics | null;
+}
+
+const Panel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+`;
+
+const VENDOR_COLORS: Record<string, string> = {
+  amd: '#d32f2f',
+  nvidia: '#5a8a00',
+  apple: '#6e6e73',
+  intel: '#0068b5',
+};
+
+const VendorPill = styled.span<{ $vendor?: string }>`
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 4px;
+  /* Self-contained palette (not theme tokens) so the badge stays legible on
+     any background and never collapses to one-color-on-itself. */
+  color: #fff;
+  background: ${({ $vendor }) => VENDOR_COLORS[$vendor ?? ''] ?? '#555'};
+`;
+
+const Name = styled.span`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const Row = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+`;
+
+const Key = styled.div`
+  color: ${({ theme }) => theme.colors.textMuted};
+`;
+
+const Value = styled.div`
+  font-family: 'SF Mono', Monaco, monospace;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const BarTrack = styled.div`
+  height: 6px;
+  border-radius: 3px;
+  background: ${({ theme }) => theme.colors.gpuBarBg};
+  overflow: hidden;
+`;
+
+const BarFill = styled.div<{ $ratio: number }>`
+  height: 100%;
+  width: ${({ $ratio }) => Math.min(100, Math.max(0, $ratio * 100))}%;
+  background: ${({ theme }) => theme.colors.accent};
+`;
+
+const NOT_REPORTED = 'not reported';
+
+function gib(bytes?: number | null): string {
+  if (bytes == null) return NOT_REPORTED;
+  return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+}
+
+function pct(ratio?: number | null): string {
+  if (ratio == null) return NOT_REPORTED;
+  return `${Math.round(ratio * 100)}%`;
+}
+
+function watts(w?: number | null): string {
+  if (w == null) return NOT_REPORTED;
+  return `${w.toFixed(1)} W`;
+}
+
+function celsius(c?: number | null): string {
+  if (c == null) return NOT_REPORTED;
+  return `${Math.round(c)}°C`;
+}
+
+function mhz(m?: number | null): string {
+  if (m == null) return NOT_REPORTED;
+  return `${m} MHz`;
+}
+
+/**
+ * Renders a node's normalized GPU/accelerator metrics uniformly across vendors
+ * (Apple, AMD, NVIDIA). Driven entirely by the collector-agnostic
+ * {@link AcceleratorMetrics} block, so a Strix Halo node and an Apple Silicon
+ * node display the same shape; fields a collector cannot measure show
+ * "not reported" instead of a fake zero. Returns null when no accelerator is
+ * reported at all (e.g. a management node).
+ */
+export function AcceleratorPanel({ accelerator }: AcceleratorPanelProps) {
+  if (!accelerator) return null;
+  const vendor = accelerator.vendor ?? 'unknown';
+  const used = accelerator.vramUsedBytes;
+  const total = accelerator.vramTotalBytes;
+  const vramRatio = used != null && total != null && total > 0 ? used / total : null;
+
+  return (
+    <Panel>
+      <Header>
+        <VendorPill $vendor={vendor}>{vendor}</VendorPill>
+        <Name>{accelerator.name ?? 'Unknown'}</Name>
+      </Header>
+      <Row>
+        <Key>Utilization</Key>
+        <Value>{pct(accelerator.utilizationRatio)}</Value>
+      </Row>
+      <Row>
+        <Key>VRAM</Key>
+        <Value>
+          {total == null ? NOT_REPORTED : `${gib(used)} / ${gib(total)}`}
+        </Value>
+      </Row>
+      {vramRatio != null && (
+        <BarTrack>
+          <BarFill $ratio={vramRatio} />
+        </BarTrack>
+      )}
+      <Row>
+        <Key>Power</Key>
+        <Value>{watts(accelerator.powerWatts)}</Value>
+      </Row>
+      <Row>
+        <Key>Temperature</Key>
+        <Value>{celsius(accelerator.temperatureCelsius)}</Value>
+      </Row>
+      <Row>
+        <Key>Clock</Key>
+        <Value>{mhz(accelerator.clockMhz)}</Value>
+      </Row>
+    </Panel>
+  );
+}

--- a/dashboard-react/src/components/observability/NodeTab.tsx
+++ b/dashboard-react/src/components/observability/NodeTab.tsx
@@ -3,6 +3,7 @@ import { copyToClipboard } from '../../utils/clipboard';
 import { useTailscaleStatus } from '../../hooks/useTailscaleStatus';
 import styled from 'styled-components';
 import { Button } from '../common/Button';
+import { AcceleratorPanel } from './AcceleratorPanel';
 import { CenteredSpinner, Spinner } from '../common/Spinner';
 import { formatBytes } from '../../utils/format';
 import { useClusterState } from '../../hooks/useClusterState';
@@ -584,6 +585,13 @@ export function NodeTab({ nodeId }: NodeTabProps) {
               <Row><Key>Temp</Key><Value>{system?.temp != null ? `${Math.round(system.temp)}°C` : 'unknown'}</Value></Row>
               <Row><Key>Power</Key><Value>{system?.sysPower != null ? `${Math.round(system.sysPower)}W` : 'unknown'}</Value></Row>
             </Section>
+
+            {system?.accelerator && (
+              <Section>
+                <SectionTitle>Accelerator</SectionTitle>
+                <AcceleratorPanel accelerator={system.accelerator} />
+              </Section>
+            )}
 
             <Section>
               <SectionTitle>Placements</SectionTitle>

--- a/dashboard-react/src/store/endpoints/cluster.ts
+++ b/dashboard-react/src/store/endpoints/cluster.ts
@@ -17,12 +17,24 @@ export interface RawMemoryUsage {
   ramAvailable?: { inBytes: number };
 }
 
+export interface RawAcceleratorMetrics {
+  vendor?: string;
+  name?: string;
+  utilizationRatio?: number | null;
+  vramTotalBytes?: number | null;
+  vramUsedBytes?: number | null;
+  powerWatts?: number | null;
+  temperatureCelsius?: number | null;
+  clockMhz?: number | null;
+}
+
 export interface RawSystemPerformanceProfile {
   gpuUsage?: number;
   temp?: number;
   sysPower?: number;
   pcpuUsage?: number;
   ecpuUsage?: number;
+  accelerator?: RawAcceleratorMetrics | null;
 }
 
 export interface RawNetworkInterfaceInfo {

--- a/dashboard-react/src/types/diagnostics.ts
+++ b/dashboard-react/src/types/diagnostics.ts
@@ -198,6 +198,16 @@ export interface NodeResourceDiagnostics {
     sysPower?: number;
     pcpuUsage?: number;
     ecpuUsage?: number;
+    accelerator?: {
+      vendor?: string;
+      name?: string;
+      utilizationRatio?: number | null;
+      vramTotalBytes?: number | null;
+      vramUsedBytes?: number | null;
+      powerWatts?: number | null;
+      temperatureCelsius?: number | null;
+      clockMhz?: number | null;
+    } | null;
   } | null;
 }
 


### PR DESCRIPTION
The visible payoff of the telemetry normalization (#353): one accelerator card that renders every node the same way, so a heterogeneous fleet reads uniformly.

## What
- **`AcceleratorPanel`** (new): renders the normalized `AcceleratorMetrics` block — vendor badge + name, utilization, VRAM used/total with a usage bar, power, temperature, clock. Any field a collector can't measure shows **"not reported"** (never a fake zero).
- **`NodeTab`**: new "Accelerator" section fed by `diagnostics.resources.system.accelerator` (already populated from the telemetry view, so it works live for both Mac and AMD nodes — no new data wiring).
- Added `accelerator` to the dashboard `/state` + diagnostics types.
- Storybook story (Apple / AMD-idle / AMD-busy) for the component.

## Why it matters
An Apple node (unified memory) correctly shows VRAM/clock as "not reported"; an AMD Strix Halo node surfaces its **64 GiB GPU VRAM pool** with a usage bar. Same shape, different vendor.

Frontend-only; **no wire change, no fleet redeploy**. Verified: `npm run build` + `build-storybook` clean; screenshot captured from the stories (Apple + AMD idle/busy).

Follow-up (per #353 review): migrate the topology GPU bar + PowerSampler to read `accelerator.power_watts` (cross-vendor) instead of the legacy `sys_power`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)