### PR TITLE
fix(llama.cpp): strip harmony markers from gpt-oss assistant history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Changed
+
+- **The llama.cpp engine now loads models with Flash Attention by default.** It
+  is the modern llama.cpp default and matters most for models whose per-layer V
+  embeddings differ (gemma's interleaved sliding-window attention): without it
+  llama.cpp pads the V cache and falls back to a full-size sliding-window cache,
+  wasting VRAM and slowing attention. Set `SKULK_LLAMA_CPP_FLASH_ATTN=0` to
+  disable on a backend whose compiled build lacks Flash Attention kernels.
+
 ### Fixed
 
 - **The model store now advertises a routable IP, so downloads no longer fail
@@ -20,17 +29,6 @@ This project records release notes here and mirrors public-facing notes in
   preferred over a Tailscale/CGNAT address; loopback and link-local are skipped),
   and an operator-supplied routable IP in `store_http_host` is still honored
   verbatim.
-
-### Changed
-
-- **The llama.cpp engine now loads models with Flash Attention by default.** It
-  is the modern llama.cpp default and matters most for models whose per-layer V
-  embeddings differ (gemma's interleaved sliding-window attention): without it
-  llama.cpp pads the V cache and falls back to a full-size sliding-window cache,
-  wasting VRAM and slowing attention. Set `SKULK_LLAMA_CPP_FLASH_ATTN=0` to
-  disable on a backend whose compiled build lacks Flash Attention kernels.
-
-### Fixed
 
 - **gpt-oss conversations no longer wedge on follow-up turns when the history
   carries raw harmony markers.** A gpt-oss assistant turn captured before the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- **gpt-oss conversations no longer wedge on follow-up turns when the history
+  carries raw harmony markers.** A gpt-oss assistant turn captured before the
+  output was channel-parsed (or echoed back by any client) keeps `<|channel|>`
+  markers in its `content`, and llama.cpp's gpt-oss chat template rejects that
+  with a hard error, so every later turn of the conversation returned no
+  response. The llama.cpp runner now strips harmony markers from assistant
+  history (reducing it to the final-channel text) before handing it to the
+  template, so a client can never wedge inference by replaying the model's own
+  output format and existing conversations resume cleanly.
+
 ### Changed
 
 - **The llama.cpp engine now loads models with Flash Attention by default.** It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Changed
+
+- **The llama.cpp engine now loads models with Flash Attention by default.** It
+  is the modern llama.cpp default and matters most for models whose per-layer V
+  embeddings differ (gemma's interleaved sliding-window attention): without it
+  llama.cpp pads the V cache and falls back to a full-size sliding-window cache,
+  wasting VRAM and slowing attention. Set `SKULK_LLAMA_CPP_FLASH_ATTN=0` to
+  disable on a backend whose compiled build lacks Flash Attention kernels.
+
 ### Fixed
 
 - **gpt-oss conversations no longer wedge on follow-up turns when the history
@@ -18,17 +27,6 @@ This project records release notes here and mirrors public-facing notes in
   history (reducing it to the final-channel text) before handing it to the
   template, so a client can never wedge inference by replaying the model's own
   output format and existing conversations resume cleanly.
-
-### Changed
-
-- **The llama.cpp engine now loads models with Flash Attention by default.** It
-  is the modern llama.cpp default and matters most for models whose per-layer V
-  embeddings differ (gemma's interleaved sliding-window attention): without it
-  llama.cpp pads the V cache and falls back to a full-size sliding-window cache,
-  wasting VRAM and slowing attention. Set `SKULK_LLAMA_CPP_FLASH_ATTN=0` to
-  disable on a backend whose compiled build lacks Flash Attention kernels.
-
-### Fixed
 
 - **gpt-oss models on the llama.cpp engine no longer leak raw "harmony" markers
   into the answer, and their reasoning is now separated from content.** llama.cpp

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -939,7 +939,15 @@ class Runner:
         gpt-oss variant rather than matching model-id substrings here.
         """
         card = self.shard_metadata.model_card
-        profile = resolve_model_capability_profile(card.model_id, model_card=card)
+        try:
+            profile = resolve_model_capability_profile(card.model_id, model_card=card)
+        except Exception:  # noqa: BLE001 - an unresolvable card is just not gpt-oss
+            # Never crash generation on capability resolution: now that the
+            # harmony history sanitize runs before the tool branch in _generate,
+            # the tool path resolves the profile too. A card we cannot resolve is
+            # treated as non-harmony (harmony-specific handling skipped) rather
+            # than raising.
+            return False
         return profile.output_parser == OutputParserType.GptOss
 
     def _send_token_chunk(

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -231,8 +231,10 @@ def messages_for_llama(task_params: TextGenerationTaskParams) -> list[dict[str, 
     no rendered messages are present.
     """
     if task_params.chat_template_messages:
-        return _splice_images_into_messages(
-            task_params.chat_template_messages, task_params.images
+        return _sanitize_harmony_assistant_messages(
+            _splice_images_into_messages(
+                task_params.chat_template_messages, task_params.images
+            )
         )
     messages: list[dict[str, Any]] = []
     if task_params.instructions:
@@ -246,7 +248,40 @@ def messages_for_llama(task_params: TextGenerationTaskParams) -> list[dict[str, 
                 "content": content if isinstance(content, str) else str(content),
             }
         )
-    return messages
+    return _sanitize_harmony_assistant_messages(messages)
+
+
+def _sanitize_harmony_assistant_messages(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Strip gpt-oss harmony channel markers from assistant history content.
+
+    gpt-oss's llama.cpp chat template raises when an assistant message's
+    ``content`` contains ``<|channel|>`` markers (it expects the analysis channel
+    in a separate ``thinking`` field), which wedges every follow-up turn of a
+    conversation that stored a raw, pre-parse assistant response. A client must
+    never be able to break inference by echoing the model's own output format, so
+    any marker-laden assistant content is reduced to just its final-channel text
+    (dropping the analysis channel and all control markers) before reaching the
+    template. Content without markers (and non-string content, e.g. vision parts)
+    is passed through untouched.
+    """
+    sanitized: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content")
+        if (
+            message.get("role") == "assistant"
+            and isinstance(content, str)
+            and "<|channel|>" in content
+        ):
+            parser = HarmonyTextParser()
+            emissions = parser.feed(content) + parser.flush()
+            final_text = "".join(
+                text for text, is_thinking in emissions if not is_thinking
+            )
+            message = {**message, "content": final_text}
+        sanitized.append(message)
+    return sanitized
 
 
 def _generation_kwargs(task_params: TextGenerationTaskParams) -> dict[str, Any]:

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -313,13 +313,27 @@ def _harmony_history_text(content: str) -> str:
 
     Only the ``final`` channel carries the user-facing answer, so analysis
     (reasoning) and commentary (tool-call plumbing) channels are dropped rather
-    than replayed as assistant prose. A turn with no ``final`` channel
-    (commentary/tool-call-only, or truncated before one) reduces to an empty
-    string instead of echoing tool-call JSON back into the next prompt. Either
-    way no ``<|channel|>`` marker survives, which the gpt-oss template rejects.
+    than replayed as assistant prose. A turn with a ``<|message|>`` body but no
+    ``final`` channel is analysis-only or commentary/tool-call, so it reduces to
+    an empty string instead of echoing reasoning or tool-call JSON into the next
+    prompt. A turn with a stray/partial control marker and NO ``<|message|>`` at
+    all carries no channel body (e.g. generation truncated right at a
+    ``<|channel|>`` header): that is plain prose that happens to include a
+    marker, so the control tokens are stripped and the surviving text kept rather
+    than erasing genuine history. Either way no ``<|channel|>`` marker survives,
+    which the gpt-oss template rejects.
     """
     final_text = _harmony_final_channel_text(content)
-    return final_text if final_text is not None else ""
+    if final_text is not None:
+        return final_text
+    if "<|message|>" in content:
+        # A real (analysis/commentary/tool-call) channel body with no final:
+        # drop it so reasoning/JSON is never replayed as assistant prose.
+        return ""
+    stripped = content
+    for token in _HARMONY_CONTROL_TOKENS:
+        stripped = stripped.replace(token, "")
+    return stripped.strip()
 
 
 def _sanitize_harmony_assistant_messages(

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -231,10 +231,8 @@ def messages_for_llama(task_params: TextGenerationTaskParams) -> list[dict[str, 
     no rendered messages are present.
     """
     if task_params.chat_template_messages:
-        return _sanitize_harmony_assistant_messages(
-            _splice_images_into_messages(
-                task_params.chat_template_messages, task_params.images
-            )
+        return _splice_images_into_messages(
+            task_params.chat_template_messages, task_params.images
         )
     messages: list[dict[str, Any]] = []
     if task_params.instructions:
@@ -248,7 +246,82 @@ def messages_for_llama(task_params: TextGenerationTaskParams) -> list[dict[str, 
                 "content": content if isinstance(content, str) else str(content),
             }
         )
-    return _sanitize_harmony_assistant_messages(messages)
+    return messages
+
+
+_HARMONY_CONTROL_TOKENS: Final = (
+    "<|start|>",
+    "<|end|>",
+    "<|return|>",
+    "<|message|>",
+    "<|channel|>",
+    "<|call|>",
+    "<|constrain|>",
+)
+
+
+def _harmony_final_channel_text(content: str) -> str | None:
+    """Return the concatenated text of the harmony ``final`` channel(s), or None.
+
+    Walks the harmony control markers and collects only the body of the ``final``
+    channel, so analysis (reasoning) and commentary/tool-call channels are
+    dropped. Returns ``None`` when no ``final`` channel body is present (e.g. a
+    truncated or commentary-only turn), letting the caller fall back rather than
+    invent an answer.
+    """
+    final_parts: list[str] = []
+    found_final = False
+    in_body = False
+    channel: str | None = None
+    header = ""
+    index = 0
+    length = len(content)
+    while index < length:
+        marker: str | None = None
+        for token in _HARMONY_CONTROL_TOKENS:
+            if content.startswith(token, index):
+                marker = token
+                break
+        if marker is not None:
+            if marker == "<|channel|>":
+                in_body = False
+                header = ""
+            elif marker == "<|message|>":
+                stripped = header.strip()
+                channel = stripped.split()[0] if stripped else None
+                header = ""
+                in_body = True
+                if channel == "final":
+                    found_final = True
+            elif marker != "<|constrain|>":
+                in_body = False
+                channel = None
+                header = ""
+            index += len(marker)
+            continue
+        if in_body:
+            if channel == "final":
+                final_parts.append(content[index])
+        else:
+            header += content[index]
+        index += 1
+    return "".join(final_parts) if found_final else None
+
+
+def _harmony_history_text(content: str) -> str:
+    """Reduce a raw harmony assistant turn to safe, marker-free replay text.
+
+    Prefers the ``final`` channel answer; if none is present, strips all control
+    markers and keeps the non-analysis text. Either way no ``<|channel|>`` marker
+    survives (the gpt-oss template rejects them) and the text is never truncated
+    to nothing by a partial/odd marker sequence.
+    """
+    final_text = _harmony_final_channel_text(content)
+    if final_text is not None and final_text.strip():
+        return final_text
+    parser = HarmonyTextParser()
+    emissions = parser.feed(content) + parser.flush()
+    return "".join(text for text, is_thinking in emissions if not is_thinking)
 
 
 def _sanitize_harmony_assistant_messages(
@@ -256,15 +329,17 @@ def _sanitize_harmony_assistant_messages(
 ) -> list[dict[str, Any]]:
     """Strip gpt-oss harmony channel markers from assistant history content.
 
-    gpt-oss's llama.cpp chat template raises when an assistant message's
-    ``content`` contains ``<|channel|>`` markers (it expects the analysis channel
-    in a separate ``thinking`` field), which wedges every follow-up turn of a
-    conversation that stored a raw, pre-parse assistant response. A client must
-    never be able to break inference by echoing the model's own output format, so
-    any marker-laden assistant content is reduced to just its final-channel text
-    (dropping the analysis channel and all control markers) before reaching the
-    template. Content without markers (and non-string content, e.g. vision parts)
-    is passed through untouched.
+    Apply ONLY when serving a gpt-oss (harmony) model: its llama.cpp chat
+    template raises when an assistant message's ``content`` contains
+    ``<|channel|>`` markers (it expects the analysis channel in a separate
+    ``thinking`` field), which wedges every follow-up turn of a conversation that
+    stored a raw, pre-parse assistant response. A client must never be able to
+    break inference by echoing the model's own output format, so any marker-laden
+    assistant content is reduced to safe, marker-free replay text (the final
+    channel, see ``_harmony_history_text``). Content without markers (and
+    non-string content, e.g. vision parts) is passed through untouched. Gating to
+    harmony models keeps a normal llama.cpp model's literal ``<|channel|>`` text
+    intact.
     """
     sanitized: list[dict[str, Any]] = []
     for message in messages:
@@ -274,12 +349,7 @@ def _sanitize_harmony_assistant_messages(
             and isinstance(content, str)
             and "<|channel|>" in content
         ):
-            parser = HarmonyTextParser()
-            emissions = parser.feed(content) + parser.flush()
-            final_text = "".join(
-                text for text, is_thinking in emissions if not is_thinking
-            )
-            message = {**message, "content": final_text}
+            message = {**message, "content": _harmony_history_text(content)}
         sanitized.append(message)
     return sanitized
 
@@ -713,6 +783,14 @@ class Runner:
         model_id = self.shard_metadata.model_card.model_id
         command_id = task.command_id
         messages = messages_for_llama(task.task_params)
+        # gpt-oss only: a harmony assistant turn whose content still carries raw
+        # <|channel|> markers (captured before output parsing, or echoed by a
+        # client) makes llama.cpp's gpt-oss template reject the whole request, so
+        # reduce such history to safe marker-free text. Gated to harmony models so
+        # a normal model's literal <|channel|> text is left intact. Covers the
+        # tools path too: _generate_with_tools is handed these same messages.
+        if self._is_harmony_model():
+            messages = _sanitize_harmony_assistant_messages(messages)
         kwargs = _generation_kwargs(task.task_params)
 
         want_logprobs = wants_logprobs(

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -273,7 +273,7 @@ def _harmony_final_channel_text(content: str) -> str | None:
     found_final = False
     in_body = False
     channel: str | None = None
-    header = ""
+    header_parts: list[str] = []
     index = 0
     length = len(content)
     while index < length:
@@ -285,43 +285,41 @@ def _harmony_final_channel_text(content: str) -> str | None:
         if marker is not None:
             if marker == "<|channel|>":
                 in_body = False
-                header = ""
+                header_parts = []
             elif marker == "<|message|>":
-                stripped = header.strip()
+                stripped = "".join(header_parts).strip()
                 channel = stripped.split()[0] if stripped else None
-                header = ""
+                header_parts = []
                 in_body = True
                 if channel == "final":
                     found_final = True
             elif marker != "<|constrain|>":
                 in_body = False
                 channel = None
-                header = ""
+                header_parts = []
             index += len(marker)
             continue
         if in_body:
             if channel == "final":
                 final_parts.append(content[index])
         else:
-            header += content[index]
+            header_parts.append(content[index])
         index += 1
     return "".join(final_parts) if found_final else None
 
 
 def _harmony_history_text(content: str) -> str:
-    """Reduce a raw harmony assistant turn to safe, marker-free replay text.
+    """Reduce a raw harmony assistant turn to its replayable final-channel text.
 
-    Prefers the ``final`` channel answer; if none is present, strips all control
-    markers and keeps the non-analysis text. Either way no ``<|channel|>`` marker
-    survives (the gpt-oss template rejects them) and the text is never truncated
-    to nothing by a partial/odd marker sequence.
+    Only the ``final`` channel carries the user-facing answer, so analysis
+    (reasoning) and commentary (tool-call plumbing) channels are dropped rather
+    than replayed as assistant prose. A turn with no ``final`` channel
+    (commentary/tool-call-only, or truncated before one) reduces to an empty
+    string instead of echoing tool-call JSON back into the next prompt. Either
+    way no ``<|channel|>`` marker survives, which the gpt-oss template rejects.
     """
     final_text = _harmony_final_channel_text(content)
-    if final_text is not None and final_text.strip():
-        return final_text
-    parser = HarmonyTextParser()
-    emissions = parser.feed(content) + parser.flush()
-    return "".join(text for text, is_thinking in emissions if not is_thinking)
+    return final_text if final_text is not None else ""
 
 
 def _sanitize_harmony_assistant_messages(
@@ -941,12 +939,17 @@ class Runner:
         card = self.shard_metadata.model_card
         try:
             profile = resolve_model_capability_profile(card.model_id, model_card=card)
-        except Exception:  # noqa: BLE001 - an unresolvable card is just not gpt-oss
+        except Exception as exc:  # noqa: BLE001 - an unresolvable card is just not gpt-oss
             # Never crash generation on capability resolution: now that the
             # harmony history sanitize runs before the tool branch in _generate,
             # the tool path resolves the profile too. A card we cannot resolve is
             # treated as non-harmony (harmony-specific handling skipped) rather
-            # than raising.
+            # than raising. Log it so a real resolution regression (which would
+            # silently disable gpt-oss parsing) is still visible.
+            logger.opt(exception=exc).warning(
+                f"capability resolution failed for {card.model_id}; "
+                "treating as non-harmony"
+            )
             return False
         return profile.output_parser == OutputParserType.GptOss
 

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
@@ -18,6 +18,7 @@ from skulk.worker.runner.llama_cpp.runner import (
     _logits_all_n_ctx,
     _logprob_fields,
     _map_finish_reason,
+    _sanitize_harmony_assistant_messages,
     _serving_n_ctx,
     _splice_images_into_messages,
     _tool_calls_from_message,
@@ -119,6 +120,46 @@ def test_messages_fallback_from_input_and_instructions() -> None:
     result = messages_for_llama(params)
     assert result[0] == {"role": "system", "content": "be brief"}
     assert result[1]["role"] == "user"
+
+
+def test_sanitize_harmony_assistant_messages() -> None:
+    raw_assistant = (
+        "<|channel|>analysis<|message|>thinking out loud"
+        "<|end|><|start|>assistant<|channel|>final<|message|>The answer is 4."
+    )
+    messages = [
+        {"role": "user", "content": "what is 2+2?"},
+        {"role": "assistant", "content": raw_assistant},
+        {"role": "user", "content": "and 3+3?"},
+    ]
+    out = _sanitize_harmony_assistant_messages(messages)
+    # Assistant content reduced to the final channel; no markers, no analysis.
+    assert out[1]["content"] == "The answer is 4."
+    assert "<|channel|>" not in out[1]["content"]
+    # User turns are untouched.
+    assert out[0]["content"] == "what is 2+2?"
+    assert out[2]["content"] == "and 3+3?"
+
+
+def test_sanitize_harmony_leaves_clean_and_nonstring_content() -> None:
+    messages = [
+        {"role": "assistant", "content": "already clean"},
+        {"role": "user", "content": "<|channel|>not sanitized for user role"},
+        {"role": "assistant", "content": [{"type": "image"}]},
+    ]
+    out = _sanitize_harmony_assistant_messages(messages)
+    assert out == messages  # no markers in assistant str / non-str -> untouched
+
+
+def test_messages_for_llama_sanitizes_assistant_history() -> None:
+    raw = "<|channel|>analysis<|message|>hmm<|end|><|start|>assistant<|channel|>final<|message|>Hi!"
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": raw},
+        {"role": "user", "content": "again"},
+    ]
+    out = messages_for_llama(_params(chat_template_messages=msgs))
+    assert out[1]["content"] == "Hi!"
 
 
 def test_generation_kwargs_passes_logprobs() -> None:

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
@@ -195,6 +195,19 @@ def test_sanitize_harmony_no_final_channel_drops_to_empty() -> None:
     assert "functions" not in out2[0]["content"]
 
 
+def test_sanitize_harmony_stray_marker_without_body_keeps_text() -> None:
+    # A stray/partial control marker with NO <|message|> body (e.g. generation
+    # truncated right at a <|channel|> header) is plain prose that happens to
+    # include a marker: strip the control tokens and keep the surviving text
+    # rather than erasing genuine assistant history. No marker may survive.
+    stray = "Here is the answer: 4 <|channel|>"
+    out = _sanitize_harmony_assistant_messages(
+        [{"role": "assistant", "content": stray}]
+    )
+    assert out[0]["content"] == "Here is the answer: 4"
+    assert "<|channel|>" not in out[0]["content"]
+
+
 def test_generation_kwargs_passes_logprobs() -> None:
     assert "logprobs" not in _generation_kwargs(_params())
     kw = _generation_kwargs(_params(logprobs=True, top_logprobs=3))

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
@@ -173,21 +173,26 @@ def test_sanitize_harmony_keeps_only_final_channel() -> None:
     assert "functions" not in out[0]["content"]
 
 
-def test_sanitize_harmony_fallback_strips_markers_without_truncating() -> None:
-    # No final channel (analysis-only / incomplete): never leave <|channel|>
-    # markers (the template rejects them) and never drop genuine leading text.
+def test_sanitize_harmony_no_final_channel_drops_to_empty() -> None:
+    # No final channel (analysis-only, or a commentary/tool-call-only turn): the
+    # turn carried no user-facing answer, so it reduces to an empty string rather
+    # than replaying reasoning or tool-call JSON as assistant prose. Either way no
+    # <|channel|> marker survives (the gpt-oss template rejects them).
     analysis_only = "<|channel|>analysis<|message|>just thinking, no answer"
     out = _sanitize_harmony_assistant_messages(
         [{"role": "assistant", "content": analysis_only}]
     )
-    assert "<|channel|>" not in out[0]["content"]
-    # Leading text before a stray marker is preserved by the fallback.
-    stray = "Here is the answer: 4 <|channel|>"
-    out2 = _sanitize_harmony_assistant_messages(
-        [{"role": "assistant", "content": stray}]
+    assert out[0]["content"] == ""
+    # A pure tool-call/commentary turn must not leak its JSON body into history.
+    commentary_only = (
+        '<|channel|>commentary to=functions.get_weather <|constrain|>json'
+        '<|message|>{"city": "SF"}<|call|>'
     )
-    assert "<|channel|>" not in out2[0]["content"]
-    assert "Here is the answer: 4" in out2[0]["content"]
+    out2 = _sanitize_harmony_assistant_messages(
+        [{"role": "assistant", "content": commentary_only}]
+    )
+    assert out2[0]["content"] == ""
+    assert "functions" not in out2[0]["content"]
 
 
 def test_generation_kwargs_passes_logprobs() -> None:

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_helpers.py
@@ -151,15 +151,43 @@ def test_sanitize_harmony_leaves_clean_and_nonstring_content() -> None:
     assert out == messages  # no markers in assistant str / non-str -> untouched
 
 
-def test_messages_for_llama_sanitizes_assistant_history() -> None:
+def test_messages_for_llama_does_not_sanitize() -> None:
+    # Sanitization is applied by the runner only for harmony (gpt-oss) models, so
+    # messages_for_llama itself leaves the raw history untouched.
     raw = "<|channel|>analysis<|message|>hmm<|end|><|start|>assistant<|channel|>final<|message|>Hi!"
-    msgs = [
-        {"role": "user", "content": "hi"},
-        {"role": "assistant", "content": raw},
-        {"role": "user", "content": "again"},
-    ]
-    out = messages_for_llama(_params(chat_template_messages=msgs))
-    assert out[1]["content"] == "Hi!"
+    msgs = [{"role": "assistant", "content": raw}]
+    assert messages_for_llama(_params(chat_template_messages=msgs)) == msgs
+
+
+def test_sanitize_harmony_keeps_only_final_channel() -> None:
+    # A commentary/tool-call channel must NOT be replayed: only the final answer.
+    raw = (
+        '<|channel|>commentary to=functions.get_weather <|constrain|>json'
+        '<|message|>{"city": "SF"}<|call|>'
+        "<|channel|>final<|message|>It is sunny."
+    )
+    out = _sanitize_harmony_assistant_messages(
+        [{"role": "assistant", "content": raw}]
+    )
+    assert out[0]["content"] == "It is sunny."
+    assert "functions" not in out[0]["content"]
+
+
+def test_sanitize_harmony_fallback_strips_markers_without_truncating() -> None:
+    # No final channel (analysis-only / incomplete): never leave <|channel|>
+    # markers (the template rejects them) and never drop genuine leading text.
+    analysis_only = "<|channel|>analysis<|message|>just thinking, no answer"
+    out = _sanitize_harmony_assistant_messages(
+        [{"role": "assistant", "content": analysis_only}]
+    )
+    assert "<|channel|>" not in out[0]["content"]
+    # Leading text before a stray marker is preserved by the fallback.
+    stray = "Here is the answer: 4 <|channel|>"
+    out2 = _sanitize_harmony_assistant_messages(
+        [{"role": "assistant", "content": stray}]
+    )
+    assert "<|channel|>" not in out2[0]["content"]
+    assert "Here is the answer: 4" in out2[0]["content"]
 
 
 def test_generation_kwargs_passes_logprobs() -> None:


### PR DESCRIPTION
## Problem (the dashboard "no response")

A gpt-oss chat in the dashboard returns **no response on follow-up turns**, while a fresh conversation works. Root cause, confirmed live:

- Before output channel-parsing (#403) deployed, gpt-oss responses carried raw `<|channel|>analysis…final…` markers in `content`. The dashboard's content splitter only strips `<think>`/gemma tags, so it **stored those marker-laden assistant messages** in the conversation.
- On the next turn the dashboard replays that history, and llama.cpp's gpt-oss chat template **rejects an assistant `content` containing `<|channel|>`** with `ValueError` → HTTP 400 → the dashboard fetch throws → no response.

Reproduced with curl: a marker-free single-turn works; an assistant message with `<|channel|>` markers → 400. A client must never be able to wedge inference by echoing the model's own output format.

## Fix

`messages_for_llama` now runs assistant history through `_sanitize_harmony_assistant_messages`: any assistant `content` containing `<|channel|>` is reduced to just its **final-channel text** (analysis channel + all control markers dropped) via the existing `HarmonyTextParser`. Clean content and non-string (vision) content pass through untouched. So old conversations resume cleanly and no client input can break inference.

## Tests

`_sanitize_harmony_assistant_messages` (markers→final, user-role/clean/non-string untouched) and `messages_for_llama` end-to-end sanitization. 30 llama.cpp-helper tests pass; basedpyright 0, ruff clean, nix fmt clean, no em-dashes.

This is the server-side half. A companion dashboard change (its content splitter also strips harmony markers, healing already-stored history on render) + the `/i18n` 404 fix follow in a separate PR.