### PR TITLE
fix(dashboard): parse gpt-oss harmony channels in chat; drop i18n 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dashboard: gpt-oss chats render cleanly and stop leaking harmony markers.**
+  The chat reasoning/content splitter now also understands gpt-oss "harmony"
+  channel markers (`<|channel|>analysis…final…`), so the analysis channel shows
+  as collapsible reasoning and the answer renders without raw `<|...|>`
+  scaffolding. This also heals conversations that stored marker-laden assistant
+  turns before the server-side parsing landed, so they display correctly.
+- **Dashboard: no more `404 /i18n/skulk/en.json`.** English ships bundled in the
+  app, so the Tolgee CDN fetch is now only enabled when an additional language is
+  configured; the default English-only build no longer requests (and 404s on) the
+  runtime translations endpoint.
+
 ### Changed
 
 - **The llama.cpp engine now loads models with Flash Attention by default.** It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,6 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
-### Fixed
-
-- **Dashboard: gpt-oss chats render cleanly and stop leaking harmony markers.**
-  The chat reasoning/content splitter now also understands gpt-oss "harmony"
-  channel markers (`<|channel|>analysis…final…`), so the analysis channel shows
-  as collapsible reasoning and the answer renders without raw `<|...|>`
-  scaffolding. This also heals conversations that stored marker-laden assistant
-  turns before the server-side parsing landed, so they display correctly.
-- **Dashboard: no more `404 /i18n/skulk/en.json`.** English ships bundled in the
-  app, so the Tolgee CDN fetch is now only enabled when an additional language is
-  configured; the default English-only build no longer requests (and 404s on) the
-  runtime translations endpoint.
-
 ### Changed
 
 - **The llama.cpp engine now loads models with Flash Attention by default.** It
@@ -30,6 +17,17 @@ This project records release notes here and mirrors public-facing notes in
   disable on a backend whose compiled build lacks Flash Attention kernels.
 
 ### Fixed
+
+- **Dashboard: gpt-oss chats render cleanly and stop leaking harmony markers.**
+  The chat reasoning/content splitter now also understands gpt-oss "harmony"
+  channel markers (`<|channel|>analysis...final...`), so the analysis channel
+  shows as collapsible reasoning and the answer renders without raw `<|...|>`
+  scaffolding. This also heals conversations that stored marker-laden assistant
+  turns before the server-side parsing landed, so they display correctly.
+- **Dashboard: no more `404 /i18n/skulk/en.json`.** English ships bundled in the
+  app, so the Tolgee CDN fetch is now only enabled when an additional language is
+  configured; the default English-only build no longer requests (and 404s on) the
+  runtime translations endpoint.
 
 - **gpt-oss models on the llama.cpp engine no longer leak raw "harmony" markers
   into the answer, and their reasoning is now separated from content.** llama.cpp

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -80,6 +80,17 @@ const THINK_TAG_START = '<think>';
 const THINK_TAG_END = '</think>';
 const GEMMA_THINK_START = '<|channel>thought\n';
 const GEMMA_THINK_END = '<channel|>';
