### PR TITLE
feat(telemetry): Linux node identity (model/chip/OS) from sysfs

### DIFF
--- a/dashboard-react/src/components/topology/ClusterNode.tsx
+++ b/dashboard-react/src/components/topology/ClusterNode.tsx
@@ -51,8 +51,14 @@ function buildDebugContent(
 
   const chip = nodeInfo.system_info?.chip ?? '';
   const modelId = nodeInfo.system_info?.model_id ?? 'Unknown';
+  // macOS reports a bare version ("15.3"), so prefix "macOS"; Linux reports a
+  // self-naming string ("Ubuntu 26.04 LTS"), so show it as-is rather than
+  // mislabeling a non-Mac node "macOS".
+  const osBuild = nodeInfo.os_build_version ? ` (${nodeInfo.os_build_version})` : '';
   const os = nodeInfo.os_version
-    ? `macOS ${nodeInfo.os_version}${nodeInfo.os_build_version ? ` (${nodeInfo.os_build_version})` : ''}`
+    ? /^\d/.test(nodeInfo.os_version)
+      ? `macOS ${nodeInfo.os_version}${osBuild}`
+      : `${nodeInfo.os_version}${osBuild}`
     : '';
   // Group outbound connections by target node
   const byTarget = new Map<string, string[]>();

--- a/src/skulk/utils/info_gatherer/system_info.py
+++ b/src/skulk/utils/info_gatherer/system_info.py
@@ -62,10 +62,14 @@ def get_os_version() -> str:
 
 
 async def get_os_build_version() -> str:
-    """Return the macOS build version string (e.g. ``"24D5055b"``).
+    """Return the OS build version string.
 
-    On non-macOS platforms, returns ``"Unknown"``.
+    macOS: the build version (e.g. ``"24D5055b"``). Linux: the kernel release
+    (e.g. ``"6.14.0-12-generic"``), the closest build analog. Other platforms:
+    ``"Unknown"``.
     """
+    if sys.platform.startswith("linux"):
+        return platform.release() or "Unknown"
     if sys.platform != "darwin":
         return "Unknown"
 

--- a/src/skulk/utils/info_gatherer/system_info.py
+++ b/src/skulk/utils/info_gatherer/system_info.py
@@ -8,16 +8,56 @@ from anyio import run_process
 
 from skulk.shared.types.profiling import InterfaceType, NetworkInterfaceInfo
 
+# DMI fields are frequently populated with OEM placeholder junk; treat these
+# (case-insensitively) as "not set" so a node reports a real name or nothing.
+_DMI_JUNK = {
+    "",
+    "to be filled by o.e.m.",
+    "default string",
+    "system product name",
+    "system manufacturer",
+    "none",
+    "not applicable",
+    "not specified",
+    "oem",
+    "o.e.m.",
+}
+
+
+def _read_text(path: str) -> str:
+    """Read and strip a small system file, or return '' if unavailable."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            return handle.read().strip()
+    except OSError:
+        return ""
+
+
+def _clean_dmi(value: str) -> str:
+    """Return a DMI value, or '' if it is empty or a known OEM placeholder."""
+    return "" if value.strip().lower() in _DMI_JUNK else value.strip()
+
+
+def _linux_os_pretty_name() -> str:
+    """Return /etc/os-release PRETTY_NAME (e.g. 'Ubuntu 26.04 LTS') or ''."""
+    for line in _read_text("/etc/os-release").splitlines():
+        if line.startswith("PRETTY_NAME="):
+            return line.split("=", 1)[1].strip().strip('"')
+    return ""
+
 
 def get_os_version() -> str:
     """Return the OS version string for this node.
 
-    On macOS this is the macOS version (e.g. ``"15.3"``).
-    On other platforms it falls back to the platform name (e.g. ``"Linux"``).
+    On macOS this is the macOS version (e.g. ``"15.3"``). On Linux it is the
+    distro pretty name from ``/etc/os-release`` (e.g. ``"Ubuntu 26.04 LTS"``),
+    falling back to the bare platform name.
     """
     if sys.platform == "darwin":
         version = platform.mac_ver()[0]
         return version if version else "Unknown"
+    if sys.platform.startswith("linux"):
+        return _linux_os_pretty_name() or platform.system() or "Unknown"
     return platform.system() or "Unknown"
 
 
@@ -139,12 +179,45 @@ async def get_network_interfaces() -> list[NetworkInterfaceInfo]:
     return interfaces_info
 
 
+def _linux_model_and_chip() -> tuple[str, str]:
+    """Derive (model, chip) for a Linux node from sysfs/procfs (no subprocess).
+
+    Model comes from DMI (``/sys/class/dmi/id``): the product name, falling back
+    to the board name, prefixed with the vendor when it adds information (e.g.
+    ``"Nimo Direct Inc. MME3L"``). Chip is the CPU brand string from
+    ``/proc/cpuinfo`` (``"AMD RYZEN AI MAX+ 395 w/ Radeon 8060S"``), which on an
+    APU usefully also names the integrated GPU. Either falls back to the Mac-style
+    ``"Unknown Model"`` / ``"Unknown Chip"`` so callers stay uniform.
+    """
+    dmi = "/sys/class/dmi/id"
+    product = _clean_dmi(_read_text(f"{dmi}/product_name")) or _clean_dmi(
+        _read_text(f"{dmi}/board_name")
+    )
+    vendor = _clean_dmi(_read_text(f"{dmi}/sys_vendor"))
+    if product and vendor and vendor.lower() not in product.lower():
+        model = f"{vendor} {product}"
+    else:
+        model = product or "Unknown Model"
+
+    chip = "Unknown Chip"
+    for line in _read_text("/proc/cpuinfo").splitlines():
+        if line.lower().startswith("model name"):
+            chip = line.split(":", 1)[1].strip() or "Unknown Chip"
+            break
+    return (model, chip)
+
+
 async def get_model_and_chip() -> tuple[str, str]:
-    """Get Mac system information using system_profiler."""
+    """Get this node's hardware model and chip names.
+
+    macOS uses ``system_profiler``; Linux reads DMI + ``/proc/cpuinfo`` (see
+    ``_linux_model_and_chip``); other platforms report ``Unknown``.
+    """
     model = "Unknown Model"
     chip = "Unknown Chip"
 
-    # TODO: better non mac support
+    if sys.platform.startswith("linux"):
+        return _linux_model_and_chip()
     if sys.platform != "darwin":
         return (model, chip)
 

--- a/src/skulk/utils/info_gatherer/tests/test_linux_identity.py
+++ b/src/skulk/utils/info_gatherer/tests/test_linux_identity.py
@@ -1,0 +1,58 @@
+# pyright: reportPrivateUsage=false
+"""Tests for the Linux identity helpers in system_info (no real /sys needed)."""
+
+import pytest
+
+from skulk.utils.info_gatherer import system_info
+
+# kite4's real values (Strix Halo / Nimo mini-PC) used as the fixture.
+_FILES = {
+    "/sys/class/dmi/id/product_name": "MME3L\n",
+    "/sys/class/dmi/id/board_name": "NIMO Mini PC\n",
+    "/sys/class/dmi/id/sys_vendor": "Nimo Direct Inc.\n",
+    "/proc/cpuinfo": (
+        "processor\t: 0\n"
+        "vendor_id\t: AuthenticAMD\n"
+        "model name\t: AMD RYZEN AI MAX+ 395 w/ Radeon 8060S\n"
+        "processor\t: 1\n"
+        "model name\t: AMD RYZEN AI MAX+ 395 w/ Radeon 8060S\n"
+    ),
+    "/etc/os-release": 'NAME="Ubuntu"\nPRETTY_NAME="Ubuntu 26.04 LTS"\nID=ubuntu\n',
+}
+
+
+@pytest.fixture
+def fake_files(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(system_info, "_read_text", lambda path: _FILES.get(path, ""))
+
+
+def test_linux_model_and_chip(fake_files: None) -> None:
+    model, chip = system_info._linux_model_and_chip()
+    assert model == "Nimo Direct Inc. MME3L"  # vendor prefixed onto product
+    assert chip == "AMD RYZEN AI MAX+ 395 w/ Radeon 8060S"  # from /proc/cpuinfo
+
+
+def test_linux_os_pretty_name(fake_files: None) -> None:
+    assert system_info._linux_os_pretty_name() == "Ubuntu 26.04 LTS"
+
+
+def test_clean_dmi_filters_oem_junk() -> None:
+    assert system_info._clean_dmi("To Be Filled By O.E.M.") == ""
+    assert system_info._clean_dmi("Default string") == ""
+    assert system_info._clean_dmi("  ") == ""
+    assert system_info._clean_dmi("MME3L") == "MME3L"
+
+
+def test_linux_model_falls_back_to_board_then_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # product_name is OEM junk -> use board_name; no cpuinfo -> Unknown Chip.
+    files = {
+        "/sys/class/dmi/id/product_name": "Default string",
+        "/sys/class/dmi/id/board_name": "NIMO Mini PC",
+        "/sys/class/dmi/id/sys_vendor": "Default string",
+    }
+    monkeypatch.setattr(system_info, "_read_text", lambda path: files.get(path, ""))
+    model, chip = system_info._linux_model_and_chip()
+    assert model == "NIMO Mini PC"  # vendor was junk, product junk -> board name
+    assert chip == "Unknown Chip"


### PR DESCRIPTION
Closes the gap surfaced while looking at the topology: a Linux/AMD node rendered as **"Unknown Model / Unknown Chip / Linux"** because `get_model_and_chip` and `get_os_version` were macOS-only.

## What
Linux paths via pure sysfs/procfs reads (no subprocess):
- **model** ← DMI (`/sys/class/dmi/id/product_name` → `board_name`, prefixed with `sys_vendor`), with OEM placeholder junk filtered ("Default string", "To Be Filled By O.E.M.", …).
- **chip** ← `/proc/cpuinfo` "model name" — on an APU this also names the iGPU (e.g. `AMD RYZEN AI MAX+ 395 w/ Radeon 8060S`).
- **OS** ← `/etc/os-release` `PRETTY_NAME` (`Ubuntu 26.04 LTS`) instead of bare "Linux".

Value-only change to the existing `StaticNodeInformation` gossip — **no wire schema change** (deploys to a single node fine, no mixed-version concern).

## Validation
Unit tests (using kite4's real values as the fixture). Will deploy to kite4 and confirm the topology shows "Nimo Direct Inc. MME3L / AMD RYZEN AI MAX+ 395 w/ Radeon 8060S / Ubuntu 26.04 LTS" before merge.

Note: network-interface typing on Linux is unchanged (interfaces are already reported via psutil, typed "unknown"); proper Linux interface typing is a smaller follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)