### PR TITLE
docs(model-card): document the full ModelCard interface in-code + sync the guide

### DIFF
--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -111,12 +111,21 @@ class ModelTask(str, Enum):
 
 
 class ComponentInfo(CamelCaseModel):
+    """One weight component of a multi-component model (e.g. a diffusion stack)."""
+
     component_name: str
+    """Logical name of this component (e.g. ``text_encoder``, ``transformer``)."""
     component_path: str
+    """Repo-relative subdirectory holding this component's weights."""
     storage_size: Memory
+    """On-disk size of this component's weights."""
     n_layers: PositiveInt | None = None
+    """Layer count for this component when it is shardable; ``None`` otherwise."""
     can_shard: bool
+    """Whether this component may be split across nodes (vs. loaded whole)."""
     safetensors_index_filename: str | None = None
+    """The component's ``*.safetensors.index.json`` filename when sharded across
+    files; ``None`` for a single-file component."""
 
 
 class VisionCardConfig(CamelCaseModel):
@@ -126,12 +135,20 @@ class VisionCardConfig(CamelCaseModel):
     auto-detected from ``config.json`` during card creation."""
 
     image_token_id: int
+    """Token id the model uses as the image placeholder in the prompt."""
     model_type: str
+    """Vision model-type tag from ``config.json``, selecting the image processor."""
     weights_repo: str = ""
+    """Repo holding the vision-tower weights when separate from the LM; empty if
+    bundled with the main weights."""
     image_token: str | None = None
+    """The literal image placeholder string, when distinct from ``image_token_id``."""
     processor_repo: str | None = None
+    """Repo providing the image processor/preprocessor config, if not the main repo."""
     boi_token_id: int | None = None
+    """Begin-of-image token id, for families that bracket image spans."""
     eoi_token_id: int | None = None
+    """End-of-image token id, for families that bracket image spans."""
 
 
 def multi_node_speculation_disabled(
@@ -196,10 +213,16 @@ class ReasoningCardConfig(CamelCaseModel):
     """Optional advanced reasoning capability declarations for a model card."""
 
     supports_toggle: bool | None = None
+    """Whether the model can have reasoning turned on/off per request."""
     supports_budget: bool | None = None
+    """Whether the model accepts a reasoning-effort/budget control."""
     format: ReasoningFormat | None = None
+    """How reasoning is marked in the output stream: ``none``, ``token_delimited``
+    (special tokens), or ``channel_delimited`` (a separate reasoning channel)."""
     default_effort: ReasoningEffort | None = None
+    """Reasoning effort applied when the request does not specify one."""
     disabled_effort: ReasoningEffort | None = None
+    """The effort value that means "reasoning off" for this model."""
 
     @field_validator("format", mode="before")
     @classmethod
@@ -215,15 +238,22 @@ class ModalitiesCardConfig(CamelCaseModel):
     """Optional advanced modality declarations for a model card."""
 
     supports_audio_input: bool | None = None
+    """Whether the model accepts audio input."""
     supports_native_multimodal: bool | None = None
+    """Whether the model natively interleaves modalities (vs. a bolt-on adapter)."""
 
 
 class ToolingCardConfig(CamelCaseModel):
     """Optional tool-calling behavior declarations for a model card."""
 
     supports_tool_calling: bool | None = None
+    """Whether the model supports function/tool calling."""
     tool_call_format: ToolCallFormat | None = None
+    """The wire format the model emits tool calls in (``generic``, ``gemma4``,
+    ``gpt_oss``, ``dsml``), selecting the output parser."""
     builtin_tools: list[BuiltinToolType] | None = None
+    """Builtin tools Skulk advertises to this model (e.g. ``web_search``,
+    ``open_url``, ``extract_page``)."""
 
     @field_validator("tool_call_format", mode="before")
     @classmethod
@@ -316,7 +346,12 @@ class RuntimeCapabilityCardConfig(CamelCaseModel):
     """Optional runtime behavior hints for a model card."""
 
     prompt_renderer: PromptRendererType | None = None
+    """How prompts are rendered for this model (``tokenizer`` chat template,
+    ``gemma4``, ``dsml``); ``None`` uses the family default."""
     output_parser: OutputParserType | None = None
+    """How model output is parsed (``generic``, ``gemma4``, ``gpt_oss``,
+    ``deepseek_v32``), e.g. for reasoning/tool-call extraction; ``None`` uses the
+    family default."""
     metal_fast_synch: bool | None = None
     """Per-model override for the MLX ``MLX_METAL_FAST_SYNCH`` flag.
 
