### PR TITLE
fix(store): honor a card's pinned GGUF quant on store download (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **The centralized store now honors a card's pinned GGUF quant on download
+  (#344).** A store-routed download re-derived the quant from the model id alone
+  (the default preference), so a custom card pinning a non-default quant (e.g.
+  `Q8_0`, `Q3_K_M`) silently got the default instead. The store download request
+  now carries the card's `gguf_file`: the worker's store client sends it in the
+  `POST /models/{id}/download` body, the store fetches that quant's shard group,
+  and a pin absent from the repo falls back to the default. Auto-built cards
+  (whose pin matches the default) are unaffected.
+
 - **A llama.cpp request between the KV budget and the model's context ceiling is
   now cleanly rejected instead of failing at the runner (#362).** The llama.cpp
   runner allocates its KV cache up front and caps the loaded context to

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -75,6 +75,7 @@ from skulk.shared.types.worker.downloads import FileListEntry
 
 def select_store_gguf_download_files(
     file_list: list[FileListEntry],
+    pinned_gguf: str | None = None,
 ) -> list[FileListEntry]:
     """Filter a repo's file list to what the store host should download (#339).
 
@@ -89,6 +90,11 @@ def select_store_gguf_download_files(
 
     Args:
         file_list: The full recursive repo file list.
+        pinned_gguf: The card's pinned GGUF file (``ModelCard.gguf_file``), when
+            the requester carries one. The store fetches *that* quant's shard
+            group, honoring a custom/non-default pin (#344). When ``None`` (or
+            the pin is absent from the repo) the store falls back to the default
+            quant preference, matching the prior behavior.
 
     Returns:
         The subset to download. Identical to the input for non-GGUF repos.
@@ -108,9 +114,22 @@ def select_store_gguf_download_files(
     if not gguf_weights:
         return file_list  # not a GGUF repo (or vision-only projector): unchanged
 
-    selected = select_preferred_gguf(
-        [(entry.path, entry.size or 0) for entry in gguf_weights]
-    )
+    # Honor a card's pinned quant when it names a file actually in the repo;
+    # otherwise fall back to the default preference (#344). The pin is matched by
+    # exact repo-relative path so a stale/typo'd pin can't silently select the
+    # wrong file -- it just degrades to the default.
+    pinned_paths = {entry.path for entry in gguf_weights}
+    if pinned_gguf and pinned_gguf in pinned_paths:
+        selected = pinned_gguf
+    else:
+        if pinned_gguf:
+            logger.warning(
+                f"ModelStore: pinned GGUF {pinned_gguf!r} not found in repo; "
+                "falling back to the default quant preference"
+            )
+        selected = select_preferred_gguf(
+            [(entry.path, entry.size or 0) for entry in gguf_weights]
+        )
     # Match the direct-HF GGUF allow-list exactly: the selected shard group
     # (``gguf_allow_patterns`` returns either the single file or the
     # ``<base>-*-of-*.gguf`` glob) plus ``config.json``. Patterns and paths are
@@ -361,11 +380,16 @@ class ModelStore:
     # Store-side HuggingFace downloads
     # ------------------------------------------------------------------
 
-    async def request_download(self, model_id: str) -> StoreDownloadStatus:
+    async def request_download(
+        self, model_id: str, pinned_gguf: str | None = None
+    ) -> StoreDownloadStatus:
         """Request that the store download a model from HuggingFace.
 
         Deduplicates: if the model is already downloading, returns the
         existing status.  If already in the store, returns "complete".
+
+        ``pinned_gguf`` is the requester's card-pinned GGUF file, forwarded so a
+        GGUF repo fetches that quant's shard group rather than the default (#344).
         """
         async with self._download_lock:
             existing = self._active_downloads.get(model_id)
@@ -380,7 +404,7 @@ class ModelStore:
                 )
             status = StoreDownloadStatus(model_id=model_id, status="pending")
             self._active_downloads[model_id] = status
-        task = asyncio.create_task(self._do_download(model_id))
+        task = asyncio.create_task(self._do_download(model_id, pinned_gguf))
         self._download_tasks.add(task)
         task.add_done_callback(self._download_tasks.discard)
         return status
@@ -403,8 +427,14 @@ class ModelStore:
             if s.status in ("pending", "downloading")
         ]
 
-    async def _do_download(self, model_id: str) -> None:
-        """Download a model from HuggingFace into the store and register it."""
+    async def _do_download(
+        self, model_id: str, pinned_gguf: str | None = None
+    ) -> None:
+        """Download a model from HuggingFace into the store and register it.
+
+        ``pinned_gguf`` (the requester's ``ModelCard.gguf_file``) selects which
+        GGUF quant's shard group to fetch, honoring a custom pin (#344).
+        """
         from skulk.download.download_utils import (
             download_file_with_retry,
             fetch_file_list_with_cache,
@@ -428,7 +458,7 @@ class ModelStore:
             # For a GGUF repo, fetch only the preferred quant's shard group plus
             # config.json (dropping other quants, original/*, metal/*, etc.),
             # mirroring the direct-HF selective download (#339).
-            selected_files = select_store_gguf_download_files(file_list)
+            selected_files = select_store_gguf_download_files(file_list, pinned_gguf)
             if len(selected_files) != len(file_list):
                 logger.info(
                     f"ModelStore: {model_id} is a GGUF repo; downloading "

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -432,6 +432,7 @@ class ModelStoreClient:
         on_progress: Callable[[float], Awaitable[None]] | None = None,
         timeout: float = 7200,
         poll_interval: float = 5.0,
+        pinned_gguf: str | None = None,
     ) -> bool:
         """Request the store host download a model from HuggingFace, then wait.
 
@@ -443,6 +444,10 @@ class ModelStoreClient:
             on_progress: Called with progress (0.0-1.0) on each poll.
             timeout: Maximum wait time in seconds.
             poll_interval: Seconds between status polls.
+            pinned_gguf: The card's pinned GGUF file (``ModelCard.gguf_file``),
+                sent in the POST body so the store fetches that quant's shard
+                group rather than its default (#344). ``None`` for non-GGUF
+                models or when no pin applies.
 
         Returns:
             ``True`` if download completed successfully.
@@ -455,13 +460,17 @@ class ModelStoreClient:
 
         encoded_id = quote(model_id, safe="")
 
-        # Request download
+        # Request download. Send the pinned quant in the body when present; an
+        # older store host ignores the unknown body and uses its default (#344).
         url = _make_store_url(
             self._store_host, self._store_port, f"/models/{encoded_id}/download"
         )
+        post_kwargs: dict[str, object] = (
+            {"json": {"gguf_file": pinned_gguf}} if pinned_gguf else {}
+        )
         async with (
             create_http_session(timeout_profile="short") as session,
-            session.post(url) as resp,
+            session.post(url, **post_kwargs) as resp,  # pyright: ignore[reportArgumentType]
         ):
             if resp.status not in (200, 201):
                 raise RuntimeError(f"Store download request failed: HTTP {resp.status}")
@@ -921,6 +930,9 @@ class ModelStoreDownloader(ShardDownloader):
                     on_progress=lambda _p: self._emit_progress(
                         shard, status="in_progress"
                     ),
+                    # Forward the card's pinned quant so the store fetches it
+                    # rather than its default preference (#344).
+                    pinned_gguf=shard.model_card.gguf_file,
                 )
             except (RuntimeError, TimeoutError) as exc:
                 raise ModelNotInStoreError(

--- a/src/skulk/store/model_store_server.py
+++ b/src/skulk/store/model_store_server.py
@@ -64,7 +64,7 @@ Example requests::
 from __future__ import annotations
 
 import shutil
-from typing import final
+from typing import cast, final
 
 import aiofiles
 import aiofiles.os as aios
@@ -290,9 +290,25 @@ class ModelStoreServer:
         return web.json_response({"modelId": model_id, "deleted": True})
 
     async def _handle_download_request(self, request: web.Request) -> web.Response:
-        """``POST /models/{model_id}/download`` — request store-side HF download."""
+        """``POST /models/{model_id}/download``: request store-side HF download.
+
+        Optional JSON body ``{"gguf_file": "<path>"}`` pins which GGUF quant's
+        shard group the store fetches, honoring a card's custom pin (#344). The
+        body is optional: a request without it (or a non-JSON body) falls back to
+        the default quant preference, preserving the prior contract.
+        """
         model_id = _sanitize_model_id(request.match_info["model_id"])
-        status = await self._store.request_download(model_id)
+        pinned_gguf: str | None = None
+        if request.can_read_body:
+            try:
+                body: object = cast("object", await request.json())
+            except Exception:  # noqa: BLE001 - tolerate empty / non-JSON body
+                body = None
+            if isinstance(body, dict):
+                raw = cast("dict[str, object]", body).get("gguf_file")
+                if isinstance(raw, str) and raw:
+                    pinned_gguf = raw
+        status = await self._store.request_download(model_id, pinned_gguf)
         return web.json_response(
             {
                 "modelId": status.model_id,

--- a/src/skulk/store/tests/test_store_gguf_selection.py
+++ b/src/skulk/store/tests/test_store_gguf_selection.py
@@ -105,3 +105,60 @@ def test_single_quant_repo_keeps_quant_and_config() -> None:
     ]
     kept = {e.path for e in select_store_gguf_download_files(files)}
     assert kept == {"config.json", "model-Q4_K_M.gguf"}
+
+
+def test_pinned_quant_overrides_default_preference() -> None:
+    # #344: when the card pins a non-default quant, the store fetches THAT quant's
+    # shard group, not its default preference (Q4_K_M).
+    files = [
+        _entry("config.json"),
+        _entry("model-Q4_K_M.gguf", 800),  # would be the default pick
+        _entry("model-Q8_0.gguf", 1300),
+    ]
+    kept = {e.path for e in select_store_gguf_download_files(files, "model-Q8_0.gguf")}
+    assert kept == {"config.json", "model-Q8_0.gguf"}
+
+
+def test_pinned_sharded_quant_keeps_its_whole_group() -> None:
+    files = [
+        _entry("config.json"),
+        _entry("m-Q4_K_M.gguf", 800),
+        _entry("m-Q6_K-00001-of-00002.gguf", 900),
+        _entry("m-Q6_K-00002-of-00002.gguf", 950),
+    ]
+    kept = {
+        e.path
+        for e in select_store_gguf_download_files(files, "m-Q6_K-00001-of-00002.gguf")
+    }
+    assert kept == {
+        "config.json",
+        "m-Q6_K-00001-of-00002.gguf",
+        "m-Q6_K-00002-of-00002.gguf",
+    }
+
+
+def test_pin_absent_from_repo_falls_back_to_default() -> None:
+    # A stale/typo'd pin not present in the repo degrades to the default pick
+    # rather than selecting nothing.
+    files = [
+        _entry("config.json"),
+        _entry("model-Q4_K_M.gguf", 800),
+        _entry("model-Q8_0.gguf", 1300),
+    ]
+    kept = {
+        e.path for e in select_store_gguf_download_files(files, "model-Q3_K_M.gguf")
+    }
+    assert kept == {"config.json", "model-Q4_K_M.gguf"}  # default preference
+
+
+def test_pinned_none_matches_prior_default_behavior() -> None:
+    files = [
+        _entry("config.json"),
+        _entry("model-Q4_K_M.gguf", 800),
+        _entry("model-Q8_0.gguf", 1300),
+    ]
+    assert (
+        {e.path for e in select_store_gguf_download_files(files, None)}
+        == {e.path for e in select_store_gguf_download_files(files)}
+        == {"config.json", "model-Q4_K_M.gguf"}
+    )

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -717,6 +717,11 @@ Use this to inspect in-progress shared-store download activity.
 
 Use this when you want the store host to fetch and register a model.
 
+Optional JSON body `{"gguf_file": "<repo-relative path>"}` pins which GGUF quant
+the store fetches for a multi-quant GGUF repo (it downloads that file's shard
+group plus `config.json`). Omit the body to use the default quant preference.
+A pin naming a file not present in the repo falls back to the default.
+
 ### Store download status
 
 **GET** `/store/models/{model_id}/download/status`


### PR DESCRIPTION
## What

Closes #344. The centralized store now downloads the GGUF quant a card pins, instead of always re-deriving the default preference from the model id.

## Root cause

The store download HTTP contract only carried the model id, so `select_store_gguf_download_files` re-picked the default quant via `select_preferred_gguf`. A hand-edited card pinning a non-default quant (`Q8_0`, `Q3_K_M`, ...) was silently ignored on the store path; the runner then loaded whatever default landed on disk.

## Fix

Thread the card's `gguf_file` through the contract:
- **client** (`request_and_wait_for_download`): sends `{"gguf_file": <pin>}` in the `POST /models/{id}/download` body (omitted when no pin; an older store host ignores the unknown body).
- **server** (`_handle_download_request`): parses it, tolerating an empty/non-JSON body.
- **store** (`request_download` -> `_do_download` -> `select_store_gguf_download_files`): fetches the pinned quant's shard group.
- The call site passes `shard.model_card.gguf_file`.

A pin absent from the repo falls back to the default (no silent empty selection). Auto-built cards (pin == default) are unaffected. Doc: `api-guide.md` notes the optional body param.

## Tests
Pinned overrides default; pinned sharded keeps its group; absent pin falls back; `None` matches prior behavior. Full gate green: basedpyright 0, ruff clean, 1238 passed / 1 skipped, fmt clean, no em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)