### PR TITLE
feat(served): Gemma 4 channel parser + MTP card (own the draft)

### DIFF
--- a/resources/inference_model_cards/google--gemma-4-31B-it-qat-q4_0-gguf.toml
+++ b/resources/inference_model_cards/google--gemma-4-31B-it-qat-q4_0-gguf.toml
@@ -1,0 +1,50 @@
+# Gemma 4 31B-it (official Google QAT Q4_0 GGUF) served via the llama_server
+# engine with native MTP. Base is Google's own GGUF. Gemma 4 is a reasoning model
+# that emits its thinking as literal <|channel>thought ... <channel|> markers in
+# the output (not tokenizer special tokens, no template strips them), and
+# llama-server's reasoning parsers don't understand those tokens, so the served
+# runner reparses them itself (output_parser = "gemma4"): the thought channel
+# becomes reasoning, the rest becomes content, markers stripped.
+#
+# Gemma 4's MTP is its assistant as a SEPARATE draft GGUF via --model-draft
+# (--spec-type draft-mtp). Google ships the assistant only as safetensors, so we
+# publish our OWN GGUF conversion (SWP) of the official QAT assistant rather than
+# depend on a third-party conversion; the draft's template is irrelevant
+# (llama-server templates with this base). Text-only (the repo's mmproj projector
+# is not loaded). supports_tensor = false: served single-node. Architecture from
+# google/gemma-4-31B-it (60 layers, hidden 5376, 16 KV heads, 262144 ctx).
+model_id = "google/gemma-4-31B-it-qat-q4_0-gguf"
+n_layers = 60
+hidden_size = 5376
+num_key_value_heads = 16
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "gemma"
+quantization = "Q4_0"
+base_model = "Gemma 4 31B-it (QAT)"
+capabilities = ["text", "thinking"]
+context_length = 262144
+gguf_file = "gemma-4-31B_q4_0-it.gguf"
+trust_remote_code = false
+
+[tooling]
+supports_tool_calling = true
+tool_call_format = "generic"
+
+[runtime]
+# Native MTP via the Gemma 4 QAT assistant as a SEPARATE draft GGUF
+# (--model-draft); our own SWP conversion of the official Google assistant.
+served_spec_type = "draft_mtp"
+served_spec_n_max = 4
+served_spec_draft_repo = "FoxlightAI/gemma-4-31B-it-qat-mtp-draft-GGUF"
+served_spec_draft_file = "gemma-4-31B-it-qat-q4_0-unquantized-assistant-Q8_0.gguf"
+# Gemma 4 emits <|channel> reasoning markers as literal text; the served runner
+# strips them and splits reasoning from content (llama-server can't parse them).
+output_parser = "gemma4"
+
+[placement]
+compatible_backends = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_server-cpu"]
+backend_preference = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_server-cpu"]
+
+[storage_size]
+in_bytes = 17650000000