+// gpt-oss "harmony" channel markers (distinct from Gemma's `<|channel>thought`).
+const HARMONY_CHANNEL_MARK = '<|channel|>';
+const HARMONY_CONTROL_TOKENS = [
+  '<|start|>',
+  '<|end|>',
+  '<|return|>',
+  '<|message|>',
+  '<|channel|>',
+  '<|call|>',
+  '<|constrain|>',
+];
 const MAX_TOOL_ROUNDS = 4;
 const GPT_OSS_BROWSER_TOOLS = {
   web_search: {
@@ -191,7 +202,61 @@ interface ExtractPageToolResponse {
   provider: string;
 }
 
+// Split a gpt-oss harmony stream/string into final content vs analysis thinking,
+// stripping every control marker. Mirrors the server-side parser so already-stored
+// conversations (captured before output channel-parsing) render cleanly, and the
+// raw scaffolding never leaks into a message bubble.
+function splitHarmonyChannels(raw: string): { content: string; thinking: string } {
+  let content = '';
+  let thinking = '';
+  let inBody = true; // start in content passthrough (text before any channel marker)
+  let channel: string | null = null;
+  let header = '';
+  let i = 0;
+
+  while (i < raw.length) {
+    let matched: string | null = null;
+    for (const token of HARMONY_CONTROL_TOKENS) {
+      if (raw.startsWith(token, i)) {
+        matched = token;
+        break;
+      }
+    }
+    if (matched) {
+      if (matched === '<|channel|>') {
+        inBody = false;
+        header = '';
+      } else if (matched === '<|message|>') {
+        const name = header.trim().split(/\s+/)[0];
+        channel = name && name.length > 0 ? name : null;
+        header = '';
+        inBody = true;
+      } else if (matched !== '<|constrain|>') {
+        // <|end|> / <|start|> / <|return|> / <|call|>: end of body.
+        inBody = false;
+        channel = null;
+        header = '';
+      }
+      i += matched.length;
+      continue;
+    }
+    const char = raw[i];
+    if (inBody) {
+      if (channel === 'analysis') thinking += char;
+      else content += char;
+    } else {
+      header += char;
+    }
+    i += 1;
+  }
+
+  return { content, thinking };
+}
+
 function splitReasoningDecoratedContent(raw: string): { content: string; thinking: string } {
+  if (raw.includes(HARMONY_CHANNEL_MARK)) {
+    return splitHarmonyChannels(raw);
+  }
   let content = '';
   let thinking = '';
   let i = 0;

--- a/dashboard-react/src/i18n/tolgee.ts
+++ b/dashboard-react/src/i18n/tolgee.ts
@@ -39,12 +39,23 @@ const availableLanguages = parseConfiguredLanguages(
 
 const tolgeeBuilder = Tolgee()
   .use(LanguageStorage())
-  .use(LanguageDetector())
-  .use(BackendFetch({
+  .use(LanguageDetector());
+
+// Only fetch runtime translations from the CDN when a non-English language is
+// actually configured. English ships bundled in `staticData`, so on a default
+// (English-only) deployment a BackendFetch just 404s on `/i18n/skulk/en.json`
+// before falling back to the bundle — harmless but noisy. Skipping it entirely
+// avoids the 404; deployments with extra languages keep the CDN backend.
+const hasRuntimeLanguages = availableLanguages.some(
+  (language) => language !== DEFAULT_LANGUAGE,
+);
+if (hasRuntimeLanguages) {
+  tolgeeBuilder.use(BackendFetch({
     prefix: import.meta.env.VITE_TOLGEE_CDN_PREFIX ?? DEFAULT_CDN_PREFIX,
     fallbackOnFail: true,
     timeout: CDN_TIMEOUT_MS,
   }));
+}
 
 if (import.meta.env.DEV) {
   tolgeeBuilder.use(DevTools());

--- a/dashboard-react/src/i18n/tolgee.ts
+++ b/dashboard-react/src/i18n/tolgee.ts
@@ -44,7 +44,7 @@ const tolgeeBuilder = Tolgee()
 // Only fetch runtime translations from the CDN when a non-English language is
 // actually configured. English ships bundled in `staticData`, so on a default
 // (English-only) deployment a BackendFetch just 404s on `/i18n/skulk/en.json`
-// before falling back to the bundle — harmless but noisy. Skipping it entirely
+// before falling back to the bundle (harmless but noisy). Skipping it entirely
 // avoids the 404; deployments with extra languages keep the CDN backend.
 const hasRuntimeLanguages = availableLanguages.some(
   (language) => language !== DEFAULT_LANGUAGE,


### PR DESCRIPTION
The frontend half of the gpt-oss chat fixes, plus the i18n 404. (Server-side history sanitization is #407.)

## #2 — gpt-oss harmony rendering

The chat content/reasoning splitter (`splitReasoningDecoratedContent`) only stripped `<think>`/gemma tags, so gpt-oss "harmony" output (`<|channel|>analysis…final…`) leaked raw markers into the bubble, and a conversation that stored a marker-laden assistant turn (captured before output channel-parsing) couldn't render or resume.

Added `splitHarmonyChannels`: when `<|channel|>` is present, it routes the **analysis** channel to collapsible reasoning and the **final** channel to clean content, stripping every control marker. Mirrors the server-side `HarmonyTextParser`; verified against the same cases (final/analysis split, plain passthrough, ordered-integers, commentary/`to=`/`<|constrain|>` header). Heals already-stored history on render.

## #3 — `404 /i18n/skulk/en.json`

English ships bundled in Tolgee `staticData`, but `BackendFetch` always tried the CDN first (`/i18n/skulk/en.json`), 404ing before falling back — harmless but noisy. The CDN backend is now only added when a non-English language is configured (`VITE_TOLGEE_AVAILABLE_LANGUAGES`); the default English-only build skips it entirely.

## Validation

`splitHarmonyChannels` logic verified (all cases pass, no marker leak); `tsc --noEmit` clean; eslint 0 errors (pre-existing hook-deps warnings only); `npm run build` succeeds; no em-dashes. (No JS test convention exists in the dashboard yet, so no test file added; the algorithm is the proven server-side parser.)