### PR TITLE
feat(llama.cpp): serve vision GGUF VLMs (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Added
+
+- **Vision GGUF VLMs now run on the llama.cpp engine (#128).** A vision GGUF
+  (LLaVA / Qwen-VL style, with a separate `mmproj` projector) can be served on a
+  llama.cpp node: the runner loads the projector through llama-cpp-python's
+  multimodal chat handler (the general `MTMDChatHandler` by default, or a
+  family-specific handler selected from the card's vision `model_type`), and an
+  image request's content is passed inline so the handler splices the image
+  features itself. A GGUF repo is marked vision-capable from its `config.json`
+  vision section when present, or, for the many GGUF VLM repos that ship no
+  `config.json`, from the mere presence of an `mmproj` projector. Validated live
+  on an AMD Strix Halo (Vulkan) node serving `Qwen2-VL-2B-Instruct-GGUF`
+  (reads text in images and describes structured scenes). `image_token_id` on
+  the vision card config is now optional: it is required only by the MLX vision
+  path; the llama.cpp handler inserts image features without it.
+
 ### Fixed
 
 - **Vision GGUF models now download their multimodal projector (#346).** The

--- a/reports/skulk-performance-report-2026-06-22.md
+++ b/reports/skulk-performance-report-2026-06-22.md
@@ -1,0 +1,260 @@
+# Skulk Performance Improvement Report
+
+Date: 2026-06-22
+
+Scope: read-only architecture and source pass over the Skulk runtime path, with
+emphasis on the request-to-runner flow, generation hot paths, placement,
+batching, speculative decoding, cache behavior, and data-plane routing.
+
+This report is based on the current repository source and existing in-repo docs.
+It did not run a live benchmark or change code.
+
+## Executive summary
+
+Skulk's performance is dominated less by API/master overhead and more by how
+well a request maps onto runner execution:
+
+- whether the model can use speculative decoding;
+- whether the selected generator is sequential or batched;
+- whether placement uses the smallest fast-connected node cycle that fits;
+- whether prompt prefixes and KV cache are reused;
+- whether multi-node streaming uses the DATA plane efficiently; and
+- whether operators avoid settings that disable fast paths.
+
+The highest-impact operational changes are:
+
+1. Keep speculative decoding active for supported models.
+2. Avoid forcing `SKULK_FAST_SYNCH=on` unless the exact model/backend has been
+   measured with it.
+3. Use the smallest high-bandwidth placement cycle that fits the model.
+4. Prefer Thunderbolt/LAN links over VPN paths for inference rings.
+5. Use multiple replicas for high concurrency when a model is forced onto
+   sequential serving.
+6. Preserve batching for batch-eligible models.
+7. Shape prompts to get KV prefix-cache hits.
+8. Treat quantized KV as a memory lever, not a default speed lever.
+9. Enable Zenoh DATA plane for multi-node output-stream latency when the network
+   and security posture are ready for it.
+
+The highest-impact engineering work is:
+
+1. Add MTP-aware batching or replica autoscaling for models that cannot batch
+   while speculative decoding is active.
+2. Replace placement's label-based transport ranking with measured topology
+   scoring, then include observed TTFT/TPS and link latency/bandwidth in
+   placement decisions.
+
+## Runtime mental model
+
+Skulk is an event-sourced control plane around worker-owned runner subprocesses.
+A single node hosts router, worker, election, optional master, and optional API
+components in `Node` ([src/skulk/main.py](../src/skulk/main.py#L247)).
+
+Chat requests enter `/v1/chat/completions` or `/bench/chat/completions`
+([src/skulk/api/main.py](../src/skulk/api/main.py#L1032)) and become
+`TextGeneration` commands owned by the API node
+([src/skulk/api/main.py](../src/skulk/api/main.py#L2164)). The master does not
+generate tokens. For text generation it selects an existing instance by task
+count and emits `TaskCreated` for the chosen instance
+([src/skulk/master/main.py](../src/skulk/master/main.py#L344)).
+
+Workers run the local planner in `plan()`
+([src/skulk/worker/plan.py](../src/skulk/worker/plan.py#L48)). The planner is
+the local decision engine: create or tear down runners, stage downloads,
+connect distributed backends, load, warm up, and dispatch tasks. Actual model
+work runs inside per-shard runner subprocesses spawned by `RunnerSupervisor`
+([src/skulk/worker/runner/runner_supervisor.py](../src/skulk/worker/runner/runner_supervisor.py#L173)).
+
+The key performance detail is that per-token output no longer has to go through
+the master event log. `ChunkGenerated` is diverted to the DATA plane when a data
+sender is wired
+([src/skulk/worker/runner/runner_supervisor.py](../src/skulk/worker/runner/runner_supervisor.py#L225)).
+The API then receives chunks from the serving worker rather than replaying them
+as master-indexed events
+([src/skulk/api/main.py](../src/skulk/api/main.py#L3474)). With Zenoh enabled,
+DATA is addressed to `data/<node_id>` and each node subscribes only to its own
+output key ([src/skulk/routing/router.py](../src/skulk/routing/router.py#L177),
+[src/skulk/routing/router.py](../src/skulk/routing/router.py#L321)).
+
+## Highest-impact speed methods
+
+### 1. Keep speculative decoding active
+
+Speculative decoding is the biggest documented single-stream speed lever. The
+operator docs describe it as a supported fast path across single-node,
+tensor-parallel, and pipeline-parallel MLX execution
+([website/docs/speculative-decoding.md](../website/docs/speculative-decoding.md#L36)).
+
+The practical implication is to make sure the needed sidecar/assistant drafter
+assets are staged and to avoid request options that disable the speculative
+path. In the current generation code, active logits processors disable MTP for
+that request
+([src/skulk/worker/engines/mlx/generator/generate.py](../src/skulk/worker/engines/mlx/generator/generate.py#L2963)).
+That commonly means options such as repetition penalties should be used only
+when they are worth giving up speculation.
+
+### 2. Do not force `SKULK_FAST_SYNCH=on` as a generic speed tweak
+
+`FAST_SYNCH_CLUSTER_DEFAULT` is currently false
+([src/skulk/worker/runner/bootstrap.py](../src/skulk/worker/runner/bootstrap.py#L34)).
+The resolver docstring says FAST_SYNCH is catastrophically incompatible with the
+current speculative decoding loop on at least one measured Qwen3.5-9B-4bit
+case, dropping from 27.8 tok/s to 0.6 tok/s
+([src/skulk/worker/runner/bootstrap.py](../src/skulk/worker/runner/bootstrap.py#L88)).
+
+Use FAST_SYNCH only as a measured, model-specific override. It should not be a
+default "go faster" knob.
+
+### 3. Place on the smallest fast-connected cycle that fits
+
+Placement already filters by memory and then narrows to the smallest fitting
+cycles ([src/skulk/master/placement.py](../src/skulk/master/placement.py#L352)).
+That is the right speed bias: over-sharding adds pipeline hops, coordination,
+and transport cost. The speculative-decoding docs call this out directly:
+shard to the smallest node count that fits the model
+([website/docs/speculative-decoding.md](../website/docs/speculative-decoding.md#L110)).
+
+### 4. Prefer real high-bandwidth local links for inference rings
+
+Ring transport selection prioritizes links by detected interface type today,
+and the code explicitly notes that actual connection speeds are still a TODO
+([src/skulk/master/placement_utils.py](../src/skulk/master/placement_utils.py#L706),
+[src/skulk/master/placement_utils.py](../src/skulk/master/placement_utils.py#L713)).
+
+Operationally, avoid Tailscale/DERP-backed paths for inference rings. Prefer
+Thunderbolt or wired LAN. Request `MlxJaccl` only where RDMA connectivity is
+actually present and measured.
+
+### 5. Use replicas for high concurrency on sequential-only models
+
+Several important fast paths force `SequentialGenerator`: quantized KV backends,
+Gemma 4, MTP speculative decoding, and explicit batching disablement
+([src/skulk/worker/runner/llm_inference/runner.py](../src/skulk/worker/runner/llm_inference/runner.py#L824)).
+
+That means a single runner can be excellent for one stream but poor for many
+concurrent streams. Since the master chooses among existing instances by task
+count for `TextGeneration`
+([src/skulk/master/main.py](../src/skulk/master/main.py#L344)), multiple
+replicas of the same model can improve aggregate throughput even when each
+runner is FIFO.
+
+### 6. Preserve batching where models are batch-eligible
+
+For batch-eligible models, `BatchGenerator` admits queued work up to
+`SKULK_MAX_CONCURRENT_REQUESTS`
+([src/skulk/worker/runner/llm_inference/batch_generator.py](../src/skulk/worker/runner/llm_inference/batch_generator.py#L516),
+[src/skulk/worker/runner/llm_inference/batch_generator.py](../src/skulk/worker/runner/llm_inference/batch_generator.py#L634)).
+The default limit is 8
+([src/skulk/shared/constants.py](../src/skulk/shared/constants.py#L165)).
+
+Avoid `--no-batch` / `SKULK_NO_BATCH` for throughput workloads unless the model
+or debugging case requires it. Avoid options that force extra per-token work
+unless they are product-critical.
+
+### 7. Use KV prefix caching as a TTFT accelerator
+
+The MLX cache implements longest-prefix lookup
+([src/skulk/worker/engines/mlx/cache.py](../src/skulk/worker/engines/mlx/cache.py#L217)).
+Stable system/developer prompts and repeated conversation prefixes should
+reduce prefill work and improve TTFT for follow-up requests. Benchmark mode
+deliberately disables this cache in the generation path, so live behavior and
+benchmark behavior can diverge on repeated-prefix workloads.
+
+### 8. Treat quantized KV as a memory lever
+
+Quantized KV can improve system-level speed indirectly when it lets a model fit
+on fewer nodes or prevents memory pressure. It should not be assumed to improve
+per-runner decode speed. The docs describe the default KV cache as the fastest
+baseline and quantized backends as moderate or near-baseline, depending on the
+backend ([website/docs/kv-cache-backends.md](../website/docs/kv-cache-backends.md#L84)).
+
+### 9. Enable Zenoh DATA plane for multi-node streaming latency
+
+Zenoh DATA does not make MLX forward passes faster, but it removes generation
+output from whole-cluster gossipsub/event-log traffic. It is most relevant for
+multi-node streaming latency and backpressure behavior.
+
+Zenoh defaults on only when configured with `SKULK_ZENOH_LISTEN`
+([src/skulk/main.py](../src/skulk/main.py#L145)). Its security posture matters:
+the operator should bind it intentionally and keep it on a trusted network
+segment.
+
+## Best engineering bets
+
+### A. MTP-aware batching or replica autoscaling
+
+Today speculative decoding is one of the strongest single-stream speed levers,
+but MTP/speculative models force `SequentialGenerator`
+([src/skulk/worker/runner/llm_inference/runner.py](../src/skulk/worker/runner/llm_inference/runner.py#L835)).
+That creates a throughput tradeoff: fast single request, queued concurrent
+requests.
+
+Two useful approaches:
+
+1. Build an MTP-aware batch scheduler that can preserve speculative correctness
+   while serving multiple active requests.
+2. Add an autoscaling placement strategy that prefers extra replicas for
+   batch-ineligible models when queue depth rises.
+
+The second is likely lower risk and easier to validate first. It fits the
+existing master's "least active tasks among instances" behavior.
+
+### B. Measured topology scoring
+
+Placement currently has the right high-level bias, but it still uses
+interface-label heuristics where it should eventually use live measurements.
+The code says the missing piece plainly: "Profile and get actual connection
+speeds" ([src/skulk/master/placement_utils.py](../src/skulk/master/placement_utils.py#L713)).
+
+The performance-oriented placement score should include:
+
+- link latency between candidate nodes;
+- sustained bandwidth between candidate nodes;
+- whether the link is Thunderbolt, wired LAN, Wi-Fi, or VPN as a fallback hint;
+- observed model-specific TTFT and tokens/sec per node or per placement shape;
+- active queue depth per instance; and
+- memory headroom after admitted context.
+
+This would make the default placement faster without requiring operators to
+manually know every node-pair bottleneck.
+
+## Suggested validation plan
+
+Use the sibling harness or a dedicated benchmark script to measure these
+dimensions separately:
+
+1. Single-stream TPS and TTFT with speculative decoding on/off for the same
+   model and prompt set.
+2. Same test with and without active logits processors such as repetition
+   penalty.
+3. Same model on the smallest fitting cycle versus one extra shard.
+4. Thunderbolt/LAN versus VPN path for the same multi-node placement.
+5. One sequential speculative runner versus two or more replicas under
+   concurrent load.
+6. Batch-eligible model with batching enabled versus disabled.
+7. Repeated-prefix prompt set with KV prefix cache warm and cold.
+8. Gossipsub DATA fallback versus Zenoh DATA for output streaming latency.
+
+The useful report metrics are:
+
+- TTFT p50/p95;
+- output tokens/sec p50/p95 per request;
+- aggregate tokens/sec under concurrency;
+- queue wait time;
+- prefill time;
+- decode time;
+- accepted speculative tokens per round;
+- memory headroom before and after load;
+- placement shape and transport path; and
+- failure/retry counts.
+
+## Bottom line
+
+The most immediate performance gains are operational: keep speculation enabled,
+avoid settings that disable it, choose smaller fast-connected placements, and
+use replicas for concurrency when the generator is forced sequential.
+
+The most valuable product work is to make those choices automatic: measured
+topology-aware placement plus replica scaling for sequential/speculative
+models. Those changes would move Skulk from "fast when configured correctly" to
+"fast by default under changing workloads."

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -134,10 +134,17 @@ class VisionCardConfig(CamelCaseModel):
     Populated from the ``[vision]`` section of a TOML model card or
     auto-detected from ``config.json`` during card creation."""
 
-    image_token_id: int
-    """Token id the model uses as the image placeholder in the prompt."""
-    model_type: str
-    """Vision model-type tag from ``config.json``, selecting the image processor."""
+    image_token_id: int | None = None
+    """Token id the model uses as the image placeholder in the prompt. Required by
+    the MLX vision path (which splices image embeddings at this token); ``None``
+    is allowed for a llama.cpp-only vision GGUF, whose chat handler inserts image
+    features itself and never reads this. MLX cards always set it (from
+    ``config.json``)."""
+    model_type: str = ""
+    """Vision model-type tag (from ``config.json``'s ``vision_config``), selecting
+    the image processor (MLX) or chat handler (llama.cpp). Empty when a bare GGUF
+    repo only signals vision via its ``mmproj`` projector; the llama.cpp runner
+    then falls back to its general multimodal handler."""
     weights_repo: str = ""
     """Repo holding the vision-tower weights when separate from the LM; empty if
     bundled with the main weights."""
@@ -149,6 +156,20 @@ class VisionCardConfig(CamelCaseModel):
     """Begin-of-image token id, for families that bracket image spans."""
     eoi_token_id: int | None = None
     """End-of-image token id, for families that bracket image spans."""
+
+    @property
+    def required_image_token_id(self) -> int:
+        """``image_token_id`` for the MLX vision path, which requires it.
+
+        The MLX VisionProcessor splices image embeddings at this token, so it
+        must be present. Raises if absent (a llama.cpp-only vision GGUF may leave
+        it ``None``, but such a model never routes to the MLX path)."""
+        if self.image_token_id is None:
+            raise ValueError(
+                "vision_config.image_token_id is required for the MLX vision "
+                "path but was not set on this card"
+            )
+        return self.image_token_id
 
 
 def multi_node_speculation_disabled(
@@ -691,6 +712,23 @@ class ModelCard(CamelCaseModel):
             num_key_value_heads = fields.num_key_value_heads
             context_length = fields.context_length
 
+        # Mark the card vision-capable so the llama.cpp runner loads the mmproj
+        # projector (#128, #346). Prefer the rich config.json vision_config when
+        # the repo ships one (image_token_id, model_type). Otherwise, many popular
+        # GGUF VLM repos (e.g. bartowski) ship NO config.json at all, so fall back
+        # to the projector's presence as the vision signal and stamp a minimal
+        # vision config: the llama.cpp chat handler inserts image features itself
+        # and never needs image_token_id, and an empty model_type routes it to the
+        # general multimodal handler. The mmproj weights are fetched via the
+        # projector glob in gguf_allow_patterns, not from config.json.
+        vision = getattr(config_data, "vision", None) if config_data is not None else None
+        if vision is None and gguf_repo_has_projector(model_id):
+            logger.info(
+                f"GGUF repo {model_id} ships an mmproj projector but no vision "
+                "config; marking vision-capable with the general handler"
+            )
+            vision = VisionCardConfig()
+
         return ModelCard(
             model_id=ModelId(model_id),
             storage_size=selected_size,
@@ -703,6 +741,7 @@ class ModelCard(CamelCaseModel):
             tasks=[ModelTask.TextGeneration],
             quantization=_gguf_quant_label(selected),
             gguf_file=selected,
+            vision=vision,
             trust_remote_code=False,
             is_custom=True,
             placement=PlacementCardConfig(
@@ -877,6 +916,26 @@ async def fetch_safetensors_size(model_id: ModelId) -> Memory:
     if info.safetensors is None:
         raise ValueError(f"No safetensors info found for {model_id}")
     return Memory.from_bytes(info.safetensors.total)
+
+
+def gguf_repo_has_projector(model_id: ModelId) -> bool:
+    """Whether a GGUF repo ships a multimodal projector (``*mmproj*.gguf``).
+
+    A vision GGUF (LLaVA/Qwen-VL style) carries its projector as a separate
+    ``mmproj`` file. Many popular GGUF VLM repos ship no ``config.json`` (so the
+    config-based vision detection cannot fire), but the projector's presence is
+    itself a reliable "this is a vision model" signal. Best-effort: returns
+    ``False`` if the HF probe fails, so a transient error never misclassifies.
+    """
+    try:
+        info = model_info(model_id, files_metadata=True)
+    except Exception:  # noqa: BLE001 - best-effort probe, mirror gguf_weight_siblings
+        return False
+    siblings = info.siblings or []
+    return any(
+        sibling.rfilename.endswith(".gguf") and "mmproj" in sibling.rfilename.lower()
+        for sibling in siblings
+    )
 
 
 def gguf_weight_siblings(model_id: ModelId) -> "list[tuple[str, int]]":

--- a/src/skulk/worker/engines/mlx/vision.py
+++ b/src/skulk/worker/engines/mlx/vision.py
@@ -1448,7 +1448,7 @@ class VisionProcessor:
 
         image_token = self.vision_config.image_token
         if image_token is None:
-            image_token = tokenizer.decode([self.vision_config.image_token_id])
+            image_token = tokenizer.decode([self.vision_config.required_image_token_id])
 
         formatted_messages = _format_vlm_messages(
             chat_template_messages, self.vision_config.model_type, task_id=task_id
@@ -1478,7 +1478,7 @@ class VisionProcessor:
         prompt_tokens: mx.array = encode_prompt(tokenizer, prompt)
         prompt_tokens = fix_unmatched_think_end_tokens(prompt_tokens, tokenizer)
         n_image_tokens = int(
-            mx.sum(mx.equal(prompt_tokens, self.vision_config.image_token_id)).item()
+            mx.sum(mx.equal(prompt_tokens, self.vision_config.required_image_token_id)).item()
         )
         record_runner_phase(
             "vision_preprocess",
@@ -1498,14 +1498,14 @@ class VisionProcessor:
             model,
             prompt_tokens,
             image_features,
-            self.vision_config.image_token_id,
+            self.vision_config.required_image_token_id,
         )
         mx.eval(embeddings)
 
         media_regions = _find_media_regions(
             prompt_tokens,
             images,
-            self.vision_config.image_token_id,
+            self.vision_config.required_image_token_id,
             boi_token_id=self.vision_config.boi_token_id,
             eoi_token_id=self.vision_config.eoi_token_id,
         )
@@ -1640,7 +1640,7 @@ class VisionProcessor:
 
         image_token = self.vision_config.image_token
         if image_token is None:
-            image_token = tokenizer.decode([self.vision_config.image_token_id])
+            image_token = tokenizer.decode([self.vision_config.required_image_token_id])
 
         formatted_messages = _format_vlm_messages(
             chat_template_messages, self.vision_config.model_type, task_id=task_id
@@ -1665,7 +1665,7 @@ class VisionProcessor:
         prompt_tokens: mx.array = encode_prompt(tokenizer, prompt)
         prompt_tokens = fix_unmatched_think_end_tokens(prompt_tokens, tokenizer)
         n_image_tokens = int(
-            mx.sum(mx.equal(prompt_tokens, self.vision_config.image_token_id)).item()
+            mx.sum(mx.equal(prompt_tokens, self.vision_config.required_image_token_id)).item()
         )
         record_runner_phase(
             "vision_preprocess",
@@ -1686,7 +1686,7 @@ class VisionProcessor:
         media_regions = _find_media_regions(
             prompt_tokens,
             images,
-            self.vision_config.image_token_id,
+            self.vision_config.required_image_token_id,
             boi_token_id=self.vision_config.boi_token_id,
             eoi_token_id=self.vision_config.eoi_token_id,
         )

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -19,7 +19,7 @@ cleanly on nodes (e.g. Macs) where the binding is not installed.
 import os
 import time
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Final, Literal
 
 from anyio import WouldBlock
 
@@ -84,15 +84,153 @@ def select_gguf_file(model_dir: Path) -> Path:
     return candidates[0]
 
 
+# Map a model card's vision family (``VisionCardConfig.model_type``) to the
+# llama-cpp-python chat handler that knows how to splice that family's image
+# features. ``MTMDChatHandler`` is the modern unified multimodal handler in
+# current llama.cpp and the safe default for any family without a bespoke entry.
+# Handler classes are resolved lazily (by name) so importing this module never
+# requires the vision symbols, which only exist on a vision-capable build.
+_VISION_HANDLER_BY_MODEL_TYPE: dict[str, str] = {
+    "gemma4": "Gemma4ChatHandler",
+    "gemma3": "Gemma4ChatHandler",
+    "qwen-vl": "Qwen25VLChatHandler",
+    "qwen2.5-vl": "Qwen25VLChatHandler",
+    "qwen2_vl": "Qwen25VLChatHandler",
+    "minicpm": "MiniCPMv26ChatHandler",
+    "minicpmv": "MiniCPMv26ChatHandler",
+    "llava": "Llava16ChatHandler",
+    "llava-1.6": "Llava16ChatHandler",
+    "llava-1.5": "Llava15ChatHandler",
+    "moondream": "MoondreamChatHandler",
+    "nanollava": "NanoLlavaChatHandler",
+}
+_DEFAULT_VISION_HANDLER: Final = "MTMDChatHandler"
+
+
+def find_mmproj_file(model_dir: "Path") -> "Path | None":
+    """Return the multimodal projector GGUF in a staged model dir, or ``None``.
+
+    A vision GGUF repo ships its projector as a separate ``*mmproj*.gguf`` (kept
+    by the download allow-list since #346). ``select_gguf_file`` deliberately
+    skips it when picking the LM weights, so the runner locates it here to hand
+    to the vision chat handler. Returns the first match (repos ship one), or
+    ``None`` for a text-only model.
+    """
+    candidates = sorted(model_dir.glob("**/*.gguf"))
+    for path in candidates:
+        if "mmproj" in path.name.lower():
+            return path
+    return None
+
+
+def _build_vision_chat_handler(model_type: str, mmproj_path: "Path") -> object | None:
+    """Construct the llama-cpp-python vision chat handler for a model family.
+
+    Resolves the handler class named by ``_VISION_HANDLER_BY_MODEL_TYPE`` (or the
+    ``MTMDChatHandler`` default) from ``llama_cpp.llama_chat_format`` and builds
+    it with the projector path. Returns ``None`` if the installed binding lacks
+    the chosen handler (an older / non-vision build), so the caller can fail with
+    a clear message rather than crash on import.
+    """
+    handler_name = _VISION_HANDLER_BY_MODEL_TYPE.get(
+        model_type.lower(), _DEFAULT_VISION_HANDLER
+    )
+    import llama_cpp.llama_chat_format as chat_format
+
+    handler_cls = getattr(chat_format, handler_name, None)
+    if handler_cls is None:
+        handler_cls = getattr(chat_format, _DEFAULT_VISION_HANDLER, None)
+    if handler_cls is None:
+        return None
+    logger.info(
+        f"vision: {handler_cls.__name__} clip_model_path={mmproj_path.name}"
+    )
+    return handler_cls(clip_model_path=str(mmproj_path), verbose=False)
+
+
+def _image_data_uri(b64: str) -> str:
+    """Wrap a raw base64 image as a ``data:`` URI llama.cpp's vision handler reads.
+
+    Sniffs the format from the decoded magic bytes (PNG vs JPEG vs GIF vs WEBP)
+    so the MIME label is accurate; defaults to ``image/png`` when unrecognized.
+    The handler base64-decodes and re-sniffs anyway, so the label is advisory,
+    but an accurate one avoids surprising a stricter decoder.
+    """
+    import base64
+
+    mime = "image/png"
+    try:
+        head = base64.b64decode(b64[:24], validate=False)
+        if head.startswith(b"\xff\xd8\xff"):
+            mime = "image/jpeg"
+        elif head.startswith(b"GIF8"):
+            mime = "image/gif"
+        elif head[8:12] == b"WEBP":
+            mime = "image/webp"
+    except Exception:  # noqa: BLE001 - format sniff is best-effort, default png
+        pass
+    return f"data:{mime};base64,{b64}"
+
+
+def _splice_images_into_messages(
+    messages: list[dict[str, Any]], images: list[str]
+) -> list[dict[str, Any]]:
+    """Turn the MLX-shaped ``{"type": "image"}`` placeholders into llama.cpp's
+    OpenAI ``image_url`` parts, pulling base64 data from ``images`` in order.
+
+    The API renders ``chat_template_messages`` for the MLX path: image parts are
+    bare ``{"type": "image"}`` placeholders and the actual base64 lives in the
+    ordered ``task_params.images`` list (embedding fusion happens later for MLX).
+    llama.cpp instead wants the image bytes inline in the message content as
+    ``{"type": "image_url", "image_url": {"url": "data:..."}}``, which its vision
+    chat handler decodes. Walk the messages and replace each placeholder with the
+    next image (by position), leaving text parts untouched. Returns the messages
+    unchanged when there are no images.
+    """
+    if not images:
+        return messages
+    image_iter = iter(images)
+    spliced: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            spliced.append(message)
+            continue
+        new_parts: list[dict[str, Any]] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "image":
+                b64 = next(image_iter, None)
+                if b64 is None:
+                    # More placeholders than images: drop the stray placeholder
+                    # rather than emit a malformed part.
+                    continue
+                new_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": _image_data_uri(b64)},
+                    }
+                )
+            else:
+                new_parts.append(part)
+        spliced.append({**message, "content": new_parts})
+    return spliced
+
+
 def messages_for_llama(task_params: TextGenerationTaskParams) -> list[dict[str, Any]]:
     """Build the chat-completion messages llama.cpp's chat template expects.
 
     Prefers ``chat_template_messages`` (already-rendered OpenAI-style dicts that
-    the API populates on the chat path). Falls back to reconstructing a minimal
-    message list from ``instructions`` + ``input`` when that is absent.
+    the API populates on the chat path). When the request carries images, the
+    MLX-shaped ``{"type": "image"}`` placeholders are rewritten into llama.cpp's
+    inline ``image_url`` data-URI parts (see ``_splice_images_into_messages``) so
+    a vision GGUF's chat handler receives the image bytes. Falls back to
+    reconstructing a minimal message list from ``instructions`` + ``input`` when
+    no rendered messages are present.
     """
     if task_params.chat_template_messages:
-        return task_params.chat_template_messages
+        return _splice_images_into_messages(
+            task_params.chat_template_messages, task_params.images
+        )
     messages: list[dict[str, Any]] = []
     if task_params.instructions:
         messages.append({"role": "system", "content": task_params.instructions})
@@ -426,9 +564,29 @@ class Runner:
         # _logits_all_enabled / _logits_all_n_ctx.
         logits_all = _logits_all_enabled()
         n_ctx = _serving_n_ctx(self.context_token_limit, logits_all)
+        # Vision GGUF (#128): when the card declares a vision config, load the
+        # multimodal projector via the family's chat handler so image inputs are
+        # spliced server-side by llama.cpp. Text-only cards take the plain path.
+        vision = self.shard_metadata.model_card.vision
+        chat_handler: object | None = None
+        if vision is not None:
+            mmproj_path = find_mmproj_file(model_dir)
+            if mmproj_path is None:
+                raise RuntimeError(
+                    f"vision model {model_id} declares a vision config but no "
+                    f"mmproj projector GGUF was found in {model_dir}; the "
+                    "projector download may have failed"
+                )
+            chat_handler = _build_vision_chat_handler(vision.model_type, mmproj_path)
+            if chat_handler is None:
+                raise RuntimeError(
+                    f"vision model {model_id} needs a llama.cpp vision chat "
+                    f"handler for model_type={vision.model_type!r}, but the "
+                    "installed llama-cpp-python build exposes none"
+                )
         logger.info(
             f"loading GGUF {gguf_path.name} for {model_id} "
-            f"(n_ctx={n_ctx}, logits_all={logits_all})"
+            f"(n_ctx={n_ctx}, logits_all={logits_all}, vision={vision is not None})"
         )
         self.model = Llama(
             model_path=str(gguf_path),
@@ -436,6 +594,7 @@ class Runner:
             n_ctx=n_ctx,
             logits_all=logits_all,
             verbose=False,
+            chat_handler=chat_handler,
         )
         self.current_status = RunnerReady()
         logger.info(

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
@@ -1,4 +1,4 @@
-# pyright: reportPrivateUsage=false
+# pyright: reportPrivateUsage=false, reportAny=false, reportUnknownMemberType=false
 """Tests for the pure helpers of the llama.cpp runner (no llama_cpp needed)."""
 
 from pathlib import Path
@@ -9,13 +9,18 @@ from skulk.shared.models.memory_estimate import KV_CONTEXT_BUDGET_TOKENS
 from skulk.shared.types.common import ModelId
 from skulk.shared.types.text_generation import InputMessage, TextGenerationTaskParams
 from skulk.worker.runner.llama_cpp.runner import (
+    _DEFAULT_VISION_HANDLER,
+    _VISION_HANDLER_BY_MODEL_TYPE,
     _generation_kwargs,
+    _image_data_uri,
     _logits_all_enabled,
     _logits_all_n_ctx,
     _logprob_fields,
     _map_finish_reason,
     _serving_n_ctx,
+    _splice_images_into_messages,
     _tool_calls_from_message,
+    find_mmproj_file,
     messages_for_llama,
     select_gguf_file,
 )
@@ -176,3 +181,99 @@ def test_logprob_fields_absent_or_malformed() -> None:
     assert _logprob_fields({}) == (None, None)
     assert _logprob_fields({"logprobs": None}) == (None, None)
     assert _logprob_fields({"logprobs": {"content": []}}) == (None, None)
+
+
+# --- vision (#128) ---------------------------------------------------------
+
+
+def test_image_data_uri_sniffs_png_and_jpeg() -> None:
+    import base64
+
+    png = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16).decode()
+    jpeg = base64.b64encode(b"\xff\xd8\xff\xe0" + b"\x00" * 16).decode()
+    assert _image_data_uri(png).startswith("data:image/png;base64,")
+    assert _image_data_uri(jpeg).startswith("data:image/jpeg;base64,")
+    # Unrecognized bytes default to png rather than raising.
+    assert _image_data_uri(base64.b64encode(b"zzzz").decode()).startswith(
+        "data:image/png;base64,"
+    )
+
+
+def test_splice_images_replaces_placeholders_in_order() -> None:
+    messages = [
+        {"role": "system", "content": "be brief"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "compare"},
+                {"type": "image"},
+                {"type": "image"},
+            ],
+        },
+    ]
+    import base64
+
+    a = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode()
+    b = base64.b64encode(b"\xff\xd8\xff\xe0").decode()
+    out = _splice_images_into_messages(messages, [a, b])
+    # system message untouched (string content)
+    assert out[0] == {"role": "system", "content": "be brief"}
+    parts = out[1]["content"]
+    assert parts[0] == {"type": "text", "text": "compare"}
+    assert parts[1]["type"] == "image_url"
+    assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert parts[2]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_splice_images_noop_without_images() -> None:
+    messages = [{"role": "user", "content": "hi"}]
+    assert _splice_images_into_messages(messages, []) is messages
+
+
+def test_splice_images_drops_extra_placeholder() -> None:
+    # More placeholders than images: stray placeholder dropped, not malformed.
+    messages = [
+        {"role": "user", "content": [{"type": "image"}, {"type": "image"}]}
+    ]
+    import base64
+
+    only = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode()
+    out = _splice_images_into_messages(messages, [only])
+    parts = out[0]["content"]
+    assert len(parts) == 1
+    assert parts[0]["type"] == "image_url"
+
+
+def test_messages_for_llama_splices_images() -> None:
+    import base64
+
+    img = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode()
+    params = _params(
+        chat_template_messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image"},
+                ],
+            }
+        ],
+        images=[img],
+    )
+    out = messages_for_llama(params)
+    assert out[0]["content"][1]["type"] == "image_url"
+
+
+def test_find_mmproj_file(tmp_path: Path) -> None:
+    (tmp_path / "model-Q4_K_M.gguf").touch()
+    assert find_mmproj_file(tmp_path) is None
+    (tmp_path / "mmproj-model-f16.gguf").touch()
+    found = find_mmproj_file(tmp_path)
+    assert found is not None and "mmproj" in found.name.lower()
+
+
+def test_vision_handler_map_defaults_to_mtmd() -> None:
+    # Known families map to a bespoke handler; unknown falls back to MTMD.
+    assert _VISION_HANDLER_BY_MODEL_TYPE["qwen2.5-vl"] == "Qwen25VLChatHandler"
+    assert _VISION_HANDLER_BY_MODEL_TYPE.get("some-new-vlm") is None
+    assert _DEFAULT_VISION_HANDLER == "MTMDChatHandler"

--- a/website/docs/amd-strix-halo-nodes.md
+++ b/website/docs/amd-strix-halo-nodes.md
@@ -106,6 +106,9 @@ other Skulk model, with the same streaming behavior. It matches the MLX nodes on
 the generation capabilities llama.cpp supports:
 
 - **Text generation**, streamed token by token.
+- **Vision / image input** for a vision GGUF (with an `mmproj` projector): send
+  images as OpenAI `image_url` content and the model describes or reasons over
+  them. The projector loads through llama.cpp's multimodal chat handler.
 - **Logprobs** (opt-in): per-token logprobs and ranked alternatives (`logprobs`
   / `top_logprobs`). This needs the model loaded so it retains per-token logits,
   which pre-allocates a large buffer (context length x vocab), so it is off by
@@ -122,7 +125,14 @@ the generation capabilities llama.cpp supports:
   on the model and its embedded chat template, which Skulk uses as-is; either way
   the request completes through the normal streaming path.
 
-Two things are deliberately not on the AMD path today:
+**Vision / multimodal GGUF** models are served. A vision GGUF that ships a
+separate `mmproj` projector (LLaVA / Qwen-VL style) runs on an AMD node: the
+projector downloads alongside the weights and the runner loads it through
+llama.cpp's multimodal chat handler, so image chat requests (OpenAI `image_url`
+content) work. A repo is recognized as a vision model from its `config.json`
+vision section, or, when it ships none, from the presence of the `mmproj` file.
+
+One thing is deliberately not on the AMD path today:
 
 - **Multi-token prediction (MTP) / speculative decoding is MLX-only.** Those
   speedups come from MLX-specific drafting (model-native prediction heads or a
@@ -130,7 +140,6 @@ Two things are deliberately not on the AMD path today:
   not implement, so an AMD node runs plain autoregressive decoding. GGUF models
   advertise no MTP capability, so it is never shown as available for them (there
   is no promise to fall short of); the AMD node serves at its native decode speed.
-- **Vision / multimodal GGUF** models are not served yet (text generation only).
 
 ## Scope
 


### PR DESCRIPTION
## What

Closes #128. Vision GGUF VLMs (LLaVA / Qwen-VL style, with a separate `mmproj` projector) now serve on the llama.cpp engine.

## How

- **Runner image input** (`messages_for_llama` / `_splice_images_into_messages`): rewrites the MLX-shaped `{"type":"image"}` placeholders into llama.cpp's inline `image_url` data-URI parts from `task_params.images`, with format sniffing.
- **Runner load** (`_load_model` + `_build_vision_chat_handler`): when the card declares vision, locate the `*mmproj*.gguf` and load it via the family's llama-cpp-python chat handler (`MTMDChatHandler` default; mapped from `VisionCardConfig.model_type`).
- **Card autodetect** (`_fetch_gguf_from_hf`): mark a GGUF repo vision-capable from its `config.json` vision section, or — for the many VLM GGUF repos that ship no `config.json` (e.g. bartowski) — from the presence of an `mmproj` projector (`gguf_repo_has_projector`).
- `VisionCardConfig.image_token_id` made optional (MLX-only; the llama.cpp handler inserts image features itself). The 7 MLX vision sites use a new `required_image_token_id` property that raises if absent.

## Live validation (kite4, Vulkan)

`bartowski/Qwen2-VL-2B-Instruct-GGUF` (a no-config.json repo → mmproj fallback path):
- vision auto-detected, mmproj loaded via `MTMDChatHandler`, RunnerReady ~78s.
- **Reads a black "7"** (OCR) and **lists RGB stripe order correctly** top-to-bottom.
- (Flat solid-color naming is unreliable on this 2B model — an out-of-distribution model weakness, not an ingestion bug; structured content is accurate.)

## Tests
Unit: image data-URI sniffing, placeholder splicing (in-order / extra-placeholder / no-op), mmproj discovery, handler map default. Full gate green: basedpyright 0, ruff clean, 1230 passed / 1 skipped, fmt clean.

## Note for review
Touches a **shared wire type** (`VisionCardConfig.image_token_id` now optional), so the whole fleet must run the same version. Validated fleet-wide on the branch.

Foundation: builds on the mmproj download fix (#346).

🤖 Generated with [Claude Code](https://claude.com/claude-code)