### PR TITLE
fix(api): settle placement through the post-teardown telemetry lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,19 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Back-to-back placements no longer spuriously fail right after a teardown.**
+  Tearing an instance down frees GPU memory that takes a moment to reflect in
+  gossiped `ram_available` (the worker re-samples only after the runner process
+  exits and Metal/VRAM reclaims, then gossips it). A placement attempted in that
+  window saw stale-low memory and returned "No usable placement preview found" /
+  a 400, which made tear-down-then-place loops (the test matrix, redeploys) fail
+  on a transient. The API placement dry-run and previews now wait for the freed
+  memory to settle (`_POST_TEARDOWN_SETTLE_SECONDS`) before declaring no fit,
+  only within a window after a teardown this node served. It waits for memory to
+  actually free rather than crediting it optimistically, so there is no
+  over-admit; the worker's local pre-spawn guard stays the backstop, and a cold
+  request with no recent teardown still fails fast on a genuine shortfall.
+
 - **Placement now admits GPU-offload nodes against their discrete VRAM, not
   system RAM.** The memory fit check capped every node at
   `GPU_WORKING_SET_FRACTION` (0.75) of *system* RAM, a Metal/Apple-unified-memory

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -157,7 +157,7 @@ from skulk.api.types.openai_responses import (
 from skulk.connectivity.remote_access import RemoteAccessInfo, build_remote_access_info
 from skulk.connectivity.tailscale import TailscaleStatus, query_tailscale_status
 from skulk.master.image_store import ImageStore
-from skulk.master.placement import PlacementInfoPendingError
+from skulk.master.placement import PlacementError, PlacementInfoPendingError
 from skulk.master.placement import place_instance as get_instance_placements
 from skulk.master.placement_utils import usable_vram_by_node
 from skulk.shared.apply import apply
@@ -377,6 +377,20 @@ _TERMINAL_TASK_STATUSES: frozenset[task_types.TaskStatus] = frozenset(
 # formation (identities present) and the first NodeGatheredInfo from every
 # node — observed to resolve within a few seconds on a LAN cluster.
 _PLACEMENT_INFO_WAIT_SECONDS = 15.0
+
+# After this node tears an instance down, the freed GPU memory takes a moment to
+# reflect in gossiped `ram_available` (telemetry plane, last-write-wins: the
+# worker re-samples memory only after the runner process exits and Metal/VRAM
+# reclaims, then gossips it). A placement attempted in that window sees stale-low
+# memory and spuriously finds no fit. So within this window after a teardown the
+# placement dry-run and previews wait+retry for the telemetry to settle rather
+# than failing, so back-to-back "tear down model A, place model B" (the test
+# harness's matrix loop, and any redeploy) stops failing on a transient. We WAIT
+# for memory to actually free rather than optimistically crediting it, so there
+# is no over-admit; the worker's local pre-spawn guard remains the backstop. A
+# cold request with no recent teardown is unaffected (a genuine "too big" still
+# fails fast).
+_POST_TEARDOWN_SETTLE_SECONDS = 30.0
 ONBOARDING_COMPLETE_FILE = SKULK_CACHE_HOME / "onboarding_complete"
 
 # A node with no live runners should sit near its idle wired baseline
@@ -690,6 +704,11 @@ class API:
         )
         self._event_log = DiskEventLog(_API_EVENT_LOG_DIR) if enable_event_log else None
         self._event_log_appends_since_retention_check = 0
+        # Monotonic time of the last instance teardown this node served. Within
+        # _POST_TEARDOWN_SETTLE_SECONDS of it, the placement dry-run and previews
+        # wait for the freed memory to reflect in gossiped telemetry instead of
+        # failing on a transient shortfall (see _POST_TEARDOWN_SETTLE_SECONDS).
+        self._last_teardown_monotonic: float = 0.0
         self._system_id = SystemId()
         self.command_sender = command_sender
         self.download_command_sender = download_command_sender
@@ -1566,6 +1585,15 @@ class API:
                         detail=f"{exc} (waited {_PLACEMENT_INFO_WAIT_SECONDS:.0f}s)",
                     ) from exc
                 await anyio.sleep(1)
+            except PlacementError as exc:
+                # A memory shortfall right after this node tore an instance down
+                # is usually transient (freed memory not yet gossiped). Wait for
+                # the settle window rather than failing the placement; outside it,
+                # treat the shortfall as real and 400.
+                if self._post_teardown_settle_remaining() > 0:
+                    await anyio.sleep(1)
+                    continue
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -1651,8 +1679,31 @@ class API:
         node_ids: Annotated[list[NodeId] | None, Query()] = None,
         excluded_node_ids: Annotated[list[NodeId] | None, Query()] = None,
     ) -> PlacementPreviewResponse:
