### PR TITLE
feat(connectivity): macOS Local Network probe + actionable denial warning (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
-### Fixed
+### Added
+
+- **macOS Local Network permission is now diagnosable and the denial warning is
+  actionable (#267).** macOS attributes Local Network access to the responsible
+  app in the launch chain (a terminal when run interactively, "Python" over SSH
+  / launchd / headless), so generic "grant the app you launched from" advice is
+  the part users get wrong. A new read-only probe, `uv run
+  skulk-macos-local-network-probe` (text or `--json`), walks the process tree,
+  resolves each process's nearest `.app` bundle identity, runs the existing
+  reachability check, and reports exactly which identity macOS will attribute the
+  grant to. A companion `skulk-build-macos-local-network-probe-app` builds a
+  throwaway ad-hoc-signed probe `.app` (with `NSLocalNetworkUsageDescription`) to
+  compare terminal vs Skulk-named attribution during development. The startup
+  DENIED warning now names the detected app to enable (e.g. "enable 'iTerm2'" or
+  "enable 'Python'") instead of generic advice, and points at the probe command.
 
 - **Auto-imported Qwen3 reasoning models no longer return empty content (#384).**
   A Qwen3-family model with no built-in card (a fresh quant imported on demand,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
 
 [project.scripts]
 skulk = "skulk.main:main"
+skulk-build-macos-local-network-probe-app = "skulk.connectivity.local_network_probe_app:main"
+skulk-macos-local-network-probe = "skulk.connectivity.local_network_probe:main"
 
 # dependencies only required for development
 [dependency-groups]

--- a/src/skulk/connectivity/local_network.py
+++ b/src/skulk/connectivity/local_network.py
@@ -106,3 +106,34 @@ LOCAL_NETWORK_DENIED_MESSAGE = (
     "from (e.g. Terminal), then restart Skulk. See the Thunderbolt clustering "
     "guide in the Skulk documentation for details."
 )
+
+
+def local_network_denied_message() -> str:
+    """The DENIED warning, naming the exact app to grant when detectable (#267).
+
+    macOS attributes the Local Network grant to the responsible app in the launch
+    chain (a terminal when run interactively, or "Python" over SSH / launchd /
+    headless). Generic advice to "enable the app you launched from" is the part
+    users get wrong, so this resolves the actual identity via the process-tree
+    probe and names it. Falls back to :data:`LOCAL_NETWORK_DENIED_MESSAGE` if the
+    identity cannot be determined. Does not re-probe the network.
+    """
+    label: str | None = None
+    try:
+        from skulk.connectivity.local_network_probe import responsible_app_label
+
+        label = responsible_app_label()
+    except Exception:  # noqa: BLE001 - identity hint is best-effort
+        label = None
+    if not label:
+        return LOCAL_NETWORK_DENIED_MESSAGE
+    return (
+        "macOS Local Network access appears to be DENIED for this process. Skulk "
+        "cannot reach peers on your local network or Thunderbolt bridge, so the "
+        "cluster will not form over Ethernet/Thunderbolt (a Tailscale overlay, "
+        "if present, is exempt and still works). Grant access: System Settings → "
+        f"Privacy & Security → Local Network → enable '{label}', then restart "
+        "Skulk. (Run 'uv run skulk-macos-local-network-probe' to confirm which "
+        "identity macOS attributes the grant to.) See the Thunderbolt clustering "
+        "guide in the Skulk documentation for details."
+    )

--- a/src/skulk/connectivity/local_network_probe.py
+++ b/src/skulk/connectivity/local_network_probe.py
@@ -252,6 +252,49 @@ def _notes(
     return notes
 
 
+_FRIENDLY_EXECUTABLE_LABELS = {"uv": "uv"}
+
+
+def _friendly_executable_label(executable: str | None) -> str | None:
+    """A human label for a bare executable (no .app), e.g. ``Python``."""
+    if not executable:
+        return None
+    name = Path(executable).name
+    if name.startswith("python"):
+        # pythonNN / python3.13 / Python -> "Python" (how macOS surfaces it).
+        return "Python"
+    return _FRIENDLY_EXECUTABLE_LABELS.get(name, name)
+
+
+def responsible_app_label(max_ancestors: int = 8) -> str | None:
+    """Best guess at the app macOS attributes a Local Network grant to.
+
+    macOS attributes local-network access to the "responsible" app in the launch
+    chain, not necessarily the python binary: a GUI terminal/launcher holds the
+    grant when present, otherwise the executable itself does. This returns the
+    display name of the nearest ancestor ``.app`` bundle (the terminal that
+    launched Skulk), or a friendly executable name (``"Python"`` for any
+    ``pythonNN``) when there is no ``.app`` in the chain (SSH / launchd /
+    headless), which is exactly the identity a user must enable in System
+    Settings. ``None`` when the process tree cannot be read. Does NOT touch the
+    network, so it is cheap and safe to call alongside the reachability check.
+    """
+    try:
+        current = psutil.Process()
+    except (psutil.Error, OSError):
+        return None
+    identity = _process_identity(current)
+    for item in (identity, *_ancestor_identities(current, max(0, max_ancestors))):
+        if item.app_bundle is not None:
+            bundle = item.app_bundle
+            return (
+                bundle.display_name
+                or bundle.bundle_name
+                or Path(bundle.path).stem
+            )
+    return _friendly_executable_label(identity.executable)
+
+
 def collect_local_network_identity_probe(
     max_ancestors: int = 8,
 ) -> LocalNetworkIdentityProbe:

--- a/src/skulk/connectivity/local_network_probe.py
+++ b/src/skulk/connectivity/local_network_probe.py
@@ -1,0 +1,413 @@
+"""Read-only macOS Local Network permission identity probe.
+
+The probe records the process identity macOS is likely to attribute to a local
+network access attempt, then runs Skulk's existing Local Network reachability
+check. It is intentionally diagnostic-only: it does not alter privacy settings,
+network services, Thunderbolt Bridge, RDMA state, or launchd configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import plistlib
+import socket
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import cast, final
+
+import psutil
+from pydantic import Field
+
+from skulk.connectivity.local_network import (
+    LocalNetworkStatus,
+    check_local_network_access,
+)
+from skulk.utils.pydantic_ext import FrozenModel
+
+
+@final
+class AppBundleIdentity(FrozenModel):
+    """Metadata read from an ancestor ``.app`` bundle, when present.
+
+    Attributes:
+        path: Absolute path to the discovered ``.app`` bundle.
+        bundle_identifier: ``CFBundleIdentifier`` from ``Info.plist``.
+        display_name: Human-facing ``CFBundleDisplayName`` from ``Info.plist``.
+        bundle_name: ``CFBundleName`` from ``Info.plist``.
+        executable_name: ``CFBundleExecutable`` from ``Info.plist``.
+    """
+
+    path: str = Field(description="Absolute path to the discovered .app bundle.")
+    bundle_identifier: str | None = Field(
+        default=None,
+        description="CFBundleIdentifier from the bundle Info.plist.",
+    )
+    display_name: str | None = Field(
+        default=None,
+        description="CFBundleDisplayName from the bundle Info.plist.",
+    )
+    bundle_name: str | None = Field(
+        default=None,
+        description="CFBundleName from the bundle Info.plist.",
+    )
+    executable_name: str | None = Field(
+        default=None,
+        description="CFBundleExecutable from the bundle Info.plist.",
+    )
+
+
+@final
+class ProcessIdentity(FrozenModel):
+    """One process identity entry in the probe's process tree.
+
+    Attributes:
+        pid: Operating-system process identifier.
+        ppid: Parent process identifier, when available.
+        name: Process name reported by ``psutil``.
+        executable: Absolute executable path reported by ``psutil``.
+        command_line: Command-line vector reported by ``psutil``.
+        app_bundle: Nearest ancestor ``.app`` bundle for ``executable``.
+    """
+
+    pid: int = Field(description="Operating-system process identifier.")
+    ppid: int | None = Field(
+        default=None,
+        description="Parent process identifier, when available.",
+    )
+    name: str | None = Field(
+        default=None,
+        description="Process name reported by psutil.",
+    )
+    executable: str | None = Field(
+        default=None,
+        description="Absolute executable path reported by psutil.",
+    )
+    command_line: list[str] = Field(
+        default_factory=list,
+        description="Command-line vector reported by psutil.",
+    )
+    app_bundle: AppBundleIdentity | None = Field(
+        default=None,
+        description="Nearest ancestor .app bundle for executable.",
+    )
+
+
+@final
+class LocalNetworkIdentityProbe(FrozenModel):
+    """Read-only report for macOS Local Network permission attribution.
+
+    Attributes:
+        local_network_status: Result from Skulk's Local Network access check.
+        platform_system: Operating system name from ``platform.system()``.
+        macos_version: macOS version string on Darwin, otherwise ``None``.
+        hostname: Local hostname.
+        process: Identity for the current process.
+        ancestors: Parent process chain, nearest parent first.
+        notes: Human-facing interpretation hints.
+    """
+
+    local_network_status: LocalNetworkStatus = Field(
+        description="Result from Skulk's Local Network access check.",
+    )
+    platform_system: str = Field(description="Operating system name.")
+    macos_version: str | None = Field(
+        default=None,
+        description="macOS version string on Darwin, otherwise None.",
+    )
+    hostname: str = Field(description="Local hostname.")
+    process: ProcessIdentity = Field(description="Identity for the current process.")
+    ancestors: list[ProcessIdentity] = Field(
+        description="Parent process chain, nearest parent first.",
+    )
+    notes: list[str] = Field(description="Human-facing interpretation hints.")
+
+
+def _string_value(info: dict[object, object], key: str) -> str | None:
+    value = info.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _app_bundle_for_executable(executable: str | None) -> AppBundleIdentity | None:
+    """Return metadata for the nearest containing ``.app`` bundle.
+
+    Args:
+        executable: Executable path to inspect.
+
+    Returns:
+        Bundle metadata when the executable lives inside a macOS app bundle;
+        otherwise ``None``.
+    """
+
+    if executable is None:
+        return None
+
+    path = Path(executable).expanduser()
+    for candidate in (path, *path.parents):
+        if candidate.suffix != ".app":
+            continue
+        info_path = candidate / "Contents" / "Info.plist"
+        info: dict[object, object] = {}
+        if info_path.exists():
+            try:
+                with info_path.open("rb") as file:
+                    raw_info = cast("object", plistlib.load(file))
+                if isinstance(raw_info, dict):
+                    info = cast("dict[object, object]", raw_info)
+            except (OSError, plistlib.InvalidFileException):
+                info = {}
+        return AppBundleIdentity(
+            path=str(candidate),
+            bundle_identifier=_string_value(info, "CFBundleIdentifier"),
+            display_name=_string_value(info, "CFBundleDisplayName"),
+            bundle_name=_string_value(info, "CFBundleName"),
+            executable_name=_string_value(info, "CFBundleExecutable"),
+        )
+    return None
+
+
+def _process_identity(process: psutil.Process) -> ProcessIdentity:
+    """Return a best-effort identity snapshot for ``process``.
+
+    Args:
+        process: Process to inspect.
+
+    Returns:
+        A strict, JSON-serialisable identity snapshot.
+    """
+
+    try:
+        name = process.name()
+    except (psutil.Error, OSError):
+        name = None
+
+    try:
+        executable = process.exe() or None
+    except (psutil.Error, OSError):
+        executable = None
+
+    try:
+        command_line = process.cmdline()
+    except (psutil.Error, OSError):
+        command_line = []
+
+    try:
+        ppid = process.ppid()
+    except (psutil.Error, OSError):
+        ppid = None
+
+    return ProcessIdentity(
+        pid=process.pid,
+        ppid=ppid,
+        name=name,
+        executable=executable,
+        command_line=command_line,
+        app_bundle=_app_bundle_for_executable(executable),
+    )
+
+
+def _ancestor_identities(process: psutil.Process, max_ancestors: int) -> list[ProcessIdentity]:
+    ancestors: list[ProcessIdentity] = []
+    parent = process.parent()
+    while parent is not None and len(ancestors) < max_ancestors:
+        ancestors.append(_process_identity(parent))
+        parent = parent.parent()
+    return ancestors
+
+
+def _notes(
+    *,
+    local_network_status: LocalNetworkStatus,
+    process: ProcessIdentity,
+    ancestors: Sequence[ProcessIdentity],
+) -> list[str]:
+    notes = [
+        "This probe is read-only except for one local TCP reachability attempt.",
+        "It does not grant permissions or change Thunderbolt/RDMA configuration.",
+    ]
+    if local_network_status == "blocked":
+        notes.append(
+            "Local Network access appears blocked for this launch identity; "
+            "macOS may show or require a grant for the process/app named above."
+        )
+    elif local_network_status == "ok":
+        notes.append("Local Network access appears usable for this launch identity.")
+    else:
+        notes.append("Local Network status is inconclusive on this machine or OS.")
+
+    if process.app_bundle is None:
+        notes.append(
+            "The current executable is not inside a .app bundle; prompts may name "
+            "a launcher, terminal, Python, uv, or another runtime component."
+        )
+
+    app_ancestors = [item for item in ancestors if item.app_bundle is not None]
+    if app_ancestors:
+        notes.append(
+            "At least one parent process belongs to a .app bundle; compare that "
+            "bundle with the Local Network entry shown in System Settings."
+        )
+
+    return notes
+
+
+def collect_local_network_identity_probe(
+    max_ancestors: int = 8,
+) -> LocalNetworkIdentityProbe:
+    """Collect a read-only macOS Local Network identity probe.
+
+    Args:
+        max_ancestors: Maximum number of parent processes to include.
+
+    Returns:
+        A structured probe report.
+    """
+
+    current_process = psutil.Process()
+    max_ancestors = max(0, max_ancestors)
+    process = _process_identity(current_process)
+    ancestors = _ancestor_identities(current_process, max_ancestors)
+    local_network_status = check_local_network_access()
+    system = platform.system()
+    return LocalNetworkIdentityProbe(
+        local_network_status=local_network_status,
+        platform_system=system,
+        macos_version=platform.mac_ver()[0] if system == "Darwin" else None,
+        hostname=socket.gethostname(),
+        process=process,
+        ancestors=ancestors,
+        notes=_notes(
+            local_network_status=local_network_status,
+            process=process,
+            ancestors=ancestors,
+        ),
+    )
+
+
+def _format_bundle(bundle: AppBundleIdentity | None) -> str:
+    if bundle is None:
+        return "none"
+    labels = [
+        f"path={bundle.path}",
+        f"id={bundle.bundle_identifier or 'unknown'}",
+        f"name={bundle.display_name or bundle.bundle_name or 'unknown'}",
+    ]
+    return ", ".join(labels)
+
+
+def _format_process(identity: ProcessIdentity) -> str:
+    executable = identity.executable or "unknown"
+    name = identity.name or "unknown"
+    return (
+        f"pid={identity.pid} ppid={identity.ppid or 'unknown'} "
+        f"name={name} executable={executable} app_bundle=({_format_bundle(identity.app_bundle)})"
+    )
+
+
+def format_local_network_identity_probe(report: LocalNetworkIdentityProbe) -> str:
+    """Format a probe report for humans.
+
+    Args:
+        report: Structured probe report to format.
+
+    Returns:
+        Multi-line human-readable text.
+    """
+
+    lines = [
+        "Skulk macOS Local Network identity probe",
+        "",
+        f"Local Network status: {report.local_network_status}",
+        f"Platform: {report.platform_system}",
+        f"macOS version: {report.macos_version or 'n/a'}",
+        f"Hostname: {report.hostname}",
+        "",
+        "Current process:",
+        f"  {_format_process(report.process)}",
+    ]
+    if report.process.command_line:
+        lines.append(f"  argv: {report.process.command_line}")
+
+    lines.append("")
+    lines.append("Parent processes:")
+    if report.ancestors:
+        for index, ancestor in enumerate(report.ancestors, start=1):
+            lines.append(f"  {index}. {_format_process(ancestor)}")
+            if ancestor.command_line:
+                lines.append(f"     argv: {ancestor.command_line}")
+    else:
+        lines.append("  none")
+
+    lines.append("")
+    lines.append("Notes:")
+    lines.extend(f"  - {note}" for note in report.notes)
+    return "\n".join(lines)
+
+
+def run_local_network_identity_probe(
+    *,
+    json_output: bool = False,
+    fail_on_blocked: bool = False,
+    max_ancestors: int = 8,
+) -> int:
+    """Run the probe, print the report, and return a process exit status.
+
+    Args:
+        json_output: Print JSON instead of human-readable text.
+        fail_on_blocked: Return status 2 when Local Network access is blocked.
+        max_ancestors: Maximum number of parent processes to include.
+
+    Returns:
+        ``0`` on a completed probe, or ``2`` when ``fail_on_blocked`` is true
+        and the probe detects a Local Network denial.
+    """
+
+    report = collect_local_network_identity_probe(max_ancestors=max_ancestors)
+    if json_output:
+        print(report.model_dump_json(indent=2))
+    else:
+        print(format_local_network_identity_probe(report))
+    return 2 if fail_on_blocked and report.local_network_status == "blocked" else 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the probe as a standalone command-line utility.
+
+    Args:
+        argv: Optional argument vector, excluding program name.
+
+    Returns:
+        Process exit status.
+    """
+
+    parser = argparse.ArgumentParser(
+        prog="skulk-macos-local-network-probe",
+        description="Read-only macOS Local Network permission identity probe.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    parser.add_argument(
+        "--fail-on-blocked",
+        action="store_true",
+        help="Exit with status 2 when Local Network access appears blocked.",
+    )
+    parser.add_argument(
+        "--max-ancestors",
+        type=int,
+        default=8,
+        help="Maximum number of parent processes to include.",
+    )
+    parsed_values = cast("dict[str, object]", vars(parser.parse_args(argv)))
+    max_ancestors_value = parsed_values.get("max_ancestors", 8)
+    max_ancestors = (
+        max_ancestors_value if isinstance(max_ancestors_value, int) else 8
+    )
+    return run_local_network_identity_probe(
+        json_output=parsed_values.get("json") is True,
+        fail_on_blocked=parsed_values.get("fail_on_blocked") is True,
+        max_ancestors=max_ancestors,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/skulk/connectivity/local_network_probe_app.py
+++ b/src/skulk/connectivity/local_network_probe_app.py
@@ -1,0 +1,683 @@
+"""Build a local macOS app bundle for Local Network attribution probes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import plistlib
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal, cast, final
+
+from pydantic import Field
+
+from skulk.utils.pydantic_ext import FrozenModel
+
+DEFAULT_BUNDLE_IDENTIFIER = "foundation.foxlight.skulk.local-network-probe"
+DEFAULT_DISPLAY_NAME = "Skulk Local Network Probe"
+DEFAULT_EXECUTABLE_NAME = "SkulkLocalNetworkProbe"
+DEFAULT_OUTPUT_APP = Path("/tmp/SkulkLocalNetworkProbe.app")
+DEFAULT_LOG_DIR = Path("~/Library/Logs/SkulkLocalNetworkProbe")
+LOCAL_NETWORK_USAGE_DESCRIPTION = (
+    "Skulk uses the local network to discover and connect to nearby Skulk "
+    "nodes, including Thunderbolt-connected peers."
+)
+LauncherKind = Literal["native", "script"]
+
+
+@final
+class MacOSLocalNetworkProbeAppBuild(FrozenModel):
+    """Result of building a throwaway macOS Local Network probe app.
+
+    Attributes:
+        app_path: Absolute path to the generated ``.app`` bundle.
+        executable_path: Absolute path to the bundle executable.
+        info_plist_path: Absolute path to the generated ``Info.plist``.
+        log_dir: Directory where the app writes the probe output.
+        launcher_kind: Launcher implementation used inside ``Contents/MacOS``.
+        ad_hoc_signed: Whether the app was successfully ad-hoc code signed.
+        codesign_message: Warning or error text from codesign, when present.
+    """
+
+    app_path: str = Field(description="Absolute path to the generated .app bundle.")
+    executable_path: str = Field(
+        description="Absolute path to the bundle executable.",
+    )
+    info_plist_path: str = Field(
+        description="Absolute path to the generated Info.plist.",
+    )
+    log_dir: str = Field(description="Directory where the app writes probe output.")
+    launcher_kind: LauncherKind = Field(
+        description="Launcher implementation used inside Contents/MacOS.",
+    )
+    ad_hoc_signed: bool = Field(
+        description="Whether the app was successfully ad-hoc code signed.",
+    )
+    codesign_message: str | None = Field(
+        default=None,
+        description="Warning or error text from codesign, when present.",
+    )
+
+
+def _info_plist(
+    *,
+    bundle_identifier: str,
+    display_name: str,
+    executable_name: str,
+) -> dict[str, object]:
+    return {
+        "CFBundleDevelopmentRegion": "en",
+        "CFBundleDisplayName": display_name,
+        "CFBundleExecutable": executable_name,
+        "CFBundleIdentifier": bundle_identifier,
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleName": display_name,
+        "CFBundlePackageType": "APPL",
+        "CFBundleShortVersionString": "1.0",
+        "CFBundleVersion": "1",
+        "LSMinimumSystemVersion": "15.0",
+        "NSLocalNetworkUsageDescription": LOCAL_NETWORK_USAGE_DESCRIPTION,
+    }
+
+
+def _launcher_script(*, repo_root: Path, log_dir: Path) -> str:
+    quoted_repo_root = shlex.quote(str(repo_root))
+    quoted_log_dir = shlex.quote(str(log_dir.expanduser()))
+    return f"""#!/usr/bin/env bash
+set -u
+
+REPO_ROOT={quoted_repo_root}
+DEFAULT_LOG_DIR={quoted_log_dir}
+LOG_DIR="${{SKULK_LOCAL_NETWORK_PROBE_LOG_DIR:-$DEFAULT_LOG_DIR}}"
+JSON_OUT="${{LOG_DIR}}/latest.json"
+STDERR_OUT="${{LOG_DIR}}/latest.stderr.log"
+STATUS_OUT="${{LOG_DIR}}/latest.status"
+
+mkdir -p "$LOG_DIR" || exit 73
+cd "$REPO_ROOT" || exit 70
+
+if command -v uv >/dev/null 2>&1; then
+  UV_BIN="$(command -v uv)"
+elif [[ -x "$HOME/.local/bin/uv" ]]; then
+  UV_BIN="$HOME/.local/bin/uv"
+elif [[ -x "/opt/homebrew/bin/uv" ]]; then
+  UV_BIN="/opt/homebrew/bin/uv"
+else
+  printf 'uv not found in PATH, ~/.local/bin, or /opt/homebrew/bin\\n' >"$STDERR_OUT"
+  printf '%s\\n' '127' >"$STATUS_OUT"
+  exit 127
+fi
+
+"$UV_BIN" run skulk-macos-local-network-probe --json >"$JSON_OUT" 2>"$STDERR_OUT"
+STATUS=$?
+printf '%s\\n' "$STATUS" >"$STATUS_OUT"
+exit "$STATUS"
+"""
+
+
+def _native_launcher_source(*, repo_root: Path, log_dir: Path) -> str:
+    repo_root_literal = json.dumps(str(repo_root))
+    log_dir_literal = json.dumps(str(log_dir.expanduser()))
+    probe_command_literal = json.dumps(
+        str(repo_root / ".venv" / "bin" / "skulk-macos-local-network-probe")
+    )
+    return f"""#import <AppKit/AppKit.h>
+
+#include <arpa/inet.h>
+#include <dispatch/dispatch.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static const char *REPO_ROOT = {repo_root_literal};
+static const char *DEFAULT_LOG_DIR = {log_dir_literal};
+static const char *PROBE_COMMAND = {probe_command_literal};
+static const int PROBE_PORT = 9;
+
+static int join_path(char *destination, size_t destination_size, const char *directory, const char *filename) {{
+    int written = snprintf(destination, destination_size, "%s/%s", directory, filename);
+    return written < 0 || (size_t)written >= destination_size ? -1 : 0;
+}}
+
+static int mkdir_p(const char *path) {{
+    char buffer[PATH_MAX];
+    size_t length = strnlen(path, sizeof(buffer));
+    if (length == 0 || length >= sizeof(buffer)) {{
+        return -1;
+    }}
+
+    memcpy(buffer, path, length + 1);
+    if (buffer[length - 1] == '/') {{
+        buffer[length - 1] = '\\0';
+    }}
+
+    for (char *cursor = buffer + 1; *cursor != '\\0'; cursor++) {{
+        if (*cursor != '/') {{
+            continue;
+        }}
+        *cursor = '\\0';
+        if (mkdir(buffer, 0755) != 0 && errno != EEXIST) {{
+            return -1;
+        }}
+        *cursor = '/';
+    }}
+
+    return mkdir(buffer, 0755) == 0 || errno == EEXIST ? 0 : -1;
+}}
+
+static int default_gateway_ipv4(char *gateway, size_t gateway_size) {{
+    FILE *route_output = popen("/sbin/route -n get default 2>/dev/null", "r");
+    if (route_output == NULL) {{
+        return -1;
+    }}
+
+    char line[256];
+    int found = -1;
+    while (fgets(line, sizeof(line), route_output) != NULL) {{
+        char parsed_gateway[128];
+        if (sscanf(line, " gateway: %127s", parsed_gateway) == 1) {{
+            int written = snprintf(gateway, gateway_size, "%s", parsed_gateway);
+            found = written >= 0 && (size_t)written < gateway_size ? 0 : -1;
+            break;
+        }}
+    }}
+    pclose(route_output);
+    return found;
+}}
+
+static const char *probe_local_network(const char *gateway, int *probe_errno) {{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {{
+        *probe_errno = errno;
+        return "unknown";
+    }}
+
+    struct timeval timeout;
+    timeout.tv_sec = 2;
+    timeout.tv_usec = 0;
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+
+    struct sockaddr_in address;
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_port = htons(PROBE_PORT);
+    if (inet_pton(AF_INET, gateway, &address.sin_addr) != 1) {{
+        close(fd);
+        *probe_errno = EINVAL;
+        return "unknown";
+    }}
+
+    int result = connect(fd, (struct sockaddr *)&address, sizeof(address));
+    if (result == 0) {{
+        close(fd);
+        *probe_errno = 0;
+        return "ok";
+    }}
+
+    int connect_errno = errno;
+    close(fd);
+    *probe_errno = connect_errno;
+    return connect_errno == EHOSTUNREACH ? "blocked" : "ok";
+}}
+
+static void write_launcher_probe_file(const char *path) {{
+    char gateway[128];
+    const char *status = "unknown";
+    int probe_errno = 0;
+    if (default_gateway_ipv4(gateway, sizeof(gateway)) == 0) {{
+        status = probe_local_network(gateway, &probe_errno);
+    }} else {{
+        snprintf(gateway, sizeof(gateway), "%s", "");
+    }}
+
+    FILE *file = fopen(path, "w");
+    if (file != NULL) {{
+        fprintf(
+            file,
+            "{{\\n"
+            "  \\"local_network_status\\": \\"%s\\",\\n"
+            "  \\"gateway\\": \\"%s\\",\\n"
+            "  \\"errno\\": %d,\\n"
+            "  \\"pid\\": %d,\\n"
+            "  \\"process\\": \\"SkulkLocalNetworkProbe\\"\\n"
+            "}}\\n",
+            status,
+            gateway,
+            probe_errno,
+            getpid()
+        );
+        fclose(file);
+    }}
+}}
+
+static void write_status_file(const char *status_path, int status) {{
+    FILE *file = fopen(status_path, "w");
+    if (file != NULL) {{
+        fprintf(file, "%d\\n", status);
+        fclose(file);
+    }}
+}}
+
+static int run_probe(void) {{
+    const char *log_dir = getenv("SKULK_LOCAL_NETWORK_PROBE_LOG_DIR");
+    if (log_dir == NULL || log_dir[0] == '\\0') {{
+        log_dir = DEFAULT_LOG_DIR;
+    }}
+
+    if (mkdir_p(log_dir) != 0) {{
+        return 73;
+    }}
+
+    char json_path[PATH_MAX];
+    char launcher_probe_path[PATH_MAX];
+    char stderr_path[PATH_MAX];
+    char status_path[PATH_MAX];
+    if (
+        join_path(json_path, sizeof(json_path), log_dir, "latest.json") != 0 ||
+        join_path(launcher_probe_path, sizeof(launcher_probe_path), log_dir, "launcher-preflight.json") != 0 ||
+        join_path(stderr_path, sizeof(stderr_path), log_dir, "latest.stderr.log") != 0 ||
+        join_path(status_path, sizeof(status_path), log_dir, "latest.status") != 0
+    ) {{
+        return 75;
+    }}
+
+    write_launcher_probe_file(launcher_probe_path);
+
+    int json_fd = open(json_path, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+    int stderr_fd = open(stderr_path, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+    if (json_fd < 0 || stderr_fd < 0) {{
+        if (json_fd >= 0) {{
+            close(json_fd);
+        }}
+        if (stderr_fd >= 0) {{
+            close(stderr_fd);
+        }}
+        return 74;
+    }}
+
+    if (access(PROBE_COMMAND, X_OK) != 0) {{
+        dprintf(stderr_fd, "probe command is not executable: %s: %s\\n", PROBE_COMMAND, strerror(errno));
+        close(json_fd);
+        close(stderr_fd);
+        write_status_file(status_path, 127);
+        return 127;
+    }}
+
+    pid_t pid = fork();
+    if (pid < 0) {{
+        dprintf(stderr_fd, "fork failed: %s\\n", strerror(errno));
+        close(json_fd);
+        close(stderr_fd);
+        write_status_file(status_path, 71);
+        return 71;
+    }}
+
+    if (pid == 0) {{
+        if (chdir(REPO_ROOT) != 0) {{
+            dprintf(stderr_fd, "chdir failed: %s: %s\\n", REPO_ROOT, strerror(errno));
+            _exit(70);
+        }}
+        if (dup2(json_fd, STDOUT_FILENO) < 0 || dup2(stderr_fd, STDERR_FILENO) < 0) {{
+            _exit(74);
+        }}
+        close(json_fd);
+        close(stderr_fd);
+
+        char *const argv[] = {{
+            (char *)PROBE_COMMAND,
+            "--json",
+            NULL,
+        }};
+        execv(PROBE_COMMAND, argv);
+        fprintf(stderr, "execv failed: %s: %s\\n", PROBE_COMMAND, strerror(errno));
+        _exit(127);
+    }}
+
+    close(json_fd);
+    close(stderr_fd);
+
+    int wait_status = 0;
+    if (waitpid(pid, &wait_status, 0) < 0) {{
+        write_status_file(status_path, 72);
+        return 72;
+    }}
+
+    int exit_status = 1;
+    if (WIFEXITED(wait_status)) {{
+        exit_status = WEXITSTATUS(wait_status);
+    }} else if (WIFSIGNALED(wait_status)) {{
+        exit_status = 128 + WTERMSIG(wait_status);
+    }}
+    write_status_file(status_path, exit_status);
+    return exit_status;
+}}
+
+int main(int argc, char *argv[]) {{
+    (void)argc;
+    (void)argv;
+    @autoreleasepool {{
+        [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+        [NSApp activateIgnoringOtherApps:NO];
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{{
+            int status = run_probe();
+            exit(status);
+        }});
+        [NSApp run];
+    }}
+    return 0;
+}}
+"""
+
+
+def _compile_native_launcher(
+    *,
+    source_path: Path,
+    executable_path: Path,
+) -> tuple[bool, str | None]:
+    clang = shutil.which("clang")
+    if clang is None:
+        return False, "clang not found"
+
+    completed = subprocess.run(
+        [
+            clang,
+            "-Wall",
+            "-Wextra",
+            "-O2",
+            "-fobjc-arc",
+            "-framework",
+            "AppKit",
+            str(source_path),
+            "-o",
+            str(executable_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode == 0:
+        return True, None
+
+    message = completed.stderr.strip() or completed.stdout.strip()
+    if not message:
+        message = f"clang exited with status {completed.returncode}"
+    return False, message
+
+
+def _ad_hoc_sign(app_path: Path) -> tuple[bool, str | None]:
+    codesign = shutil.which("codesign")
+    if codesign is None:
+        return False, "codesign not found"
+
+    completed = subprocess.run(
+        [codesign, "--force", "--deep", "--sign", "-", str(app_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode == 0:
+        return True, None
+
+    message = completed.stderr.strip() or completed.stdout.strip()
+    if not message:
+        message = f"codesign exited with status {completed.returncode}"
+    return False, message
+
+
+def build_macos_local_network_probe_app(
+    *,
+    output_app: Path,
+    repo_root: Path,
+    log_dir: Path = DEFAULT_LOG_DIR,
+    bundle_identifier: str = DEFAULT_BUNDLE_IDENTIFIER,
+    display_name: str = DEFAULT_DISPLAY_NAME,
+    executable_name: str = DEFAULT_EXECUTABLE_NAME,
+    launcher_kind: LauncherKind = "native",
+    ad_hoc_sign: bool = True,
+    replace_existing: bool = False,
+) -> MacOSLocalNetworkProbeAppBuild:
+    """Build a disposable macOS app bundle that launches the probe command.
+
+    Args:
+        output_app: Destination ``.app`` bundle path.
+        repo_root: Skulk repository root that contains the ``uv`` environment.
+        log_dir: Directory where the app should write ``latest.json``.
+        bundle_identifier: Stable bundle identifier for macOS privacy identity.
+        display_name: Human-facing app name used by Finder and privacy prompts.
+        executable_name: Name of the executable inside ``Contents/MacOS``.
+        launcher_kind: Use a native Mach-O launcher or a shell-script control.
+        ad_hoc_sign: Attempt to ad-hoc sign the generated app bundle.
+        replace_existing: Remove an existing app bundle at ``output_app`` first.
+
+    Returns:
+        Metadata for the generated app bundle.
+
+    Raises:
+        FileExistsError: If ``output_app`` exists and replacement is disabled.
+        ValueError: If ``output_app`` is not a ``.app`` bundle path.
+    """
+
+    resolved_output_app = output_app.expanduser().resolve()
+    resolved_repo_root = repo_root.expanduser().resolve()
+    expanded_log_dir = log_dir.expanduser()
+    if resolved_output_app.suffix != ".app":
+        msg = f"output path must end with .app: {resolved_output_app}"
+        raise ValueError(msg)
+
+    if resolved_output_app.exists():
+        if not replace_existing:
+            msg = f"{resolved_output_app} already exists; pass --replace to rebuild it"
+            raise FileExistsError(msg)
+        shutil.rmtree(resolved_output_app)
+
+    contents_dir = resolved_output_app / "Contents"
+    macos_dir = contents_dir / "MacOS"
+    resources_dir = contents_dir / "Resources"
+    info_plist_path = contents_dir / "Info.plist"
+    executable_path = macos_dir / executable_name
+
+    macos_dir.mkdir(parents=True)
+    resources_dir.mkdir()
+    with info_plist_path.open("wb") as file:
+        plistlib.dump(
+            _info_plist(
+                bundle_identifier=bundle_identifier,
+                display_name=display_name,
+                executable_name=executable_name,
+            ),
+            file,
+        )
+
+    if launcher_kind == "native":
+        launcher_source_path = resources_dir / "launcher.m"
+        launcher_source_path.write_text(
+            _native_launcher_source(
+                repo_root=resolved_repo_root,
+                log_dir=expanded_log_dir,
+            ),
+            encoding="utf-8",
+        )
+        compiled, compile_message = _compile_native_launcher(
+            source_path=launcher_source_path,
+            executable_path=executable_path,
+        )
+        if not compiled:
+            msg = f"failed to compile native launcher: {compile_message}"
+            raise RuntimeError(msg)
+    else:
+        executable_path.write_text(
+            _launcher_script(repo_root=resolved_repo_root, log_dir=expanded_log_dir),
+            encoding="utf-8",
+        )
+    executable_mode = executable_path.stat().st_mode
+    executable_path.chmod(
+        executable_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+
+    ad_hoc_signed = False
+    codesign_message: str | None = None
+    if ad_hoc_sign:
+        ad_hoc_signed, codesign_message = _ad_hoc_sign(resolved_output_app)
+
+    return MacOSLocalNetworkProbeAppBuild(
+        app_path=str(resolved_output_app),
+        executable_path=str(executable_path),
+        info_plist_path=str(info_plist_path),
+        log_dir=str(expanded_log_dir),
+        launcher_kind=launcher_kind,
+        ad_hoc_signed=ad_hoc_signed,
+        codesign_message=codesign_message,
+    )
+
+
+def format_macos_local_network_probe_app_build(
+    result: MacOSLocalNetworkProbeAppBuild,
+) -> str:
+    """Format app build output with the commands needed for the experiment.
+
+    Args:
+        result: Build result to format.
+
+    Returns:
+        Multi-line human-readable instructions.
+    """
+
+    quoted_app_path = shlex.quote(result.app_path)
+    quoted_json_path = shlex.quote(str(Path(result.log_dir).expanduser() / "latest.json"))
+    lines = [
+        f"Built {result.app_path}",
+        f"Executable: {result.executable_path}",
+        f"Info.plist: {result.info_plist_path}",
+        f"Probe output: {Path(result.log_dir).expanduser() / 'latest.json'}",
+        f"Launcher preflight: {Path(result.log_dir).expanduser() / 'launcher-preflight.json'}",
+        f"Launcher: {result.launcher_kind}",
+        f"Ad-hoc signed: {'yes' if result.ad_hoc_signed else 'no'}",
+        "",
+        "Run:",
+        f"  open -W {quoted_app_path}",
+        "",
+        "Inspect:",
+        f"  cat {quoted_json_path}",
+    ]
+    if result.codesign_message is not None:
+        lines.extend(["", f"codesign: {result.codesign_message}"])
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build the macOS app bundle from the command line.
+
+    Args:
+        argv: Optional argument vector, excluding program name.
+
+    Returns:
+        Process exit status.
+    """
+
+    parser = argparse.ArgumentParser(
+        prog="skulk-build-macos-local-network-probe-app",
+        description="Build a disposable Skulk.app-style Local Network probe.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_APP,
+        help=f"Destination .app bundle path. Defaults to {DEFAULT_OUTPUT_APP}.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Skulk repository root. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=DEFAULT_LOG_DIR,
+        help=f"Probe output directory. Defaults to {DEFAULT_LOG_DIR}.",
+    )
+    parser.add_argument(
+        "--bundle-identifier",
+        default=DEFAULT_BUNDLE_IDENTIFIER,
+        help=f"Bundle identifier. Defaults to {DEFAULT_BUNDLE_IDENTIFIER}.",
+    )
+    parser.add_argument(
+        "--display-name",
+        default=DEFAULT_DISPLAY_NAME,
+        help=f"Display name. Defaults to {DEFAULT_DISPLAY_NAME}.",
+    )
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Replace an existing app bundle at --output.",
+    )
+    parser.add_argument(
+        "--launcher",
+        choices=("native", "script"),
+        default="native",
+        help="Launcher implementation. Defaults to native.",
+    )
+    parser.add_argument(
+        "--no-ad-hoc-sign",
+        action="store_true",
+        help="Skip ad-hoc codesigning of the generated app bundle.",
+    )
+    parsed_values = cast("dict[str, object]", vars(parser.parse_args(argv)))
+
+    output = parsed_values.get("output", DEFAULT_OUTPUT_APP)
+    repo_root = parsed_values.get("repo_root", Path.cwd())
+    log_dir = parsed_values.get("log_dir", DEFAULT_LOG_DIR)
+    if not isinstance(output, Path):
+        output = DEFAULT_OUTPUT_APP
+    if not isinstance(repo_root, Path):
+        repo_root = Path.cwd()
+    if not isinstance(log_dir, Path):
+        log_dir = DEFAULT_LOG_DIR
+    launcher_raw = parsed_values.get("launcher", "native")
+    launcher_kind: LauncherKind = "script" if launcher_raw == "script" else "native"
+    bundle_identifier_raw = parsed_values.get(
+        "bundle_identifier",
+        DEFAULT_BUNDLE_IDENTIFIER,
+    )
+    display_name_raw = parsed_values.get("display_name", DEFAULT_DISPLAY_NAME)
+    bundle_identifier = (
+        bundle_identifier_raw
+        if isinstance(bundle_identifier_raw, str)
+        else DEFAULT_BUNDLE_IDENTIFIER
+    )
+    display_name = (
+        display_name_raw if isinstance(display_name_raw, str) else DEFAULT_DISPLAY_NAME
+    )
+
+    result = build_macos_local_network_probe_app(
+        output_app=output,
+        repo_root=repo_root,
+        log_dir=log_dir,
+        bundle_identifier=bundle_identifier,
+        display_name=display_name,
+        launcher_kind=launcher_kind,
+        ad_hoc_sign=parsed_values.get("no_ad_hoc_sign") is not True,
+        replace_existing=parsed_values.get("replace") is True,
+    )
+    print(format_macos_local_network_probe_app_build(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/skulk/connectivity/tests/test_local_network.py
+++ b/src/skulk/connectivity/tests/test_local_network.py
@@ -1,10 +1,13 @@
-# pyright: reportPrivateUsage=false, reportAny=false
+# pyright: reportPrivateUsage=false, reportAny=false, reportUnknownLambdaType=false
+# pyright: reportUnknownArgumentType=false
 """Tests for macOS Local Network Privacy detection."""
 
 from __future__ import annotations
 
 import errno
 from unittest import mock
+
+from pytest import MonkeyPatch
 
 from skulk.connectivity import local_network
 
@@ -76,3 +79,27 @@ def test_blocked_message_is_actionable() -> None:
     msg = local_network.LOCAL_NETWORK_DENIED_MESSAGE
     assert "Local Network" in msg
     assert "System Settings" in msg
+
+
+def test_local_network_denied_message_names_detected_app(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # When the responsible app is detectable, the warning names it (#267).
+    import skulk.connectivity.local_network_probe as probe
+
+    monkeypatch.setattr(probe, "responsible_app_label", lambda *a, **k: "iTerm2")
+    message = local_network.local_network_denied_message()
+    assert "'iTerm2'" in message
+    assert "skulk-macos-local-network-probe" in message
+
+
+def test_local_network_denied_message_falls_back_when_unknown(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    import skulk.connectivity.local_network_probe as probe
+
+    monkeypatch.setattr(probe, "responsible_app_label", lambda *a, **k: None)
+    assert (
+        local_network.local_network_denied_message()
+        == local_network.LOCAL_NETWORK_DENIED_MESSAGE
+    )

--- a/src/skulk/connectivity/tests/test_local_network_probe.py
+++ b/src/skulk/connectivity/tests/test_local_network_probe.py
@@ -1,0 +1,119 @@
+# pyright: reportPrivateUsage=false
+"""Tests for the macOS Local Network identity probe."""
+
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+from skulk.connectivity import local_network_probe
+from skulk.connectivity.local_network_probe import (
+    LocalNetworkIdentityProbe,
+    ProcessIdentity,
+)
+
+
+def test_app_bundle_for_executable_reads_info_plist(tmp_path: Path) -> None:
+    app_root = tmp_path / "Skulk.app"
+    executable = app_root / "Contents" / "MacOS" / "Skulk"
+    info_plist = app_root / "Contents" / "Info.plist"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("", encoding="utf-8")
+    with info_plist.open("wb") as file:
+        plistlib.dump(
+            {
+                "CFBundleIdentifier": "foundation.foxlight.skulk",
+                "CFBundleDisplayName": "Skulk",
+                "CFBundleName": "Skulk",
+                "CFBundleExecutable": "Skulk",
+            },
+            file,
+        )
+
+    bundle = local_network_probe._app_bundle_for_executable(str(executable))
+
+    assert bundle is not None
+    assert bundle.path == str(app_root)
+    assert bundle.bundle_identifier == "foundation.foxlight.skulk"
+    assert bundle.display_name == "Skulk"
+    assert bundle.executable_name == "Skulk"
+
+
+def test_app_bundle_for_executable_returns_none_without_app(tmp_path: Path) -> None:
+    executable = tmp_path / "bin" / "python"
+    executable.parent.mkdir()
+    executable.write_text("", encoding="utf-8")
+
+    assert local_network_probe._app_bundle_for_executable(str(executable)) is None
+
+
+def test_format_probe_report_includes_status_and_process() -> None:
+    report = LocalNetworkIdentityProbe(
+        local_network_status="blocked",
+        platform_system="Darwin",
+        macos_version="26.0",
+        hostname="kite1",
+        process=ProcessIdentity(
+            pid=123,
+            ppid=1,
+            name="python",
+            executable="/usr/bin/python3",
+            command_line=["python3", "-m", "skulk"],
+            app_bundle=None,
+        ),
+        ancestors=[],
+        notes=["Local Network access appears blocked."],
+    )
+
+    text = local_network_probe.format_local_network_identity_probe(report)
+
+    assert "Local Network status: blocked" in text
+    assert "pid=123" in text
+    assert "python3" in text
+    assert "Local Network access appears blocked." in text
+
+
+def test_run_probe_returns_two_when_blocked_and_fail_enabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    report = LocalNetworkIdentityProbe(
+        local_network_status="blocked",
+        platform_system="Darwin",
+        macos_version="26.0",
+        hostname="kite1",
+        process=ProcessIdentity(pid=123),
+        ancestors=[],
+        notes=[],
+    )
+    monkeypatch.setattr(
+        local_network_probe,
+        "collect_local_network_identity_probe",
+        lambda max_ancestors=8: report,
+    )
+
+    assert local_network_probe.run_local_network_identity_probe(
+        fail_on_blocked=True
+    ) == 2
+
+
+def test_run_probe_returns_zero_when_blocked_without_fail(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    report = LocalNetworkIdentityProbe(
+        local_network_status="blocked",
+        platform_system="Darwin",
+        macos_version="26.0",
+        hostname="kite1",
+        process=ProcessIdentity(pid=123),
+        ancestors=[],
+        notes=[],
+    )
+    monkeypatch.setattr(
+        local_network_probe,
+        "collect_local_network_identity_probe",
+        lambda max_ancestors=8: report,
+    )
+
+    assert local_network_probe.run_local_network_identity_probe() == 0

--- a/src/skulk/connectivity/tests/test_local_network_probe.py
+++ b/src/skulk/connectivity/tests/test_local_network_probe.py
@@ -1,4 +1,5 @@
-# pyright: reportPrivateUsage=false
+# pyright: reportPrivateUsage=false, reportUnknownLambdaType=false
+# pyright: reportUnknownArgumentType=false, reportUnknownMemberType=false
 """Tests for the macOS Local Network identity probe."""
 
 from __future__ import annotations
@@ -117,3 +118,39 @@ def test_run_probe_returns_zero_when_blocked_without_fail(
     )
 
     assert local_network_probe.run_local_network_identity_probe() == 0
+
+
+def test_friendly_executable_label_maps_python_variants() -> None:
+    assert local_network_probe._friendly_executable_label("/x/python3.13") == "Python"
+    assert local_network_probe._friendly_executable_label("/usr/bin/python") == "Python"
+    assert local_network_probe._friendly_executable_label("/opt/uv") == "uv"
+    assert local_network_probe._friendly_executable_label("/x/mylauncher") == "mylauncher"
+    assert local_network_probe._friendly_executable_label(None) is None
+
+
+def test_responsible_app_label_prefers_nearest_app_bundle(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # A process chain where an ancestor lives in a .app bundle: that bundle's
+    # display name is what macOS attributes the grant to.
+    bundle = local_network_probe.AppBundleIdentity(
+        path="/Applications/iTerm.app", display_name="iTerm2"
+    )
+    current = ProcessIdentity(pid=1, executable="/x/python3.13")
+    ancestor = ProcessIdentity(pid=2, executable="/Applications/iTerm.app/Contents/MacOS/iTerm2", app_bundle=bundle)
+    monkeypatch.setattr(local_network_probe.psutil, "Process", lambda: object())
+    monkeypatch.setattr(local_network_probe, "_process_identity", lambda _p: current)
+    monkeypatch.setattr(local_network_probe, "_ancestor_identities", lambda _p, _n: [ancestor])
+
+    assert local_network_probe.responsible_app_label() == "iTerm2"
+
+
+def test_responsible_app_label_falls_back_to_executable_when_no_bundle(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    current = ProcessIdentity(pid=1, executable="/opt/python3.13")
+    monkeypatch.setattr(local_network_probe.psutil, "Process", lambda: object())
+    monkeypatch.setattr(local_network_probe, "_process_identity", lambda _p: current)
+    monkeypatch.setattr(local_network_probe, "_ancestor_identities", lambda _p, _n: [])
+
+    assert local_network_probe.responsible_app_label() == "Python"

--- a/src/skulk/connectivity/tests/test_local_network_probe_app.py
+++ b/src/skulk/connectivity/tests/test_local_network_probe_app.py
@@ -1,0 +1,144 @@
+# pyright: reportPrivateUsage=false
+"""Tests for the disposable macOS Local Network probe app builder."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import stat
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pytest import MonkeyPatch
+
+from skulk.connectivity import local_network_probe_app
+from skulk.connectivity.local_network_probe_app import (
+    DEFAULT_BUNDLE_IDENTIFIER,
+    DEFAULT_DISPLAY_NAME,
+    DEFAULT_EXECUTABLE_NAME,
+    LOCAL_NETWORK_USAGE_DESCRIPTION,
+    build_macos_local_network_probe_app,
+)
+
+
+def test_build_macos_local_network_probe_app_writes_bundle(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    log_dir = tmp_path / "logs"
+    output_app = tmp_path / "SkulkLocalNetworkProbe.app"
+
+    result = build_macos_local_network_probe_app(
+        output_app=output_app,
+        repo_root=repo_root,
+        log_dir=log_dir,
+        launcher_kind="script",
+        ad_hoc_sign=False,
+    )
+
+    info_plist = output_app / "Contents" / "Info.plist"
+    executable = output_app / "Contents" / "MacOS" / DEFAULT_EXECUTABLE_NAME
+    with info_plist.open("rb") as file:
+        loaded_info = cast("object", plistlib.load(file))
+    assert isinstance(loaded_info, dict)
+    raw_info = cast("dict[object, object]", loaded_info)
+
+    assert result.app_path == str(output_app.resolve())
+    assert raw_info["CFBundleIdentifier"] == DEFAULT_BUNDLE_IDENTIFIER
+    assert raw_info["CFBundleDisplayName"] == DEFAULT_DISPLAY_NAME
+    assert raw_info["CFBundleExecutable"] == DEFAULT_EXECUTABLE_NAME
+    assert raw_info["NSLocalNetworkUsageDescription"] == LOCAL_NETWORK_USAGE_DESCRIPTION
+    assert executable.exists()
+    assert executable.stat().st_mode & stat.S_IXUSR
+    launcher = executable.read_text(encoding="utf-8")
+    assert str(repo_root.resolve()) in launcher
+    assert str(log_dir) in launcher
+    assert "skulk-macos-local-network-probe --json" in launcher
+
+
+def test_build_macos_local_network_probe_app_can_use_native_launcher(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    output_app = tmp_path / "SkulkLocalNetworkProbe.app"
+
+    def fake_compile(*, source_path: Path, executable_path: Path) -> tuple[bool, str | None]:
+        assert source_path.exists()
+        executable_path.write_text("native", encoding="utf-8")
+        return True, None
+
+    monkeypatch.setattr(
+        local_network_probe_app,
+        "_compile_native_launcher",
+        fake_compile,
+    )
+
+    result = build_macos_local_network_probe_app(
+        output_app=output_app,
+        repo_root=repo_root,
+        ad_hoc_sign=False,
+    )
+
+    launcher_source = output_app / "Contents" / "Resources" / "launcher.m"
+    assert result.launcher_kind == "native"
+    assert launcher_source.exists()
+    assert "static const char *REPO_ROOT" in launcher_source.read_text(
+        encoding="utf-8"
+    )
+    assert (
+        output_app / "Contents" / "MacOS" / DEFAULT_EXECUTABLE_NAME
+    ).read_text(encoding="utf-8") == "native"
+
+
+def test_build_macos_local_network_probe_app_refuses_non_app_path(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="must end with .app"):
+        build_macos_local_network_probe_app(
+            output_app=tmp_path / "SkulkLocalNetworkProbe",
+            repo_root=tmp_path,
+            launcher_kind="script",
+            ad_hoc_sign=False,
+        )
+
+
+def test_build_macos_local_network_probe_app_refuses_existing_path(
+    tmp_path: Path,
+) -> None:
+    output_app = tmp_path / "SkulkLocalNetworkProbe.app"
+    output_app.mkdir()
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        build_macos_local_network_probe_app(
+            output_app=output_app,
+            repo_root=tmp_path,
+            launcher_kind="script",
+            ad_hoc_sign=False,
+        )
+
+
+def test_build_macos_local_network_probe_app_replaces_existing_path(
+    tmp_path: Path,
+) -> None:
+    output_app = tmp_path / "SkulkLocalNetworkProbe.app"
+    stale_file = output_app / "stale"
+    output_app.mkdir()
+    stale_file.write_text("old", encoding="utf-8")
+
+    build_macos_local_network_probe_app(
+        output_app=output_app,
+        repo_root=tmp_path,
+        launcher_kind="script",
+        ad_hoc_sign=False,
+        replace_existing=True,
+    )
+
+    assert not stale_file.exists()
+    assert os.access(
+        output_app / "Contents" / "MacOS" / DEFAULT_EXECUTABLE_NAME,
+        os.X_OK,
+    )

--- a/src/skulk/main.py
+++ b/src/skulk/main.py
@@ -17,8 +17,8 @@ from pydantic import PositiveInt
 import skulk.routing.topics as topics
 from skulk.api.main import API
 from skulk.connectivity.local_network import (
-    LOCAL_NETWORK_DENIED_MESSAGE,
     check_local_network_access,
+    local_network_denied_message,
 )
 from skulk.connectivity.tailscale import query_tailscale_status
 from skulk.download.coordinator import DownloadCoordinator
@@ -1017,7 +1017,7 @@ def main():
     # / Thunderbolt peers (EHOSTUNREACH), so cluster discovery never forms.
     # Detect it early and tell the operator how to grant access.
     if check_local_network_access() == "blocked":
-        logger.warning(LOCAL_NETWORK_DENIED_MESSAGE)
+        logger.warning(local_network_denied_message())
 
     if args.offline:
         logger.info("Running in OFFLINE mode — no internet checks, local models only")

--- a/website/docs/thunderbolt-clustering.md
+++ b/website/docs/thunderbolt-clustering.md
@@ -60,6 +60,43 @@ Click **Allow**. If you missed it (or are running over SSH and never saw it):
 Skulk detects this denial at startup and logs a warning telling you to grant
 access, so you are never left guessing.
 
+To see which process/app identity macOS is likely to attach the grant to, run
+the read-only probe from the same launch path you plan to use for Skulk:
+
+```bash
+uv run skulk-macos-local-network-probe
+```
+
+For scripts or issue reports, JSON output is also available:
+
+```bash
+uv run skulk-macos-local-network-probe --json
+```
+
+The probe may trigger the Local Network prompt because it performs one local
+TCP reachability attempt, but it does not grant permissions or change
+Thunderbolt/RDMA/network settings.
+
+To compare Terminal attribution with a Skulk-named app bundle during
+development, build the disposable native probe app and launch it with `open`:
+
+```bash
+uv run skulk-build-macos-local-network-probe-app --replace
+open -W /tmp/SkulkLocalNetworkProbe.app
+cat ~/Library/Logs/SkulkLocalNetworkProbe/launcher-preflight.json
+cat ~/Library/Logs/SkulkLocalNetworkProbe/latest.json
+```
+
+The generated app is not installed permanently; it is a throwaway bundle under
+`/tmp`. Its executable is a tiny native launcher, and its `Info.plist` includes
+`NSLocalNetworkUsageDescription`. The `launcher-preflight.json` file records
+the native bundled process's own Local Network status before it launches the
+Python probe, so we can distinguish app-bundle permission from child-process
+inheritance. Treat this as a diagnostic harness, not the final packaged Skulk
+runtime: if the launcher preflight reports `blocked`, a wrapper app is not
+sufficient on that machine and the next test should be a frozen/signed
+`Contents/MacOS/Skulk` runtime.
+
 > **The grant follows the launching app.** macOS attributes Local Network
 > access to the app a process is launched *from*. Run Skulk from the **Terminal
 > you granted** (i.e. `uv run skulk` in that Terminal) and it inherits the

--- a/website/docs/thunderbolt-clustering.md
+++ b/website/docs/thunderbolt-clustering.md
@@ -58,7 +58,9 @@ Click **Allow**. If you missed it (or are running over SSH and never saw it):
 3. Restart Skulk.
 
 Skulk detects this denial at startup and logs a warning telling you to grant
-access, so you are never left guessing.
+access, naming the specific app to enable (the terminal you launched from, or
+`Python` when launched over SSH or as a service), so you are never left
+guessing.
 
 To see which process/app identity macOS is likely to attach the grant to, run
 the read-only probe from the same launch path you plan to use for Skulk:


### PR DESCRIPTION
Closes #267. v1.3 — Release readiness milestone. Folds in the in-progress macos-networking-probe work and completes the runtime wiring it was missing.

## Problem
macOS attributes Local Network access to the "responsible app" in the launch chain: the terminal when run interactively, but **"Python"** over SSH / launchd / headless (and an OS update can silently reset a working grant). The failure is indirect: gossip still flows over Tailscale so the node *looks* clustered, but per-interface mDNS is blocked, so the master never sees the node's LAN/Thunderbolt links and ring placement silently falls back to Tailscale (possibly DERP-relayed) paths. Users see "slow inference / 4-node won't form," three layers from the cause.

## What this delivers (issue proposals 1 + 2, with groundwork for 3)
- **Proposal 1 — actionable warning:** the startup DENIED warning now names the exact app to enable ("enable 'iTerm2'" / "enable 'Python'") via `responsible_app_label()`, which walks the process tree and resolves the nearest `.app` bundle identity (network-free), falling back to the generic text only when the identity can't be resolved.
- **Proposal 2 — doctor/preflight:** `uv run skulk-macos-local-network-probe` (text or `--json`, `--fail-on-blocked`) reports the launch identity, each ancestor's `.app` bundle, the reachability status, and interpretation notes. Read-only except for one local TCP reachability attempt.
- **Proposal 3 groundwork:** `skulk-build-macos-local-network-probe-app` builds a throwaway ad-hoc-signed probe `.app` (with `NSLocalNetworkUsageDescription`) to compare terminal vs Skulk-named attribution. Full signed-app packaging for the product remains the macOS-packaging lane.

## Tests
`test_local_network_probe.py` / `test_local_network_probe_app.py` (the probe + builder) and new cases: `responsible_app_label` (nearest-bundle vs executable fallback), `_friendly_executable_label`, and the actionable/fallback denial message. 30 connectivity tests pass.

## Validation
basedpyright + ruff clean on `src/skulk/connectivity/` and `src/skulk/main.py`; `nix fmt` no-op; full connectivity suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)