### PR TITLE
fix(placement): cap GGUF admission ceiling to the KV budget (#362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- **A llama.cpp request between the KV budget and the model's context ceiling is
+  now cleanly rejected instead of failing at the runner (#362).** The llama.cpp
+  runner allocates its KV cache up front and caps the loaded context to
+  `KV_CONTEXT_BUDGET_TOKENS` (8192; `_serving_n_ctx`), but the API's admission
+  ceiling (`instance_context_token_limit`) was the memory/card value, often tens
+  of thousands of tokens. A request above the budget was therefore admitted and
+  then failed or truncated at generation. The admission ceiling for a
+  GGUF/llama.cpp instance is now capped to the same budget, so the API returns a
+  clear `context_length_exceeded` up front and admission matches what the runner
+  serves. (Enabling logprobs lowers the runner window further; this was the
+  originally reported case, now subsumed. A node that overrides
+  `SKULK_LLAMA_CPP_LOGITS_ALL_N_CTX` *below* the budget remains a narrow per-node
+  residual, since the master cannot see node-local env at placement.)
+
 ### Added
 
 - **Vision GGUF VLMs now run on the llama.cpp engine (#128).** A vision GGUF

--- a/src/skulk/shared/models/memory_estimate.py
+++ b/src/skulk/shared/models/memory_estimate.py
@@ -262,7 +262,28 @@ def instance_context_token_limit(
 
     card_limit = model_card.context_length if model_card.context_length > 0 else None
     if memory_limit is None:
-        return card_limit
-    if card_limit is None:
-        return memory_limit
-    return min(memory_limit, card_limit)
+        limit = card_limit
+    elif card_limit is None:
+        limit = memory_limit
+    else:
+        limit = min(memory_limit, card_limit)
+
+    # The llama.cpp runner allocates its KV cache up front and caps the loaded
+    # context to KV_CONTEXT_BUDGET_TOKENS (the same budget placement reserves; see
+    # the runner's _serving_n_ctx). The memory/card ceiling above can be far
+    # larger (tens of thousands of tokens), so without this a request between the
+    # budget and that ceiling is ADMITTED by the API but exceeds the runner's
+    # loaded window and fails/truncates at generation instead of being cleanly
+    # rejected (#362; logprobs lowers the runner window further, the original
+    # report). Cap a GGUF/llama.cpp instance's admission ceiling to the budget so
+    # admission matches what the runner actually serves. (Serving beyond the
+    # budget needs placement to reserve the larger KV footprint first, tracked
+    # with VRAM-aware admission; when that lands both this cap and _serving_n_ctx
+    # move together off the shared constant.)
+    if model_card.gguf_file:
+        limit = (
+            KV_CONTEXT_BUDGET_TOKENS
+            if limit is None
+            else min(limit, KV_CONTEXT_BUDGET_TOKENS)
+        )
+    return limit

--- a/src/skulk/shared/models/tests/test_memory_estimate.py
+++ b/src/skulk/shared/models/tests/test_memory_estimate.py
@@ -99,6 +99,7 @@ def test_gpu_working_set_ceiling_is_fraction_of_total():
 # --- Context-admission ceiling (#145) ---------------------------------------
 
 from skulk.shared.models.memory_estimate import (  # noqa: E402
+    KV_CONTEXT_BUDGET_TOKENS,
     KV_DTYPE_BYTES,
     KV_HEAD_DIM_FALLBACK,
     instance_context_token_limit,
@@ -230,6 +231,63 @@ def test_instance_limit_none_when_nothing_enforceable():
         card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
     )
     assert instance_context_token_limit(assignments, {}) is None
+
+
+def test_instance_limit_gguf_capped_to_kv_budget():
+    # #362: a GGUF/llama.cpp instance whose memory + card ceiling exceed the
+    # runner's loaded window (KV_CONTEXT_BUDGET_TOKENS, _serving_n_ctx) must admit
+    # only up to that window, else a request beyond it is admitted then fails at
+    # the runner. Card advertises a large context, lots of memory -> would be huge.
+    card = _card(1, kv_heads=8, n_layers=32, gguf_file="m-Q4_K_M.gguf").model_copy(
+        update={"context_length": 131072}
+    )
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    assert (
+        instance_context_token_limit(assignments, {NodeId("n0"): Memory.from_gb(64)})
+        == KV_CONTEXT_BUDGET_TOKENS
+    )
+
+
+def test_instance_limit_gguf_capped_even_without_memory_or_card_limit():
+    # A bare GGUF card (no advertised context, no node memory) still serves a
+    # bounded n_ctx, so admission is the budget, not None.
+    card = _card(4, kv_heads=8, n_layers=32, gguf_file="m-Q4_K_M.gguf")
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    assert instance_context_token_limit(assignments, {}) == KV_CONTEXT_BUDGET_TOKENS
+
+
+def test_instance_limit_gguf_below_budget_unchanged():
+    # A GGUF card whose advertised context is already below the budget keeps that
+    # smaller limit (the cap is a ceiling, never raises a smaller real limit).
+    card = _card(1, kv_heads=8, n_layers=32, gguf_file="m-Q4_K_M.gguf").model_copy(
+        update={"context_length": 2048}
+    )
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    assert (
+        instance_context_token_limit(assignments, {NodeId("n0"): Memory.from_gb(64)})
+        == 2048
+    )
+
+
+def test_instance_limit_mlx_not_capped_to_kv_budget():
+    # The cap is GGUF-only: an MLX card (no gguf_file) keeps its memory/card
+    # ceiling, which grows the KV cache per request rather than allocating up front.
+    card = _card(1, kv_heads=8, n_layers=32).model_copy(
+        update={"context_length": 131072}
+    )
+    assignments = _assignments(
+        card, {"r0": (_pipeline_shard(card, start=0, end=32), "n0")}
+    )
+    limit = instance_context_token_limit(
+        assignments, {NodeId("n0"): Memory.from_gb(64)}
+    )
+    assert limit is not None and limit > KV_CONTEXT_BUDGET_TOKENS
 
 
 def test_instance_limit_unknown_kv_cost_falls_back_to_card():


### PR DESCRIPTION
## What

Closes #362. A llama.cpp request longer than the runner's loaded context window was admitted by the API and then failed/truncated at generation. Now it's cleanly rejected up front.

## Root cause

The llama.cpp runner allocates its KV cache up front and caps the loaded context to `KV_CONTEXT_BUDGET_TOKENS` (8192) via `_serving_n_ctx`. But the API's admission ceiling (`instance_context_token_limit`) returned the memory/card-derived value — often tens of thousands of tokens for a GGUF model. So a request between 8192 and that ceiling passed admission, then exceeded the runner's actual `n_ctx`.

This is broader than the original #362 report (which framed it around logprobs): the mismatch exists for any GGUF model whose ceiling exceeds the budget. Enabling logprobs (`SKULK_LLAMA_CPP_LOGITS_ALL=1`) just lowers the runner window further, so it's a sub-case.

## Fix

Cap a GGUF/llama.cpp instance's `instance_context_token_limit` to `KV_CONTEXT_BUDGET_TOKENS` — the same constant `_serving_n_ctx` uses — so admission matches what the runner serves. Deterministic (shared constant), so all ranks compute the identical ceiling. MLX is unaffected (it grows the KV cache per request).

## Residual (documented, out of scope)
A node that overrides `SKULK_LLAMA_CPP_LOGITS_ALL_N_CTX` *below* the budget would load an even smaller window; the master can't see node-local env at placement, so that narrow case would need the runner to report its loaded `n_ctx` back (a bigger change). The default and common cases are fully covered.

## Tests
GGUF capped to budget (large memory + card); capped even with no memory/card limit; below-budget card unchanged; MLX not capped. Full gate green: basedpyright 0, ruff clean, 1234 passed / 1 skipped, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)