### PR TITLE
fix(capabilities): recognize the Qwen3 thinking family (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Auto-imported Qwen3 reasoning models no longer return empty content (#384).**
+  A Qwen3-family model with no built-in card (a fresh quant imported on demand,
+  e.g. `Qwen3.6-35B-A3B-nvfp4`) arrived with empty capabilities, so its resolved
+  profile reported no thinking and no thinking toggle. Thinking is on by default
+  for Qwen3, so the model reasoned unconditionally and a normal chat request
+  spent its whole token budget on the reasoning channel, returning empty
+  `content`. Capability resolution now recognizes the Qwen3 / Qwen3.5 / Qwen3.6
+  family (token-delimited `<think>` toggle), so an auto-imported variant is
+  treated as toggle-capable and the dashboard/API off-by-default path can
+  suppress thinking. Built-in cards keep their explicit declarations, an explicit
+  `reasoning` section still overrides the family default, and Coder variants
+  (instruct-only, no thinking) are excluded.
+
 - **A runner that never reports after spawn no longer stalls an instance forever
   (#272).** A runner frozen between spawn and its first status report (a
   SIGSTOP, a hang in early import or device init) left the instance stuck in

--- a/src/skulk/shared/models/capabilities.py
+++ b/src/skulk/shared/models/capabilities.py
@@ -128,6 +128,23 @@ def _is_gpt_oss_family(profile_family: str, normalized_model_id: str) -> bool:
     )
 
 
+def _is_qwen3_thinking_family(profile_family: str, normalized_model_id: str) -> bool:
+    """Qwen3 and its point releases (Qwen3.5, Qwen3.6) are hybrid thinking models.
+
+    They reason behind a token-delimited ``<think>`` toggle. Built-in cards
+    declare ``thinking``/``thinking_toggle`` explicitly, but an auto-imported
+    card (no built-in entry, e.g. a fresh quant) arrives with empty capabilities
+    and would otherwise resolve to no-thinking, so the model reasons
+    unconditionally and returns empty content under a normal request (#384).
+    Matched on the normalized id or the inferred family token. The ``Coder``
+    variants are instruct-only (no thinking mode) and are excluded; Qwen2.x and
+    earlier never contain ``qwen3`` so they fall through to generic handling.
+    """
+    if "coder" in normalized_model_id:
+        return False
+    return "qwen3" in normalized_model_id or profile_family.lower().startswith("qwen3")
+
+
 def resolve_model_capability_profile(
     model_id: ModelId,
     *,
@@ -232,6 +249,20 @@ def resolve_model_capability_profile(
                 "supports_tool_calling": True,
                 "output_parser": OutputParserType.GptOss,
                 "tool_call_format": ToolCallFormat.GptOss,
+            }
+        )
+    elif _is_qwen3_thinking_family(profile.family, normalized_model_id):
+        # Qwen3/3.5/3.6 reason behind a token-delimited <think> toggle. Default
+        # the thinking contract on so an auto-imported card (empty capabilities)
+        # is still treated as toggle-capable, instead of resolving to
+        # no-thinking and reasoning unconditionally into empty content (#384).
+        # Only the thinking fields are set; tool/prompt/parser behavior stays
+        # generic. Explicit card.reasoning still overrides below.
+        profile = profile.model_copy(
+            update={
+                "supports_thinking": True,
+                "supports_thinking_toggle": True,
+                "thinking_format": ReasoningFormat.TokenDelimited,
             }
         )
 

--- a/src/skulk/shared/tests/test_model_capabilities.py
+++ b/src/skulk/shared/tests/test_model_capabilities.py
@@ -597,3 +597,80 @@ def test_is_gemma4_family_resource_cards_other_families_dont_match() -> None:
         assert is_gemma4_family(card) is False, (
             f"{path.name} should not match the gemma4 predicate"
         )
+
+
+def _autoimport_card(model_id: str, family: str) -> ModelCard:
+    """An auto-imported card: no built-in entry, so empty capabilities."""
+    return ModelCard(
+        model_id=ModelId(model_id),
+        storage_size=Memory.from_mb(100),
+        n_layers=10,
+        hidden_size=1024,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family=family,
+        capabilities=[],
+    )
+
+
+def test_qwen3_autoimport_resolves_thinking_toggle() -> None:
+    # The #384 case: an auto-imported Qwen3.6 quant with empty capabilities and a
+    # raw family token must still resolve as a toggle-capable thinking model, or
+    # it reasons unconditionally and returns empty content.
+    card = _autoimport_card("mlx-community/Qwen3.6-35B-A3B-nvfp4", "Qwen3.6")
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.supports_thinking is True
+    assert profile.supports_thinking_toggle is True
+    assert profile.thinking_format == ReasoningFormat.TokenDelimited
+
+
+def test_qwen3_point_releases_match_by_id() -> None:
+    for model_id in (
+        "mlx-community/Qwen3-8B-4bit",
+        "mlx-community/Qwen3.5-9B-4bit",
+        "mlx-community/Qwen3.6-27B-4bit",
+    ):
+        card = _autoimport_card(model_id, "qwen")
+        profile = resolve_model_capability_profile(card.model_id, model_card=card)
+        assert profile.supports_thinking_toggle is True, model_id
+
+
+def test_qwen3_coder_excluded_from_thinking_default() -> None:
+    # Coder variants are instruct-only; the family default must not flip them to
+    # thinking when their card does not declare it.
+    card = _autoimport_card("mlx-community/Qwen3-Coder-30B-A3B-Instruct", "qwen")
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.supports_thinking is False
+    assert profile.supports_thinking_toggle is False
+
+
+def test_qwen2_not_matched_by_qwen3_default() -> None:
+    card = _autoimport_card("mlx-community/Qwen2.5-7B-Instruct", "qwen")
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.supports_thinking is False
+    assert profile.supports_thinking_toggle is False
+
+
+def test_qwen3_explicit_card_reasoning_still_overrides_family_default() -> None:
+    # A card that explicitly disables the toggle must win over the family default.
+    card = ModelCard(
+        model_id=ModelId("mlx-community/Qwen3.6-Custom"),
+        storage_size=Memory.from_mb(100),
+        n_layers=10,
+        hidden_size=1024,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family="qwen",
+        capabilities=[],
+        reasoning=ReasoningCardConfig(supports_toggle=False),
+    )
+
+    profile = resolve_model_capability_profile(card.model_id, model_card=card)
+
+    assert profile.supports_thinking_toggle is False


### PR DESCRIPTION
Closes #384. v1.3 — Release readiness milestone.

## Problem
An auto-imported Qwen3-family model (no built-in card, e.g. a fresh quant like `Qwen3.6-35B-A3B-nvfp4`) resolved to `supports_thinking=False` / `supports_thinking_toggle=False` because its imported card had empty `capabilities` and a raw family token. Qwen3 reasons by default, so the model thought unconditionally and a normal chat request returned **empty `content`** (the whole token budget spent on the reasoning channel). Confirmed in the battery: 0/3 for `Qwen3.6-35B-A3B-nvfp4` while built-in siblings (`Qwen3.5-9B`, `Qwen3.6-27B`, both `caps:[text,thinking,thinking_toggle]`) passed.

## Fix
`resolve_model_capability_profile` gains a Qwen3 family override (`_is_qwen3_thinking_family`, mirroring the gemma4/deepseek/gpt-oss overrides): Qwen3 / Qwen3.5 / Qwen3.6 (matched by normalized id or family token) default `supports_thinking` + `supports_thinking_toggle` + token-delimited `thinking_format` on. So an auto-imported variant is treated as toggle-capable and the API/dashboard off-by-default path can suppress thinking.

Guards:
- **Built-in cards keep their explicit capabilities** (the override is a default; explicit fields and an explicit `card.reasoning` section still win — verified by test).
- **Coder variants excluded** (`Qwen3-Coder*` is instruct-only, no thinking).
- **Qwen2.x not matched** (never contains `qwen3`).

## Tests
`test_model_capabilities.py` +5: auto-import resolves the toggle, point releases match by id, Coder excluded, Qwen2.x not matched, explicit `reasoning` overrides the default. Full capability suite (33) passes.

## Note
This is the server-side capability fix. The harness's `enable_thinking` default (skulk-test-harness) already reads `supports_thinking_toggle`, so once a node serves this, the harness will correctly send `enable_thinking=false` for these models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)