### PR TITLE
fix(store): clear cached download status on delete; re-download stale "complete" when files gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- **Store re-download after a delete no longer silently no-ops.** `ModelStore`
+  caches per-model download status in memory; `delete_model` removed the registry
+  entry and on-disk files but left a stale `"complete"` status behind, so a later
+  `request_download` short-circuited on it and never re-fetched. The model would
+  then appear "complete" while absent from the registry and disk, and a worker
+  staging it failed with "not found in store". `delete_model` now clears the
+  cached status, and `request_download` treats a cached `"complete"` as stale
+  whenever the model is no longer actually in the store (a backstop for any cause
+  of files-gone, including out-of-band removal). This unblocks re-provisioning a
+  model after a store-delete (e.g. the download/delete/re-download cycle the test
+  harness drives for served-MTP GGUFs).
+
 ### Added
 
 - **Store-delete now evicts worker-staged copies cluster-wide (#427).** Deleting a

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -351,13 +351,18 @@ class ModelStore:
                 indent=2,
             )
         )
-        # Drop any cached download status for the deleted model. Leaving a stale
-        # "complete" here makes a later request_download short-circuit and never
-        # re-fetch the model we just removed (the registry entry and files are
-        # gone but the in-memory status would still say complete). request_download
-        # also re-checks is_in_store as a backstop, but clearing it at the source
-        # keeps the cache honest.
-        self._active_downloads.pop(model_id, None)
+        # Drop a *terminal* cached download status for the deleted model. Leaving
+        # a stale "complete" here makes a later request_download short-circuit and
+        # never re-fetch the model we just removed (the registry entry and files
+        # are gone but the in-memory status would still say complete). Only clear
+        # complete/failed entries: an in-flight (pending/downloading) entry is
+        # held by a live _do_download task, and popping it would crash that task
+        # (it reads self._active_downloads[model_id]). request_download also
+        # re-checks is_in_store as a backstop, so a surviving in-flight entry that
+        # later completes against a since-deleted model is still self-correcting.
+        cached = self._active_downloads.get(model_id)
+        if cached is not None and cached.status in ("complete", "failed"):
+            del self._active_downloads[model_id]
         return True
 
     def register_model(

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -351,6 +351,13 @@ class ModelStore:
                 indent=2,
             )
         )