@@ -420,33 +455,97 @@ class RuntimeCapabilityCardConfig(CamelCaseModel):
 
 
 class ModelCard(CamelCaseModel):
+    """The persisted, declarative metadata Skulk holds for one model.
+
+    This is the **model-card interface**: the single source of truth for how a
+    model is sized, sharded, placed, and run. It is created once (from a
+    HuggingFace repo or hand-authored), broadcast cluster-wide, and read by the
+    planner (placement), the downloader (sizing + which files to fetch), and the
+    worker runner (engine + behavior). As a ``CamelCaseModel`` it is camelCase on
+    the wire and strict (``extra="forbid"``), so every node in a cluster must run
+    the same Skulk version (a stale node rejects newer fields).
+
+    Two layers live here: the *card* (this declarative metadata) and the
+    normalized *resolved capability profile* derived from it plus family defaults
+    (see ``capabilities.py`` and ``website/docs/model-capabilities.md``). The
+    optional ``reasoning`` / ``modalities`` / ``tooling`` / ``runtime`` /
+    ``vision`` / ``placement`` sub-configs refine that resolution; when absent,
+    conservative family defaults apply.
+    """
+
     model_id: ModelId
+    """The model's identifier (a HuggingFace repo id, e.g.
+    ``mlx-community/Qwen3.5-9B-4bit``, or a custom id). Slashes become ``--`` in
+    the on-disk store directory name."""
     storage_size: Memory
+    """On-disk size of the weights this card loads (for a GGUF card, just the
+    selected quant's shard group, not every quant the repo hosts). The planner
+    uses this for memory-fit and placement-width decisions."""
     n_layers: PositiveInt
+    """Number of transformer layers. Drives pipeline sharding (how layers split
+    across nodes) and KV-cache sizing."""
     hidden_size: PositiveInt
+    """Model hidden dimension, used in memory/KV-cache estimates."""
     supports_tensor: bool
+    """Whether the model may be served with tensor parallelism (``Sharding.Tensor``).
+    GGUF/llama.cpp cards set this ``False`` (single-node engine)."""
     num_key_value_heads: PositiveInt | None = None
+    """KV-head count for grouped-query attention, used in KV-cache sizing. ``None``
+    when unknown/not applicable."""
     tasks: list[ModelTask]
+    """The task types this model serves (e.g. ``TextGeneration``, ``TextEmbedding``,
+    ``ImageGeneration``); selects which runner handles it."""
     components: list[ComponentInfo] | None = None
+    """For multi-component models (e.g. a diffusion stack), the per-component
+    weight layout. ``None`` for a single-weights model."""
     family: str = ""
+    """Model family token (e.g. ``qwen3``, ``gemma4``) used to pick family-specific
+    defaults during capability resolution. Empty when not classified."""
     quantization: str = ""
+    """Human quantization label (e.g. ``4bit``, ``Q4_K_M``); informational."""
     base_model: str = ""
