### PR TITLE
fix(logging): bound node logs so they cannot fill the disk (#382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Node logs are now bounded and cannot fill the disk (#382).** Two paths grew
+  without limit: the durable `~/.skulk/logs/skulk.log` rotated only once at
+  startup, so a long-lived node grew it forever; and the service-manager capture
+  files (`skulk.stderr.log` / `skulk.stdout.log`) accumulated across restarts,
+  reaching tens of GB on the fleet. Now `skulk.log` rotates at 100 MB with the
+  last few runs kept as compressed archives; the capture files are truncated on
+  each restart (keeping a 5 MB tail of the previous run as `*.log.1`, tunable via
+  `SKULK_CAPTURE_KEEP_BYTES`); the console sink drops ANSI color when stderr is
+  not a terminal so captured logs are plain and greppable; and the service now
+  launches at info verbosity by default instead of `-v` debug (the libp2p
+  transport firehose was the bulk of the volume). Set `SKULK_VERBOSITY=-v` to opt
+  back into verbose logging while debugging.
+
 - **The centralized store now honors a card's pinned GGUF quant on download
   (#344).** A store-routed download re-derived the quant from the model id alone
   (the default preference), so a custom card pinning a non-default quant (e.g.

--- a/deployment/install/skulk-startup.sh
+++ b/deployment/install/skulk-startup.sh
@@ -22,6 +22,27 @@ PREP_LOG="$HOME/.skulk/logs/skulk.prep.log"
 
 mkdir -p "$(dirname "$PREP_LOG")"
 
+LOG_DIR="$HOME/.skulk/logs"
+# Tail of the previous run kept across a restart for crash diagnosis before the
+# captured file is truncated. The authoritative, size-rotated record is
+# ~/.skulk/logs/skulk.log; these launchd/systemd capture files are a boot- and
+# crash-time safety net, not the durable log.
+CAPTURE_KEEP_BYTES="${SKULK_CAPTURE_KEEP_BYTES:-5242880}"  # 5 MB
+
+# Bound the launchd/systemd-captured stdout/stderr so they cannot accumulate
+# across restarts (#382). launchd holds these fds open for this process, so the
+# file must be truncated in place (same inode) rather than renamed: a renamed
+# file would still receive this run's output. We snapshot the tail to ".1"
+# first so the previous run's final output survives one restart.
+rotate_capture() {
+    local f="$1"
+    [[ -s "$f" ]] || return 0
+    tail -c "$CAPTURE_KEEP_BYTES" "$f" > "${f}.1" 2>/dev/null || true
+    : > "$f"
+}
+rotate_capture "$LOG_DIR/skulk.stdout.log"
+rotate_capture "$LOG_DIR/skulk.stderr.log"
+
 # Timestamped operator-facing log of what the prep phase did. Distinct
 # from the captured stdout/stderr launchd writes for the skulk process
 # itself so operators can audit boot-time updates separately.
@@ -55,7 +76,11 @@ export PATH
 unset _d
 
 AUTO_UPDATE="${SKULK_AUTO_UPDATE:-1}"
-VERBOSITY="${SKULK_VERBOSITY:--v}"
+# Default to INFO. DEBUG (-v) is opt-in via SKULK_VERBOSITY=-v because at DEBUG
+# the libp2p transport logs a per-dial firehose that grew skulk.stderr.log to
+# tens of GB on long-lived nodes (#382). The durable, size-rotated record lives
+# in ~/.skulk/logs/skulk.log regardless of this setting.
+VERBOSITY="${SKULK_VERBOSITY:-}"
 # Headless nodes serve the API without the web UI (no dashboard build).
 HEADLESS="${SKULK_HEADLESS:-0}"
 

--- a/src/skulk/shared/logging.py
+++ b/src/skulk/shared/logging.py
@@ -10,11 +10,11 @@ import socket
 import subprocess
 import sys
 import traceback
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import UTC
 from io import TextIOWrapper
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TextIO
 
 import zstandard
 from hypercorn import Config
@@ -25,6 +25,11 @@ if TYPE_CHECKING:
     from loguru import Message
 
 _MAX_LOG_ARCHIVES = 5
+# Hard size cap per skulk.log generation. With _MAX_LOG_ARCHIVES that bounds the
+# durable log at ~5 * 100 MB uncompressed (far less on disk: archives are
+# zstd-compressed). The previous policy rotated only once on startup, so a node
+# that ran for days without restarting grew its log file without bound (#382).
+_MAX_LOG_BYTES = 100 * 1024 * 1024
 _json_sink_id: int | None = None
 _vector_process: subprocess.Popen[bytes] | None = None
 _vector_pipe: TextIOWrapper | None = None
@@ -45,6 +50,26 @@ def _once_then_never() -> Iterator[bool]:
     yield True
     while True:
         yield False
+
+
+def _make_rotation_policy() -> Callable[[Message, TextIO], bool]:
+    """Build a loguru rotation policy: fresh log per run, then bounded by size.
+
+    Returns a callable loguru invokes before each write. It rotates once on the
+    first message (so every process start begins a clean ``skulk.log`` and the
+    previous run is retained as a compressed archive) and thereafter whenever the
+    next write would push the file past :data:`_MAX_LOG_BYTES`. The size bound is
+    what the prior once-on-startup-only policy lacked: a long-lived node now caps
+    its durable log instead of growing it without limit (#382).
+    """
+    rotate_once = _once_then_never()
+
+    def _should_rotate(message: Message, file: TextIO) -> bool:
+        if next(rotate_once):
+            return True
+        return file.tell() + len(message) > _MAX_LOG_BYTES
+
+    return _should_rotate
 
 
 class InterceptLogger(HypercornLogger):
@@ -242,12 +267,19 @@ def logger_setup(
     # replace all stdlib loggers with _InterceptHandlers that log to loguru
     logging.basicConfig(handlers=[_InterceptHandler()], level=0)
 
+    # Colorize only when stderr is an interactive terminal. Under launchd /
+    # systemd the console stream is captured to a file, where ANSI escape codes
+    # are noise that also inflate the captured size (#382) and make the log
+    # ungreppable. A non-TTY (or detached) stderr gets plain text.
+    _stderr = sys.__stderr__
+    console_is_tty = bool(_stderr is not None and _stderr.isatty())
+
     if verbosity == 0:
         logger.add(
             sys.__stderr__,  # type: ignore
             format="[ {time:hh:mm:ss.SSSSA} | <level>{level: <8}</level>] <level>{message}</level>",
             level="INFO",
-            colorize=True,
+            colorize=console_is_tty,
             enqueue=True,
         )
     else:
@@ -255,18 +287,17 @@ def logger_setup(
             sys.__stderr__,  # type: ignore
             format="[ {time:HH:mm:ss.SSS} | <level>{level: <8}</level> | {name}:{function}:{line} ] <level>{message}</level>",
             level="DEBUG",
-            colorize=True,
+            colorize=console_is_tty,
             enqueue=True,
         )
     if log_file:
-        rotate_once = _once_then_never()
         logger.add(
             log_file,
             format="[ {time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} ] {message}",
             level="INFO",
             colorize=False,
             enqueue=True,
-            rotation=lambda _, __: next(rotate_once),
+            rotation=_make_rotation_policy(),
             retention=_MAX_LOG_ARCHIVES,
             compression=_zstd_compress,
         )

--- a/src/skulk/shared/tests/test_logging_rotation.py
+++ b/src/skulk/shared/tests/test_logging_rotation.py
@@ -1,0 +1,50 @@
+# pyright: reportPrivateUsage=false, reportArgumentType=false
+"""Tests for skulk.log rotation policy (#382).
+
+The durable log must rotate once per process start (fresh log per run, previous
+run retained as a compressed archive) AND whenever a write would push the file
+past the size cap, so a long-lived node cannot grow its log without bound.
+"""
+
+from __future__ import annotations
+
+from skulk.shared import logging as skulk_logging
+
+
+class _FakeFile:
+    """Minimal stand-in for loguru's open file handle: only ``tell`` is used."""
+
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def tell(self) -> int:
+        return self._size
+
+
+def test_rotation_policy_rotates_once_on_startup() -> None:
+    policy = skulk_logging._make_rotation_policy()
+    # The first write of a run always rotates (begins a clean skulk.log).
+    assert policy("first message", _FakeFile(0)) is True
+
+
+def test_rotation_policy_no_rotate_below_cap_after_startup() -> None:
+    policy = skulk_logging._make_rotation_policy()
+    policy("startup", _FakeFile(0))  # consume the once-on-startup rotation
+    # A small write into a small file does not rotate.
+    assert policy("x" * 100, _FakeFile(1024)) is False
+
+
+def test_rotation_policy_rotates_when_write_exceeds_cap() -> None:
+    policy = skulk_logging._make_rotation_policy()
+    policy("startup", _FakeFile(0))  # consume the once-on-startup rotation
+    # A write that would push the file past the cap triggers rotation.
+    near_cap = _FakeFile(skulk_logging._MAX_LOG_BYTES - 10)
+    assert policy("this message is more than ten bytes", near_cap) is True
+
+
+def test_rotation_policy_independent_instances() -> None:
+    # Each call site gets its own once-on-startup latch.
+    first = skulk_logging._make_rotation_policy()
+    second = skulk_logging._make_rotation_policy()
+    assert first("m", _FakeFile(0)) is True
+    assert second("m", _FakeFile(0)) is True

--- a/website/docs/run-skulk-as-a-service.md
+++ b/website/docs/run-skulk-as-a-service.md
@@ -120,6 +120,20 @@ If it doesn't, jump to [Things that go wrong](#things-that-go-wrong).
 | Stop it (stays stopped) | `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user stop skulk` |
 | Start it back up | `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/foundation.foxlight.skulk.plist` | `systemctl --user start skulk` |
 
+### Log files and rotation
+
+Skulk keeps its **durable** log at `~/.skulk/logs/skulk.log`. It starts fresh on
+every launch (the previous run is kept as a compressed `skulk.log.<n>.zst`
+archive) and rotates again whenever it reaches 100 MB, keeping the last few
+archives. That bound holds no matter how long a node runs, so the log directory
+cannot fill the disk.
+
+The `skulk.stdout.log` / `skulk.stderr.log` files are the raw stream the service
+manager captures. They are a boot- and crash-time safety net, not the durable
+record: each is truncated on restart (with the tail of the previous run kept as
+`*.log.1`), and at the default info verbosity they stay small. For day-to-day
+tailing either file is fine; for after-the-fact history, read `skulk.log`.
+
 ### Customizing how the service runs (`~/.skulk/skulk.env`)
 
 The installer puts a plain-text env file at `~/.skulk/skulk.env`. Open it in any editor — every line is `KEY=value` and the comments explain what each setting does. After saving, restart the service to pick up your changes:
@@ -137,7 +151,8 @@ Common things to change:
 | Setting | What it does | Default |
 | --- | --- | --- |
 | `SKULK_AUTO_UPDATE` | `1` = auto-update on every boot, `0` = run whatever's already on disk | `1` |
-| `SKULK_VERBOSITY` | Verbosity flag passed to skulk. `-v` is normal verbose, `-vv` is debug, empty string is info-only | `-v` |
+| `SKULK_VERBOSITY` | Verbosity flag passed to skulk. Empty (the default) is info-only, `-v` is verbose, `-vv` is debug. Debug logs the libp2p transport at a high rate, so leave it empty unless you are actively debugging | empty (info) |
+| `SKULK_CAPTURE_KEEP_BYTES` | How much of the previous run's captured stdout/stderr to keep (as `*.log.1`) when the service restarts. The live capture file is truncated on each launch so it cannot grow without bound | `5242880` (5 MB) |
 | `SKULK_LIBP2P_NAMESPACE` | Cluster namespace — nodes only join clusters with the same value. Use a unique value per cluster | `foxlight-main` |
 | `SKULK_LOGGING_INGEST_URL` | Where Vector ships logs (only relevant if you have the Vector agent installed) | the in-house VictoriaLogs endpoint |
 


### PR DESCRIPTION
Closes #382. First blocker on the **v1.3 — Release readiness** milestone.

## Problem
Two log paths grew without bound and reached tens of GB on the fleet — it caused a real disk-full cascade during the e2e battery (kite1 filled, downloads failed, an instance wedged):

1. **Durable `~/.skulk/logs/skulk.log`** rotated *only once at startup*, so a node that ran for days grew it forever.
2. **Service-manager capture files** (`skulk.stderr.log` / `skulk.stdout.log`) accumulated across restarts. The kite files were 280–345 MB and climbing; one hit ~29 GB.

Root contributor: the launchd/systemd wrapper defaulted to `-v` (DEBUG), and the libp2p transport logs a per-dial firehose at DEBUG. The captured files were also full of ANSI color escape codes.

## Fix
- **`skulk.log` size rotation**: new `_make_rotation_policy()` rotates once per run (fresh log, previous run kept as a compressed archive) **and** whenever a write would exceed `_MAX_LOG_BYTES` (100 MB), keeping `_MAX_LOG_ARCHIVES` archives. Bounds the durable log regardless of uptime.
- **Capture files bounded per launch**: `skulk-startup.sh` truncates `skulk.stdout.log` / `skulk.stderr.log` in place on each launch (launchd holds the fd, so truncate rather than rename), first snapshotting a 5 MB tail of the previous run to `*.log.1` for crash diagnosis (`SKULK_CAPTURE_KEEP_BYTES`).
- **Default verbosity is now info**, not `-v`. `SKULK_VERBOSITY=-v` opts back into debug.
- **No ANSI color when stderr is not a TTY**, so service-captured logs are plain text and greppable.

## Tests
`src/skulk/shared/tests/test_logging_rotation.py` covers the once-then-size rotation policy (startup rotation, no-rotate below cap, rotate when a write would exceed the cap, independent per-sink latches).

## Docs
`website/docs/run-skulk-as-a-service.md` (verbosity default, new `SKULK_CAPTURE_KEEP_BYTES`, a "Log files and rotation" section) and `CHANGELOG.md`.

## Validation
`basedpyright` clean on touched files, `ruff` clean, `nix fmt` no-op, `bash -n` on the wrapper OK, focused logging tests pass (15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)