--- a/src/skulk/worker/runner/llama_server/channel_text_parser.py
+++ b/src/skulk/worker/runner/llama_server/channel_text_parser.py
@@ -1,0 +1,134 @@
+"""Streaming parser for Gemma 4's ``<|channel>`` reasoning markers.
+
+Gemma 4 is a reasoning model: it emits its thinking in a channel and then the
+answer, as *literal generated text* (the markers are not tokenizer special
+tokens, and there is no chat template that strips them). Served via llama-server
+with ``--reasoning-format none`` the raw markers therefore arrive in the content
+stream:
+
+    <|channel>thought
+    ...the model's reasoning...
+    <channel|>...the answer...
+
+llama-server's own reasoning parsers don't understand these tokens (``auto`` puts
+the *answer* in ``reasoning_content``; ``none`` leaves the raw markers in
+``content``), so the served runner parses them itself, the same way the
+in-process runner reparses gpt-oss harmony markers (see
+``llm_inference/harmony_text_parser.py``). Pure-Python, no MLX, runs on AMD nodes.
+
+Grammar (observed; verified on kite4 against google/gemma-4-31B-it-qat-q4_0-gguf):
+
+- ``<|channel>`` opens a channel header; the channel *name* runs to the next
+  newline, then the channel body begins.
+- ``<channel|>`` closes the current channel and returns to the default (answer)
+  body.
+- A channel named ``thought`` / ``analysis`` / ``reasoning`` is flagged
+  ``is_thinking``; the default body and any other channel are content.
+- All markers (and the header newline) are stripped from the output.
+"""
+
+from __future__ import annotations
+
+from typing import Final, final
+
+#: Opens a channel header (channel name follows, up to the next newline).
+_OPEN: Final = "<|channel>"
+#: Closes the current channel, returning to the default (answer) body.
+_CLOSE: Final = "<channel|>"
+
+# Channel names whose body is reasoning rather than answer content.
+_THINKING_CHANNELS: frozenset[str] = frozenset({"thought", "analysis", "reasoning"})
+
+
+@final
+class GemmaChannelTextParser:
+    """Incrementally strip ``<|channel>`` markers and split reasoning from content.
+
+    Feed raw string deltas with :meth:`feed`; it returns ``(text, is_thinking)``
+    emissions (often empty until a marker/header boundary resolves). Call
+    :meth:`flush` once the stream ends to drain the tail. Starts in the default
+    content body, so a model that never emits a channel marker passes its text
+    through unchanged.
+    """
+
+    def __init__(self) -> None:
+        self._buffer: str = ""
+        # While inside an open ``<|channel>`` header (accumulating the name).
+        self._in_header: bool = False
+        self._header: str = ""
+        # Current channel name; ``None`` is the default (answer) body.
+        self._channel: str | None = None
+
+    @property
+    def _is_thinking(self) -> bool:
+        return self._channel in _THINKING_CHANNELS
+
+    def feed(self, text: str) -> list[tuple[str, bool]]:
+        """Consume a raw delta, returning ``(text, is_thinking)`` emissions."""
+        if text:
+            self._buffer += text
+        emissions: list[tuple[str, bool]] = []
+        self._drain(emissions, final=False)
+        return emissions
+
+    def flush(self) -> list[tuple[str, bool]]:
+        """Drain any remaining buffered text once the stream has ended."""
+        emissions: list[tuple[str, bool]] = []
+        self._drain(emissions, final=True)
+        return emissions
+
+    def _drain(self, emissions: list[tuple[str, bool]], *, final: bool) -> None:
+        # Resolve every complete boundary (a marker, or a header-ending newline)
+        # currently in the buffer, then emit text that can't be a partial marker.
+        while self._buffer:
+            if self._in_header:
+                newline = self._buffer.find("\n")
+                if newline == -1:
+                    break  # header name not yet complete
+                self._header += self._buffer[:newline]
+                self._channel = self._header.strip() or None
+                self._header = ""
+                self._in_header = False
+                self._buffer = self._buffer[newline + 1 :]
+                continue
+
+            open_at = self._buffer.find(_OPEN)
+            close_at = self._buffer.find(_CLOSE)
+            candidates = [i for i in (open_at, close_at) if i != -1]
+            if not candidates:
+                break
+            index = min(candidates)
+            self._emit(self._buffer[:index], emissions)
+            if index == open_at and (close_at == -1 or open_at <= close_at):
+                self._buffer = self._buffer[index + len(_OPEN) :]
+                self._in_header = True
+            else:
+                self._buffer = self._buffer[index + len(_CLOSE) :]
+                self._channel = None
+
+        # Hold back a trailing partial marker mid-stream so a marker split across
+        # deltas isn't mistaken for literal text; flush everything on ``final``.
+        if not self._buffer or self._in_header:
+            if final and self._in_header:
+                # Stream ended mid-header: the (unterminated) header name is not
+                # output; nothing to emit.
+                self._header = ""
+                self._buffer = ""
+            return
+        if final:
+            self._emit(self._buffer, emissions)
+            self._buffer = ""
+            return
+        last_open = self._buffer.rfind("<")
+        if last_open != -1:
+            tail = self._buffer[last_open:]
+            if _OPEN.startswith(tail) or _CLOSE.startswith(tail):
+                self._emit(self._buffer[:last_open], emissions)
+                self._buffer = tail
+                return
+        self._emit(self._buffer, emissions)
+        self._buffer = ""
+
+    def _emit(self, text: str, emissions: list[tuple[str, bool]]) -> None:
+        if text:
+            emissions.append((text, self._is_thinking))

--- a/src/skulk/worker/runner/llama_server/runner.py
+++ b/src/skulk/worker/runner/llama_server/runner.py
@@ -40,6 +40,7 @@ import httpx
 from anyio import WouldBlock
 
 from skulk.shared.backends import LLAMA_SERVER_BIN_ENV
