### PR TITLE
fix(served): forward thinking-control to llama-server (empty answers, #428/#420)

### DIFF
--- a/src/skulk/worker/runner/llama_server/runner.py
+++ b/src/skulk/worker/runner/llama_server/runner.py
@@ -155,6 +155,35 @@ def _model_declares_reasoning(card: Any) -> bool:
         return True
     return "thinking" in (getattr(card, "capabilities", None) or [])
 
+
+def reasoning_request_overrides(task_params: Any) -> dict[str, Any]:
+    """Map Skulk's thinking controls onto llama-server request fields.
+
+    ``generation_kwargs`` carries sampling params but NOT thinking control, so
+    without this the served runner never tells llama-server to suppress reasoning.
+    A reasoning model then thinks on every request regardless of
+    ``enable_thinking=False``, and on a bounded ``max_tokens`` it can spend the
+    whole budget thinking and return EMPTY content (#428/#420).
+
+    llama-server exposes two levers, forwarded here:
+
+    - ``chat_template_kwargs`` -> the model's jinja chat template. ``enable_thinking``
+      is the canonical Qwen3 / Gemma toggle; a template that doesn't understand it
+      simply ignores it, so forwarding is safe across families.
+    - ``reasoning_effort`` -> OpenAI-style effort for harmony models (gpt-oss).
+      ``"none"`` is not a valid server value; disabling is expressed via
+      ``enable_thinking=False`` instead, so it is dropped here.
+    """
+    overrides: dict[str, Any] = {}
+    enable_thinking = getattr(task_params, "enable_thinking", None)
+    if enable_thinking is not None:
+        overrides["chat_template_kwargs"] = {"enable_thinking": enable_thinking}
+    effort = getattr(task_params, "reasoning_effort", None)
+    if effort is not None and effort != "none":
+        overrides["reasoning_effort"] = effort
+    return overrides
+
+
 # How long to wait for the server to finish loading the model and report healthy.
 # A large GGUF on a GPU node can take a while to map + warm up.
 _HEALTH_DEADLINE_S: Final = 600.0
@@ -575,15 +604,17 @@ class Runner:
         command_id = task.command_id
         body: dict[str, Any] = generation_kwargs(task.task_params)
         body["messages"] = messages_for_llama(task.task_params)
+        # Forward thinking-control (enable_thinking / reasoning_effort) to
+        # llama-server. Without this a reasoning model thinks on every request and
+        # can return empty content under a bounded budget (#428/#420).
+        body.update(reasoning_request_overrides(task.task_params))
 
         try:
             # Per-token logprobs are not wired over the SSE proxy yet. Fail loud
             # rather than return a successful response with logprobs silently
             # missing, matching the in-process runner's #385 no-silent-empty
             # contract (the raise surfaces as an ErrorChunk below).
-            if wants_logprobs(
-                task.task_params.logprobs, task.task_params.top_logprobs
-            ):
+            if wants_logprobs(task.task_params.logprobs, task.task_params.top_logprobs):
                 body.pop("logprobs", None)
                 body.pop("top_logprobs", None)
                 raise RuntimeError(

--- a/src/skulk/worker/runner/llama_server/tests/test_reasoning_overrides.py
+++ b/src/skulk/worker/runner/llama_server/tests/test_reasoning_overrides.py
@@ -1,0 +1,55 @@
+"""Tests for thinking-control forwarding to llama-server (#428/#420)."""
+
+from __future__ import annotations
+
+from skulk.shared.types.common import ModelId
+from skulk.shared.types.text_generation import (
+    InputMessage,
+    TextGenerationTaskParams,
+)
+from skulk.worker.runner.llama_server.runner import reasoning_request_overrides
+
+
+def _params(**kwargs: object) -> TextGenerationTaskParams:
+    return TextGenerationTaskParams(
+        model=ModelId("m"),
+        input=[InputMessage(role="user", content="hi")],
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_enable_thinking_false_forwards_chat_template_kwargs() -> None:
+    # The throughput-cell case: enable_thinking=False must reach llama-server, or
+    # the model reasons through the whole budget and returns empty content (#428).
+    overrides = reasoning_request_overrides(_params(enable_thinking=False))
+    assert overrides["chat_template_kwargs"] == {"enable_thinking": False}
+    assert "reasoning_effort" not in overrides
+
+
+def test_enable_thinking_true_forwards_toggle() -> None:
+    overrides = reasoning_request_overrides(_params(enable_thinking=True))
+    assert overrides["chat_template_kwargs"] == {"enable_thinking": True}
+
+
+def test_reasoning_effort_forwarded_but_none_dropped() -> None:
+    assert reasoning_request_overrides(_params(reasoning_effort="high")) == {
+        "reasoning_effort": "high"
+    }
+    # "none" is not a valid server effort; disabling is expressed via
+    # enable_thinking, so it must not be forwarded as reasoning_effort.
+    assert reasoning_request_overrides(_params(reasoning_effort="none")) == {}
+
+
+def test_no_controls_yields_no_overrides() -> None:
+    # Neither set -> let the model's own default behavior stand.
+    assert reasoning_request_overrides(_params()) == {}
+
+
+def test_both_controls_combine() -> None:
+    overrides = reasoning_request_overrides(
+        _params(enable_thinking=True, reasoning_effort="medium")
+    )
+    assert overrides == {
+        "chat_template_kwargs": {"enable_thinking": True},
+        "reasoning_effort": "medium",
+    }


### PR DESCRIPTION
## Why

The served (`llama_server`) runner forwarded sampling params but **never thinking-control**, so a served reasoning model reasoned on every request regardless of `enable_thinking=False`. With a bounded `max_tokens` it spends the whole budget in the reasoning channel and returns **empty content** — a blank answer the user can't turn off.

The post-reboot e2e MTP battery hit this on **all four** served models (Qwen3.5-9B / Qwen3.6-27B / 35B-A3B-MTP + Gemma-4-31B): 2,200–2,580 chars of reasoning, **0 content**, 20/20.

## Fix

Add `reasoning_request_overrides()` and merge it into the chat request body:
- `enable_thinking` → `chat_template_kwargs={"enable_thinking": ...}` (the canonical Qwen3/Gemma jinja toggle; templates that don't understand it ignore it)
- `reasoning_effort` → the OpenAI-style field for harmony models; `"none"` dropped (disabling is via `enable_thinking`)

This is the long-tracked served thinking-control parity item (#420).

## Validation

**On-device** (kite4, transient llama-server, Qwen3.5-9B-MTP), "capital of France, one word":
| request | content | reasoning |
|---|---|---|
| without thinking-control (bug) | `''` | 213 chars |
| with `chat_template_kwargs:{enable_thinking:false}` (what this sends) | **`Paris`** | 0 |

Plus **5 unit tests** asserting the body gets the right fields. basedpyright + ruff clean; 36 served-runner tests pass.

## Scope note

The in-process `llama_cpp` engine (#425) **cannot** be fixed this way — `llama-cpp-python 0.3.31` has no `chat_template_kwargs` / `**kwargs` / thinking params (verified on kite4). The served engine is the path to thinking-control on GGUF nodes.

Fixes #428. Addresses #420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)