+    """The upstream base model id when this is a quant/finetune of another; empty
+    if not applicable."""
     gguf_file: str | None = None
     """For GGUF (llama.cpp) models: the repo-relative path of the weights file the
     runner loads (the selected quant's first shard). Resolved once at card creation
     (preferring a quant over BF16) so the download fetches only that quant and the
-    runner loads deterministically, instead of each layer re-globbing/guessing."""
+    runner loads deterministically, instead of each layer re-globbing/guessing.
+    ``None`` for non-GGUF (safetensors/MLX) cards."""
     capabilities: list[str] = []
+    """Free-form capability tags carried for compatibility/auxiliary use; the
+    structured ``reasoning``/``modalities``/``tooling`` configs are authoritative
+    for capability resolution."""
     context_length: int = 0
+    """The model's advertised maximum context length in tokens (``0`` if unknown).
+    The admission ceiling is the smaller of this and what fits in memory."""
     uses_cfg: bool = False
+    """Whether the model uses classifier-free guidance (relevant to some image /
+    diffusion models)."""
     trust_remote_code: bool = True
+    """Passed to the model loader: whether to execute the repo's custom Python.
+    Defaults ``True`` to match upstream loaders; set ``False`` to refuse it."""
     is_custom: bool = False
+    """Marks an operator-added custom card (not from the curated catalog). Excluded
+    from the persisted card file so it is recomputed per environment."""
     vision: VisionCardConfig | None = None
+    """Optional vision (image-input) configuration; ``None`` for text-only models."""
     reasoning: ReasoningCardConfig | None = None
+    """Optional reasoning/thinking configuration (toggle, budget, format, default
+    effort); ``None`` falls back to family defaults."""
     modalities: ModalitiesCardConfig | None = None
+    """Optional extra-modality flags (audio input, native multimodal); ``None``
+    falls back to family defaults."""
     tooling: ToolingCardConfig | None = None
+    """Optional tool-calling configuration (support, call format, builtin tools);
+    ``None`` falls back to family defaults."""
     runtime: RuntimeCapabilityCardConfig | None = None
+    """Optional runtime-behavior configuration (prompt renderer, output parser,
+    MTP/speculative-decoding sidecar, MLX knobs); ``None`` falls back to defaults."""
     placement: PlacementCardConfig = PlacementCardConfig()
+    """Where the model is allowed to run and which backend is preferred: the
+    ``compatible_backends`` hard filter and ``backend_preference`` soft score the
+    planner uses to route the model to suitable nodes."""
 
     @model_validator(mode="after")
     def _fill_vision_weights_repo(self) -> "ModelCard":

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -493,8 +493,8 @@ class ModelCard(CamelCaseModel):
     """KV-head count for grouped-query attention, used in KV-cache sizing. ``None``
     when unknown/not applicable."""
     tasks: list[ModelTask]
-    """The task types this model serves (e.g. ``TextGeneration``, ``TextEmbedding``,
-    ``ImageGeneration``); selects which runner handles it."""
+    """The task types this model serves (``TextGeneration``, ``TextEmbedding``,
+    ``TextToImage``, ``ImageToImage``); selects which runner handles it."""
     components: list[ComponentInfo] | None = None
     """For multi-component models (e.g. a diffusion stack), the per-component
     weight layout. ``None`` for a single-weights model."""

--- a/src/skulk/utils/pydantic_ext.py
+++ b/src/skulk/utils/pydantic_ext.py
@@ -20,6 +20,10 @@ class CamelCaseModel(BaseModel):
         validate_by_name=True,
         extra="forbid",
         strict=True,
+        # Include each field's attribute docstring as its JSON-schema description,
+        # so in-code field docs (e.g. on ModelCard) become the published OpenAPI
+        # reference instead of needing a parallel hand-maintained description.
+        use_attribute_docstrings=True,
     )
 
 
@@ -30,6 +34,7 @@ class FrozenModel(BaseModel):
         extra="forbid",
         strict=True,
         frozen=True,
+        use_attribute_docstrings=True,
     )
 
 

--- a/website/docs/model-cards.md
+++ b/website/docs/model-cards.md
@@ -48,8 +48,8 @@ Every field is documented in that model, and the exhaustive, always-current fiel
 reference is the generated API schema (`ModelCard` and its nested
 `PlacementCardConfig` / `RuntimeCapabilityCardConfig` / `VisionCardConfig` /
 `ReasoningCardConfig` / `ModalitiesCardConfig` / `ToolingCardConfig` /
-`ComponentInfo`) in the [API reference](api). This page is the curated narrative;
-when in doubt about an exact field, the schema is canonical.
+`ComponentInfo`) in the [API reference](/api/skulk-api). This page is the curated
+narrative; when in doubt about an exact field, the schema is canonical.
 
 Cards are camelCase on the wire and strict (unknown fields are rejected), so every
 node in a cluster must run the same Skulk version.
@@ -128,10 +128,12 @@ it is how a heterogeneous cluster keeps each model on hardware that can run it.
 
 Backends are named `<engine>-<compute>` tags (for example `mlx-metal`,
 `llama_cpp-vulkan`, `llama_cpp-rocm`, `llama_cpp-cpu`). The engine selects the
-worker runner; the compute names the accelerator.
+worker runner; the compute names the accelerator. A bare engine tag (e.g. `mlx`)
+is also valid vocabulary: nodes advertise it alongside their compound tags, so a
+card written against the original `{"mlx"}` set keeps matching.
 
 - `compatible_backends`
-  - the hard filter: the set of backend tags this model may run on. The planner excludes any node whose advertised backends do not intersect this set. An MLX card lists MLX tags (default `{"mlx"}`); a GGUF card lists the llama.cpp tags. This is what keeps an MLX model off an AMD node and a GGUF model off a Mac.
+  - the hard filter: the set of backend tags this model may run on. The planner excludes any node whose advertised backends do not intersect this set. The default is `{"mlx"}` (so an unannotated card stays on MLX nodes); a GGUF card lists the llama.cpp tags. This is what keeps an MLX model off an AMD node and a GGUF model off a Mac.
 - `backend_preference`
   - the soft score: an ordered list of preferred tags. When several compatible nodes qualify, the planner prefers the node whose backend ranks earliest, with graceful fallback to the rest. This lets a card say "fastest on Vulkan, but ROCm is fine."
 - `min_vram_gib`

--- a/website/docs/model-cards.md
+++ b/website/docs/model-cards.md
@@ -39,6 +39,21 @@ Built-in cards are shipped in:
 
 Custom cards are stored under the user data directory and synced through the cluster event flow.
 
+## The card interface (source of truth)
+
+The authoritative definition of the model-card interface is the `ModelCard`
+type in
+[`src/skulk/shared/models/model_cards.py`](https://github.com/Foxlight-Foundation/Skulk/tree/main/src/skulk/shared/models/model_cards.py).
+Every field is documented in that model, and the exhaustive, always-current field
+reference is the generated API schema (`ModelCard` and its nested
+`PlacementCardConfig` / `RuntimeCapabilityCardConfig` / `VisionCardConfig` /
+`ReasoningCardConfig` / `ModalitiesCardConfig` / `ToolingCardConfig` /
+`ComponentInfo`) in the [API reference](api). This page is the curated narrative;
+when in doubt about an exact field, the schema is canonical.
+
+Cards are camelCase on the wire and strict (unknown fields are rejected), so every
+node in a cluster must run the same Skulk version.
+
 ## Core Fields
 
 ### Identity and size
@@ -53,15 +68,21 @@ Custom cards are stored under the user data directory and synced through the clu
   - hidden dimension used for placement and compatibility checks
 - `num_key_value_heads`
   - optional KV head count for tensor compatibility decisions
+- `gguf_file`
+  - for GGUF (llama.cpp) models only: the repo-relative weights file the runner loads (the selected quant's first shard), resolved once at card creation; `null` for safetensors/MLX cards
+- `components`
+  - for multi-component models (such as a diffusion stack): the per-component weight layout; `null` for a single-weights model
 
 ### Runtime and placement
 
 - `supports_tensor`
-  - whether tensor-style placement is allowed
+  - whether tensor-style placement is allowed (GGUF/llama.cpp cards set this `false`)
 - `tasks`
   - supported task families such as `TextGeneration`, `TextEmbedding`, or image tasks
 - `trust_remote_code`
   - whether the loader may enable remote-code behavior for this model
+- `uses_cfg`
+  - whether the model uses classifier-free guidance (relevant to some image/diffusion models)
 
 ### Catalog metadata
 
@@ -98,6 +119,25 @@ Fields include:
   - optional begin-of-image token id
 - `eoi_token_id`
   - optional end-of-image token id
+
+## Placement Section
+
+`[placement]` declares where a model is allowed to run and which backend is
+preferred. It is what the planner reads to route a model to suitable nodes, and
+it is how a heterogeneous cluster keeps each model on hardware that can run it.
+
+Backends are named `<engine>-<compute>` tags (for example `mlx-metal`,
+`llama_cpp-vulkan`, `llama_cpp-rocm`, `llama_cpp-cpu`). The engine selects the
+worker runner; the compute names the accelerator.
+
+- `compatible_backends`
+  - the hard filter: the set of backend tags this model may run on. The planner excludes any node whose advertised backends do not intersect this set. An MLX card lists MLX tags (default `{"mlx"}`); a GGUF card lists the llama.cpp tags. This is what keeps an MLX model off an AMD node and a GGUF model off a Mac.
+- `backend_preference`
+  - the soft score: an ordered list of preferred tags. When several compatible nodes qualify, the planner prefers the node whose backend ranks earliest, with graceful fallback to the rest. This lets a card say "fastest on Vulkan, but ROCm is fine."
+- `min_vram_gib`
+  - optional minimum accelerator memory a node must have to be eligible.
+- `max_context_tokens`
+  - optional cap on the admission context for this model, independent of the model's trained context length.
 
 ## Extended Capability Sections
 
@@ -156,14 +196,22 @@ Declares runtime integration preferences:
   - maximum draft depth the MTP heads support; start at `1` for Apple Silicon (deeper values rarely amortize on Metal due to near-linear verify-pass scaling)
 - `mtp_sidecar_repo`
   - Hugging Face repo ID containing the published `mtp.safetensors` sidecar (e.g. `"FoxlightAI/qwen3-5-7b-instruct-mtp-q4k"`); produced by SWP from the original BF16 checkpoint
+- `mtp_norm_convention`
+  - how the MTP heads normalize hidden states (`zero_centered` or `actual_scale`); must match how the sidecar was produced
+- `mtp_concat_order`
+  - the order the MTP heads concatenate the embedding and hidden state (`embed_first` or `hidden_first`); must match the sidecar
+- `speculative_multi_node`
+  - set to `false` to forbid speculative decoding when the model is sharded across multiple nodes (it stays single-node speculative); the runner and the generation loop read this to make the same rank-symmetric decision
+- `assistant_model_repo`
+  - Hugging Face repo of a small companion model used as an external drafter for speculative decoding (the Gemma 4 path), as opposed to native MTP heads
 
 ## MTP Speculative Decoding
 
-Some models include native multi-token prediction (MTP) heads baked into their checkpoint weights. Skulk uses these heads for speculative decoding: the MTP heads draft candidate tokens cheaply, a full forward pass verifies them, and accepted tokens are emitted in bulk — substantially increasing throughput with no accuracy loss.
+Some models include native multi-token prediction (MTP) heads baked into their checkpoint weights. Skulk uses these heads for speculative decoding: the MTP heads draft candidate tokens cheaply, a full forward pass verifies them, and accepted tokens are emitted in bulk, substantially increasing throughput with no accuracy loss.
 
 ### Why a sidecar
 
-Standard quantization pipelines — including mlx-lm's `sanitize()` — strip `mtp.*` tensor keys at conversion time. The MLX-quantized checkpoint you download from Hugging Face typically does not contain MTP weights.
+Standard quantization pipelines (including mlx-lm's `sanitize()`) strip `mtp.*` tensor keys at conversion time. The MLX-quantized checkpoint you download from Hugging Face typically does not contain MTP weights.
 
 SWP (Skulk Weights Publisher) solves this by re-extracting the `mtp.*` tensors from the original BF16 checkpoint, quantizing only those tensors, and publishing the result as `mtp.safetensors` to a dedicated sidecar repo on Hugging Face. This is the same pattern Skulk uses for vision encoder weights.
 
@@ -183,7 +231,7 @@ If the sidecar is declared but the file is not found locally, Skulk logs a warni
 - Qwen3.6 variants
 - DeepSeek V3 / R1
 
-Gemma 4 does **not** use native MTP heads — it uses an external drafter model for speculative decoding, which is a separate feature.
+Gemma 4 does **not** use native MTP heads; it uses an external drafter model (`assistant_model_repo`) for speculative decoding, which is a separate feature.
 
 ### Adding MTP to a card
 


### PR DESCRIPTION
## Why

There was no single, authoritative, browsable definition of the model-card interface (flagged in conversation). The Python `ModelCard` is the de facto source of truth, but **22 of 23 top-level fields had no in-code description** (only `gguf_file`), and `ComponentInfo`/`Vision`/`Reasoning`/`Modalities`/`Tooling` had class docstrings but no per-field docs. The hand-written `model-cards.md` was **stale by omission**: no `[placement]` section at all, no `gguf_file`/GGUF, no `uses_cfg`/`components`, and 4 newer `[runtime]` fields missing. `/v1/models` returns a trimmed view (no `placement`/`gguf_file`), so the dashboard isn't a reference either.

## What

**In-code (the central source of truth):** add attribute docstrings to every `ModelCard` top-level field and to the previously-bare nested-config fields. This makes the pydantic self-documenting (also satisfies the CLAUDE.md "all pydantic fields must have descriptions" rule it was violating) and **flows into the generated OpenAPI schema**, so the exhaustive, always-current field reference is now auto-published.

**Narrative (`website/docs/model-cards.md`):** 
- New "card interface (source of truth)" pointer to the pydantic + generated schema.
- Document the **`[placement]`** section (`compatible_backends` hard filter, `backend_preference` soft score, `min_vram_gib`, `max_context_tokens`) — the biggest gap, and what the planner actually reads.
- Add `gguf_file`/GGUF cards, `uses_cfg`, `components`, and the 4 missing `[runtime]` fields (`mtp_norm_convention`, `mtp_concat_order`, `speculative_multi_node`, `assistant_model_repo`).
- Remove pre-existing em dashes.

## Gate
basedpyright 0, ruff clean, model_cards tests 37 pass, em-dash check 0, nix fmt no-op. Docs-only + in-code docstrings (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)