### PR TITLE
fix(store): refuse to register a vision GGUF missing its projector (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ This project records release notes here and mirrors public-facing notes in
   so staging it to a worker produced an unloadable model that failed only as a
   runner crash at load time on a remote node. The store host now verifies the
   projector actually landed before registering a vision GGUF and refuses with a
-  clear error otherwise (re-running the download re-fetches it), so the failure
-  is a loud, fixable download error on the store host instead of a confusing
-  crash elsewhere.
+  clear error otherwise, so an incomplete vision model can never be registered.
+  An existing stale entry self-heals: a download request for an in-store vision
+  GGUF whose entry lacks the projector re-downloads (reusing the already-present
+  weights and fetching only the missing projector) instead of being
+  short-circuited as "complete", so the failure becomes a loud, fixable download
+  error on the store host instead of a confusing crash elsewhere.
 
 - **A borderline multi-node placement is no longer refused on sub-GB memory
   jitter (#383).** The master admits a placement on each node's *gossiped* usable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **The model store no longer registers a vision GGUF without its projector.**
+  A vision GGUF (LLaVA/Qwen-VL/Gemma-VLM style) ships its multimodal projector
+  as a separate `mmproj` file; without it the llama.cpp runner cannot load the
+  model. The selective store download already keeps the projector glob, but a
+  store entry registered before that logic landed could list only the LM quant,
+  so staging it to a worker produced an unloadable model that failed only as a
+  runner crash at load time on a remote node. The store host now verifies the
+  projector actually landed before registering a vision GGUF and refuses with a
+  clear error otherwise (re-running the download re-fetches it), so the failure
+  is a loud, fixable download error on the store host instead of a confusing
+  crash elsewhere.
+
 - **A borderline multi-node placement is no longer refused on sub-GB memory
   jitter (#383).** The master admits a placement on each node's *gossiped* usable
   memory, but the worker's pre-load guard re-measures *live* at load; on a tight

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -394,17 +394,55 @@ class ModelStore:
     # Store-side HuggingFace downloads
     # ------------------------------------------------------------------
 
+    async def _store_entry_missing_projector(self, model_id: str) -> bool:
+        """True when an in-store GGUF entry is a vision model missing its projector.
+
+        Recovers stale entries registered before the projector was retained
+        (#346): such an entry lists only the LM quant, so staging it produces an
+        unloadable vision model. We detect that here so a re-download request is
+        not short-circuited as "already complete": the re-download skips the
+        already-present weights (size-matched) and fetches only the missing
+        projector, then re-registers a complete entry. Returns ``False`` when the
+        model is absent, already has a projector, is not a vision GGUF, or the
+        repo listing cannot be fetched (offline): we only force the redownload on
+        positive evidence of an incomplete vision entry.
+        """
+        files = self.list_files_for_model(model_id)
+        if files is None or has_gguf_projector(files):
+            return False
+        from skulk.download.download_utils import fetch_file_list_with_cache
+        from skulk.shared.models.model_cards import ModelId
+
+        try:
+            repo_files = await fetch_file_list_with_cache(
+                ModelId(model_id), "main", recursive=True
+            )
+        except Exception as exc:
+            logger.debug(
+                f"ModelStore: could not check projector completeness for "
+                f"{model_id} ({exc}); leaving the existing entry as-is"
+            )
+            return False
+        return has_gguf_projector(f.path for f in repo_files)
+
     async def request_download(
         self, model_id: str, pinned_gguf: str | None = None
     ) -> StoreDownloadStatus:
         """Request that the store download a model from HuggingFace.
 
         Deduplicates: if the model is already downloading, returns the
-        existing status.  If already in the store, returns "complete".
+        existing status.  If already in the store, returns "complete", unless it
+        is a vision GGUF whose stored entry is missing its ``mmproj`` projector
+        (a stale pre-#346 entry), in which case it re-downloads to recover the
+        projector instead of staging an unloadable model.
 
         ``pinned_gguf`` is the requester's card-pinned GGUF file, forwarded so a
         GGUF repo fetches that quant's shard group rather than the default (#344).
         """
+        # Checked outside the lock: it may do a (cached) repo file-list fetch, and
+        # holding the download lock across network I/O would serialize unrelated
+        # requests.
+        missing_projector = await self._store_entry_missing_projector(model_id)
         async with self._download_lock:
             existing = self._active_downloads.get(model_id)
             if existing is not None:
@@ -412,9 +450,15 @@ class ModelStore:
                     del self._active_downloads[model_id]
                 else:
                     return existing
-            if self.is_in_store(model_id):
+            if self.is_in_store(model_id) and not missing_projector:
                 return StoreDownloadStatus(
                     model_id=model_id, status="complete", progress=1.0
+                )
+            if missing_projector:
+                logger.warning(
+                    f"ModelStore: {model_id} is in the store but its entry is "
+                    "missing the mmproj projector for a vision GGUF; "
+                    "re-downloading to recover it (existing weights are reused)."
                 )
             status = StoreDownloadStatus(model_id=model_id, status="pending")
             self._active_downloads[model_id] = status

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -143,6 +144,19 @@ def select_store_gguf_download_files(
         return any(fnmatch(entry.path, pattern) for pattern in keep_patterns)
 
     return [entry for entry in file_list if _keep(entry)]
+
+
+def has_gguf_projector(paths: Iterable[str]) -> bool:
+    """Whether any path is a multimodal projector GGUF (``*mmproj*.gguf``).
+
+    A vision GGUF ships its projector as a separate ``mmproj`` file alongside the
+    LM weights; the store uses this both to detect that a repo is a vision GGUF
+    (from its full file list) and to verify the projector actually landed before
+    registering the model (#346).
+    """
+    return any(
+        p.lower().endswith(".gguf") and "mmproj" in p.lower() for p in paths
+    )
 
 
 @final
@@ -452,17 +466,31 @@ class ModelStore:
         try:
             await aios.makedirs(str(target_dir), exist_ok=True)
 
-            file_list = await fetch_file_list_with_cache(
+            repo_file_list = await fetch_file_list_with_cache(
                 ModelId(model_id), "main", recursive=True
+            )
+            # A vision GGUF (LLaVA/Qwen-VL/Gemma-VLM style) ships its multimodal
+            # projector as a separate ``*mmproj*.gguf`` alongside the LM weights;
+            # the llama.cpp runner cannot load the model without it. Detect that
+            # from the full repo listing so we can verify the projector actually
+            # lands before registering (see the post-download guard below): a
+            # store entry that omits the projector stages an unloadable vision
+            # model, which surfaces only as a runner crash at load time (#346).
+            repo_ships_projector = has_gguf_projector(
+                f.path for f in repo_file_list
             )
             # For a GGUF repo, fetch only the preferred quant's shard group plus
             # config.json (dropping other quants, original/*, metal/*, etc.),
-            # mirroring the direct-HF selective download (#339).
-            selected_files = select_store_gguf_download_files(file_list, pinned_gguf)
-            if len(selected_files) != len(file_list):
+            # mirroring the direct-HF selective download (#339). The projector
+            # glob is retained by ``gguf_allow_patterns``, so a vision GGUF keeps
+            # its ``*mmproj*.gguf``.
+            selected_files = select_store_gguf_download_files(
+                repo_file_list, pinned_gguf
+            )
+            if len(selected_files) != len(repo_file_list):
                 logger.info(
                     f"ModelStore: {model_id} is a GGUF repo; downloading "
-                    f"{len(selected_files)}/{len(file_list)} files (selected "
+                    f"{len(selected_files)}/{len(repo_file_list)} files (selected "
                     "quant's shard group + config.json only)"
                 )
             file_list = selected_files
@@ -497,6 +525,20 @@ class ModelStore:
                 for p in target_dir.rglob("*")
                 if p.is_file()
             ]
+            # Vision-projector completeness guard (#346): a vision GGUF whose repo
+            # ships an ``mmproj`` projector MUST land its projector, or staging it
+            # to a worker produces an unloadable model that only fails as a runner
+            # crash at load time. Refuse to register an incomplete vision model so
+            # the failure is a loud, fixable download error here (re-running the
+            # download re-fetches the projector, which the selective allow-list
+            # already retains) instead of a confusing crash on a remote node.
+            if repo_ships_projector and not has_gguf_projector(files):
+                raise RuntimeError(
+                    f"{model_id} is a vision GGUF whose repo ships an mmproj "
+                    "projector, but none landed in the store download; refusing to "
+                    "register an unusable vision model. Re-run the download to "
+                    "re-fetch the projector."
+                )
             total = sum(p.stat().st_size for p in target_dir.rglob("*") if p.is_file())
             self.register_model(model_id, target_dir, files, total)
 

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -141,6 +141,14 @@ def select_store_gguf_download_files(
     keep_patterns = [*gguf_allow_patterns(selected), "config.json"]
 
     def _keep(entry: FileListEntry) -> bool:
+        # Keep the selected quant's shard group + config.json, plus the
+        # multimodal projector matched case-insensitively: ``has_gguf_projector``
+        # (used to detect a vision repo and to verify completeness) is
+        # case-insensitive, so the selection MUST be too, or an uppercase
+        # ``MMPROJ-*.gguf`` would be detected-but-never-selected and the
+        # registration guard would fail every retry.
+        if has_gguf_projector([entry.path]):
+            return True
         return any(fnmatch(entry.path, pattern) for pattern in keep_patterns)
 
     return [entry for entry in file_list if _keep(entry)]
@@ -394,7 +402,7 @@ class ModelStore:
     # Store-side HuggingFace downloads
     # ------------------------------------------------------------------
 
-    async def _store_entry_missing_projector(self, model_id: str) -> bool:
+    async def vision_entry_missing_projector(self, model_id: str) -> bool:
         """True when an in-store GGUF entry is a vision model missing its projector.
 
         Recovers stale entries registered before the projector was retained
@@ -442,7 +450,7 @@ class ModelStore:
         # Checked outside the lock: it may do a (cached) repo file-list fetch, and
         # holding the download lock across network I/O would serialize unrelated
         # requests.
-        missing_projector = await self._store_entry_missing_projector(model_id)
+        missing_projector = await self.vision_entry_missing_projector(model_id)
         async with self._download_lock:
             existing = self._active_downloads.get(model_id)
             if existing is not None:

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -161,10 +161,14 @@ def has_gguf_projector(paths: Iterable[str]) -> bool:
     LM weights; the store uses this both to detect that a repo is a vision GGUF
     (from its full file list) and to verify the projector actually landed before
     registering the model (#346).
+
+    Matches the same convention as the card resolver (``gguf_repo_has_projector``)
+    and the runner (``find_mmproj_file``): a case-sensitive ``.gguf`` extension
+    (HF GGUF files are always lowercase-extension) with a case-insensitive
+    ``mmproj`` name. Keeping all three aligned avoids a file being detected or
+    selected here but then not found by the loader.
     """
-    return any(
-        p.lower().endswith(".gguf") and "mmproj" in p.lower() for p in paths
-    )
+    return any(p.endswith(".gguf") and "mmproj" in p.lower() for p in paths)
 
 
 @final
@@ -194,6 +198,12 @@ class StoreModelEntry(BaseModel):
     files: list[str]
     downloaded_at: str
     total_bytes: int
+    # Whether the upstream repo ships a multimodal projector, recorded at
+    # registration so the availability hot path can decide a vision GGUF's
+    # completeness without an HF repo-list probe (#346). ``None`` on entries
+    # written before this field existed (legacy): those fall back to a one-time
+    # HF probe until they are re-registered.
+    repo_has_projector: bool | None = None
 
 
 @dataclass
@@ -322,6 +332,7 @@ class ModelStore:
         model_path: Path,
         files: list[str],
         total_bytes: int,
+        repo_has_projector: bool | None = None,
     ) -> None:
         """Add or update *model_id* in the registry.
 
@@ -342,6 +353,7 @@ class ModelStore:
             files=files,
             downloaded_at=datetime.now(tz=timezone.utc).isoformat(),
             total_bytes=total_bytes,
+            repo_has_projector=repo_has_projector,
         )
         self._write_registry_entry(entry)
         logger.info(
@@ -415,16 +427,20 @@ class ModelStore:
         repo listing cannot be fetched (offline): we only force the redownload on
         positive evidence of an incomplete vision entry.
         """
-        files = self.list_files_for_model(model_id)
-        if files is None or has_gguf_projector(files):
+        entry = self._read_registry().get(model_id)
+        if entry is None or has_gguf_projector(entry.files):
             return False
-        # Only a GGUF repo carries a separate ``mmproj`` projector; an MLX /
-        # safetensors vision model bundles its vision weights and is complete
-        # without one. This runs on the store-availability hot path, so restrict
-        # the (cached, but occasionally networked) HF repo-list probe to
-        # registered GGUF entries; never probe HF for a non-GGUF model just to
-        # decide it isn't missing a projector it never has.
-        if not any(name.lower().endswith(".gguf") for name in files):
+        # Steady state: the registration guard records whether the upstream repo
+        # ships a projector, so the answer is local: no HF probe on this hot
+        # path (it backs the worker's store-availability check). A vision GGUF
+        # missing its projector is stale; a text model (no projector upstream) is
+        # complete.
+        if entry.repo_has_projector is not None:
+            return entry.repo_has_projector
+        # Legacy entry (written before the flag existed): fall back to a one-time
+        # (cached) HF probe, restricted to GGUF entries so an MLX/safetensors
+        # model is never probed. After it re-registers, the flag above takes over.
+        if not any(name.endswith(".gguf") for name in entry.files):
             return False
         from skulk.download.download_utils import fetch_file_list_with_cache
         from skulk.shared.models.model_cards import ModelId
@@ -600,7 +616,9 @@ class ModelStore:
                     "re-fetch the projector."
                 )
             total = sum(p.stat().st_size for p in target_dir.rglob("*") if p.is_file())
-            self.register_model(model_id, target_dir, files, total)
+            self.register_model(
+                model_id, target_dir, files, total, repo_has_projector=repo_ships_projector
+            )
 
             status.status = "complete"
             status.progress = 1.0

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -165,10 +165,16 @@ def has_gguf_projector(paths: Iterable[str]) -> bool:
     Matches the same convention as the card resolver (``gguf_repo_has_projector``)
     and the runner (``find_mmproj_file``): a case-sensitive ``.gguf`` extension
     (HF GGUF files are always lowercase-extension) with a case-insensitive
-    ``mmproj`` name. Keeping all three aligned avoids a file being detected or
-    selected here but then not found by the loader.
+    ``mmproj`` in the **basename**. The runner identifies the projector by
+    basename, so matching on the basename here (not anywhere in the path) keeps
+    all three aligned and avoids misclassifying a non-projector GGUF that merely
+    sits under a directory whose name contains ``mmproj``.
     """
-    return any(p.endswith(".gguf") and "mmproj" in p.lower() for p in paths)
+    for path in paths:
+        name = path.rsplit("/", 1)[-1]
+        if name.endswith(".gguf") and "mmproj" in name.lower():
+            return True
+    return False
 
 
 @final

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -418,6 +418,14 @@ class ModelStore:
         files = self.list_files_for_model(model_id)
         if files is None or has_gguf_projector(files):
             return False
+        # Only a GGUF repo carries a separate ``mmproj`` projector; an MLX /
+        # safetensors vision model bundles its vision weights and is complete
+        # without one. This runs on the store-availability hot path, so restrict
+        # the (cached, but occasionally networked) HF repo-list probe to
+        # registered GGUF entries; never probe HF for a non-GGUF model just to
+        # decide it isn't missing a projector it never has.
+        if not any(name.lower().endswith(".gguf") for name in files):
+            return False
         from skulk.download.download_utils import fetch_file_list_with_cache
         from skulk.shared.models.model_cards import ModelId
 

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -143,6 +143,27 @@ def _staged_directory_looks_complete(directory: Path) -> bool:
     return (directory / "mtp.safetensors").is_file()
 
 
+def _staged_vision_projector_missing(
+    shard: ShardMetadata, directory: Path
+) -> bool:
+    """True when a vision GGUF's staged dir is missing its ``mmproj`` projector.
+
+    The generic completeness probe (``_staged_directory_looks_complete``)
+    excludes ``mmproj`` files, so a vision GGUF staged without its projector
+    still "looks complete" yet crashes the runner at load. Treating such a dir
+    as incomplete forces re-staging, which (with a projector-complete store
+    entry) pulls the projector down too (#346). Non-vision models are never
+    affected.
+    """
+    if shard.model_card.vision is None:
+        return False
+    from skulk.store.model_store import has_gguf_projector
+
+    return not has_gguf_projector(
+        path.name for path in directory.rglob("*") if path.is_file()
+    )
+
+
 @final
 class StoreHealthInfo:
     """Parsed response from ``GET /health`` on the store server.
@@ -863,8 +884,10 @@ class ModelStoreDownloader(ShardDownloader):
                 direct_path = self._store_client.local_store_path / _sanitize_model_id(
                     model_id
                 )
-                if direct_path.exists() and _staged_directory_looks_complete(
-                    direct_path
+                if (
+                    direct_path.exists()
+                    and _staged_directory_looks_complete(direct_path)
+                    and not _staged_vision_projector_missing(shard, direct_path)
                 ):
                     logger.info(
                         f"ModelStoreDownloader: staging disabled — loading {model_id} directly from store at {direct_path}"
@@ -881,7 +904,11 @@ class ModelStoreDownloader(ShardDownloader):
         # broken model, so incomplete dirs fall through to re-staging
         # (which resumes partial files via HTTP Range).
         dest_path = _staging_dir(self._staging_config.node_cache_path, model_id)
-        if dest_path.exists() and _staged_directory_looks_complete(dest_path):
+        if (
+            dest_path.exists()
+            and _staged_directory_looks_complete(dest_path)
+            and not _staged_vision_projector_missing(shard, dest_path)
+        ):
             logger.info(
                 f"ModelStoreDownloader: {model_id} already staged at {dest_path} — skipping availability probe"
             )

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -146,16 +146,22 @@ def _staged_directory_looks_complete(directory: Path) -> bool:
 def _staged_vision_projector_missing(
     shard: ShardMetadata, directory: Path
 ) -> bool:
-    """True when a vision GGUF's staged dir is missing its ``mmproj`` projector.
+    """True when a GGUF vision model's staged dir is missing its ``mmproj``.
 
     The generic completeness probe (``_staged_directory_looks_complete``)
-    excludes ``mmproj`` files, so a vision GGUF staged without its projector
-    still "looks complete" yet crashes the runner at load. Treating such a dir
-    as incomplete forces re-staging, which (with a projector-complete store
-    entry) pulls the projector down too (#346). Non-vision models are never
-    affected.
+    excludes ``mmproj`` files, so a GGUF vision model staged without its
+    projector still "looks complete" yet crashes the runner at load. Treating
+    such a dir as incomplete forces re-staging, which (with a projector-complete
+    store entry) pulls the projector down too (#346).
+
+    Scoped to GGUF vision models (``gguf_file`` set): an MLX / safetensors vision
+    model bundles its vision weights and has no separate projector, so it is
+    complete without one; flagging it here would wrongly disable the staged-cache
+    fast path and force needless store/HF re-resolution. Non-vision and non-GGUF
+    models are never affected.
     """
-    if shard.model_card.vision is None:
+    card = shard.model_card
+    if card.vision is None or not card.gguf_file:
         return False
     from skulk.store.model_store import has_gguf_projector
 

--- a/src/skulk/store/model_store_server.py
+++ b/src/skulk/store/model_store_server.py
@@ -190,6 +190,18 @@ class ModelStoreServer:
         model_path = self._store.get_store_path(model_id)
         if model_path is None:
             raise web.HTTPNotFound(reason=f"Model not in store: {model_id}")
+        # A stale vision-GGUF entry missing its mmproj projector is reported as
+        # NOT available so the worker's ensure_shard path (which stages directly
+        # on a 200 here) falls through to a download request, which re-fetches the
+        # projector and re-registers a complete entry (#346). Without this, the
+        # worker stages the incomplete entry and the runner crashes on load.
+        if await self._store.vision_entry_missing_projector(model_id):
+            raise web.HTTPNotFound(
+                reason=(
+                    f"Model in store but missing its vision projector "
+                    f"(will re-download): {model_id}"
+                )
+            )
         files = [
             str(p.relative_to(model_path)) for p in model_path.rglob("*") if p.is_file()
         ]

--- a/src/skulk/store/tests/test_staged_vision_projector.py
+++ b/src/skulk/store/tests/test_staged_vision_projector.py
@@ -1,0 +1,77 @@
+# pyright: reportPrivateUsage=false
+"""Staged-directory projector completeness, scoped to GGUF vision models (#346).
+
+A GGUF vision model carries a separate ``mmproj`` projector that the generic
+completeness probe ignores, so a staged dir without it must be re-staged. An
+MLX / safetensors vision model bundles its vision weights and has no separate
+projector, so it must NOT be flagged (doing so would disable the staged-cache
+fast path that keeps inference working when the store is unreachable).
+"""
+
+from pathlib import Path
+
+from skulk.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    ModelTask,
+    VisionCardConfig,
+)
+from skulk.shared.types.memory import Memory
+from skulk.shared.types.worker.shards import PipelineShardMetadata
+from skulk.store.model_store_client import _staged_vision_projector_missing
+
+
+def _shard(
+    *, vision: bool, gguf_file: str | None
+) -> PipelineShardMetadata:
+    card = ModelCard(
+        model_id=ModelId("org/model"),
+        storage_size=Memory.from_gb(1.0),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        gguf_file=gguf_file,
+        vision=VisionCardConfig() if vision else None,
+    )
+    return PipelineShardMetadata(
+        model_card=card,
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=1,
+        n_layers=1,
+    )
+
+
+def _write(directory: Path, *names: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (directory / name).write_text("x")
+    return directory
+
+
+def test_gguf_vision_without_projector_is_flagged(tmp_path: Path) -> None:
+    staged = _write(tmp_path, "model-Q4_K_M.gguf", "config.json")
+    shard = _shard(vision=True, gguf_file="model-Q4_K_M.gguf")
+    assert _staged_vision_projector_missing(shard, staged) is True
+
+
+def test_gguf_vision_with_projector_is_complete(tmp_path: Path) -> None:
+    staged = _write(tmp_path, "model-Q4_K_M.gguf", "mmproj-F16.gguf", "config.json")
+    shard = _shard(vision=True, gguf_file="model-Q4_K_M.gguf")
+    assert _staged_vision_projector_missing(shard, staged) is False
+
+
+def test_mlx_vision_without_projector_is_not_flagged(tmp_path: Path) -> None:
+    # An MLX vision model has no GGUF projector; it must not be flagged, or the
+    # staged-cache fast path is wrongly disabled for it.
+    staged = _write(tmp_path, "model.safetensors", "config.json")
+    shard = _shard(vision=True, gguf_file=None)
+    assert _staged_vision_projector_missing(shard, staged) is False
+
+
+def test_non_vision_gguf_is_not_flagged(tmp_path: Path) -> None:
+    staged = _write(tmp_path, "model-Q4_K_M.gguf", "config.json")
+    shard = _shard(vision=False, gguf_file="model-Q4_K_M.gguf")
+    assert _staged_vision_projector_missing(shard, staged) is False

--- a/src/skulk/store/tests/test_store_gguf_selection.py
+++ b/src/skulk/store/tests/test_store_gguf_selection.py
@@ -81,7 +81,10 @@ def test_has_gguf_projector_detects_mmproj() -> None:
     # and (b) verify the projector actually landed before registering (#346).
     assert has_gguf_projector(["model-Q4_K_M.gguf", "mmproj-F16.gguf"]) is True
     assert has_gguf_projector(["nested/mmproj-model-f16.gguf"]) is True
-    assert has_gguf_projector(["MMPROJ-F32.GGUF"]) is True  # case-insensitive
+    # Name is case-insensitive; the .gguf extension follows the HF convention
+    # (and the resolver/runner): lowercase extension required.
+    assert has_gguf_projector(["MMPROJ-F16.gguf"]) is True
+    assert has_gguf_projector(["mmproj-F32.GGUF"]) is False  # uppercase ext
 
 
 def test_has_gguf_projector_false_without_projector() -> None:
@@ -92,17 +95,18 @@ def test_has_gguf_projector_false_without_projector() -> None:
     assert has_gguf_projector([]) is False
 
 
-def test_uppercase_projector_is_kept_matching_case_insensitive_detection() -> None:
-    # has_gguf_projector is case-insensitive, so the selection must keep an
-    # uppercase projector too -- otherwise it would be detected-as-vision but
-    # never selected, and the registration guard would fail every retry.
+def test_mixed_case_projector_name_is_kept() -> None:
+    # The projector NAME is matched case-insensitively (matching the card
+    # resolver and the runner's find_mmproj_file), so an uppercase-named
+    # projector with the conventional lowercase .gguf extension is still kept and
+    # selected -- detection and selection stay aligned.
     files = [
         _entry("config.json"),
         _entry("model-Q4_K_M.gguf", 800),
-        _entry("MMPROJ-F32.GGUF", 600),
+        _entry("MMPROJ-F16.gguf", 600),
     ]
     kept = {e.path for e in select_store_gguf_download_files(files)}
-    assert kept == {"config.json", "model-Q4_K_M.gguf", "MMPROJ-F32.GGUF"}
+    assert kept == {"config.json", "model-Q4_K_M.gguf", "MMPROJ-F16.gguf"}
 
 
 def test_non_gguf_repo_unchanged() -> None:

--- a/src/skulk/store/tests/test_store_gguf_selection.py
+++ b/src/skulk/store/tests/test_store_gguf_selection.py
@@ -92,6 +92,19 @@ def test_has_gguf_projector_false_without_projector() -> None:
     assert has_gguf_projector([]) is False
 
 
+def test_uppercase_projector_is_kept_matching_case_insensitive_detection() -> None:
+    # has_gguf_projector is case-insensitive, so the selection must keep an
+    # uppercase projector too -- otherwise it would be detected-as-vision but
+    # never selected, and the registration guard would fail every retry.
+    files = [
+        _entry("config.json"),
+        _entry("model-Q4_K_M.gguf", 800),
+        _entry("MMPROJ-F32.GGUF", 600),
+    ]
+    kept = {e.path for e in select_store_gguf_download_files(files)}
+    assert kept == {"config.json", "model-Q4_K_M.gguf", "MMPROJ-F32.GGUF"}
+
+
 def test_non_gguf_repo_unchanged() -> None:
     files = [
         _entry("config.json"),

--- a/src/skulk/store/tests/test_store_gguf_selection.py
+++ b/src/skulk/store/tests/test_store_gguf_selection.py
@@ -87,6 +87,13 @@ def test_has_gguf_projector_detects_mmproj() -> None:
     assert has_gguf_projector(["mmproj-F32.GGUF"]) is False  # uppercase ext
 
 
+def test_has_gguf_projector_matches_basename_not_directory() -> None:
+    # Matches the runner's find_mmproj_file (basename), so a non-projector GGUF
+    # under a directory whose name contains "mmproj" is NOT a false positive.
+    assert has_gguf_projector(["mmproj-tools/model.gguf"]) is False
+    assert has_gguf_projector(["sub/mmproj-f16.gguf"]) is True
+
+
 def test_has_gguf_projector_false_without_projector() -> None:
     # A text-only GGUF set has no projector; an mmproj-named non-gguf file does
     # not count (the projector is always a .gguf).

--- a/src/skulk/store/tests/test_store_gguf_selection.py
+++ b/src/skulk/store/tests/test_store_gguf_selection.py
@@ -7,7 +7,10 @@ not ``original/*`` full-precision weights, not ``metal/*`` artifacts).
 """
 
 from skulk.shared.types.worker.downloads import FileListEntry
-from skulk.store.model_store import select_store_gguf_download_files
+from skulk.store.model_store import (
+    has_gguf_projector,
+    select_store_gguf_download_files,
+)
 
 
 def _entry(path: str, size: int = 100) -> FileListEntry:
@@ -71,6 +74,22 @@ def test_mmproj_projector_is_kept_for_vision_models() -> None:
     ]
     kept = {e.path for e in select_store_gguf_download_files(files)}
     assert kept == {"config.json", "model-Q4_K_M.gguf", "mmproj-model-f16.gguf"}
+
+
+def test_has_gguf_projector_detects_mmproj() -> None:
+    # The store uses this to (a) detect a vision GGUF from its full repo listing
+    # and (b) verify the projector actually landed before registering (#346).
+    assert has_gguf_projector(["model-Q4_K_M.gguf", "mmproj-F16.gguf"]) is True
+    assert has_gguf_projector(["nested/mmproj-model-f16.gguf"]) is True
+    assert has_gguf_projector(["MMPROJ-F32.GGUF"]) is True  # case-insensitive
+
+
+def test_has_gguf_projector_false_without_projector() -> None:
+    # A text-only GGUF set has no projector; an mmproj-named non-gguf file does
+    # not count (the projector is always a .gguf).
+    assert has_gguf_projector(["model-Q4_K_M.gguf", "config.json"]) is False
+    assert has_gguf_projector(["mmproj-notes.txt"]) is False
+    assert has_gguf_projector([]) is False
 
 
 def test_non_gguf_repo_unchanged() -> None:

--- a/src/skulk/store/tests/test_vision_entry_projector.py
+++ b/src/skulk/store/tests/test_vision_entry_projector.py
@@ -1,0 +1,72 @@
+"""Store-side stale-vision detection via the registered projector flag (#346).
+
+``vision_entry_missing_projector`` decides whether an in-store GGUF entry is a
+vision model missing its projector. The registration guard records whether the
+upstream repo ships a projector, so the steady-state answer is local (no HF
+probe on the store-availability hot path); only legacy entries (flag ``None``)
+fall back to a probe.
+"""
+
+from pathlib import Path
+
+from skulk.store.model_store import ModelStore
+
+
+def _register(
+    store: ModelStore,
+    model_id: str,
+    files: list[str],
+    repo_has_projector: bool | None,
+) -> None:
+    model_dir = store.store_path / model_id.replace("/", "--")
+    model_dir.mkdir(parents=True, exist_ok=True)
+    for name in files:
+        (model_dir / name).write_text("x")
+    store.register_model(
+        model_id, model_dir, files, 1, repo_has_projector=repo_has_projector
+    )
+
+
+async def test_flagged_vision_entry_without_projector_is_stale(tmp_path: Path) -> None:
+    store = ModelStore(tmp_path)
+    _register(
+        store, "org/vlm", ["model-Q4_K_M.gguf", "config.json"], repo_has_projector=True
+    )
+    assert await store.vision_entry_missing_projector("org/vlm") is True
+
+
+async def test_flagged_text_entry_is_not_stale_without_hf(tmp_path: Path) -> None:
+    store = ModelStore(tmp_path)
+    _register(
+        store, "org/text", ["model-Q4_K_M.gguf", "config.json"], repo_has_projector=False
+    )
+    assert await store.vision_entry_missing_projector("org/text") is False
+
+
+async def test_entry_with_projector_is_complete(tmp_path: Path) -> None:
+    store = ModelStore(tmp_path)
+    _register(
+        store,
+        "org/vlm",
+        ["model-Q4_K_M.gguf", "mmproj-F16.gguf", "config.json"],
+        repo_has_projector=True,
+    )
+    assert await store.vision_entry_missing_projector("org/vlm") is False
+
+
+async def test_absent_model_is_not_stale(tmp_path: Path) -> None:
+    store = ModelStore(tmp_path)
+    assert await store.vision_entry_missing_projector("org/missing") is False
+
+
+async def test_legacy_non_gguf_entry_skips_hf_probe(tmp_path: Path) -> None:
+    # Legacy entry (flag None) that is not a GGUF model must short-circuit to
+    # False without any HF probe (an MLX model has no projector to be missing).
+    store = ModelStore(tmp_path)
+    _register(
+        store,
+        "org/mlx",
+        ["model.safetensors", "config.json"],
+        repo_has_projector=None,
+    )
+    assert await store.vision_entry_missing_projector("org/mlx") is False


### PR DESCRIPTION
## What

Found during the v1.3 e2e battery: placing `unsloth/gemma-4-31B-it-GGUF` (a popular Gemma 4 vision VLM) on the AMD node failed with:

> vision model `unsloth/gemma-4-31B-it-GGUF` declares a vision config but no mmproj projector GGUF was found in `.../staging/...`; the projector download may have failed

## Root cause

A vision GGUF ships its multimodal projector as a separate `mmproj-*.gguf` alongside the LM weights; the llama.cpp runner cannot load the model without it. The store staged the 18GB `Q4_K_M` weights + `config.json` from the store host **but not the projector**.

The selective store download (`select_store_gguf_download_files`) *does* retain the projector glob (`gguf_allow_patterns` includes `*mmproj*.gguf`), so a **fresh** download includes it. The failure was a **stale store registry entry** created before that logic (#346) landed — its file list lacks the projector, and `stage_shard` faithfully copies only what the registry lists. The failure surfaced only as a runner crash at load time on a remote node, far from the cause.

## Fix

The store host now detects a vision GGUF from its full repo listing and **verifies the projector actually landed before registering**; if not, it refuses with a clear error instead of registering an unusable vision model. Re-running the download re-fetches the projector (the selective allow-list keeps it), so the error is self-correcting. The failure becomes a loud, fixable download error **on the store host** rather than a confusing crash elsewhere.

- New `has_gguf_projector()` helper (testable) used both to detect a vision repo and to verify completeness.
- Post-download / pre-register guard in `ModelStore._do_download`.

## Scope

Full vision-GGUF *inference* on llama.cpp is the separate fast-follow (#128); this is the prerequisite store-integrity fix so vision GGUFs are never registered incomplete. The pre-existing failure mode was already legible and contained (clean error, no node death) — this makes it impossible to reach from the store path.

## Tests / validation

- `test_store_gguf_selection.py`: added `has_gguf_projector` detection tests; existing `test_mmproj_projector_is_kept_for_vision_models` covers the selection invariant. 13 pass.
- `basedpyright src/skulk/store` 0 errors, `ruff` clean, `nix fmt` clean, em-dash check clean.

## Follow-ups (noted, not in this PR)

- **#128**: vision-GGUF inference + a worker-side stage-completeness self-heal for already-registered stale entries.
- **#388 gap**: this class of failure is a load-time runner crash, not a terminal `DownloadFailed`, so the new node-health badge does not surface it — worth flagging "ready-but-crash-looping" nodes.
- Operationally re-register `gemma-4-31B` in the live store so its entry includes the projector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)