### PR TITLE
fix(download): bound in-progress gossip by fraction, not duration (#364)

### DIFF
--- a/src/skulk/download/coordinator.py
+++ b/src/skulk/download/coordinator.py
@@ -3,7 +3,7 @@ import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import cast
+from typing import ClassVar, cast
 
 import anyio
 import yaml
@@ -73,8 +73,29 @@ class DownloadCoordinator:
     _tg: TaskGroup = field(init=False, default_factory=TaskGroup)
     _stopped: anyio.Event = field(init=False, default_factory=anyio.Event)
 
-    # Per-model throttle for download progress events
+    # Per-model throttle for in-progress download events. Each emission is a
+    # FULL ordered event (master indexes it, appends the event log, persists a
+    # snapshot, and rebroadcasts to every node), so the in_progress stream must be
+    # bounded by total count, not by rate: the raw downloader fires per 8MB chunk
+    # across parallel files (thousands of callbacks for a large model), and a
+    # pure time gate still scales event volume with download DURATION, which
+    # saturates the gossip send queue and can drop the terminal DownloadCompleted
+    # so a placement wedges in RunnerLoading (#364). The fraction-delta gate caps
+    # a download to ~ (1 / _PROGRESS_STEP) in_progress events regardless of size
+    # or duration; the heartbeat still shows life on a slow download; terminal
+    # complete/failed transitions always pass.
     _last_progress_time: dict[ModelId, float] = field(default_factory=dict)
+    _last_progress_fraction: dict[ModelId, float] = field(default_factory=dict)
+
+    # Emit an in_progress update only after the download advances this fraction
+    # (so ~20 events total), never faster than the min interval (no bursts on a
+    # fast/cached download), and at least once per heartbeat (so a slow download
+    # still updates). Dropping intermediate updates is loss-free: apply()
+    # overwrites the per-(node, model) download entry, so only the dashboard
+    # progress bar is coarser.
+    _PROGRESS_STEP: ClassVar[float] = 0.05
+    _MIN_INTERVAL_SECS: ClassVar[float] = 1.0
+    _HEARTBEAT_SECS: ClassVar[float] = 30.0
 
     def __post_init__(self) -> None:
         self.shard_downloader.on_progress(self._download_progress_callback)
@@ -82,11 +103,31 @@ class DownloadCoordinator:
     def _model_dir(self, model_id: ModelId) -> str:
         return str(SKULK_MODELS_DIR / model_id.normalize())
 
+    def _should_emit_in_progress(self, model_id: ModelId, fraction: float) -> bool:
+        """Whether to emit an in_progress event given how far the download advanced.
+
+        Bounds the high-frequency in_progress stream so it cannot saturate the
+        ordered control plane (#364): emit on a fraction-delta step (rate-floored
+        to avoid bursts) or a slow-download heartbeat.
+        """
+        now = current_time()
+        last_time = self._last_progress_time.get(model_id, 0.0)
+        last_fraction = self._last_progress_fraction.get(model_id, -1.0)
+        advanced = (
+            fraction - last_fraction >= self._PROGRESS_STEP
+            and now - last_time >= self._MIN_INTERVAL_SECS
+        )
+        heartbeat = now - last_time >= self._HEARTBEAT_SECS
+        if advanced or heartbeat:
+            self._last_progress_time[model_id] = now
+            self._last_progress_fraction[model_id] = fraction
+            return True
+        return False
+
     async def _download_progress_callback(
         self, callback_shard: ShardMetadata, progress: RepoDownloadProgress
     ) -> None:
         model_id = callback_shard.model_card.model_id
-        throttle_interval_secs = 1.0
 
         if progress.status == "complete":
             completed = DownloadCompleted(
@@ -100,11 +141,14 @@ class DownloadCoordinator:
                 NodeDownloadProgress(download_progress=completed)
             )
             self._last_progress_time.pop(model_id, None)
-        elif (
-            progress.status == "in_progress"
-            and current_time() - self._last_progress_time.get(model_id, 0.0)
-            > throttle_interval_secs
-        ):
+            self._last_progress_fraction.pop(model_id, None)
+        elif progress.status == "in_progress":
+            total_bytes = progress.total.in_bytes
+            fraction = (
+                progress.downloaded.in_bytes / total_bytes if total_bytes > 0 else 0.0
+            )
+            if not self._should_emit_in_progress(model_id, fraction):
+                return
             ongoing = DownloadOngoing(
                 node_id=self.node_id,
                 shard_metadata=callback_shard,
@@ -117,7 +161,6 @@ class DownloadCoordinator:
             await self.event_sender.send(
                 NodeDownloadProgress(download_progress=ongoing)
             )
-            self._last_progress_time[model_id] = current_time()
 
     async def run(self) -> None:
         logger.info(

--- a/src/skulk/download/coordinator.py
+++ b/src/skulk/download/coordinator.py
@@ -111,8 +111,21 @@ class DownloadCoordinator:
         to avoid bursts) or a slow-download heartbeat.
         """
         now = current_time()
+        # First observation, or a fraction regression (a restarted/cancelled
+        # download whose fraction reset back toward 0): always emit and re-seat
+        # the baseline. Otherwise the delta gate would measure against a stale,
+        # higher baseline and suppress the new download's progress until it
+        # surpassed the old attempt -- a frozen progress bar on download churn.
+        if model_id not in self._last_progress_fraction:
+            self._last_progress_time[model_id] = now
+            self._last_progress_fraction[model_id] = fraction
+            return True
         last_time = self._last_progress_time.get(model_id, 0.0)
-        last_fraction = self._last_progress_fraction.get(model_id, -1.0)
+        last_fraction = self._last_progress_fraction[model_id]
+        if fraction < last_fraction:
+            self._last_progress_time[model_id] = now
+            self._last_progress_fraction[model_id] = fraction
+            return True
         advanced = (
             fraction - last_fraction >= self._PROGRESS_STEP
             and now - last_time >= self._MIN_INTERVAL_SECS

--- a/src/skulk/download/tests/test_progress_throttle.py
+++ b/src/skulk/download/tests/test_progress_throttle.py
@@ -1,0 +1,99 @@
+# pyright: reportPrivateUsage=false
+"""Download-progress throttle bounds the in_progress event stream (#364).
+
+A large download fires a progress callback per 8MB chunk across parallel files,
+and each emitted ``NodeDownloadProgress`` is a full ordered event (master indexes
+it, appends the event log, persists a snapshot, and rebroadcasts to every node).
+So the in_progress stream must be bounded by total count, not by rate -- a pure
+time gate still scales event volume with download duration, which saturated the
+gossip send queue and dropped the terminal ``DownloadCompleted`` so placements
+wedged in RunnerLoading. The fraction-delta gate caps a download to roughly
+``1 / _PROGRESS_STEP`` in_progress events regardless of size or duration.
+"""
+
+from typing import cast
+
+import pytest
+
+from skulk.download import coordinator as coordinator_mod
+from skulk.download.coordinator import DownloadCoordinator
+from skulk.shared.models.model_cards import ModelId
+from skulk.shared.types.common import NodeId
+from skulk.utils.channels import channel
+
+
+class _FakeDownloader:
+    def on_progress(self, callback: object) -> None:
+        pass
+
+
+def _make_coordinator() -> DownloadCoordinator:
+    _, cmd_recv = channel[object]()
+    event_send, _ = channel[object]()
+    return DownloadCoordinator(
+        node_id=NodeId("n1"),
+        shard_downloader=cast("object", _FakeDownloader()),  # pyright: ignore[reportArgumentType]
+        download_command_receiver=cast("object", cmd_recv),  # pyright: ignore[reportArgumentType]
+        event_sender=cast("object", event_send),  # pyright: ignore[reportArgumentType]
+    )
+
+
+def test_in_progress_throttle_gates_by_fraction_rate_and_heartbeat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    co = _make_coordinator()
+    mid = ModelId("org/model")
+    clock = {"now": 1000.0}
+
+    def fake_now() -> float:
+        return clock["now"]
+
+    monkeypatch.setattr(coordinator_mod, "current_time", fake_now)
+
+    # First update always emits (establishes the baseline).
+    assert co._should_emit_in_progress(mid, 0.0) is True
+
+    # A >=step advance but within the rate floor (<1s) is suppressed.
+    clock["now"] = 1000.5
+    assert co._should_emit_in_progress(mid, 0.20) is False
+
+    # A >=step advance after the rate floor emits.
+    clock["now"] = 1002.0
+    assert co._should_emit_in_progress(mid, 0.20) is True
+
+    # A sub-step advance (<5%) is suppressed even after the rate floor.
+    clock["now"] = 1004.0
+    assert co._should_emit_in_progress(mid, 0.23) is False
+
+    # No meaningful advance, but the heartbeat interval elapsed -> emit.
+    clock["now"] = 1002.0 + co._HEARTBEAT_SECS + 1
+    assert co._should_emit_in_progress(mid, 0.24) is True
+
+
+def test_in_progress_throttle_bounds_event_count_for_a_long_download(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Simulate the raw downloader's per-8MB-chunk firing for a large model:
+    # thousands of callbacks with tiny fraction deltas and sub-second spacing.
+    # The gate must admit O(1/_PROGRESS_STEP) of them, not O(callbacks).
+    co = _make_coordinator()
+    mid = ModelId("org/big")
+    clock = {"now": 0.0}
+
+    def fake_now() -> float:
+        return clock["now"]
+
+    monkeypatch.setattr(coordinator_mod, "current_time", fake_now)
+
+    emitted = 0
+    chunks = 4000  # ~32 GB at 8MB chunks
+    for i in range(1, chunks + 1):
+        clock["now"] = i * 0.1  # 100ms per chunk -> 400s total, well past heartbeats
+        if co._should_emit_in_progress(mid, i / chunks):
+            emitted += 1
+
+    # Without the fix this is ~ (400s / 1s) = 400 events; with the fraction gate
+    # plus the heartbeat it is sharply bounded. Assert it is a small fraction of
+    # the callbacks and near the step/heartbeat budget.
+    assert emitted <= 30, f"expected a small bounded count, got {emitted}"
+    assert emitted >= 1

--- a/src/skulk/download/tests/test_progress_throttle.py
+++ b/src/skulk/download/tests/test_progress_throttle.py
@@ -70,6 +70,38 @@ def test_in_progress_throttle_gates_by_fraction_rate_and_heartbeat(
     assert co._should_emit_in_progress(mid, 0.24) is True
 
 
+def test_in_progress_throttle_resets_baseline_on_fraction_regression(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A restarted/cancelled download whose fraction resets back toward 0 must
+    # re-seat the baseline and emit, not stay frozen against the old high
+    # baseline until it surpasses the prior attempt (download churn on
+    # placement re-tries). The heartbeat alone is too coarse for that case.
+    co = _make_coordinator()
+    mid = ModelId("org/model")
+    clock = {"now": 1000.0}
+
+    def fake_now() -> float:
+        return clock["now"]
+
+    monkeypatch.setattr(coordinator_mod, "current_time", fake_now)
+
+    # Climb to a high baseline.
+    assert co._should_emit_in_progress(mid, 0.0) is True
+    clock["now"] = 1002.0
+    assert co._should_emit_in_progress(mid, 0.80) is True
+
+    # A regression (new download started) emits immediately, even within the
+    # rate floor and far below the heartbeat interval.
+    clock["now"] = 1002.2
+    assert co._should_emit_in_progress(mid, 0.01) is True
+
+    # And the baseline is now the regressed value: a small further advance is
+    # gated again as usual (no longer measured against the stale 0.80).
+    clock["now"] = 1002.3
+    assert co._should_emit_in_progress(mid, 0.02) is False
+
+
 def test_in_progress_throttle_bounds_event_count_for_a_long_download(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem

Staging large GGUFs to the model store (gpt-oss-120B, Llama-3.3-70B, gemma-4-31B) wedged at `DownloadPending`/`RunnerLoading` and the logs showed `Send Queue full. Could not send Forward` ~108x. This **fundamentally breaks** big-model placement.

Root cause: every `NodeDownloadProgress` is a fully-ordered control-plane event — the master indexes it, appends the event log, persists a snapshot, and rebroadcasts to every node via `GLOBAL_EVENTS`. The raw shard downloader fires a progress callback **per 8MB chunk across parallel files**, so a large model produces thousands of callbacks. The prior throttle was a 1/sec **time** gate, so emitted event volume still scaled with download **duration**: a multi-hundred-second big download floods the (drop-on-full) gossipsub send queue, and dropping the terminal `DownloadCompleted` wedges the placement.

## Fix

Replace the time gate with a **fraction-delta gate** (`_should_emit_in_progress`):
- emit only after the download advances `_PROGRESS_STEP` (5% → ~20 in_progress events total, independent of size/duration)
- rate-floored (`_MIN_INTERVAL_SECS`) so a fast/cached download cannot burst
- heartbeat (`_HEARTBEAT_SECS`) so a slow download still shows life
- terminal complete/failed always pass

Dropping intermediate updates is loss-free for correctness: `apply()` overwrites the per-`(node, model)` download entry, so only the dashboard progress bar is coarser.

## Tests

`src/skulk/download/tests/test_progress_throttle.py` — gating semantics (fraction/rate/heartbeat) and that a 4000-chunk (~32GB) download admits ≤30 events instead of ~400.

## Validation

- `uv run basedpyright` — 0 errors
- `uv run ruff check` — clean
- `uv run pytest src/skulk/download/` — 49 passed
- Fleet deploy + big-GGUF staging smoke to follow on the PR.

## Follow-ups (out of scope, #364 structural)

- Move ongoing download progress off the ordered control plane onto the telemetry plane (LWW, like other readings).
- Control-plane backpressure instead of silent drop-on-full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)