### PR TITLE
chore(release): Skulk 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-25
+
+This release makes Skulk a **heterogeneous** inference fabric: alongside Apple
+Silicon (MLX), an AMD or other Linux GPU node can now join the same cluster and
+serve GGUF models through a new llama.cpp engine (Vulkan / ROCm). It also lands
+the control / telemetry / data plane separation (with an optional Eclipse Zenoh
+data-plane transport), a centralized model store, vision GGUF support, and
+cross-engine reasoning (gpt-oss harmony and `<think>` parsed into a separate
+reasoning channel), plus a large amount of placement, failover, and stability
+hardening. See `website/docs/release-notes/1.3.0.md` for the user-facing summary.
+
 ### Fixed
 
 - **`<think>` reasoning no longer leaks into the answer for reasoning models on

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Documentation](https://img.shields.io/badge/docs-documentation-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/)
 [![Build & Runtime Paths](https://img.shields.io/badge/docs-build_%26_runtime-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/build-and-runtime/)
-[![Release Notes](https://img.shields.io/badge/release_notes-v1.2.0-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/release-notes/1.2.0/)
+[![Release Notes](https://img.shields.io/badge/release_notes-v1.3.0-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/release-notes/1.3.0/)
 [![Architecture](https://img.shields.io/badge/docs-architecture-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/architecture/)
 
   <br>
@@ -18,10 +18,11 @@
 </div>
 
 <br>
-Skulk is an interconnect fabric for multi-node AI compute. It joins several machines into one cluster and moves work across them as if they were a single device. Its headline use today is distributed inference: point it at a few Apple Silicon machines and it pools their memory and GPUs behind one OpenAI-compatible endpoint, so you can run models far larger than any single machine could hold.
+Skulk is an interconnect fabric for multi-node AI compute. It joins several machines into one cluster and moves work across them as if they were a single device. Its headline use today is distributed inference: point it at a few machines (Apple Silicon, and now AMD or other Linux GPU nodes too) and it pools their memory and GPUs behind one OpenAI-compatible endpoint, so you can run models far larger than any single machine could hold.
 
 On top of that, Skulk adds:
 
+- Heterogeneous clusters: Apple Silicon nodes serving MLX models and AMD or other Linux GPU nodes serving GGUF models (through a llama.cpp engine on Vulkan or ROCm) in one cluster, with each model routed to a node that can run it.
 - Production-grade speculative decoding delivering 1.16–2.2× speedups across nodes and on heterogeneous hardware.
 - A real-time React dashboard with easy access to:
   - A central model store
@@ -194,20 +195,22 @@ Build/runtime note:
 
 | Platform | Current state |
 |----------|---------------|
-| macOS on Apple Silicon | Primary target. Best experience today. |
+| macOS on Apple Silicon | Primary target. Best experience today. Serves MLX models. |
 | Multi-Mac clusters | Supported. Best results on matched macOS versions and fast networking. |
 | RDMA over Thunderbolt 5 | Supported on eligible macOS 26.2+ hardware after OS-level setup. |
-| Linux | Supported, but currently CPU-oriented in this fork. |
+| AMD / Linux GPU (for example Strix Halo) | Supported. Joins a cluster and serves GGUF models on a llama.cpp engine (Vulkan or ROCm), alongside Apple Silicon nodes. See the [AMD / Strix Halo node guide](https://foxlight-foundation.github.io/Skulk/amd-strix-halo-nodes). |
+| Linux (CPU only) | Supported as a control/API node; GGUF serving on CPU is possible but slow. |
 
 ## Core Features
 
 - **Distributed inference**: split work across devices instead of treating each machine as an island.
+- **Heterogeneous engines**: Apple Silicon nodes serve MLX models and AMD or other Linux GPU nodes serve GGUF models on a llama.cpp engine (Vulkan or ROCm), in one cluster, with each model routed to a node that can run it.
 - **Speculative decoding**: measured 1.16–2.2× decode speedups via multi-token prediction, on by default for supported model cards, including multi-node placements on mixed hardware.
 - **Skulk Dashboard**: React dashboard for topology, model store, chat, settings, and placement workflows.
-- **Model Store**: centralize model files on one node and stage them to the rest of the cluster over the LAN.
+- **Model Store**: centralize model files on one node and stage them to the rest of the cluster over the LAN; for GGUF repos it downloads only the quantization a model card pins, and the store host advertises a routable address so downloads work on a Thunderbolt-meshed fleet.
 - **Cluster-wide config sync**: update config from the dashboard and sync it across nodes.
 - **Placement previews**: inspect valid placements before launching a model.
-- **Thinking-aware chat UI**: chat with compatible models and surface reasoning content.
+- **Thinking-aware chat UI**: chat with compatible models and surface reasoning content, separated from the answer on both the MLX and llama.cpp engines.
 - **Alternative API compatibility**: OpenAI Chat Completions, OpenAI Responses, Claude Messages, and Ollama.
 - **Experimental inference tuning**: OptiQ and other KV cache backends for long-context and memory experiments.
 
@@ -597,11 +600,18 @@ Draft depth is a measured property, not a guess: deeper chains trade acceptance 
 
 ## More Documentation
 
-- [Speculative Decoding guide](https://foxlight-foundation.github.io/Skulk/speculative-decoding/)
-- [docs/api.md](docs/api.md)
-- [docs/model-store.md](docs/model-store.md)
-- [docs/architecture.md](docs/architecture.md)
-- [docs/kv-cache-backends.md](docs/kv-cache-backends.md)
+The full documentation site is published at
+[foxlight-foundation.github.io/Skulk](https://foxlight-foundation.github.io/Skulk/).
+Highlights:
+
+- [AMD / Strix Halo node guide](https://foxlight-foundation.github.io/Skulk/amd-strix-halo-nodes) (heterogeneous clusters, the llama.cpp engine)
+- [Cluster communication](https://foxlight-foundation.github.io/Skulk/cluster-communication) (the control, telemetry, and data planes; the Zenoh transport)
+- [Model store](https://foxlight-foundation.github.io/Skulk/model-store)
+- [Model cards](https://foxlight-foundation.github.io/Skulk/model-cards) and [model capabilities](https://foxlight-foundation.github.io/Skulk/model-capabilities)
+- [Thunderbolt clustering](https://foxlight-foundation.github.io/Skulk/thunderbolt-clustering) and [RDMA on macOS](https://foxlight-foundation.github.io/Skulk/build-and-runtime)
+- [Speculative decoding](https://foxlight-foundation.github.io/Skulk/speculative-decoding)
+- [API guide](https://foxlight-foundation.github.io/Skulk/api-guide) and [architecture](https://foxlight-foundation.github.io/Skulk/architecture)
+- [Release notes](https://foxlight-foundation.github.io/Skulk/release-notes/1.3.0/)
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Contributing

--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard-react",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard-react",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@reduxjs/toolkit": "^2.11.2",

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard-react",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skulk"
-version = "1.2.0"
+version = "1.3.0"
 description = "Skulk — distributed MLX inference across Apple Silicon clusters"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -2862,7 +2862,7 @@ wheels = [
 
 [[package]]
 name = "skulk"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },

--- a/website/docs/model-behaviors/gpt-oss.md
+++ b/website/docs/model-behaviors/gpt-oss.md
@@ -53,6 +53,16 @@ case. It shows that model-card-backed runtime behavior can cleanly cover a
 second specialized family with different parser, reasoning, and tool semantics
 without changing generic-model behavior.
 
+## On both engines
+
+GPT-OSS harmony parsing works on the MLX engine (token level) and on the
+llama.cpp engine (string level). llama.cpp hands back already-detokenized text,
+so the runner reparses the harmony channel markers from strings into a separate
+reasoning channel, with a dependency-free parser that runs on non-Mac GPU nodes.
+The same approach covers plain `<think>`-delimited reasoning models, so a
+reasoning model's chain-of-thought lands in `reasoning_content` and the answer
+stays clean regardless of which engine serves it.
+
 ## Related
 
 - [Model Cards](../model-cards)

--- a/website/docs/model-store.md
+++ b/website/docs/model-store.md
@@ -35,6 +35,25 @@ With the model store:
 - other nodes stage needed files from that host
 - Skulk keeps the same cluster and inference architecture, but changes where model artifacts come from
 
+### GGUF repositories download only the pinned quantization
+
+A GGUF repository often ships several quantizations of the same model (for
+example `Q4_K_M`, `Q5_K_M`, `Q8_0`, `bf16`). The store downloads only the
+quantization a model card pins (its `gguf_file`), plus the multimodal projector
+for a vision model, rather than every quant in the repository. This keeps a
+single-quant download to roughly the size of that one file instead of the whole
+repo.
+
+### The store host advertises a routable address
+
+The store host broadcasts the address other nodes use to reach it. Even when you
+configure `store_host` as a hostname, the store host resolves and advertises its
+own best routable IPv4 (a private LAN address is preferred). This avoids a
+failure mode on a Thunderbolt-meshed fleet, where a bare hostname could resolve
+through mDNS to a link-local Thunderbolt address (`169.254.x`) that a peer
+without a direct Thunderbolt link cannot reach, even though the LAN path works.
+An operator-supplied routable IP in `store_http_host` is still honored as-is.
+
 ## What Does Not Change
 
 - the libp2p mesh, election, master, and worker model stay the same

--- a/website/docs/release-notes/1.0.2.md
+++ b/website/docs/release-notes/1.0.2.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.0.2
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.0.3.md
+++ b/website/docs/release-notes/1.0.3.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.0.3
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.1.0.md
+++ b/website/docs/release-notes/1.1.0.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.1.0
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.2.0.md
+++ b/website/docs/release-notes/1.2.0.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.2.0
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.3.0.md
+++ b/website/docs/release-notes/1.3.0.md
@@ -1,0 +1,100 @@
+---
+title: Release Notes 1.3.0
+sidebar_position: 1
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+Release date: 2026-06-25
+
+Skulk 1.3.0 turns the cluster into a **heterogeneous** inference fabric. Up to
+now a cluster was Apple Silicon running MLX. In 1.3.0 an AMD or other Linux GPU
+node can join the same cluster and serve models through a second inference
+engine, the cluster's networking is split into purpose-built planes, and the
+model catalog grows to cover GGUF weights, vision models, and a centralized
+model store.
+
+## Highlights
+
+- **Heterogeneous clusters: AMD / Linux GPU nodes via a llama.cpp engine.** A
+  Linux GPU box (for example an AMD Strix Halo) can now join a Skulk cluster and
+  serve GGUF models through a new llama.cpp inference engine on the Vulkan or
+  ROCm backend, side by side with Apple Silicon MLX nodes in the same cluster.
+  Each model is routed to a node that can run it: MLX weights to Apple Silicon,
+  GGUF weights to a llama.cpp node. The llama.cpp engine reaches parity with MLX
+  on tool calling and logprobs, honors cancellation, and surfaces clear errors.
+  See the [AMD / Strix Halo node guide](../amd-strix-halo-nodes.md).
+
+- **A centralized model store.** One node can act as a store host that downloads
+  model weights once and serves them to the rest of the cluster, so every node
+  does not re-download from Hugging Face. For GGUF repositories the store fetches
+  only the quantization a model card pins (not every quant in the repo), and the
+  store host advertises a routable address so downloads work on a
+  Thunderbolt-meshed fleet. See the [model store guide](../model-store.md).
+
+- **Vision models on GGUF.** Vision-language GGUF models run on the llama.cpp
+  engine: the runner loads the model's multimodal projector and accepts image
+  inputs through the standard chat API.
+
+- **Plane separation, with an optional Zenoh data plane.** Cluster traffic is now
+  split into three planes: a control plane (cluster decisions and task
+  lifecycle), a telemetry plane (last-write-wins node readings), and a data plane
+  that streams generated tokens straight to the owning API node. The data plane
+  can ride an optional [Eclipse Zenoh](https://zenoh.io) transport, which is soft
+  default-on, with per-cluster namespace isolation. See
+  [cluster communication](../cluster-communication.md).
+
+- **Cross-engine reasoning.** Reasoning models keep their chain-of-thought out of
+  the answer on both engines. gpt-oss "harmony" output and plain
+  `<think>`-delimited reasoning are parsed into a separate reasoning channel, so
+  the visible content is the clean answer and the reasoning is available
+  separately. On the llama.cpp engine this is done with a dependency-free parser
+  so it runs on non-Mac GPU nodes.
+
+- **Richer telemetry and topology.** Node readings (memory, system, disk,
+  accelerator metrics, identities) are gossiped on the telemetry plane and shown
+  in the dashboard, including a collector-agnostic accelerator block that covers
+  both Apple and AMD GPUs, heterogeneous-node identity in the topology, and
+  per-node health.
+
+## New and improved
+
+- Heterogeneous clusters: AMD / Linux GPU nodes serving GGUF through the llama.cpp
+  engine (Vulkan / ROCm), with logprobs and tool-calling parity, cancellation,
+  and structured errors.
+- Centralized model store: selective single-quant GGUF download, routable-IP
+  advertisement, and a pinned-quant download contract.
+- Vision GGUF models on llama.cpp (the multimodal projector is downloaded and
+  loaded automatically).
+- Optional Eclipse Zenoh transport for the per-token data plane, key-addressed
+  per owner, with namespace isolation and a transport-conditional reorder buffer.
+- Control / telemetry / data plane separation: generation output and
+  observational node readings move off the ordered event log.
+- Cross-engine reasoning parsing (gpt-oss harmony and `<think>`), thinking-aware
+  output on the llama.cpp engine, and recovery of empty content for auto-imported
+  Qwen3 reasoning models.
+- Context-aware admission for the llama.cpp engine, a named single-node engine
+  capability, and a resolved-backend record stamped onto each placed shard.
+- Flash Attention on by default for the llama.cpp engine.
+- Node logs are bounded so they cannot fill the disk, and structured runner
+  errors (context-length and others) surface on the API.
+
+## Fixes
+
+A large set of placement, failover, and stability fixes, including: tight
+multi-node placements no longer silently vanishing; master failover no longer
+killing a healthy serving instance or churning elections under connection churn;
+GPU-offload and unified-memory nodes admitted against the right memory; large
+GGUF loads and llama.cpp logprobs no longer OOM-killing a node; a placement right
+after a teardown no longer spuriously refused; data-plane streams no longer
+hanging on a dropped final chunk and multi-node output no longer silently
+reordered; the source-built GPU llama.cpp wheel surviving `uv sync`; and the
+macOS Local Network permission being diagnosable with a clearer denial warning.
+
+See the [CHANGELOG](https://github.com/Foxlight-Foundation/Skulk/blob/main/CHANGELOG.md)
+for the complete per-change list.
+
+## Upgrading
+
+All nodes in a cluster must run the same Skulk version. Upgrade the whole fleet
+together; a mixed-version cluster is unsupported.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -51,7 +51,7 @@ const sidebars: SidebarsConfig = {
         {
           type: "category",
           label: "Release Notes",
-          items: ["release-notes/1.2.0", "release-notes/1.1.0", "release-notes/1.0.3", "release-notes/1.0.2"],
+          items: ["release-notes/1.3.0", "release-notes/1.2.0", "release-notes/1.1.0", "release-notes/1.0.3", "release-notes/1.0.2"],
         },
         "cluster-communication",
         "architecture",


### PR DESCRIPTION
Promotes `dev` to **main** as the **1.3.0** release.

## Context
Because dev was already fast-forwarded onto main earlier today, main already contains the 1.3.0 code; this PR adds the **release commit** on top: version bump + the user-facing 1.3.0 documentation. The diff vs main is just docs + version metadata.

## Highlights (since 1.2.0)
- **Heterogeneous clusters**: AMD / Linux GPU nodes serving GGUF through a new **llama.cpp engine** (Vulkan/ROCm), alongside Apple Silicon MLX, in one cluster.
- **Centralized model store** (selective single-quant GGUF download, routable-IP advertisement).
- **Vision GGUF** models on llama.cpp.
- **Plane separation** (control/telemetry/data) with an optional **Eclipse Zenoh** data-plane transport.
- **Cross-engine reasoning** (gpt-oss harmony + `<think>` parsed into a separate reasoning channel on both engines).
- Extensive placement / failover / stability hardening.

## Release contents
- `pyproject.toml` + dashboard + `uv.lock` + README badge → 1.3.0.
- CHANGELOG `[Unreleased]` rolled into `[1.3.0]`.
- New `website/docs/release-notes/1.3.0.md` (+ sidebar).
- **README** reframed from Apple-Silicon-only to heterogeneous; the false "Linux = CPU-oriented" platform row fixed; llama.cpp engine, model-store behaviors, cross-engine reasoning, and new doc-site links added.
- model-store + gpt-oss docs updated for the new behaviors.

## Validation
- Docs site (`npm run build`) builds clean.
- e2e on dev (= this content): MLX ring + new `qwen3_5_moe` arch, llama.cpp `<think>` separation, gpt-oss harmony regression, and a second MLX model all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)