### PR TITLE
fix(api): surface runner errors structurally on Claude/Responses/Ollama (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Context-length and other runner errors now surface as structured errors on
+  the Claude, Responses, and Ollama wire formats (#276).** Those adapters
+  previously raised on a runner error (a 500 on the non-streaming path) or broke
+  out of the stream and then emitted an empty successful completion (a bogus
+  success for what is actually a clean request rejection). Since the API streams
+  every response (the HTTP status is committed to 200 before generation), each
+  adapter now emits a structured error envelope in the body and stops, reusing
+  the same `error_chunk_response` mapping the OpenAI chat-completions surface
+  uses: a `context_length_exceeded` rejection becomes an `invalid_request_error`
+  (400), everything else an internal error (500). No more empty-success-on-error
+  for clients feeling out context limits.
+
 - **A runner that never reports after spawn no longer stalls an instance forever
   (#272).** A runner frozen between spawn and its first status report (a
   SIGSTOP, a hang in early import or device init) left the instance stuck in

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -408,13 +408,13 @@ async def collect_chat_response(
                 finish_reason = chunk.finish_reason
 
     if error_message is not None:
-        if error_message.startswith(CONTEXT_LENGTH_EXCEEDED_PREFIX):
-            # The HTTP status is already committed (the body itself streams),
-            # so a runner-side context rejection surfaces as a structured
-            # OpenAI error envelope in the body rather than a broken stream.
-            yield error_chunk_response(error_message).model_dump_json()
-            return
-        raise ValueError(error_message)
+        # The HTTP status is already committed (the body itself streams), so a
+        # runner-side error surfaces as a structured OpenAI error envelope in the
+        # body rather than a broken stream or a bogus empty success.
+        # error_chunk_response maps the context sentinel to a 400 and everything
+        # else to the historical 500 internal-error shape.
+        yield error_chunk_response(error_message).model_dump_json()
+        return
 
     combined_text = "".join(text_parts)
     combined_thinking = "".join(thinking_parts) if thinking_parts else None

--- a/src/skulk/api/adapters/claude.py
+++ b/src/skulk/api/adapters/claude.py
@@ -5,7 +5,7 @@ import re
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from skulk.api.adapters.chat_completions import fetch_image_url
+from skulk.api.adapters.chat_completions import error_chunk_response, fetch_image_url
 from skulk.api.types import FinishReason, Usage
 from skulk.api.types.claude_api import (
     ClaudeContentBlock,
@@ -290,7 +290,12 @@ async def collect_claude_response(
             stop_reason = finish_reason_to_claude_stop_reason(chunk.finish_reason)
 
     if error_message is not None:
-        raise ValueError(error_message)
+        # The HTTP status is already committed (the body itself streams), so a
+        # runner-side error surfaces as a structured error envelope in the body
+        # rather than a 500 or a bogus empty success. error_chunk_response maps
+        # the context sentinel to a 400 and everything else to a 500.
+        yield error_chunk_response(error_message).model_dump_json()
+        return
 
     combined_text = "".join(text_parts)
     combined_thinking = "".join(thinking_parts)
@@ -347,6 +352,7 @@ async def generate_claude_stream(
     stop_reason: ClaudeStopReason | None = None
     last_usage: Usage | None = None
     next_block_index = 0
+    error_message: str | None = None
 
     # Track whether we've started thinking/text blocks
     thinking_block_started = False
@@ -359,7 +365,10 @@ async def generate_claude_stream(
             continue
 
         if isinstance(chunk, ErrorChunk):
-            # Close text block and bail
+            # Capture the message and bail out of the loop; the structured error
+            # is emitted below instead of falling through to the empty-success
+            # tail (which would be a bogus success for a real error).
+            error_message = chunk.error_message or "Internal server error"
             break
 
         last_usage = chunk.usage or last_usage
@@ -439,6 +448,16 @@ async def generate_claude_stream(
 
         if chunk.finish_reason is not None:
             stop_reason = finish_reason_to_claude_stop_reason(chunk.finish_reason)
+
+    if error_message is not None:
+        # The HTTP status is already committed (the body itself streams), so a
+        # runner-side error surfaces as a structured SSE error event in the body
+        # rather than falling through to the empty-success message_stop tail.
+        yield (
+            "event: error\n"
+            f"data: {error_chunk_response(error_message).model_dump_json()}\n\n"
+        )
+        return
 
     # Use actual token count from usage if available
     if last_usage is not None:

--- a/src/skulk/api/adapters/ollama.py
+++ b/src/skulk/api/adapters/ollama.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from skulk.api.adapters.chat_completions import error_chunk_response
 from skulk.api.types.ollama_api import (
     OllamaChatRequest,
     OllamaChatResponse,
@@ -296,7 +297,12 @@ async def collect_ollama_chat_response(
                 continue
 
             case ErrorChunk():
-                raise ValueError(chunk.error_message or "Internal server error")
+                # The HTTP status is already committed (the body itself streams),
+                # so a runner-side error surfaces as a structured error envelope
+                # in the body rather than a 500. error_chunk_response maps the
+                # context sentinel to a 400 and everything else to a 500.
+                yield error_chunk_response(chunk.error_message).model_dump_json() + "\n"
+                return
 
             case TokenChunk():
                 if model is None:
@@ -479,7 +485,12 @@ async def collect_ollama_generate_response(
             case PrefillProgressChunk():
                 continue
             case ErrorChunk():
-                raise ValueError(chunk.error_message or "Internal server error")
+                # The HTTP status is already committed (the body itself streams),
+                # so a runner-side error surfaces as a structured error envelope
+                # in the body rather than a 500. error_chunk_response maps the
+                # context sentinel to a 400 and everything else to a 500.
+                yield error_chunk_response(chunk.error_message).model_dump_json() + "\n"
+                return
             case TokenChunk():
                 if model is None:
                     model = str(chunk.model)

--- a/src/skulk/api/adapters/responses.py
+++ b/src/skulk/api/adapters/responses.py
@@ -5,6 +5,7 @@ from itertools import count
 from typing import Any
 
 from skulk.api.adapters.chat_completions import (
+    error_chunk_response,
     extract_base64_from_data_url,
     fetch_image_url,
 )
@@ -257,7 +258,12 @@ async def collect_responses_response(
         accumulated_text += chunk.text
 
     if error_message is not None:
-        raise ValueError(error_message)
+        # The HTTP status is already committed (the body itself streams), so a
+        # runner-side error surfaces as a structured error envelope in the body
+        # rather than a 500 or a bogus empty success. error_chunk_response maps
+        # the context sentinel to a 400 and everything else to a 500.
+        yield error_chunk_response(error_message).model_dump_json()
+        return
 
     # Create usage from usage data if available
     usage = None
@@ -333,6 +339,7 @@ async def generate_responses_stream(
     function_call_items: list[ResponseFunctionCallItem] = []
     last_usage: Usage | None = None
     next_output_index = 0
+    error_message: str | None = None
 
     # Track dynamic block creation
     reasoning_started = False
@@ -345,6 +352,10 @@ async def generate_responses_stream(
             continue
 
         if isinstance(chunk, ErrorChunk):
+            # Capture the message and bail out of the loop; the structured error
+            # is emitted below instead of falling through to the empty-success
+            # response.completed tail (a bogus success for a real error).
+            error_message = chunk.error_message or "Internal server error"
             break
 
         last_usage = chunk.usage or last_usage
@@ -522,6 +533,17 @@ async def generate_responses_stream(
             delta=chunk.text,
         )
         yield _format_sse(delta_event)
+
+    if error_message is not None:
+        # The HTTP status is already committed (the body itself streams), so a
+        # runner-side error surfaces as a structured SSE error event in the body
+        # rather than falling through to the empty-success response.completed
+        # tail.
+        yield (
+            "event: error\n"
+            f"data: {error_chunk_response(error_message).model_dump_json()}\n\n"
+        )
+        return
 
     # Close reasoning block if it was never followed by text
     if reasoning_started and not message_started:

--- a/src/skulk/api/adapters/tests/test_error_surfacing.py
+++ b/src/skulk/api/adapters/tests/test_error_surfacing.py
@@ -1,0 +1,218 @@
+"""Error-surfacing tests for the Claude/Responses/Ollama wire adapters (#276).
+
+Every adapter generator is consumed by FastAPI's ``StreamingResponse``, so the
+HTTP status is committed to 200 before the generator runs. A runner-side error
+therefore cannot raise a clean 4xx; it must be emitted as a structured error
+envelope inside the body and then returned. These tests assert that a context
+rejection (the ``context_length_exceeded:`` sentinel) maps to a 400
+``invalid_request_error`` envelope, a generic error maps to a 500 envelope, and
+neither case leaks a bogus empty successful completion into the stream.
+"""
+
+import json
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from typing import cast
+
+import pytest
+
+from skulk.api.adapters.chat_completions import (
+    collect_chat_response,
+    generate_chat_stream,
+)
+from skulk.api.adapters.claude import collect_claude_response, generate_claude_stream
+from skulk.api.adapters.ollama import (
+    collect_ollama_chat_response,
+    collect_ollama_generate_response,
+)
+from skulk.api.adapters.responses import (
+    collect_responses_response,
+    generate_responses_stream,
+)
+from skulk.shared.constants import CONTEXT_LENGTH_EXCEEDED_PREFIX
+from skulk.shared.types.chunks import (
+    ErrorChunk,
+    PrefillProgressChunk,
+    TokenChunk,
+    ToolCallChunk,
+)
+from skulk.shared.types.common import CommandId, ModelId
+
+_MODEL = ModelId("mlx-community/gemma-4-26b-a4b-it-4bit")
+_CONTEXT_MESSAGE = (
+    f"{CONTEXT_LENGTH_EXCEEDED_PREFIX} requested 9000 tokens exceeds max_tokens"
+)
+_GENERIC_MESSAGE = "runner exploded for an unrelated reason"
+
+# Markers that unambiguously indicate a bogus successful-completion leaked into
+# the body. These are the *terminal* success shapes each adapter emits when a
+# stream finishes cleanly; a real error must never reach them. (The Claude
+# streaming preamble emits a message_start with an empty assistant message
+# before any chunk is read, so a bare "role":"assistant" is NOT a reliable
+# success marker; the message_stop / message_delta tail is.)
+_SUCCESS_MARKERS = (
+    '"finish_reason":"stop"',  # chat_completions success choice
+    '"status":"completed"',  # responses success
+    '"done_reason":"stop"',  # ollama success
+    '"type":"message_stop"',  # claude streaming success tail
+    '"type":"message_delta"',  # claude streaming completion delta
+    '"stop_reason":"end_turn"',  # claude non-streaming success
+)
+
+
+async def _error_stream(
+    message: str,
+) -> AsyncGenerator[
+    ErrorChunk | ToolCallChunk | TokenChunk | PrefillProgressChunk, None
+]:
+    """Yield a single ``ErrorChunk`` carrying ``message`` and nothing else."""
+    yield ErrorChunk(model=_MODEL, error_message=message)
+
+
+def _extract_envelope(output: str) -> dict[str, object]:
+    """Find and parse the structured error envelope from adapter body output.
+
+    Adapters frame the envelope differently (raw JSON, SSE ``data:`` line,
+    NDJSON line). This locates the JSON object that carries an ``error`` field
+    so the assertions stay framing-agnostic.
+    """
+    for line in output.replace("\n\n", "\n").splitlines():
+        candidate = line
+        if candidate.startswith("data: "):
+            candidate = candidate[len("data: ") :]
+        candidate = candidate.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            parsed = cast("object", json.loads(candidate))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            envelope = cast("dict[str, object]", parsed)
+            if "error" in envelope:
+                return envelope
+    raise AssertionError(f"no structured error envelope found in body: {output!r}")
+
+
+def _error_fields(output: str) -> dict[str, object]:
+    """Return the ``error`` sub-object of the structured envelope in ``output``."""
+    envelope = _extract_envelope(output)
+    error = envelope["error"]
+    assert isinstance(error, dict), f"error field is not an object: {output!r}"
+    return cast("dict[str, object]", error)
+
+
+def _assert_no_success(output: str) -> None:
+    """Assert the body carries no bogus successful-completion markers."""
+    for marker in _SUCCESS_MARKERS:
+        assert marker not in output, (
+            f"error body leaked a successful-completion marker {marker!r}: {output!r}"
+        )
+
+
+async def _drive_chat_completions(message: str, *, stream: bool) -> str:
+    if stream:
+        gen = generate_chat_stream(CommandId("cmd"), _error_stream(message))
+    else:
+        gen = collect_chat_response(CommandId("cmd"), _error_stream(message))
+    return "".join([chunk async for chunk in gen])
+
+
+async def _drive_claude(message: str, *, stream: bool) -> str:
+    if stream:
+        gen = generate_claude_stream(CommandId("cmd"), "m", _error_stream(message))
+    else:
+        gen = collect_claude_response(CommandId("cmd"), "m", _error_stream(message))
+    return "".join([chunk async for chunk in gen])
+
+
+async def _drive_responses(message: str, *, stream: bool) -> str:
+    if stream:
+        gen = generate_responses_stream(CommandId("cmd"), "m", _error_stream(message))
+    else:
+        gen = collect_responses_response(CommandId("cmd"), "m", _error_stream(message))
+    return "".join([chunk async for chunk in gen])
+
+
+async def _drive_chat_completions_stream(message: str) -> str:
+    return await _drive_chat_completions(message, stream=True)
+
+
+async def _drive_chat_completions_collect(message: str) -> str:
+    return await _drive_chat_completions(message, stream=False)
+
+
+async def _drive_claude_stream(message: str) -> str:
+    return await _drive_claude(message, stream=True)
+
+
+async def _drive_claude_collect(message: str) -> str:
+    return await _drive_claude(message, stream=False)
+
+
+async def _drive_responses_stream(message: str) -> str:
+    return await _drive_responses(message, stream=True)
+
+
+async def _drive_responses_collect(message: str) -> str:
+    return await _drive_responses(message, stream=False)
+
+
+async def _drive_ollama_chat(message: str) -> str:
+    # Ollama streaming already emits a native done_reason="error" response and
+    # returns (no empty success), so only the non-streaming collector changed.
+    gen = collect_ollama_chat_response(CommandId("cmd"), _error_stream(message))
+    return "".join([chunk async for chunk in gen])
+
+
+async def _drive_ollama_generate(message: str) -> str:
+    gen = collect_ollama_generate_response(CommandId("cmd"), _error_stream(message))
+    return "".join([chunk async for chunk in gen])
+
+
+_Driver = Callable[[str], Awaitable[str]]
+
+# Every adapter arm that funnels an ErrorChunk into the response body. The
+# Ollama streaming functions are intentionally absent: they already emit a
+# native done_reason="error" response and return, so #276 did not change them.
+_DRIVERS: list[tuple[str, _Driver]] = [
+    ("chat_completions_stream", _drive_chat_completions_stream),
+    ("chat_completions_collect", _drive_chat_completions_collect),
+    ("claude_stream", _drive_claude_stream),
+    ("claude_collect", _drive_claude_collect),
+    ("responses_stream", _drive_responses_stream),
+    ("responses_collect", _drive_responses_collect),
+    ("ollama_chat_collect", _drive_ollama_chat),
+    ("ollama_generate_collect", _drive_ollama_generate),
+]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("label,driver", _DRIVERS, ids=[d[0] for d in _DRIVERS])
+async def test_context_error_surfaces_400_envelope(
+    label: str, driver: _Driver
+) -> None:
+    """A context rejection becomes a 400 invalid_request_error envelope."""
+    output = await driver(_CONTEXT_MESSAGE)
+
+    error = _error_fields(output)
+    assert error["type"] == "invalid_request_error", label
+    assert error["code"] == 400, label
+    assert error["message"] == _CONTEXT_MESSAGE, label
+
+    _assert_no_success(output)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("label,driver", _DRIVERS, ids=[d[0] for d in _DRIVERS])
+async def test_generic_error_surfaces_500_envelope(
+    label: str, driver: _Driver
+) -> None:
+    """A non-context error maps to the 500 internal-error envelope."""
+    output = await driver(_GENERIC_MESSAGE)
+
+    error = _error_fields(output)
+    assert error["type"] == "InternalServerError", label
+    assert error["code"] == 500, label
+    assert error["message"] == _GENERIC_MESSAGE, label
+
+    _assert_no_success(output)


### PR DESCRIPTION
Closes #276. v1.3 — Release readiness milestone.

## Problem
PR #275 gave the OpenAI chat-completions surface a structured `invalid_request_error` for `context_length_exceeded`, but the Claude, Responses, and Ollama adapters kept their historical ErrorChunk handling:
- non-streaming paths `raise ValueError` → 500
- streaming paths break and then emit an **empty successful completion** — a bogus success for a clean request rejection

Clients feeling out context limits hit this routinely.

## Fix
Every response on these surfaces is a `StreamingResponse` (status committed to 200 before generation), so errors must be emitted in the body. Each ErrorChunk arm now emits a structured envelope via the existing `error_chunk_response` (`context_length_exceeded` → `invalid_request_error`/400, else internal/500) and returns:
- **Non-streaming collectors** (claude/responses/ollama): `yield error_chunk_response(msg).model_dump_json()` + return (replaces the `raise`).
- **SSE streaming** (claude/responses): capture the message, emit `event: error\ndata: <envelope>` before the empty-success tail, return.
- **Ollama streaming** arms already emitted a native `done_reason="error"` and returned (no empty-success), so they are left unchanged.

`error_chunk_response` is reused from `chat_completions.py` (no import cycle; the adapters already import helpers from there).

## Tests
`src/skulk/api/adapters/tests/test_error_surfacing.py` parametrizes all changed arms: context sentinel → 400 envelope, generic error → 500, and asserts no terminal-success marker leaks into the body.

## Validation
basedpyright + ruff clean on `src/skulk/api/adapters/`; `pytest src/skulk/api/adapters/tests src/skulk/api/tests` → 217 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)