### PR TITLE
fix(store): advertise a routable IP, not a hostname/link-local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- **The model store now advertises a routable IP, so downloads no longer fail
+  on Thunderbolt-meshed fleets.** The store host broadcast its `store_http_host`
+  as a bare hostname (e.g. `kite3.local`); on a fleet where nodes are also linked
+  over Thunderbolt, mDNS could resolve that name to the host's link-local TB
+  address (`169.254.x`), which a peer lacking a direct TB link to it cannot route
+  to. That peer's model downloads then failed (`Cannot connect to host
+  kite3.local:58080`) even though it could reach the store fine over the LAN. The
+  store host now broadcasts its own best routable IPv4 (a private LAN address is
+  preferred over a Tailscale/CGNAT address; loopback and link-local are skipped),
+  and an operator-supplied routable IP in `store_http_host` is still honored
+  verbatim.
+
 ### Changed
 
 - **The llama.cpp engine now loads models with Flash Attention by default.** It

--- a/src/skulk/main.py
+++ b/src/skulk/main.py
@@ -9,7 +9,7 @@ import socket
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Self
+from typing import Final, Self
 
 import anyio
 import psutil
@@ -192,6 +192,32 @@ def _add_model_search_path(path: Path) -> None:
     add_model_search_path(expanded)
 
 
+_VIRTUAL_IFACE_PREFIXES: Final = (
+    "docker",
+    "br-",
+    "virbr",
+    "vmnet",
+    "vboxnet",
+    "veth",
+    "cni",
+    "flannel",
+    "kube",
+)
+
+
+def _is_virtual_iface(name: str) -> bool:
+    """Whether an interface name looks like a Docker/VM/container bridge.
+
+    These carry RFC1918 addresses (e.g. Docker's ``172.17.0.1``) that are not
+    reachable from peers on the real LAN, so they must not be advertised as the
+    store host. VPN tunnels (Tailscale ``utun``/``tailscale0``) are deliberately
+    NOT excluded: they are a valid fallback path and are already ranked below the
+    LAN address.
+    """
+    lowered = name.lower()
+    return lowered.startswith(_VIRTUAL_IFACE_PREFIXES)
+
+
 def _routable_store_advertise_host(configured: str | None, hostname_fallback: str) -> str:
     """Pick an address other nodes can actually reach the model store host at.
 
@@ -212,13 +238,25 @@ def _routable_store_advertise_host(configured: str | None, hostname_fallback: st
             literal = ipaddress.ip_address(configured)
         except ValueError:
             literal = None  # a hostname, not an IP -> recompute below
-        if literal is not None and not (
-            literal.is_loopback or literal.is_link_local or literal.is_unspecified
+        # Honor only a routable IPv4 literal: the store URL is built as
+        # http://{host}:{port} with no IPv6-bracket handling, so an IPv6 literal
+        # would produce an invalid URL -> treat it like a hostname and recompute.
+        if (
+            literal is not None
+            and literal.version == 4
+            and not (
+                literal.is_loopback or literal.is_link_local or literal.is_unspecified
+            )
         ):
             return configured
 
     routable: list[str] = []
-    for addresses in psutil.net_if_addrs().values():
+    for iface_name, addresses in psutil.net_if_addrs().items():
+        # Skip virtual bridge / container interfaces (docker0, br-*, virbr*,
+        # vmnet*, vboxnet*, veth*, k8s): they carry RFC1918 IPs that peers on the
+        # real LAN cannot route to and could otherwise outrank the LAN address.
+        if _is_virtual_iface(iface_name):
+            continue
         for address in addresses:
             if address.family != socket.AF_INET:
                 continue
@@ -680,8 +718,14 @@ class Node:
     async def _broadcast_config_if_store_host(self) -> None:
         """If this node is the store host, broadcast a valid config to all nodes.
 
-        Fixes up ``store_http_host`` so that worker nodes receive a reachable
-        address (the store host's hostname) rather than ``127.0.0.1`` or None.
+        Resolves ``store_http_host`` to a routable IPv4 (see
+        ``_routable_store_advertise_host``) so worker nodes receive an address
+        they can actually reach over HTTP, rather than a hostname that may
+        mDNS-resolve to an unreachable link-local address, ``127.0.0.1``, or
+        None. The resolved IP is broadcast to the cluster, but the **local**
+        config keeps the operator's original ``store_http_host`` so the host
+        re-resolves a fresh IP on every restart (a persisted IP would freeze a
+        stale address after a DHCP/interface change).
         """
         if self.skulk_config is None or self.skulk_config.model_store is None:
             return
@@ -706,25 +750,27 @@ class Node:
             ms.store_http_host, local_hostname
         )
 
-        config_dict = self.skulk_config.model_dump()
-        config_dict["model_store"]["store_http_host"] = reachable_host
+        import copy
 
         import yaml
 
+        config_dict = self.skulk_config.model_dump()
+
+        # Persist the local config with the operator's ORIGINAL store_http_host
+        # (a hostname / None), not the resolved IP, so the host re-resolves a
+        # fresh routable IP on the next restart instead of honoring a frozen,
+        # possibly stale address.
         config_yaml = yaml.safe_dump(
             config_dict, default_flow_style=False, sort_keys=False
         )
-
-        # Also update local config file with the fixed host
         try:
             resolve_config_path().write_text(config_yaml)
         except Exception as exc:
             logger.warning(f"Failed to update local config: {exc}")
 
-        # Strip secrets before broadcasting over gossipsub
-        import copy
-
+        # Broadcast the resolved reachable host to the cluster (secrets stripped).
         broadcast_dict = copy.deepcopy(config_dict)
+        broadcast_dict["model_store"]["store_http_host"] = reachable_host
         broadcast_dict.pop("hf_token", None)
         broadcast_yaml = yaml.safe_dump(
             broadcast_dict, default_flow_style=False, sort_keys=False

--- a/src/skulk/main.py
+++ b/src/skulk/main.py
@@ -722,10 +722,14 @@ class Node:
         ``_routable_store_advertise_host``) so worker nodes receive an address
         they can actually reach over HTTP, rather than a hostname that may
         mDNS-resolve to an unreachable link-local address, ``127.0.0.1``, or
-        None. The resolved IP is broadcast to the cluster, but the **local**
-        config keeps the operator's original ``store_http_host`` so the host
-        re-resolves a fresh IP on every restart (a persisted IP would freeze a
-        stale address after a DHCP/interface change).
+        None. An operator-supplied routable IPv4 literal is honored as-is;
+        otherwise this host's best routable LAN address is used.
+
+        The resolved address is broadcast over the cluster config-sync path,
+        which every node (including this store host, via local delivery) applies
+        and persists. We therefore do not separately write the local config file
+        here: a second write would only be clobbered by the host applying its
+        own broadcast.
         """
         if self.skulk_config is None or self.skulk_config.model_store is None:
             return
@@ -754,22 +758,11 @@ class Node:
 
         import yaml
 
-        config_dict = self.skulk_config.model_dump()
-
-        # Persist the local config with the operator's ORIGINAL store_http_host
-        # (a hostname / None), not the resolved IP, so the host re-resolves a
-        # fresh routable IP on the next restart instead of honoring a frozen,
-        # possibly stale address.
-        config_yaml = yaml.safe_dump(
-            config_dict, default_flow_style=False, sort_keys=False
-        )
-        try:
-            resolve_config_path().write_text(config_yaml)
-        except Exception as exc:
-            logger.warning(f"Failed to update local config: {exc}")
-
         # Broadcast the resolved reachable host to the cluster (secrets stripped).
-        broadcast_dict = copy.deepcopy(config_dict)
+        # The store host applies its own broadcast via local delivery and persists
+        # it through the normal config-sync path, so there is no separate local
+        # write here (it would only be clobbered by that same broadcast).
+        broadcast_dict = copy.deepcopy(self.skulk_config.model_dump())
         broadcast_dict["model_store"]["store_http_host"] = reachable_host
         broadcast_dict.pop("hf_token", None)
         broadcast_yaml = yaml.safe_dump(

--- a/src/skulk/main.py
+++ b/src/skulk/main.py
@@ -1,5 +1,6 @@
 import argparse
 import hashlib
+import ipaddress
 import multiprocessing as mp
 import os
 import resource
@@ -11,6 +12,7 @@ from pathlib import Path
 from typing import Self
 
 import anyio
+import psutil
 from loguru import logger
 from pydantic import PositiveInt
 
@@ -188,6 +190,67 @@ def _add_model_search_path(path: Path) -> None:
     from skulk.shared.constants import add_model_search_path
 
     add_model_search_path(expanded)
+
+
+def _routable_store_advertise_host(configured: str | None, hostname_fallback: str) -> str:
+    """Pick an address other nodes can actually reach the model store host at.
+
+    The store host broadcasts this as ``store_http_host`` so workers build the
+    download URL ``http://<host>:<port>``. A bare hostname (``kite3.local``) is
+    fragile on a Thunderbolt-meshed fleet: mDNS can resolve it to the host's
+    link-local TB address (``169.254.x``), which a peer lacking a direct TB link
+    cannot route to, so its downloads fail while the LAN path works fine.
+
+    An operator-supplied **routable IP literal** is honored as-is. Anything else
+    (a hostname, or a loopback/link-local literal) is replaced with this host's
+    own best routable IPv4: a private LAN address (RFC1918) is preferred over any
+    other routable address, and loopback / link-local / unspecified addresses are
+    skipped. Falls back to the hostname only when no routable IPv4 is found.
+    """
+    if configured:
+        try:
+            literal = ipaddress.ip_address(configured)
+        except ValueError:
+            literal = None  # a hostname, not an IP -> recompute below
+        if literal is not None and not (
+            literal.is_loopback or literal.is_link_local or literal.is_unspecified
+        ):
+            return configured
+
+    routable: list[str] = []
+    for addresses in psutil.net_if_addrs().values():
+        for address in addresses:
+            if address.family != socket.AF_INET:
+                continue
+            try:
+                ip = ipaddress.ip_address(address.address)
+            except ValueError:
+                continue
+            if ip.is_loopback or ip.is_link_local or ip.is_unspecified:
+                continue
+            routable.append(address.address)
+
+    # Prefer an RFC1918 LAN address (fast, reachable across the local switch)
+    # over a Tailscale/CGNAT (100.64.0.0/10) address over anything else; all beat
+    # the hostname fallback. CGNAT is also "private", so rank the ranges
+    # explicitly rather than relying on ``is_private``.
+    lan_nets = (
+        ipaddress.ip_network("10.0.0.0/8"),
+        ipaddress.ip_network("172.16.0.0/12"),
+        ipaddress.ip_network("192.168.0.0/16"),
+    )
+    cgnat_net = ipaddress.ip_network("100.64.0.0/10")
+
+    def _rank(address: str) -> int:
+        ip = ipaddress.ip_address(address)
+        if any(ip in net for net in lan_nets):
+            return 0
+        if ip in cgnat_net:
+            return 1
+        return 2
+
+    routable.sort(key=_rank)
+    return routable[0] if routable else hostname_fallback
 
 
 def _configure_model_store_runtime(
@@ -634,14 +697,14 @@ class Node:
         if not is_store_host:
             return
 
-        # Fix up store_http_host to be reachable by other nodes
-        reachable_host = local_hostname
-        if ms.store_http_host and ms.store_http_host not in (
-            "127.0.0.1",
-            "localhost",
-            "::1",
-        ):
-            reachable_host = ms.store_http_host
+        # Advertise a routable IP, not a hostname. A bare hostname (e.g.
+        # ``kite3.local``) can mDNS-resolve on a Thunderbolt-meshed fleet to the
+        # store host's link-local TB address (169.254.x), which peers without a
+        # direct TB link cannot route to, so their store downloads fail even
+        # though they can reach the host fine over the LAN.
+        reachable_host = _routable_store_advertise_host(
+            ms.store_http_host, local_hostname
+        )
 
         config_dict = self.skulk_config.model_dump()
         config_dict["model_store"]["store_http_host"] = reachable_host

--- a/src/skulk/store/config.py
+++ b/src/skulk/store/config.py
@@ -220,7 +220,12 @@ class ModelStoreConfig(FrozenModel):
             when ``None``.  Set this when ``store_host`` is a libp2p peer
             ID (which is not a valid DNS name) so that workers can still
             resolve the HTTP address (e.g. ``mac-studio-1`` or
-            ``192.168.1.10``).
+            ``192.168.1.10``).  At startup the store host replaces a
+            hostname (or a loopback/link-local literal) here with its own
+            best routable IPv4 before broadcasting it to the cluster, so a
+            bare ``.local`` name cannot resolve to an unreachable Thunderbolt
+            link-local address on peers; a routable IP literal is broadcast
+            verbatim (see ``_routable_store_advertise_host`` in ``main.py``).
         store_port: HTTP port for ``ModelStoreServer`` on the store host.
             Must be reachable from all worker nodes.
         store_path: Absolute path to the model store root on the store host.

--- a/src/skulk/tests/test_store_advertise_host.py
+++ b/src/skulk/tests/test_store_advertise_host.py
@@ -1,0 +1,90 @@
+"""Tests for the model-store advertise-host selection (routable IP, not hostname).
+
+The store host broadcasts ``store_http_host`` for workers to build the download
+URL. A bare hostname can mDNS-resolve to a Thunderbolt link-local address that
+peers without a direct TB link cannot route to, so we advertise a routable IP.
+"""
+
+import socket
+from typing import NamedTuple
+
+import pytest
+
+import skulk.main as main
+
+
+class _FakeAddr(NamedTuple):
+    """Mirror the snicaddr fields the code reads (family, address)."""
+
+    family: int
+    address: str
+
+
+def _ifaddrs(*addresses: str) -> dict[str, list[_FakeAddr]]:
+    """Build a fake ``psutil.net_if_addrs()`` return for the given IPv4 addrs."""
+    return {
+        f"if{i}": [_FakeAddr(family=socket.AF_INET, address=addr)]
+        for i, addr in enumerate(addresses)
+    }
+
+
+def test_explicit_routable_ip_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main.psutil, "net_if_addrs", lambda: _ifaddrs("192.168.0.122"))
+    # An operator-supplied routable IP literal is used verbatim.
+    assert main._routable_store_advertise_host("10.0.0.5", "kite3") == "10.0.0.5"  # pyright: ignore[reportPrivateUsage]
+
+
+def test_hostname_is_replaced_with_routable_lan_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The deployed bug: store_http_host=kite3.local resolves to a TB link-local.
+    monkeypatch.setattr(
+        main.psutil,
+        "net_if_addrs",
+        lambda: _ifaddrs("127.0.0.1", "169.254.201.94", "192.168.0.122"),
+    )
+    assert (
+        main._routable_store_advertise_host("kite3.local", "kite3")  # pyright: ignore[reportPrivateUsage]
+        == "192.168.0.122"
+    )
+
+
+def test_link_local_literal_is_replaced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main.psutil, "net_if_addrs", lambda: _ifaddrs("192.168.0.122"))
+    assert (
+        main._routable_store_advertise_host("169.254.1.1", "kite3")  # pyright: ignore[reportPrivateUsage]
+        == "192.168.0.122"
+    )
+
+
+def test_lan_preferred_over_tailscale(monkeypatch: pytest.MonkeyPatch) -> None:
+    # CGNAT (100.64/10, Tailscale) is also "private"; LAN must still win.
+    monkeypatch.setattr(
+        main.psutil,
+        "net_if_addrs",
+        lambda: _ifaddrs("100.88.129.94", "192.168.0.122"),
+    )
+    assert (
+        main._routable_store_advertise_host(None, "kite3") == "192.168.0.122"  # pyright: ignore[reportPrivateUsage]
+    )
+
+
+def test_tailscale_used_when_no_lan(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        main.psutil,
+        "net_if_addrs",
+        lambda: _ifaddrs("169.254.201.94", "100.88.129.94"),
+    )
+    assert (
+        main._routable_store_advertise_host(None, "kite3") == "100.88.129.94"  # pyright: ignore[reportPrivateUsage]
+    )
+
+
+def test_falls_back_to_hostname_when_no_routable_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Only loopback + link-local present: nothing routable, keep the hostname.
+    monkeypatch.setattr(
+        main.psutil, "net_if_addrs", lambda: _ifaddrs("127.0.0.1", "169.254.201.94")
+    )
+    assert main._routable_store_advertise_host(None, "kite3") == "kite3"  # pyright: ignore[reportPrivateUsage]

--- a/src/skulk/tests/test_store_advertise_host.py
+++ b/src/skulk/tests/test_store_advertise_host.py
@@ -88,3 +88,40 @@ def test_falls_back_to_hostname_when_no_routable_ip(
         main.psutil, "net_if_addrs", lambda: _ifaddrs("127.0.0.1", "169.254.201.94")
     )
     assert main._routable_store_advertise_host(None, "kite3") == "kite3"  # pyright: ignore[reportPrivateUsage]
+
+
+def _ifaddrs_named(pairs: list[tuple[str, str]]) -> dict[str, list[_FakeAddr]]:
+    """Fake ``net_if_addrs()`` with explicit interface names (for iface filtering)."""
+    out: dict[str, list[_FakeAddr]] = {}
+    for name, addr in pairs:
+        out.setdefault(name, []).append(
+            _FakeAddr(family=socket.AF_INET, address=addr)
+        )
+    return out
+
+
+def test_ipv6_literal_is_not_honored_and_recomputes_ipv4(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The store URL is http://{host}:{port} with no IPv6 brackets, so an IPv6
+    # literal must be treated like a hostname and replaced with a routable IPv4.
+    monkeypatch.setattr(main.psutil, "net_if_addrs", lambda: _ifaddrs("192.168.0.122"))
+    assert (
+        main._routable_store_advertise_host("2001:db8::1", "kite3")  # pyright: ignore[reportPrivateUsage]
+        == "192.168.0.122"
+    )
+
+
+def test_docker_bridge_interface_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    # docker0 carries an RFC1918 IP (172.17.x) peers can't route to; the real LAN
+    # address must win even though both rank as private.
+    monkeypatch.setattr(
+        main.psutil,
+        "net_if_addrs",
+        lambda: _ifaddrs_named(
+            [("docker0", "172.17.0.1"), ("eno1", "192.168.0.122")]
+        ),
+    )
+    assert (
+        main._routable_store_advertise_host(None, "kite4") == "192.168.0.122"  # pyright: ignore[reportPrivateUsage]
+    )

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -826,13 +826,7 @@ class Runner:
         gpt-oss variant rather than matching model-id substrings here.
         """
         card = self.shard_metadata.model_card
-        try:
-            profile = resolve_model_capability_profile(card.model_id, model_card=card)
-        except Exception:  # noqa: BLE001 - an unresolvable card is just not gpt-oss
-            # Never crash generation on capability resolution: a card we cannot
-            # resolve is treated as non-harmony (harmony-specific parsing/history
-            # handling is skipped) rather than raising.
-            return False
+        profile = resolve_model_capability_profile(card.model_id, model_card=card)
         return profile.output_parser == OutputParserType.GptOss
 
     def _send_token_chunk(

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -826,7 +826,13 @@ class Runner:
         gpt-oss variant rather than matching model-id substrings here.
         """
         card = self.shard_metadata.model_card
-        profile = resolve_model_capability_profile(card.model_id, model_card=card)
+        try:
+            profile = resolve_model_capability_profile(card.model_id, model_card=card)
+        except Exception:  # noqa: BLE001 - an unresolvable card is just not gpt-oss
+            # Never crash generation on capability resolution: a card we cannot
+            # resolve is treated as non-harmony (harmony-specific parsing/history
+            # handling is skipped) rather than raising.
+            return False
         return profile.output_parser == OutputParserType.GptOss
 
     def _send_token_chunk(


### PR DESCRIPTION
## Problem

A GGUF model a node has to **fetch from the store** can't place if that node can't reach the store host. Concretely on the fleet: kite4 couldn't place gpt-oss-120b —

```
download failed on [kite4] (Cannot connect to host kite3.local:58080 [Connect call failed ('169.254.212.254', 58080)])
```

Root cause: the store host broadcasts `store_http_host` as a **bare hostname** (`kite3.local`). On a Thunderbolt-meshed fleet, mDNS resolves that name to the host's **link-local TB address** (`169.254.x`), which a peer lacking a direct TB link to it can't route to — so its downloads fail even though it reaches the store fine over the LAN. Confirmed live:

```
kite4: kite3.local -> 169.254.201.94 (TB)        -> 100% packet loss
kite4: kite3 LAN 192.168.0.122:58080 -> HTTP 404, 0.3ms   ✅ reachable
```

## Fix

`_broadcast_config_if_store_host` now advertises a **routable IP** via `_routable_store_advertise_host`:
- An operator-supplied **routable IP literal** in `store_http_host` is honored verbatim.
- A **hostname** (or a loopback/link-local literal) is replaced with the store host's own best routable IPv4: a **private LAN (RFC1918)** address is preferred over a **Tailscale/CGNAT (100.64/10)** address; loopback and link-local are skipped. Falls back to the hostname only if no routable IPv4 exists.

So the store host (kite3) will broadcast `192.168.0.122` instead of `kite3.local`, and downloaders reach it over the LAN.

## Tests / docs

6 cases (honor-IP-literal, hostname→LAN, link-local-literal→LAN, LAN-over-Tailscale, Tailscale-when-no-LAN, hostname fallback). CHANGELOG + `store_http_host` config docstring updated. basedpyright 0, ruff clean, nix fmt clean, no em-dashes.

## Deploy note

Takes effect when the **store-host node restarts** and re-broadcasts its config. (This is the "real fix"; it supersedes the per-deploy workaround of hardcoding `store_http_host` to an IP.)

Related: the link-local addressing family also surfaced in #401 (election connection churn).