-        seen: set[tuple[ModelId, Sharding, InstanceMeta, int]] = set()
-        previews: list[PlacementPreview] = []
+        """Enumerate viable placements, settling through the post-teardown lag.
+
+        Re-runs the enumeration while no combination yields a viable placement and
+        this node is still inside the post-teardown settle window: the just-freed
+        memory of a torn-down instance may not have reflected in gossiped telemetry
+        yet, so an immediate all-errored result would be a transient false negative
+        (the tear-down-then-preview matrix loop). Outside the window the first pass
+        stands, so a genuine no-fit returns its error previews immediately.
+        """
+        while True:
+            response = await self._compute_placement_previews(
+                model_id, node_ids, excluded_node_ids
+            )
+            if any(p.instance is not None for p in response.previews):
+                return response
+            if self._post_teardown_settle_remaining() <= 0:
+                return response
+            await anyio.sleep(1)
+
+    async def _compute_placement_previews(
+        self,
+        model_id: ModelId,
+        node_ids: list[NodeId] | None = None,
+        excluded_node_ids: list[NodeId] | None = None,
+    ) -> PlacementPreviewResponse:
         required_nodes = set(node_ids) if node_ids else None
         excluded_nodes = set(excluded_node_ids) if excluded_node_ids else None
 
@@ -1679,6 +1730,8 @@ class API:
         # TODO: PDD
         # instance_combinations.append((Sharding.PrefillDecodeDisaggregation, InstanceMeta.MlxRing, 1))
 
+        seen: set[tuple[ModelId, Sharding, InstanceMeta, int]] = set()
+        previews: list[PlacementPreview] = []
         for sharding, instance_meta, min_nodes in instance_combinations:
             try:
                 placements = get_instance_placements(
@@ -1789,11 +1842,25 @@ class API:
             instance_id=instance_id,
         )
         await self._send(command)
+        # The freed GPU memory lags in gossiped telemetry; remember the teardown
+        # so a back-to-back placement waits for it to settle rather than failing
+        # on a transient shortfall (see _post_teardown_settle_remaining).
+        self._last_teardown_monotonic = time.monotonic()
         return DeleteInstanceResponse(
             message="Command received.",
             command_id=command.command_id,
             instance_id=instance_id,
         )
+
+    def _post_teardown_settle_remaining(self) -> float:
+        """Seconds left in the post-teardown placement settle window (0 if none).
+
+        Within this window the freed memory of a just-torn-down instance may not
+        yet be reflected in gossiped ``ram_available``, so placement should wait
+        for it to settle rather than fail on the transient shortfall.
+        """
+        elapsed = time.monotonic() - self._last_teardown_monotonic
+        return max(0.0, _POST_TEARDOWN_SETTLE_SECONDS - elapsed)
 
     async def cancel_command(self, command_id: CommandId) -> CancelCommandResponse:
         """Cancel an active command by closing its stream and notifying workers."""

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -1689,7 +1689,7 @@ class API:
         may not have reflected in gossiped telemetry yet, so that all-errored
         result is a transient false negative (the tear-down-then-preview matrix
         loop). A deterministic no-fit (backend mismatch, excluded nodes,
-        unsupported sharding) does not retry — waiting cannot change it — and
+        unsupported sharding) does not retry, since waiting cannot change it, and
         outside the window the first pass stands.
         """
         while True:

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -157,7 +157,7 @@ from skulk.api.types.openai_responses import (
 from skulk.connectivity.remote_access import RemoteAccessInfo, build_remote_access_info
 from skulk.connectivity.tailscale import TailscaleStatus, query_tailscale_status
 from skulk.master.image_store import ImageStore
-from skulk.master.placement import PlacementError, PlacementInfoPendingError
+from skulk.master.placement import PlacementInfoPendingError, PlacementMemoryError
 from skulk.master.placement import place_instance as get_instance_placements
 from skulk.master.placement_utils import usable_vram_by_node
 from skulk.shared.apply import apply
@@ -1585,11 +1585,13 @@ class API:
                         detail=f"{exc} (waited {_PLACEMENT_INFO_WAIT_SECONDS:.0f}s)",
                     ) from exc
                 await anyio.sleep(1)
-            except PlacementError as exc:
+            except PlacementMemoryError as exc:
                 # A memory shortfall right after this node tore an instance down
                 # is usually transient (freed memory not yet gossiped). Wait for
                 # the settle window rather than failing the placement; outside it,
-                # treat the shortfall as real and 400.
+                # treat the shortfall as real and 400. Only a *memory* shortfall
+                # is retried; a backend/topology/sharding error never clears by
+                # waiting and falls through to an immediate 400.
                 if self._post_teardown_settle_remaining() > 0:
                     await anyio.sleep(1)
                     continue
@@ -1681,20 +1683,22 @@ class API:
     ) -> PlacementPreviewResponse:
         """Enumerate viable placements, settling through the post-teardown lag.
 
