### PR TITLE
fix(llama_cpp): honor cancellation on the non-streamed tool path (#123)

### DIFF
--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -463,13 +463,27 @@ class Runner:
         calls, emits a ``ToolCallChunk``; otherwise it chose to answer in prose,
         so emits that content as a normal ``TokenChunk``. Either way a single
         terminal chunk closes the consumer's stream.
+
+        Cancellation: unlike the streaming path (which checks per token), the
+        tool call runs through one blocking ``create_chat_completion`` that
+        cannot be interrupted mid-flight. So cancellation is honored at the two
+        boundaries around it: skip the (possibly long) call entirely if the task
+        is already cancelled, and suppress the result if a cancel landed while it
+        ran. In both cases nothing is emitted and ``main`` reads the drained
+        cancellation to mark the task ``Cancelled`` rather than ``Complete``.
         """
+        if self._is_cancelled(task.task_id):
+            logger.info(f"llama.cpp tool generation skipped (cancelled): {task.task_id}")
+            return
         result = self.model.create_chat_completion(
             messages=messages,
             stream=False,
             tools=task.task_params.tools,
             **kwargs,
         )
+        if self._is_cancelled(task.task_id):
+            logger.info(f"llama.cpp tool generation cancelled: {task.task_id}")
+            return
         choice = result["choices"][0]
         message = choice.get("message", {})
         tool_calls = _tool_calls_from_message(message)

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_runner_cancel.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_runner_cancel.py
@@ -1,0 +1,180 @@
+# pyright: reportPrivateUsage=false, reportMissingParameterType=false
+"""llama.cpp runner cancellation safety (#123).
+
+The tool-calling path runs one blocking, uninterruptible
+``create_chat_completion``, so cancellation is honored at the boundaries around
+it: an already-cancelled task skips the call, and a cancel that lands while the
+call runs suppresses the result. In both cases no ``ChunkGenerated`` is emitted
+and the task ends ``Cancelled`` rather than ``Complete``. A request that is not
+cancelled still emits exactly one terminal chunk and completes.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from anyio import WouldBlock
+
+from skulk.shared.types.common import CommandId, ModelId, NodeId
+from skulk.shared.types.events import ChunkGenerated, Event, TaskStatusUpdated
+from skulk.shared.types.tasks import TaskStatus, TextGeneration
+from skulk.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+from skulk.shared.types.worker.instances import InstanceId
+from skulk.shared.types.worker.runners import RunnerId, RunnerReady
+from skulk.worker.runner.llama_cpp.runner import Runner
+
+
+class _CaptureSender:
+    """Stand-in for the runner's MpSender that records every emitted event."""
+
+    def __init__(self) -> None:
+        self.events: list[Event] = []
+
+    def send(self, item: Event) -> None:
+        self.events.append(item)
+
+
+class _OneShotReceiver:
+    """Stand-in MpReceiver that yields a fixed task list once, then stops."""
+
+    def __init__(self, items: list[object]) -> None:
+        self._items = items
+
+    def __enter__(self):
+        return iter(self._items)
+
+    def __exit__(self, *_: object) -> bool:
+        return False
+
+
+class _CancelReceiver:
+    """MpReceiver stand-in: receive_nowait pops queued ids, else raises WouldBlock."""
+
+    def __init__(self) -> None:
+        self._queue: list[object] = []
+
+    def push(self, task_id: object) -> None:
+        self._queue.append(task_id)
+
+    def receive_nowait(self) -> object:
+        if self._queue:
+            return self._queue.pop(0)
+        raise WouldBlock
+
+
+def _make_runner(cancel: _CancelReceiver) -> tuple[Runner, _CaptureSender]:
+    sender = _CaptureSender()
+    bound = SimpleNamespace(
+        instance=SimpleNamespace(),
+        bound_runner_id=RunnerId("r1"),
+        bound_shard=SimpleNamespace(
+            world_size=1,
+            model_card=SimpleNamespace(model_id=ModelId("some/gguf-model")),
+            device_rank=0,
+        ),
+        bound_node_id=NodeId("n1"),
+    )
+    runner = Runner(
+        bound_instance=cast("object", bound),  # pyright: ignore[reportArgumentType]
+        event_sender=cast("object", sender),  # pyright: ignore[reportArgumentType]
+        task_receiver=cast("object", _OneShotReceiver([])),  # pyright: ignore[reportArgumentType]
+        cancel_receiver=cast("object", cancel),  # pyright: ignore[reportArgumentType]
+    )
+    return runner, sender
+
+
+def _tool_task() -> TextGeneration:
+    return TextGeneration(
+        instance_id=InstanceId("i1"),
+        command_id=CommandId("c1"),
+        task_params=TextGenerationTaskParams.model_validate(
+            {
+                "model": ModelId("some/gguf-model"),
+                "input": [InputMessage(role="user", content="weather in SF?")],
+                "tools": [{"type": "function", "function": {"name": "get_weather"}}],
+            }
+        ),
+    )
+
+
+def _tool_result() -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "function": {"name": "get_weather", "arguments": "{}"},
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    }
+
+
+def _run_one(runner: Runner, sender: _CaptureSender, task: TextGeneration) -> TaskStatus:
+    runner.current_status = RunnerReady()
+    runner.task_receiver = cast("object", _OneShotReceiver([task]))  # pyright: ignore[reportAttributeAccessIssue]
+    runner.main()
+    return next(
+        e.task_status
+        for e in sender.events
+        if isinstance(e, TaskStatusUpdated)
+        and e.task_status in (TaskStatus.Complete, TaskStatus.Cancelled)
+    )
+
+
+def test_tool_request_cancelled_during_call_emits_nothing() -> None:
+    cancel = _CancelReceiver()
+    runner, sender = _make_runner(cancel)
+    task = _tool_task()
+
+    # The cancel arrives *while* the blocking call runs (modeled as a side effect
+    # of create_chat_completion). The assembled result must be suppressed.
+    def fake_ccc(**_kw: object) -> dict[str, Any]:
+        cancel.push(task.task_id)
+        return _tool_result()
+
+    runner.model = SimpleNamespace(create_chat_completion=fake_ccc)
+    terminal = _run_one(runner, sender, task)
+
+    assert not any(isinstance(e, ChunkGenerated) for e in sender.events)
+    assert terminal == TaskStatus.Cancelled
+
+
+def test_tool_request_already_cancelled_skips_call() -> None:
+    cancel = _CancelReceiver()
+    runner, sender = _make_runner(cancel)
+    task = _tool_task()
+    cancel.push(task.task_id)  # cancelled before generation even starts
+
+    calls = {"n": 0}
+
+    def fake_ccc(**_kw: object) -> dict[str, Any]:
+        calls["n"] += 1
+        return _tool_result()
+
+    runner.model = SimpleNamespace(create_chat_completion=fake_ccc)
+    terminal = _run_one(runner, sender, task)
+
+    assert calls["n"] == 0  # the uninterruptible call was skipped entirely
+    assert not any(isinstance(e, ChunkGenerated) for e in sender.events)
+    assert terminal == TaskStatus.Cancelled
+
+
+def test_tool_request_not_cancelled_emits_one_tool_chunk() -> None:
+    cancel = _CancelReceiver()
+    runner, sender = _make_runner(cancel)
+    task = _tool_task()
+
+    def fake_ccc(**_kw: object) -> dict[str, Any]:
+        return _tool_result()
+
+    runner.model = SimpleNamespace(create_chat_completion=fake_ccc)
+    terminal = _run_one(runner, sender, task)
+
+    chunks = [e for e in sender.events if isinstance(e, ChunkGenerated)]
+    assert len(chunks) == 1
+    assert terminal == TaskStatus.Complete


### PR DESCRIPTION
## What

AMD v1 concurrency-safety pass for the llama.cpp runner. The runner is strictly sequential (one task at a time in `main()`), so the real concurrency surface is **cancellation correctness during blocking operations**.

The streaming generation path already checks cancellation per token. The **tool path** (`_generate_with_tools`) runs one blocking, uninterruptible `create_chat_completion(stream=False)` and previously emitted its result unconditionally — so a cancel that arrived while it ran was never observed: the runner delivered output for a cancelled request and `main()` marked it `Complete` instead of `Cancelled`.

This was raised by two automated reviewers on #356 (copilot + codex P2) and deferred there to this dedicated task.

## Fix

Honor cancellation at the two boundaries around the blocking call (the call itself cannot be interrupted mid-flight):
- **Before**: skip the possibly-long call entirely when the task is already cancelled.
- **After**: suppress the assembled result when a cancel landed while it ran.

In both cases nothing is emitted, and `main()` reads the drained cancellation (via `_is_cancelled`) to mark the task `Cancelled`. This brings the tool path in line with the streaming path's cancellation semantics (no output delivered post-cancel, correct terminal status).

## Tests

A real `Runner` driven through `main()` with a cancel-receiver stand-in:
- cancel-during-call → no `ChunkGenerated`, terminal `Cancelled`
- already-cancelled → blocking call skipped entirely, terminal `Cancelled`
- uncancelled happy path → exactly one tool chunk, terminal `Complete`

Local gate green: basedpyright 0 errors, ruff clean, pytest 1130 passed / 1 skipped, nix fmt no changes.

## Scope notes
- The unbounded `seen` / `cancelled_tasks` sets (a slow memory creep over a very long-lived runner) are shared by all runners (MLX, embeddings) and are not a llama.cpp-specific concurrency hazard; left out to keep this pass tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)