+from skulk.shared.models.model_cards import OutputParserType
 from skulk.shared.types.chunks import ErrorChunk, TokenChunk, ToolCallChunk
 from skulk.shared.types.common import CommandId, ModelId
 from skulk.shared.types.events import (
@@ -78,6 +79,9 @@ from skulk.worker.runner.llama_cpp.runner import (
     serving_n_ctx,
     tool_calls_from_message,
     wants_logprobs,
+)
+from skulk.worker.runner.llama_server.channel_text_parser import (
+    GemmaChannelTextParser,
 )
 
 # Card ``served_spec_type`` value -> the ``llama-server --spec-type`` token.
@@ -272,6 +276,10 @@ class Runner:
         self.server_log: Any = None
         self.server_log_path: Path | None = None
         self.base_url: str | None = None
+        # Set at load: the card declares a channel output parser (Gemma 4), so the
+        # served runner reparses ``<|channel>`` markers out of the content stream
+        # itself (llama-server can't), splitting reasoning from the answer.
+        self._uses_channel_parser: bool = False
         self.current_status: RunnerStatus = RunnerIdle()
         logger.info("llama-server runner created")
         self.update_status(RunnerIdle())
@@ -381,11 +389,20 @@ class Runner:
         if gguf_path is None:
             gguf_path = select_gguf_file(model_dir)
 
+        # When the card declares a channel output parser we strip reasoning
+        # markers ourselves, so llama-server must hand back raw text
+        # (--reasoning-format none) regardless of whether the model "reasons":
+        # its own reasoning parsers don't understand Gemma 4's <|channel> tokens.
+        self._uses_channel_parser = (
+            card.runtime is not None
+            and card.runtime.output_parser == OutputParserType.Gemma4
+        )
+        reasoning_format_none = self._uses_channel_parser or not (
+            _model_declares_reasoning(card)
+        )
         n_ctx = serving_n_ctx(self.context_token_limit, logits_all=False)
         try:
-            self._spawn_server(
-                gguf_path, n_ctx, card.runtime, _model_declares_reasoning(card)
-            )
+            self._spawn_server(gguf_path, n_ctx, card.runtime, reasoning_format_none)
             self._await_health()
         except Exception:
             self._teardown_server()
@@ -401,7 +418,7 @@ class Runner:
         gguf_path: Path,
         n_ctx: int,
         runtime: Any,
-        model_has_reasoning: bool,
+        reasoning_format_none: bool,
     ) -> None:
         binary = os.environ.get(LLAMA_SERVER_BIN_ENV, "").strip()
         if not binary:
@@ -434,13 +451,13 @@ class Runner:
             # tool calling and reasoning-content extraction work server-side.
             "--jinja",
         ]
-        # A non-reasoning model is served with --reasoning-format none so all
-        # output stays in message.content. llama-server's default (auto) can
-        # extract a plain model's prose into reasoning_content (seen with Gemma 4
-        # under --jinja), which the runner flags as is_thinking, leaving the
-        # client's message.content empty. A reasoning model keeps the default so
-        # its thoughts land in reasoning_content (mapped to is_thinking here).
-        if not model_has_reasoning:
+        # --reasoning-format none hands back raw text in message.content. We use
+        # it for (a) plain non-reasoning models (otherwise llama-server's default
+        # `auto` extracts their prose into reasoning_content, leaving content
+        # empty) and (b) models we parse ourselves (Gemma 4's <|channel> markers,
+        # which llama-server's parsers mishandle). A reasoning model llama-server
+        # *can* parse keeps the default so its thoughts land in reasoning_content.
+        if reasoning_format_none:
             cmd += ["--reasoning-format", "none"]
         spec_type = getattr(runtime, "served_spec_type", None) if runtime else None
         if spec_type and spec_type != "none":
@@ -599,6 +616,9 @@ class Runner:
         body["stream"] = True
         assert self.base_url is not None
         emitted_finish = False
+        # Gemma 4 emits its reasoning as literal <|channel> markers in content;
+        # reparse them here (llama-server can't) into reasoning/content chunks.
+        parser = GemmaChannelTextParser() if self._uses_channel_parser else None
         # No read timeout: generation can pause between tokens on a busy GPU. The
         # connection is closed (aborting server generation) when we break out.
         timeout = httpx.Timeout(connect=15.0, read=None, write=30.0, pool=None)