-        Re-runs the enumeration while no combination yields a viable placement and
-        this node is still inside the post-teardown settle window: the just-freed
-        memory of a torn-down instance may not have reflected in gossiped telemetry
-        yet, so an immediate all-errored result would be a transient false negative
-        (the tear-down-then-preview matrix loop). Outside the window the first pass
-        stands, so a genuine no-fit returns its error previews immediately.
+        Re-runs the enumeration while no combination yields a viable placement,
+        the no-fit was a *memory* shortfall, and this node is still inside the
+        post-teardown settle window: the just-freed memory of a torn-down instance
+        may not have reflected in gossiped telemetry yet, so that all-errored
+        result is a transient false negative (the tear-down-then-preview matrix
+        loop). A deterministic no-fit (backend mismatch, excluded nodes,
+        unsupported sharding) does not retry — waiting cannot change it — and
+        outside the window the first pass stands.
         """
         while True:
-            response = await self._compute_placement_previews(
+            response, memory_shortfall = await self._compute_placement_previews(
                 model_id, node_ids, excluded_node_ids
             )
             if any(p.instance is not None for p in response.previews):
                 return response
-            if self._post_teardown_settle_remaining() <= 0:
+            if not memory_shortfall or self._post_teardown_settle_remaining() <= 0:
                 return response
             await anyio.sleep(1)
 
@@ -1703,12 +1707,19 @@ class API:
         model_id: ModelId,
         node_ids: list[NodeId] | None = None,
         excluded_node_ids: list[NodeId] | None = None,
-    ) -> PlacementPreviewResponse:
+    ) -> tuple[PlacementPreviewResponse, bool]:
+        """Enumerate placement previews once.
+
+        Returns the previews plus whether any combination failed specifically on
+        a *memory* shortfall (``PlacementMemoryError``), which the caller uses to
+        decide whether a no-fit is worth retrying through the post-teardown lag.
+        """
         required_nodes = set(node_ids) if node_ids else None
         excluded_nodes = set(excluded_node_ids) if excluded_node_ids else None
+        saw_memory_shortfall = False
 
         if len(list(self.state.topology.list_nodes())) == 0:
-            return PlacementPreviewResponse(previews=[])
+            return PlacementPreviewResponse(previews=[]), saw_memory_shortfall
 
         try:
             model_card = await ModelCard.load(model_id)
@@ -1755,6 +1766,8 @@ class API:
                     ),
                 )
             except ValueError as exc:
+                if isinstance(exc, PlacementMemoryError):
+                    saw_memory_shortfall = True
                 if (model_card.model_id, sharding, instance_meta, 0) not in seen:
                     previews.append(
                         PlacementPreview(
@@ -1827,7 +1840,7 @@ class API:
                 )
             )
 
-        return PlacementPreviewResponse(previews=previews)
+        return PlacementPreviewResponse(previews=previews), saw_memory_shortfall
 
     def get_instance(self, instance_id: InstanceId) -> Instance:
         if instance_id not in self.state.instances:

--- a/src/skulk/api/tests/test_placement_settle.py
+++ b/src/skulk/api/tests/test_placement_settle.py
@@ -74,14 +74,15 @@ async def test_previews_retry_within_settle_window(
 
     calls = {"n": 0}
 
-    async def fake_compute(*_a: Any, **_k: Any) -> PlacementPreviewResponse:
+    async def fake_compute(*_a: Any, **_k: Any) -> tuple[PlacementPreviewResponse, bool]:
         calls["n"] += 1
-        return _errored() if calls["n"] < 3 else viable
+        # (response, saw_memory_shortfall): errored-on-memory until the 3rd pass.
+        return (_errored(), True) if calls["n"] < 3 else (viable, False)
 
     api._compute_placement_previews = fake_compute
     result = await api.get_placement_previews(ModelId("m"))
     assert any(p.instance is not None for p in result.previews)
-    assert calls["n"] == 3  # retried twice, then viable
+    assert calls["n"] == 3  # retried twice through the memory lag, then viable
 
 
 async def test_previews_no_retry_outside_window(
@@ -94,11 +95,32 @@ async def test_previews_no_retry_outside_window(
 
     calls = {"n": 0}
 
-    async def fake_compute(*_a: Any, **_k: Any) -> PlacementPreviewResponse:
+    async def fake_compute(*_a: Any, **_k: Any) -> tuple[PlacementPreviewResponse, bool]:
         calls["n"] += 1
-        return _errored()
+        return _errored(), True  # memory shortfall, but out of window
 
     api._compute_placement_previews = fake_compute
     result = await api.get_placement_previews(ModelId("m"))
     assert all(p.instance is None for p in result.previews)
     assert calls["n"] == 1  # single pass, no retry
+
+
+async def test_previews_no_retry_on_deterministic_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In-window but a non-memory error (backend/topology) does not retry,
+    since waiting cannot change it, so it returns immediately."""
+    api = _api()
+    api._last_teardown_monotonic = time.monotonic()  # in-window
+    monkeypatch.setattr(anyio, "sleep", AsyncMock())
+
+    calls = {"n": 0}
+
+    async def fake_compute(*_a: Any, **_k: Any) -> tuple[PlacementPreviewResponse, bool]:
+        calls["n"] += 1
+        return _errored(), False  # deterministic (non-memory) failure
+
+    api._compute_placement_previews = fake_compute
+    result = await api.get_placement_previews(ModelId("m"))
+    assert all(p.instance is None for p in result.previews)
+    assert calls["n"] == 1  # no retry despite being in-window

