### PR TITLE
fix(llama.cpp): fail loud when logprobs requested without logits_all (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **A logprobs request to a llama.cpp node without `logits_all` now fails with a
+  clear error instead of silently returning none (#385).** Per-token logprobs on
+  the llama.cpp engine require loading the model with `logits_all=True`, which is
+  off by default because it pre-allocates a large logits buffer; a request asking
+  for `logprobs`/`top_logprobs` against a node that did not enable it used to
+  "succeed" with empty logprobs. The runner now refuses such a request with an
+  actionable message naming `SKULK_LLAMA_CPP_LOGITS_ALL=1` (delivered to the
+  client as an error chunk), so the limitation is legible rather than silent.
+  Enabling logprobs remains opt-in per node (`SKULK_LLAMA_CPP_LOGITS_ALL=1`,
+  buffer bounded by `SKULK_LLAMA_CPP_LOGITS_ALL_N_CTX`).
+
 - **The model store no longer registers a vision GGUF without its projector.**
   A vision GGUF (LLaVA/Qwen-VL/Gemma-VLM style) ships its multimodal projector
   as a separate `mmproj` file; without it the llama.cpp runner cannot load the

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -199,6 +199,17 @@ async def chat_request_to_text_generation(
         capability_profile,
     )
 
+    # Resolve the logprobs request at the boundary so every engine sees one
+    # consistent flag (#385). An explicit `logprobs` (true or false) is honored
+    # as-is; only when it is unset is it inferred from `top_logprobs` (which
+    # OpenAI treats as a logprobs request). When logprobs ends up off, drop
+    # `top_logprobs` too so a downstream completeness check cannot re-infer it.
+    logprobs_on = (
+        request.logprobs
+        if request.logprobs is not None
+        else request.top_logprobs is not None
+    )
+
     return TextGenerationTaskParams(
         model=request.model,
         input=input_messages
@@ -218,11 +229,8 @@ async def chat_request_to_text_generation(
         chat_template_messages=chat_template_messages
         if chat_template_messages
         else None,
-        # `top_logprobs` set alone implies a logprobs request (OpenAI semantics).
-        # Normalize it here, at the boundary, so every engine sees a consistent
-        # `logprobs` flag rather than each runner re-deriving it (#385).
-        logprobs=bool(request.logprobs) or request.top_logprobs is not None,
-        top_logprobs=request.top_logprobs,
+        logprobs=logprobs_on,
+        top_logprobs=request.top_logprobs if logprobs_on else None,
         min_p=request.min_p,
         repetition_penalty=request.repetition_penalty,
         repetition_context_size=request.repetition_context_size,

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -218,7 +218,10 @@ async def chat_request_to_text_generation(
         chat_template_messages=chat_template_messages
         if chat_template_messages
         else None,
-        logprobs=request.logprobs or False,
+        # `top_logprobs` set alone implies a logprobs request (OpenAI semantics).
+        # Normalize it here, at the boundary, so every engine sees a consistent
+        # `logprobs` flag rather than each runner re-deriving it (#385).
+        logprobs=bool(request.logprobs) or request.top_logprobs is not None,
         top_logprobs=request.top_logprobs,
         min_p=request.min_p,
         repetition_penalty=request.repetition_penalty,

--- a/src/skulk/api/adapters/tests/test_chat_logprobs_normalization.py
+++ b/src/skulk/api/adapters/tests/test_chat_logprobs_normalization.py
@@ -1,0 +1,37 @@
+"""top_logprobs implies logprobs at the chat-completions boundary (#385).
+
+A client may signal a logprobs request with `logprobs=true` or by setting
+`top_logprobs` alone (OpenAI semantics). Normalizing it once at the adapter
+boundary keeps every engine consistent rather than each runner re-deriving it.
+"""
+
+from skulk.api.adapters.chat_completions import chat_request_to_text_generation
+from skulk.api.types.api import ChatCompletionMessage, ChatCompletionRequest
+from skulk.shared.types.common import ModelId
+
+
+def _request(**kwargs: object) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model=ModelId("org/model"),
+        messages=[ChatCompletionMessage(role="user", content="hi")],
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+async def test_top_logprobs_alone_sets_logprobs() -> None:
+    params = await chat_request_to_text_generation(_request(top_logprobs=5))
+    assert params.logprobs is True
+    assert params.top_logprobs == 5
+
+
+async def test_explicit_logprobs_preserved() -> None:
+    params = await chat_request_to_text_generation(
+        _request(logprobs=True, top_logprobs=3)
+    )
+    assert params.logprobs is True and params.top_logprobs == 3
+
+
+async def test_no_logprobs_request_stays_off() -> None:
+    params = await chat_request_to_text_generation(_request())
+    assert params.logprobs is False
+    assert params.top_logprobs is None

--- a/src/skulk/api/adapters/tests/test_chat_logprobs_normalization.py
+++ b/src/skulk/api/adapters/tests/test_chat_logprobs_normalization.py
@@ -31,6 +31,16 @@ async def test_explicit_logprobs_preserved() -> None:
     assert params.logprobs is True and params.top_logprobs == 3
 
 
+async def test_explicit_logprobs_false_is_honored_over_top_logprobs() -> None:
+    # An explicit opt-out wins over top_logprobs; top_logprobs is dropped so a
+    # downstream completeness check cannot re-infer a logprobs request.
+    params = await chat_request_to_text_generation(
+        _request(logprobs=False, top_logprobs=5)
+    )
+    assert params.logprobs is False
+    assert params.top_logprobs is None
+
+
 async def test_no_logprobs_request_stays_off() -> None:
     params = await chat_request_to_text_generation(_request())
     assert params.logprobs is False

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -265,7 +265,10 @@ def _generation_kwargs(task_params: TextGenerationTaskParams) -> dict[str, Any]:
         kwargs["stop"] = task_params.stop
     if task_params.seed is not None:
         kwargs["seed"] = task_params.seed
-    if task_params.logprobs:
+    # `top_logprobs` set alone implies a logprobs request (OpenAI semantics), so
+    # enable logprobs for either signal, otherwise a top_logprobs-only request
+    # would return none even on a logits_all-enabled node.
+    if wants_logprobs(task_params.logprobs, task_params.top_logprobs):
         kwargs["logprobs"] = True
         if task_params.top_logprobs is not None:
             kwargs["top_logprobs"] = task_params.top_logprobs

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -346,6 +346,28 @@ def _logits_all_enabled() -> bool:
     )
 
 
+def logprobs_unavailable_error(
+    want_logprobs: bool, logits_all_on: bool
+) -> str | None:
+    """Clear error message when logprobs are requested but cannot be produced.
+
+    Returns the message to fail the request with when a client asked for
+    per-token logprobs but the runner loaded the model without ``logits_all``
+    (the default), or ``None`` when the request can proceed. Surfacing this as a
+    clear error (#385) avoids silently returning a stream with empty logprobs.
+    """
+    if want_logprobs and not logits_all_on:
+        return (
+            "Per-token logprobs are unavailable on this llama.cpp node: they "
+            "require loading the model with logits_all=True (a large "
+            "pre-allocated logits buffer), which is off by default. Set "
+            "SKULK_LLAMA_CPP_LOGITS_ALL=1 on the serving node to enable them "
+            "(and optionally bound the buffer with "
+            "SKULK_LLAMA_CPP_LOGITS_ALL_N_CTX)."
+        )
+    return None
+
+
 def _logits_all_n_ctx() -> int:
     """Context cap (tokens) to use when ``logits_all`` is on, to bound the buffer.
 
@@ -619,6 +641,19 @@ class Runner:
         kwargs = _generation_kwargs(task.task_params)
 
         try:
+            # Fail loud when logprobs are requested but the model was not loaded
+            # with logits_all (#385): llama-cpp-python gates ALL logprobs behind
+            # logits_all=True at construction, which the runner leaves off by
+            # default because the pre-allocated logits buffer is huge. Without
+            # this guard the request would "succeed" with silently-empty
+            # logprobs; instead surface a clear, actionable error (it propagates
+            # to the client as an ErrorChunk via the handler below).
+            logprobs_error = logprobs_unavailable_error(
+                task.task_params.logprobs, _logits_all_enabled()
+            )
+            if logprobs_error is not None:
+                raise RuntimeError(logprobs_error)
+
             # Tool calling can't be streamed token-by-token usefully (the caller
             # wants the assembled call), and accumulating OpenAI tool-call deltas
             # is fragile; run it non-streamed and emit one ToolCallChunk.

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -346,17 +346,28 @@ def _logits_all_enabled() -> bool:
     )
 
 
+def wants_logprobs(logprobs: bool, top_logprobs: int | None) -> bool:
+    """Whether a request is asking for per-token logprobs.
+
+    A client may signal it either with ``logprobs=true`` or by setting
+    ``top_logprobs`` alone (OpenAI treats the latter as a logprobs request), so
+    either implies logprobs are wanted.
+    """
+    return logprobs or top_logprobs is not None
+
+
 def logprobs_unavailable_error(
-    want_logprobs: bool, logits_all_on: bool
+    logprobs: bool, top_logprobs: int | None, logits_all_on: bool
 ) -> str | None:
     """Clear error message when logprobs are requested but cannot be produced.
 
     Returns the message to fail the request with when a client asked for
-    per-token logprobs but the runner loaded the model without ``logits_all``
-    (the default), or ``None`` when the request can proceed. Surfacing this as a
-    clear error (#385) avoids silently returning a stream with empty logprobs.
+    per-token logprobs (via ``logprobs`` or ``top_logprobs``) but the runner
+    loaded the model without ``logits_all`` (the default), or ``None`` when the
+    request can proceed. Surfacing this as a clear error (#385) avoids silently
+    returning a stream with empty logprobs.
     """
-    if want_logprobs and not logits_all_on:
+    if wants_logprobs(logprobs, top_logprobs) and not logits_all_on:
         return (
             "Per-token logprobs are unavailable on this llama.cpp node: they "
             "require loading the model with logits_all=True (a large "
@@ -640,6 +651,10 @@ class Runner:
         messages = messages_for_llama(task.task_params)
         kwargs = _generation_kwargs(task.task_params)
 
+        want_logprobs = wants_logprobs(
+            task.task_params.logprobs, task.task_params.top_logprobs
+        )
+
         try:
             # Fail loud when logprobs are requested but the model was not loaded
             # with logits_all (#385): llama-cpp-python gates ALL logprobs behind
@@ -649,7 +664,9 @@ class Runner:
             # logprobs; instead surface a clear, actionable error (it propagates
             # to the client as an ErrorChunk via the handler below).
             logprobs_error = logprobs_unavailable_error(
-                task.task_params.logprobs, _logits_all_enabled()
+                task.task_params.logprobs,
+                task.task_params.top_logprobs,
+                _logits_all_enabled(),
             )
             if logprobs_error is not None:
                 raise RuntimeError(logprobs_error)
@@ -662,7 +679,6 @@ class Runner:
                 self.current_status = RunnerReady()
                 return
 
-            want_logprobs = task.task_params.logprobs
             stream = self.model.create_chat_completion(
                 messages=messages, stream=True, **kwargs
             )

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
@@ -21,9 +21,25 @@ from skulk.worker.runner.llama_cpp.runner import (
     _splice_images_into_messages,
     _tool_calls_from_message,
     find_mmproj_file,
+    logprobs_unavailable_error,
     messages_for_llama,
     select_gguf_file,
 )
+
+
+def test_logprobs_request_without_logits_all_returns_clear_error() -> None:
+    msg = logprobs_unavailable_error(want_logprobs=True, logits_all_on=False)
+    assert msg is not None
+    assert "SKULK_LLAMA_CPP_LOGITS_ALL=1" in msg
+
+
+def test_logprobs_request_with_logits_all_proceeds() -> None:
+    assert logprobs_unavailable_error(want_logprobs=True, logits_all_on=True) is None
+
+
+def test_no_logprobs_request_never_errors() -> None:
+    assert logprobs_unavailable_error(want_logprobs=False, logits_all_on=False) is None
+    assert logprobs_unavailable_error(want_logprobs=False, logits_all_on=True) is None
 
 
 def test_select_gguf_picks_first_shard_skips_mmproj(tmp_path: Path) -> None:

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
@@ -127,6 +127,10 @@ def test_generation_kwargs_passes_logprobs() -> None:
     # logprobs requested without a top-N: flag on, no top_logprobs key
     kw2 = _generation_kwargs(_params(logprobs=True))
     assert kw2["logprobs"] is True and "top_logprobs" not in kw2
+    # top_logprobs set alone implies logprobs (OpenAI semantics): flag on too,
+    # so the model actually returns logprobs instead of silently none.
+    kw3 = _generation_kwargs(_params(top_logprobs=5))
+    assert kw3["logprobs"] is True and kw3["top_logprobs"] == 5
 
 
 def test_logits_all_enabled(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
@@ -28,18 +28,39 @@ from skulk.worker.runner.llama_cpp.runner import (
 
 
 def test_logprobs_request_without_logits_all_returns_clear_error() -> None:
-    msg = logprobs_unavailable_error(want_logprobs=True, logits_all_on=False)
+    msg = logprobs_unavailable_error(
+        logprobs=True, top_logprobs=None, logits_all_on=False
+    )
+    assert msg is not None
+    assert "SKULK_LLAMA_CPP_LOGITS_ALL=1" in msg
+
+
+def test_top_logprobs_alone_is_treated_as_a_logprobs_request() -> None:
+    # OpenAI treats top_logprobs (with logprobs unset) as a logprobs request, so
+    # it must also trip the guard rather than silently returning none.
+    msg = logprobs_unavailable_error(
+        logprobs=False, top_logprobs=5, logits_all_on=False
+    )
     assert msg is not None
     assert "SKULK_LLAMA_CPP_LOGITS_ALL=1" in msg
 
 
 def test_logprobs_request_with_logits_all_proceeds() -> None:
-    assert logprobs_unavailable_error(want_logprobs=True, logits_all_on=True) is None
+    assert (
+        logprobs_unavailable_error(logprobs=True, top_logprobs=5, logits_all_on=True)
+        is None
+    )
 
 
 def test_no_logprobs_request_never_errors() -> None:
-    assert logprobs_unavailable_error(want_logprobs=False, logits_all_on=False) is None
-    assert logprobs_unavailable_error(want_logprobs=False, logits_all_on=True) is None
+    assert (
+        logprobs_unavailable_error(logprobs=False, top_logprobs=None, logits_all_on=False)
+        is None
+    )
+    assert (
+        logprobs_unavailable_error(logprobs=False, top_logprobs=None, logits_all_on=True)
+        is None
+    )
 
 
 def test_select_gguf_picks_first_shard_skips_mmproj(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #385.

## Problem

Per-token logprobs on the llama.cpp/GGUF engine require loading the model with `logits_all=True`, which the runner leaves **off by default** (it pre-allocates an `n_ctx × vocab × 4` logits buffer — ~5 GiB even at an 8k cap, ~74 GiB at full context). A request asking for `logprobs`/`top_logprobs` against a node without it enabled used to **"succeed" with silently-empty logprobs**: the runner set `logprobs=True` on the call regardless, llama.cpp returned none, and `_logprob_fields` yielded `(None, None)`. The whole GGUF leg of the e2e battery failed `logprobs-parity` this way.

## Fix (fail loud, don't enable)

Enabling logprobs is an expensive, deliberate per-node opt-in — not something to force on. The right fix is to make the limitation **legible** instead of silent: the runner now refuses a logprobs request when `logits_all` is off, with an actionable message naming `SKULK_LLAMA_CPP_LOGITS_ALL=1`, delivered to the client as an error chunk via the existing `_generate` exception handler (so it's a clean per-request error, not a runner crash).

- Extracted `logprobs_unavailable_error(want_logprobs, logits_all_on) -> str | None` as a pure, tested helper; the guard runs before both the streaming and tool-call paths.
- Enabling logprobs stays opt-in per node (`SKULK_LLAMA_CPP_LOGITS_ALL=1`, buffer bounded by `SKULK_LLAMA_CPP_LOGITS_ALL_N_CTX`).

## Why not just enable logprobs?

`logits_all` is set at model construction (can't toggle per request) and pre-allocates the logits buffer for *every* load, even for the 99% of requests that never ask for logprobs. Logprobs are a specialist feature (eval harnesses, classification-by-logprob, confidence UIs) — Skulk's own serving and speculative decoding don't use the API logprobs path. So the memory tax isn't worth defaulting on; loud-fail + opt-in is the correct posture.

## Docs

The env flags were already documented and **already described this loud-failure behavior** (`architecture-reference.md` `SKULK_LLAMA_CPP_LOGITS_ALL` row: "degrades to a clear error chunk"; `amd-strix-halo-nodes.md`: "returns a clear error rather than silently omitting them"). This change makes the code match the docs — no doc change needed.

## Tests / validation

- `test_llama_cpp_helpers.py`: added 3 tests for `logprobs_unavailable_error` (errors when requested+off, proceeds when on, never errors when not requested). 28 llama.cpp helper tests pass.
- basedpyright 0 errors, ruff clean, nix fmt clean, em-dash check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)