@@ -623,15 +643,31 @@ class Runner:
                         command_id, model_id, delta.reasoning, is_thinking=True
                     )
                 if delta.content:
-                    self._send_token(command_id, model_id, delta.content)
+                    if parser is not None:
+                        for text, is_thinking in parser.feed(delta.content):
+                            self._send_token(
+                                command_id, model_id, text, is_thinking=is_thinking
+                            )
+                    else:
+                        self._send_token(command_id, model_id, delta.content)
                 if delta.finish is not None:
+                    if parser is not None:
+                        for text, is_thinking in parser.flush():
+                            self._send_token(
+                                command_id, model_id, text, is_thinking=is_thinking
+                            )
                     self._send_token(
                         command_id, model_id, "", finish_reason=delta.finish
                     )
                     emitted_finish = True
         # Guarantee a terminal chunk so the consumer's stream closes even if the
-        # server ended without an explicit finish_reason.
+        # server ended without an explicit finish_reason; drain any held tail.
         if not emitted_finish and not self._is_cancelled(task.task_id):
+            if parser is not None:
+                for text, is_thinking in parser.flush():
+                    self._send_token(
+                        command_id, model_id, text, is_thinking=is_thinking
+                    )
             self._send_token(command_id, model_id, "", finish_reason="stop")
 
     def _generate_with_tools(
@@ -686,7 +722,15 @@ class Runner:
         if reasoning:
             self._send_token(command_id, model_id, reasoning, is_thinking=True)
         if content:
-            self._send_token(command_id, model_id, content)
+            if self._uses_channel_parser:
+                # Reparse Gemma 4's <|channel> markers out of the prose answer.
+                parser = GemmaChannelTextParser()
+                for text, is_thinking in parser.feed(content) + parser.flush():
+                    self._send_token(
+                        command_id, model_id, text, is_thinking=is_thinking
+                    )
+            else:
+                self._send_token(command_id, model_id, content)
         finish = map_finish_reason(choice.get("finish_reason")) or "stop"
         self._send_token(command_id, model_id, "", finish_reason=finish)
 

--- a/src/skulk/worker/runner/llama_server/tests/test_channel_text_parser.py
+++ b/src/skulk/worker/runner/llama_server/tests/test_channel_text_parser.py
@@ -1,0 +1,105 @@
+"""Tests for the Gemma 4 ``<|channel>`` streaming parser."""
+
+from __future__ import annotations
+
+from skulk.worker.runner.llama_server.channel_text_parser import GemmaChannelTextParser
+
+
+def _collapse(emissions: list[tuple[str, bool]]) -> tuple[str, str]:
+    """Reduce emissions to ``(reasoning, content)`` strings."""
+    reasoning = "".join(t for t, thinking in emissions if thinking)
+    content = "".join(t for t, thinking in emissions if not thinking)
+    return reasoning, content
+
+
+def _parse_whole(text: str) -> tuple[str, str]:
+    p = GemmaChannelTextParser()
+    em = p.feed(text)
+    em += p.flush()
+    return _collapse(em)
+
+
+def _parse_streamed(text: str, *, step: int = 1) -> tuple[str, str]:
+    p = GemmaChannelTextParser()
+    em: list[tuple[str, bool]] = []
+    for i in range(0, len(text), step):
+        em += p.feed(text[i : i + step])
+    em += p.flush()
+    return _collapse(em)
+
+
+# The exact shape observed on kite4 (google/gemma-4-31B-it-qat-q4_0-gguf).
+_SAMPLE = (
+    "<|channel>thought\n"
+    'The user wants me to reply with exactly "Hello world".\n'
+    "<channel|>Hello world"
+)
+
+
+def test_sample_splits_reasoning_and_content() -> None:
+    reasoning, content = _parse_whole(_SAMPLE)
+    assert content == "Hello world"
+    assert reasoning == 'The user wants me to reply with exactly "Hello world".\n'
+    # No markers leak into either channel.
+    assert "<|channel>" not in reasoning + content
+    assert "<channel|>" not in reasoning + content
+    assert "thought" not in content
+
+
+def test_sample_streamed_char_by_char_matches_whole() -> None:
+    # Markers split across single-char deltas must parse identically.
+    assert _parse_streamed(_SAMPLE, step=1) == _parse_whole(_SAMPLE)
+
+
+def test_sample_streamed_various_chunk_sizes() -> None:
+    whole = _parse_whole(_SAMPLE)
+    for step in (2, 3, 5, 7, 11):
+        assert _parse_streamed(_SAMPLE, step=step) == whole
+
+
+def test_plain_text_without_markers_passes_through_as_content() -> None:
+    reasoning, content = _parse_whole("The capital of France is Paris.")
+    assert reasoning == ""
+    assert content == "The capital of France is Paris."
+
+
+def test_thought_then_answer_without_explicit_close_falls_back() -> None:
+    # If a generation ends mid-thought (no <channel|>), the thought text is still
+    # surfaced as reasoning by flush(), never swallowed.
+    reasoning, content = _parse_whole("<|channel>thought\nstill thinking")
+    assert reasoning == "still thinking"
+    assert content == ""
+
+
+def test_analysis_channel_is_also_reasoning() -> None:
+    reasoning, content = _parse_whole("<|channel>analysis\nhmm\n<channel|>answer")
+    assert reasoning == "hmm\n"
+    assert content == "answer"
+
+
+def test_non_thinking_channel_is_content() -> None:
+    # A channel that isn't a known thinking channel is treated as content.
+    reasoning, content = _parse_whole("<|channel>final\nthe answer")
+    assert reasoning == ""
+    assert content == "the answer"
+
+
+def test_leading_content_before_any_channel() -> None:
+    reasoning, content = _parse_whole("hi <|channel>thought\nx\n<channel|>bye")
+    assert reasoning == "x\n"
+    assert content == "hi bye"
+
+
+def test_partial_marker_held_until_complete() -> None:
+    p = GemmaChannelTextParser()
+    em: list[tuple[str, bool]] = []
+    # Feeding a prefix of <|channel> must not emit it as literal text: only the
+    # safe "answer " is emitted; "<|cha" is held back.
+    em += p.feed("answer <|cha")
+    assert em == [("answer ", False)]
+    # Completing the marker + header resolves to a thinking channel.
+    em += p.feed("nnel>thought\nreasoning")
+    em += p.flush()
+    reasoning, content = _collapse(em)
+    assert content == "answer "
+    assert reasoning == "reasoning"


### PR DESCRIPTION
## Why

Gemma 4 is a reasoning model that emits its thinking as **literal** `<|channel>thought … <channel|>` text (not tokenizer special tokens; no template strips them). Served via llama-server, the raw markers leak into output — `--reasoning-format auto` puts the *answer* in `reasoning_content`; `none` leaves raw markers in `content`. llama-server has no parser for Gemma's tokens, so the served runner parses them itself, the same way the in-process runner reparses gpt-oss harmony markers (#403).

## What
- **`GemmaChannelTextParser`** — dependency-free streaming parser; `thought`/`analysis` channel → reasoning, default body → content, markers stripped. 9 unit tests incl. char-by-char streaming.
- **Served runner** — gate on card `output_parser == gemma4`: feed content deltas (streaming) and the non-stream prose answer through the parser; force `--reasoning-format none` so llama-server hands back raw text, regardless of thinking capability (decoupled from `_model_declares_reasoning`).
- **Card** `google/gemma-4-31B-it-qat-q4_0-gguf` — official Google base + `output_parser=gemma4` + thinking capability + MTP via **our own** draft (`FoxlightAI/...`, SWP conversion of the official QAT assistant, not a third-party GGUF).

## On-device validation (kite4, Radeon/Vulkan, gemma-4-12B same `<|channel>` grammar)
Real output through the **actual** parser over the live llama-server SSE stream:
- raw: `<|channel>thought\n…<channel|>The capital of France is Paris.` (grammar confirmed, not assumed)
- parser → `CONTENT: 'The capital of France is Paris.'` (clean), reasoning split out, **markers stripped**
- **MTP active**: `draft-mtp`, 54.7% acceptance, mean accept-len 3.19

## Blocked / follow-up
- **Publishing our draft to `FoxlightAI` needs the org-write token** (the kite4 token is read-only — fine for gated downloads, can't create repos). The SWP converter (skulk-weights-publisher PR #47) is built + unit-tested; publishing the Gemma 4 QAT draft to FoxlightAI is the remaining step before this card resolves in production. **The card should not be relied upon until that draft is published**; the parser merges independently of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)