--- a/src/skulk/api/tests/test_placement_settle.py
+++ b/src/skulk/api/tests/test_placement_settle.py
@@ -1,0 +1,104 @@
+# pyright: reportPrivateUsage=false, reportAny=false
+"""Post-teardown placement settle window (planner lag tolerance).
+
+After this API node tears an instance down, freed GPU memory lags in gossiped
+telemetry, so a back-to-back placement preview can transiently find no fit. The
+previews path re-runs within ``_POST_TEARDOWN_SETTLE_SECONDS`` of a teardown and
+returns the first viable result; outside the window it returns immediately.
+"""
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+import anyio
+import pytest
+
+from skulk.api.main import API
+from skulk.api.types.api import PlacementPreview, PlacementPreviewResponse
+from skulk.shared.types.common import ModelId
+from skulk.shared.types.worker.instances import InstanceMeta
+from skulk.shared.types.worker.shards import Sharding
+
+
+def _api() -> Any:
+    api = object.__new__(API)
+    api._last_teardown_monotonic = 0.0
+    return api
+
+
+def _errored() -> PlacementPreviewResponse:
+    return PlacementPreviewResponse(
+        previews=[
+            PlacementPreview(
+                model_id=ModelId("m"),
+                sharding=Sharding.Pipeline,
+                instance_meta=InstanceMeta.MlxRing,
+                instance=None,
+                error="No usable placement preview found",
+            )
+        ]
+    )
+
+
+def test_settle_remaining_window() -> None:
+    api = _api()
+    assert api._post_teardown_settle_remaining() == 0.0  # never torn down
+    api._last_teardown_monotonic = time.monotonic()
+    assert api._post_teardown_settle_remaining() > 0.0  # fresh teardown
+    api._last_teardown_monotonic = time.monotonic() - 10_000
+    assert api._post_teardown_settle_remaining() == 0.0  # long past
+
+
+async def test_previews_retry_within_settle_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh teardown makes previews retry until a viable placement appears."""
+    api = _api()
+    api._last_teardown_monotonic = time.monotonic()  # in-window
+    monkeypatch.setattr(anyio, "sleep", AsyncMock())  # no real delay
+
+    # A viable preview just needs a non-None instance; model_construct skips
+    # validation so we can use a lightweight sentinel rather than a full Instance.
+    viable = PlacementPreviewResponse(
+        previews=[
+            PlacementPreview.model_construct(
+                model_id=ModelId("m"),
+                sharding=Sharding.Pipeline,
+                instance_meta=InstanceMeta.MlxRing,
+                instance=object(),
+                error=None,
+            )
+        ]
+    )
+
+    calls = {"n": 0}
+
+    async def fake_compute(*_a: Any, **_k: Any) -> PlacementPreviewResponse:
+        calls["n"] += 1
+        return _errored() if calls["n"] < 3 else viable
+
+    api._compute_placement_previews = fake_compute
+    result = await api.get_placement_previews(ModelId("m"))
+    assert any(p.instance is not None for p in result.previews)
+    assert calls["n"] == 3  # retried twice, then viable
+
+
+async def test_previews_no_retry_outside_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no recent teardown, previews return the first (all-errored) pass."""
+    api = _api()
+    api._last_teardown_monotonic = 0.0  # no recent teardown
+    monkeypatch.setattr(anyio, "sleep", AsyncMock())
+
+    calls = {"n": 0}
+
+    async def fake_compute(*_a: Any, **_k: Any) -> PlacementPreviewResponse:
+        calls["n"] += 1
+        return _errored()
+
+    api._compute_placement_previews = fake_compute
+    result = await api.get_placement_previews(ModelId("m"))
+    assert all(p.instance is None for p in result.previews)
+    assert calls["n"] == 1  # single pass, no retry

