### PR TITLE
refactor(placement): name the multi-node engine capability (#328 groundwork)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Changed
 
+- **The placement single-node constraint is now a named engine capability
+  (#328 groundwork).** The hard-coded "llama.cpp is single-node only" check in
+  the planner became `engine_supports_multi_node` (MLX yes; llama.cpp not until
+  its RPC backend is wired into the runner). Behavior is unchanged today: a
+  model whose only compatible engine is single-node is still pinned to a
+  one-node cycle, and a card that also allows a multi-node engine (MLX) still
+  places across nodes. This is the single hinge to flip when multi-node
+  llama.cpp (RPC) lands.
+
 - **Placement now records the resolved backend on each shard (#330).** The master
   resolves which backend a node will use (the card's `compatible_backends`
   intersected with that node's advertised backends, ordered by

--- a/src/skulk/master/placement.py
+++ b/src/skulk/master/placement.py
@@ -12,7 +12,11 @@ from skulk.master.placement_utils import (
     get_shard_assignments,
     get_smallest_cycles,
 )
-from skulk.shared.backends import engine_of, resolve_node_backend
+from skulk.shared.backends import (
+    engine_of,
+    engine_supports_multi_node,
+    resolve_node_backend,
+)
 from skulk.shared.models.memory_estimate import instance_context_token_limit
 from skulk.shared.models.model_cards import ModelId
 from skulk.shared.topology import Topology
@@ -268,22 +272,30 @@ def place_instance(
                     f"({sorted(compatible_backends)})."
                 )
 
-    # Single-node engine guard. The llama.cpp runner is single-node only (no ring
-    # / ConnectToGroup), so a multi-node placement of a llama.cpp-only model would
-    # download and then crash at runner startup (world_size != 1). Reject it up
-    # front: restrict candidates to single-node cycles when every compatible
-    # backend resolves to the llama_cpp engine. (A card that also allows an MLX
-    # backend can still place multi-node via MLX, so this only bites llama.cpp-only
-    # models.) This also forecloses a mixed-backend multi-node cycle (no single
-    # backend shared by all ranks), since llama.cpp is the only non-MLX engine.
+    # Single-node engine guard. Some engines cannot shard a model across nodes
+    # (today: llama.cpp -- single-node only, its multi-node RPC backend is not yet
+    # wired into the runner, which asserts world_size == 1; see #328). A
+    # multi-node placement of a model whose only compatible engine is single-node
+    # would download and then crash at runner startup. Reject it up front: when
+    # none of the card's compatible backends resolve to a multi-node-capable
+    # engine, restrict candidates to single-node cycles. A card that also allows a
+    # multi-node engine (e.g. MLX) can still place multi-node via that engine, so
+    # this only bites models whose every engine is single-node. The capability
+    # lives in `engine_supports_multi_node`; flipping llama.cpp there (once its
+    # RPC runner lands) lets such models place multi-node with no change here.
     card_backends = command.model_card.placement.compatible_backends
-    if card_backends and all(engine_of(tag) == "llama_cpp" for tag in card_backends):
+    has_multi_node_engine = any(
+        engine_supports_multi_node(engine)
+        for tag in card_backends
+        if (engine := engine_of(tag)) is not None
+    )
+    if card_backends and not has_multi_node_engine:
         candidate_cycles = [cycle for cycle in candidate_cycles if len(cycle) == 1]
         if not candidate_cycles:
             raise PlacementError(
-                "llama.cpp models are single-node only, but no single-node cycle "
-                "is available/eligible for this model. Place it on one node, or "
-                "free a node that advertises a compatible llama.cpp backend."
+                "This model's engine is single-node only, but no single-node "
+                "cycle is available/eligible for it. Place it on one node, or "
+                "free a node that advertises a compatible backend."
             )
 
     # Filter to cycles containing all required nodes (subset matching)

--- a/src/skulk/master/tests/test_placement.py
+++ b/src/skulk/master/tests/test_placement.py
@@ -1357,3 +1357,44 @@ def test_llama_cpp_single_node_placement_succeeds() -> None:
     assert len(placements) == 1
     instance = next(iter(placements.values()))
     assert len(instance.shard_assignments.node_to_runner) == 1
+
+
+def test_hybrid_card_with_multi_node_engine_places_multi_node() -> None:
+    """The single-node guard keys on engine capability, not on llama.cpp by name:
+    a card that also allows a multi-node engine (MLX) still places across nodes,
+    serving via that engine. Guards #328's generalization of the old
+    llama.cpp-only special-case."""
+    from skulk.shared.models.model_cards import PlacementCardConfig
+
+    topology = Topology()
+    node_a = NodeId()
+    node_b = NodeId()
+    topology.add_node(node_a)
+    topology.add_node(node_b)
+    topology.add_connection(
+        Connection(source=node_a, sink=node_b, edge=create_socket_connection(1))
+    )
+    topology.add_connection(
+        Connection(source=node_b, sink=node_a, edge=create_socket_connection(2))
+    )
+    node_memory = {
+        node_a: create_node_memory(Memory.from_gb(8).in_bytes),
+        node_b: create_node_memory(Memory.from_gb(8).in_bytes),
+    }
+    node_network = {node_a: create_node_network(), node_b: create_node_network()}
+    hybrid_card = ModelCard(
+        model_id=ModelId("test-hybrid"),
+        storage_size=Memory.from_mb(500),
+        n_layers=10,
+        hidden_size=1000,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        placement=PlacementCardConfig(
+            compatible_backends=frozenset({"mlx", "llama_cpp-vulkan"})
+        ),
+    )
+    command = place_instance_command(hybrid_card).model_copy(update={"min_nodes": 2})
+    # Must NOT raise the single-node guard: MLX is multi-node capable.
+    placements = place_instance(command, topology, {}, node_memory, node_network)
+    instance = next(iter(placements.values()))
+    assert len(instance.shard_assignments.node_to_runner) == 2

--- a/src/skulk/shared/backends.py
+++ b/src/skulk/shared/backends.py
@@ -78,6 +78,27 @@ def engine_of(tag: str) -> EngineType | None:
     return None
 
 
+# Engines that can serve a model sharded across multiple nodes. MLX has the
+# multi-node ring / jaccl path; llama.cpp is single-node today -- its RPC backend
+# (which shards a GGUF across machines) is not yet wired into the runner (#328),
+# and the runner asserts ``world_size == 1``. This is the single place that
+# constraint lives; flip llama_cpp in here (or make it conditional on an
+# RPC-capable build) when the multi-node llama.cpp runner lands.
+_MULTI_NODE_ENGINES: Final[frozenset[EngineType]] = frozenset({"mlx"})
+
+
+def engine_supports_multi_node(engine: EngineType) -> bool:
+    """Whether an engine can serve a model sharded across more than one node.
+
+    Placement uses this to pin a model to a single-node cycle when none of its
+    compatible engines can shard across nodes (otherwise the placement would
+    download and then crash at runner startup with ``world_size != 1``). MLX is
+    multi-node capable; llama.cpp is single-node until its RPC backend is wired
+    into the runner (#328).
+    """
+    return engine in _MULTI_NODE_ENGINES
+
+
 def resolve_node_backend(
     compatible_backends: frozenset[str],
     backend_preference: tuple[str, ...],

--- a/src/skulk/shared/tests/test_backends.py
+++ b/src/skulk/shared/tests/test_backends.py
@@ -9,6 +9,7 @@ from skulk.shared import backends
 from skulk.shared.backends import (
     LLAMA_CPP_BACKENDS_ENV,
     engine_of,
+    engine_supports_multi_node,
     make_backend_tag,
     probe_node_backends,
     resolve_node_backend,
@@ -190,3 +191,10 @@ def test_resolve_node_engine_matches_backend_engine() -> None:
     tag = resolve_node_backend(compatible, preference, node)
     assert tag == "llama_cpp-vulkan"
     assert resolve_node_engine(compatible, preference, node) == engine_of(tag)
+
+
+def test_engine_supports_multi_node() -> None:
+    # MLX shards across nodes (ring/jaccl); llama.cpp is single-node until its
+    # RPC runner lands (#328). This is the placement single-node guard's hinge.
+    assert engine_supports_multi_node("mlx") is True
+    assert engine_supports_multi_node("llama_cpp") is False


### PR DESCRIPTION
## What

Converts the planner's hard-coded "llama.cpp is single-node only" special-case into a named capability, `engine_supports_multi_node` (in `shared/backends.py`). #328 groundwork.

**Stacked on #373** (base = `feat/persist-resolved-backend`); review/merge that first. The net diff here is just the capability seam.

## Why

The single-node constraint was an `all(engine_of(tag) == "llama_cpp")` check buried in placement. Naming it:
- puts the constraint in one obvious place,
- generalizes correctly (the guard now keys on "does any compatible engine shard across nodes", not on llama.cpp by name),
- is the **single hinge to flip** when multi-node llama.cpp (RPC) lands — mark `llama_cpp` multi-node-capable (or gate on an RPC build) and placement considers multi-node cycles with no other change.

## Behavior: unchanged today
- llama.cpp-only model + forced multi-node → still rejected up front (`test_llama_cpp_multi_node_placement_is_rejected`).
- llama.cpp-only single-node → still places (`test_llama_cpp_single_node_placement_succeeds`).
- **New:** a hybrid card (MLX + llama.cpp) still places multi-node via MLX (`test_hybrid_card_with_multi_node_engine_places_multi_node`).

## Tests
`engine_supports_multi_node` unit test + the placement tests above. Full gate green: basedpyright 0, ruff clean, 1223 passed / 1 skipped, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)