+        # Drop any cached download status for the deleted model. Leaving a stale
+        # "complete" here makes a later request_download short-circuit and never
+        # re-fetch the model we just removed (the registry entry and files are
+        # gone but the in-memory status would still say complete). request_download
+        # also re-checks is_in_store as a backstop, but clearing it at the source
+        # keeps the cache honest.
+        self._active_downloads.pop(model_id, None)
         return True
 
     def register_model(
@@ -532,15 +539,26 @@ class ModelStore:
         async with self._download_lock:
             existing = self._active_downloads.get(model_id)
             if existing is not None:
-                # A failed entry retries. A cached-complete entry that is missing
-                # a newly-requested companion (or projector) is stale -- a prior
-                # base-only download in this process left a "complete" status, so
-                # returning it here would skip the recovery re-download below
-                # (the registry-based missing checks would never run). Drop it and
-                # fall through. An in-progress (downloading/pending) entry is
-                # returned as-is to dedup concurrent requests.
+                # A failed entry retries. A cached-complete entry is stale when:
+                #  - it is missing a newly-requested companion (or projector) --
+                #    a prior base-only download in this process left a "complete"
+                #    status, so returning it would skip the recovery re-download
+                #    below (the registry-based missing checks would never run); or
+                #  - the model is no longer actually in the store -- a store-delete
+                #    (``delete_model``) or out-of-band file removal drops the
+                #    registry entry and on-disk files but cannot reach this
+                #    in-memory status, so trusting it would short-circuit the
+                #    re-download and the model would never come back (staging then
+                #    fails "not found in store"). ``is_in_store`` re-checks the
+                #    registry + on-disk dir, so a cached "complete" that no longer
+                #    reflects reality is dropped and re-fetched.
+                # Drop a stale entry and fall through. An in-progress
+                # (downloading/pending) entry is returned as-is to dedup
+                # concurrent requests.
                 stale_complete = existing.status == "complete" and (
-                    missing_projector or missing_companion
+                    missing_projector
+                    or missing_companion
+                    or not self.is_in_store(model_id)
                 )
                 if existing.status == "failed" or stale_complete:
                     del self._active_downloads[model_id]

--- a/src/skulk/store/tests/test_store_download_stale_complete.py
+++ b/src/skulk/store/tests/test_store_download_stale_complete.py
@@ -41,6 +41,23 @@ def test_delete_model_clears_cached_download_status(tmp_path: Path) -> None:
     assert "org/bundle" not in store._active_downloads  # pyright: ignore[reportPrivateUsage]
 
 
+def test_delete_model_leaves_in_flight_download_status(tmp_path: Path) -> None:
+    # An in-flight (pending/downloading) status is owned by a live _do_download
+    # task that reads self._active_downloads[model_id]; delete_model must not pop
+    # it out from under that task. Only terminal (complete/failed) statuses are
+    # cleared.
+    store = ModelStore(tmp_path)
+    _register(store, "org/bundle", ["base-Q4_K_M.gguf"])
+    store._active_downloads["org/bundle"] = StoreDownloadStatus(  # pyright: ignore[reportPrivateUsage]
+        model_id="org/bundle", status="downloading", progress=0.4
+    )
+
+    assert store.delete_model("org/bundle") is True
+
+    # The in-flight entry survives so the running download task does not crash.
+    assert "org/bundle" in store._active_downloads  # pyright: ignore[reportPrivateUsage]
+
+
 async def test_request_download_redownloads_stale_complete_when_files_gone(
     tmp_path: Path,
 ) -> None:

--- a/src/skulk/store/tests/test_store_download_stale_complete.py
+++ b/src/skulk/store/tests/test_store_download_stale_complete.py
@@ -1,0 +1,70 @@
+"""A cached download status must not outlive the model's files on disk.
+
+``ModelStore._active_downloads`` caches per-model download status. A store-delete
+(``delete_model``) or out-of-band file removal drops the registry entry and the
+on-disk files but cannot reach that in-memory cache, so a stale ``"complete"``
+can linger. If ``request_download`` trusted it, the re-download would be
+short-circuited and the model would never come back, and a worker staging it
+would fail "not found in store". These tests pin the two guards that prevent
+that: ``delete_model`` clears the cache at the source, and ``request_download``
+re-checks ``is_in_store`` as a backstop for any other cause of files-gone.
+"""
+
+from pathlib import Path
+
+from skulk.store.model_store import ModelStore, StoreDownloadStatus
+
+
+def _register(store: ModelStore, model_id: str, files: list[str]) -> None:
+    model_dir = store.store_path / model_id.replace("/", "--")
+    model_dir.mkdir(parents=True, exist_ok=True)
+    for name in files:
+        (model_dir / name).write_text("x")
+    store.register_model(model_id, model_dir, files, 1, repo_has_projector=False)
+
+
+def _seed_complete(store: ModelStore, model_id: str) -> None:
+    store._active_downloads[model_id] = StoreDownloadStatus(  # pyright: ignore[reportPrivateUsage]
+        model_id=model_id, status="complete", progress=1.0
+    )
+
+
+def test_delete_model_clears_cached_download_status(tmp_path: Path) -> None:
+    store = ModelStore(tmp_path)
+    _register(store, "org/bundle", ["base-Q4_K_M.gguf", "config.json"])
+    _seed_complete(store, "org/bundle")
+
+    assert store.delete_model("org/bundle") is True
+
+    # The stale "complete" is gone, so a later request_download re-fetches the
+    # deleted model instead of short-circuiting on it.
+    assert "org/bundle" not in store._active_downloads  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_request_download_redownloads_stale_complete_when_files_gone(
+    tmp_path: Path,
+) -> None:
+    # Files were removed out-of-band (e.g. a delete that did not clear the cache,
+    # or a manual rmtree) but a "complete" status lingers in memory.
+    store = ModelStore(tmp_path)
+    _seed_complete(store, "org/gone")
+    assert store.is_in_store("org/gone") is False
+
+    status = await store.request_download("org/gone", "base-Q4_K_M.gguf", None)
+
+    # The stale complete is dropped and a real re-download is kicked off rather
+    # than returning the lie.
+    assert status.status in ("pending", "downloading")
+
+
+async def test_request_download_keeps_cached_complete_when_still_in_store(
+    tmp_path: Path,
+) -> None:
+    # Dedup is preserved for an entry that genuinely is still in the store.
+    store = ModelStore(tmp_path)
+    _register(store, "org/present", ["base-Q4_K_M.gguf", "config.json"])
+    _seed_complete(store, "org/present")
+
+    status = await store.request_download("org/present", "base-Q4_K_M.gguf", None)
+
+    assert status.status == "complete"


### PR DESCRIPTION
## What

A model could not be **re-downloaded to the store after a store-delete**: the download endpoint reported `complete` instantly while the files were absent on disk and the model was missing from the registry, so a worker staging it failed with "not found in store."

## Root cause

`ModelStore` caches per-model download status in `self._active_downloads`. `delete_model` removed the registry entry and `rmtree`'d the on-disk files but **never cleared that in-memory cache**. A later `request_download` hit the dedup path, found the stale `"complete"`, and returned it — the real re-download never ran. The dedup staleness check only re-downloaded for a missing *projector/companion*, never for *files that no longer exist*.

This was discovered re-provisioning served-MTP GGUFs on the fleet: the e2e harness downloads then deletes them (`--delete-staged-models` / store-delete), and the next run's `--ensure-store-downloads` short-circuited on the stale `"complete"`.

## Fix

Two guards in `src/skulk/store/model_store.py`:
- **`delete_model`** clears `_active_downloads[model_id]` at the source.
- **`request_download`** treats a cached `"complete"` as stale when `not is_in_store(model_id)` — a backstop covering any cause of files-gone (delete, manual removal, eviction), not just delete.

## Validation

Reproduced and fixed on the live fleet: with the stale cache cleared, `unsloth/Qwen3.5-9B-MTP-GGUF` downloaded for real (8.9 GB, registered in the store) instead of false-completing.

## Tests

`test_store_download_stale_complete.py`:
- `delete_model` clears the cached status.
- `request_download` re-downloads a stale `"complete"` when files are gone.
- `request_download` preserves dedup (returns `complete`) when the model is genuinely still in the store.

## Gates

`uv run basedpyright` 0 errors · `uv run ruff check` clean · `uv run pytest src/skulk/store/` 74 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)