### PR TITLE
fix(download): include the mmproj projector for vision GGUF models (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- **Vision GGUF models now download their multimodal projector (#346).** The
+  selective GGUF allow-list (`gguf_allow_patterns`, used by both the direct-
+  HuggingFace download and the centralized store) only matched the selected LM
+  quant's shard group, so a LLaVA-style vision GGUF fetched its weights but not
+  its separate `mmproj-*.gguf` projector, and llama.cpp could not do image
+  inference. The allow-list now always includes a `*mmproj*.gguf` glob: it
+  matches nothing on a text-only repo (no cost) and pulls the projector on a
+  vision repo. Foundation for vision GGUF VLMs on llama.cpp (#128).
+
 ### Changed
 
 - **Placement now records the resolved backend on each shard (#330).** The master

--- a/src/skulk/download/tests/test_gguf_completeness.py
+++ b/src/skulk/download/tests/test_gguf_completeness.py
@@ -118,8 +118,10 @@ async def test_resolve_allow_patterns_gguf_vs_safetensors() -> None:
         )
 
     gguf = _card("o/r", gguf_file="m-Q4_K_M.gguf")
+    # LM quant + the always-included multimodal projector glob (#346) + config.
     assert await resolve_allow_patterns(_shard(gguf)) == [
         "m-Q4_K_M.gguf",
+        "*mmproj*.gguf",
         "config.json",
     ]
 

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -962,18 +962,32 @@ def select_preferred_gguf(gguf_files: "list[tuple[str, int]]") -> str:
     )
 
 
+# Glob for the multimodal projector a vision GGUF repo ships alongside the LM
+# weights (LLaVA-style: ``mmproj-<...>.gguf``). It never matches the selected LM
+# quant's shard group, so it must be allow-listed explicitly or llama.cpp cannot
+# do image inference (#346). ``*mmproj*`` (not ``mmproj*``) so it also matches a
+# projector nested in a subdirectory, since HuggingFace allow-patterns match the
+# whole repo-relative path. A text-only repo has none, so this matches nothing
+# and costs nothing; a repo shipping several projector quants downloads each
+# (small relative to the weights, and llama.cpp loads one).
+_GGUF_PROJECTOR_PATTERN: Final = "*mmproj*.gguf"
+
+
 def gguf_allow_patterns(gguf_file: str) -> list[str]:
-    """Download allow-patterns for a card's selected GGUF (its shard group only).
+    """Download allow-patterns for a card's selected GGUF (its shard group +
+    any multimodal projector).
 
     A single-file quant downloads just itself; a sharded quant downloads its
     whole ``<base>-NNNNN-of-NNNNN`` group via a glob. This is what lets the
     downloader fetch only the chosen quant instead of every quant a multi-quant
-    repo hosts (#332). Caller adds non-weight files (e.g. ``config.json``).
+    repo hosts (#332). The ``mmproj`` projector glob is always included so a
+    vision GGUF model fetches its projector too (#346); it matches nothing on a
+    text-only repo. Caller adds non-weight files (e.g. ``config.json``).
     """
     base = _gguf_shard_base(gguf_file)
     if base is None:
-        return [gguf_file]
-    return [f"{base}-*-of-*.gguf"]
+        return [gguf_file, _GGUF_PROJECTOR_PATTERN]
+    return [f"{base}-*-of-*.gguf", _GGUF_PROJECTOR_PATTERN]
 
 
 def gguf_shard_group_size(selected: str, gguf_files: "list[tuple[str, int]]") -> Memory:

--- a/src/skulk/shared/models/tests/test_gguf_cards.py
+++ b/src/skulk/shared/models/tests/test_gguf_cards.py
@@ -352,7 +352,8 @@ def test_select_preferred_gguf_prefers_quant_over_bf16() -> None:
     sel = select_preferred_gguf(files)
     assert sel == "M-Q4_K_M.gguf"  # quant beats BF16; Q4_K_M is top preference
     assert gguf_shard_group_size(sel, files).in_bytes == 800
-    assert gguf_allow_patterns(sel) == ["M-Q4_K_M.gguf"]
+    # Single-file LM quant plus the always-included projector glob (#346).
+    assert gguf_allow_patterns(sel) == ["M-Q4_K_M.gguf", "*mmproj*.gguf"]
 
 
 def test_select_preferred_gguf_sharded_group() -> None:
@@ -370,7 +371,8 @@ def test_select_preferred_gguf_sharded_group() -> None:
     sel = select_preferred_gguf(files)
     assert sel == "big-Q4_K_M-00001-of-00002.gguf"
     assert gguf_shard_group_size(sel, files).in_bytes == 1_100  # both shards
-    assert gguf_allow_patterns(sel) == ["big-Q4_K_M-*-of-*.gguf"]
+    # Sharded LM group glob plus the always-included projector glob (#346).
+    assert gguf_allow_patterns(sel) == ["big-Q4_K_M-*-of-*.gguf", "*mmproj*.gguf"]
 
 
 async def test_gguf_card_pins_selected_quant(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/skulk/store/tests/test_store_gguf_selection.py
+++ b/src/skulk/store/tests/test_store_gguf_selection.py
@@ -59,16 +59,18 @@ def test_original_and_metal_weight_artifacts_are_dropped() -> None:
     assert kept == {"config.json", "model-Q4_K_M.gguf"}
 
 
-def test_mmproj_projector_is_dropped_to_match_direct_path() -> None:
-    # The direct-HF GGUF allow-list does not include the projector, so the store
-    # matches it (multimodal GGUF projector handling is a separate concern).
+def test_mmproj_projector_is_kept_for_vision_models() -> None:
+    # The GGUF allow-list now includes the multimodal projector (#346), so the
+    # store keeps it alongside the LM quant and config -- a vision GGUF model
+    # needs the projector or llama.cpp cannot do image inference. Still matches
+    # the direct-HF path, which includes the same projector glob.
     files = [
         _entry("config.json"),
         _entry("model-Q4_K_M.gguf", 800),
         _entry("mmproj-model-f16.gguf", 600),
     ]
     kept = {e.path for e in select_store_gguf_download_files(files)}
-    assert kept == {"config.json", "model-Q4_K_M.gguf"}
+    assert kept == {"config.json", "model-Q4_K_M.gguf", "mmproj-model-f16.gguf"}
 
 
 def test_non_gguf_repo_unchanged() -> None:


### PR DESCRIPTION
## What

Closes #346. The selective GGUF allow-list (`gguf_allow_patterns`) only matched the selected LM quant's shard group, so a vision GGUF's separate `mmproj-*.gguf` projector was never downloaded and llama.cpp couldn't do image inference. Now the allow-list always includes a `*mmproj*.gguf` glob.

## Why one change covers everything

Both the direct-HF path (`download_utils.resolve_allow_patterns`) and the store filter (`model_store.select_store_gguf_download_files`) build `[*gguf_allow_patterns(gguf_file), "config.json"]`, so adding the glob there fixes both. LM-file selection (`select_gguf_file`) still skips `mmproj`, so the projector is downloaded but never loaded as the LM.

- `*mmproj*` (not `mmproj*`) matches a projector nested in a subdirectory (HF allow-patterns match the whole repo-relative path).
- Text-only repos have no projector → glob matches nothing → no cost.

## Tests
- Updated `gguf_allow_patterns` assertions (single-file + sharded) to include the projector glob.
- Inverted the store test: the projector is now **kept** for vision models (was asserting it dropped).
- Updated `resolve_allow_patterns` GGUF assertion.
- Full gate green: basedpyright 0, ruff clean, 1223 passed / 1 skipped, fmt clean.

Foundation for #128 (vision GGUF VLMs on llama.cpp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)