--- a/src/skulk/master/placement.py
+++ b/src/skulk/master/placement.py
@@ -182,6 +182,18 @@ class PlacementInfoPendingError(PlacementError):
     """
 
 
+class PlacementMemoryError(PlacementError):
+    """No cycle has enough memory to hold the model right now.
+
+    Distinct from other ``PlacementError``s (excluded nodes, backend mismatch,
+    unsupported sharding) so a caller can treat it as possibly-transient: right
+    after an instance teardown the freed memory may not have reflected in
+    gossiped telemetry yet, so a memory shortfall can clear on its own where a
+    backend/topology error never will. The API placement path waits out a
+    post-teardown settle window only for this subclass.
+    """
+
+
 def place_instance(
     command: PlaceInstance,
     topology: Topology,
@@ -316,7 +328,7 @@ def place_instance(
             if memory_diagnostics.rejection_reasons
             else "no candidate cycles to evaluate"
         )
-        raise PlacementError(
+        raise PlacementMemoryError(
             f"No candidate cycle fits {command.model_card.model_id} "
             f"({command.model_card.storage_size.in_gb:.1f}GB of weights): {detail}"
         )


### PR DESCRIPTION
## Problem (surfaced by the e2e benchmark battery)

Tearing an instance down frees GPU memory that takes a moment to reflect in gossiped `ram_available` — the worker re-samples memory only after the runner process exits and Metal/VRAM reclaims, then gossips it (telemetry plane, last-write-wins). A placement attempted in that window sees stale-low memory: the `/place_instance` dry-run 400s and `/instance/previews` returns all-errored, which the harness reports as **"No usable placement preview found before execution."**

In the full e2e battery this skipped **6 models** between cells — including both marquee big GGUFs, **Llama-3.3-70B and gpt-oss-120B** — because the harness tears each model down (`--delete-created-instances`) then immediately previews the next. This is the #51/#290-adjacent rough edge (the foxlight-docs bench orchestrator works around it by retrying; the planner did not).

## Fix

The API placement dry-run and previews now **wait for the freed memory to settle** before declaring no fit, but only within a window after a teardown *this node served*:

- `delete_instance` stamps `_last_teardown_monotonic`.
- `_post_teardown_settle_remaining()` reports time left in `_POST_TEARDOWN_SETTLE_SECONDS` (30s).
- The `place_instance` dry-run catches `PlacementError` and retries (1s poll) while in-window; outside it, 400s as before.
- `get_placement_previews` is split into a thin settle-retry wrapper over the unchanged enumeration (`_compute_placement_previews`): re-runs while no combination is viable and in-window.

Key property: it **waits for memory to actually free** rather than crediting it optimistically, so there is **no over-admit**, and the worker's local pre-spawn guard remains the backstop. A cold request with no recent teardown is unaffected — a genuine "too big for the cluster" still fails fast.

## Tests

`src/skulk/api/tests/test_placement_settle.py` — the settle window math, retry-until-viable within window, and no-retry / fail-fast outside it.

## Validation

- `uv run basedpyright` — 0 errors
- `uv run ruff check` — clean
- `uv run pytest` — 1214 passed, 1 skipped
- Re-run of the e2e matrix on the fleet (incl the previously-skipped big GGUFs) to follow on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)