### PR TITLE
fix(download): remove total-timeout cap on large file-body downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ This project records release notes here and mirrors public-facing notes in
   downloads now have no `total` cap and are instead policed by `sock_read` /
   `sock_connect` inactivity timeouts: a genuinely stalled connection still times
   out and retries (resuming from the `.partial`), while a slow-but-alive transfer
-  of any size completes. Store download failures also now record the exception
-  type instead of an empty error string.
+  of any size completes. The worker-side wait for a store download
+  (`request_and_wait_for_download`) is likewise now progress-aware: its timeout
+  is a stall timeout (max time without progress), not a total cap, so the worker
+  no longer gives up on a live, still-progressing multi-hour download and lets
+  the master tear the placement down. Store download failures also now record the
+  exception type instead of an empty error string.
 
 - **Store re-download after a delete no longer silently no-ops.** `ModelStore`
   caches per-model download status in memory; `delete_model` removed the registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Large model downloads no longer time out mid-transfer.** The download session's
+  `long` timeout profile applied a fixed 30-minute `total` cap to the entire file
+  transfer, so a multi-GB GGUF that was downloading fine failed partway through
+  once it outlasted the cap (a 17 GB model at ~7.5 MB/s hit the cap at ~80%,
+  surfacing only as an empty-string `TimeoutError`; larger models like the 62 GB
+  gpt-oss-120B GGUF would fail sooner in percentage terms). Large file-body
+  downloads now have no `total` cap and are instead policed by `sock_read` /
+  `sock_connect` inactivity timeouts: a genuinely stalled connection still times
+  out and retries (resuming from the `.partial`), while a slow-but-alive transfer
+  of any size completes. Store download failures also now record the exception
+  type instead of an empty error string.
+
 - **Store re-download after a delete no longer silently no-ops.** `ModelStore`
   caches per-model download status in memory; `delete_model` removed the registry
   entry and on-disk files but left a stale `"complete"` status behind, so a later

--- a/src/skulk/download/download_utils.py
+++ b/src/skulk/download/download_utils.py
@@ -722,13 +722,23 @@ def create_http_session(
     auto_decompress: bool = False,
     timeout_profile: Literal["short", "long"] = "long",
 ) -> aiohttp.ClientSession:
+    total_timeout: int | None
     if timeout_profile == "short":
         total_timeout = 30
         connect_timeout = 10
         sock_read_timeout = 30
         sock_connect_timeout = 10
     else:
-        total_timeout = 1800
+        # No TOTAL cap on large file-body downloads: a fixed wall-clock total
+        # timeout caps the download by elapsed time regardless of progress, so a
+        # multi-GB GGUF that is downloading fine just fails partway through once
+        # it outlasts the cap (a 17 GB model at ~7.5 MB/s hit the old 1800 s cap
+        # at ~80%, surfacing as an empty-string TimeoutError). Progress is
+        # instead policed by ``sock_read`` (per-read inactivity) and
+        # ``sock_connect`` — a genuinely stalled connection still times out and
+        # retries (which resume from the ``.partial``), but a slow-but-alive
+        # transfer of any size completes.
+        total_timeout = None
         connect_timeout = 60
         sock_read_timeout = 60
         sock_connect_timeout = 60

--- a/src/skulk/download/tests/test_http_session_timeout.py
+++ b/src/skulk/download/tests/test_http_session_timeout.py
@@ -1,0 +1,31 @@
+"""Large file-body downloads must not be capped by a total wall-clock timeout.
+
+A fixed ``total`` timeout on the ``long`` profile caps a download by elapsed
+time regardless of progress, so a multi-GB GGUF that is downloading fine fails
+partway through once it outlasts the cap (a 17 GB model hit the old 1800 s cap
+at ~80%, surfacing as an empty-string ``TimeoutError``). The ``long`` profile
+must instead rely on ``sock_read`` / ``sock_connect`` so a stalled connection
+still times out while a slow-but-alive transfer of any size completes.
+"""
+
+from skulk.download.download_utils import create_http_session
+
+
+async def test_long_profile_has_no_total_timeout() -> None:
+    session = create_http_session(timeout_profile="long")
+    try:
+        assert session.timeout.total is None
+        # Progress is still policed by per-read / connect inactivity timeouts.
+        assert session.timeout.sock_read == 60
+        assert session.timeout.sock_connect == 60
+    finally:
+        await session.close()
+
+
+async def test_short_profile_keeps_a_total_cap() -> None:
+    # Small metadata/HEAD requests should still fail fast overall.
+    session = create_http_session(timeout_profile="short")
+    try:
+        assert session.timeout.total == 30
+    finally:
+        await session.close()

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -752,5 +752,11 @@ class ModelStore:
 
         except Exception as exc:
             status.status = "failed"
-            status.error = str(exc)
-            logger.error(f"ModelStore: download of {model_id} failed: {exc}")
+            # Always record the exception TYPE: several failure modes (notably a
+            # TimeoutError) stringify to "", which produced an empty, useless
+            # error field that hid the real cause of a stalled large download.
+            detail = str(exc)
+            status.error = f"{type(exc).__name__}: {detail}" if detail else type(exc).__name__
+            logger.exception(
+                f"ModelStore: download of {model_id} failed ({type(exc).__name__})"
+            )

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -509,7 +509,11 @@ class ModelStoreClient:
         Args:
             model_id: HuggingFace model ID.
             on_progress: Called with progress (0.0-1.0) on each poll.
-            timeout: Maximum wait time in seconds.
+            timeout: Maximum time to wait WITHOUT download progress, in seconds
+                (a stall timeout, not a total cap). A download that keeps
+                advancing never times out, however large; only a genuine stall
+                does. The store host's file-body transfer is itself uncapped, so
+                a very large model can legitimately take hours.
             poll_interval: Seconds between status polls.
             pinned_gguf: The card's pinned GGUF file (``ModelCard.gguf_file``),
                 sent in the POST body so the store fetches that quant's shard
@@ -525,7 +529,7 @@ class ModelStoreClient:
 
         Raises:
             RuntimeError: If the download failed on the store host.
-            TimeoutError: If the download didn't complete within *timeout*.
+            TimeoutError: If the download made no progress for *timeout* seconds.
         """
         import asyncio as _asyncio
 
@@ -557,36 +561,50 @@ class ModelStoreClient:
         status_url = _make_store_url(
             self._store_host, self._store_port, f"/models/{encoded_id}/download/status"
         )
-        elapsed = 0.0
-        while elapsed < timeout:
+        # The wait is progress-aware, not a fixed total. The store host's
+        # file-body download is uncapped (see create_http_session "long"), so a
+        # very large model can legitimately take hours; a fixed total wait here
+        # would give up on a live, still-progressing download and make the master
+        # tear the placement down. Reset the stall clock whenever progress
+        # advances; only a genuine stall (no progress for ``timeout`` seconds)
+        # fails. A poll that could not observe progress (network blip, or no
+        # advance) counts toward the stall.
+        last_progress = -1.0
+        stalled_for = 0.0
+        while stalled_for < timeout:
             await _asyncio.sleep(poll_interval)
-            elapsed += poll_interval
+            advanced = False
             try:
                 async with (
                     create_http_session(timeout_profile="short") as session,
                     session.get(status_url) as resp,
                 ):
-                    if resp.status != 200:
-                        continue
-                    data = await resp.json()
-                    if not isinstance(data, dict):
-                        continue
-                    status = data.get("status", "")
-                    progress = float(data.get("progress", 0.0))
-                    if on_progress is not None:
-                        await on_progress(progress)
-                    if status == "complete":
-                        return True
-                    if status == "failed":
-                        raise RuntimeError(
-                            f"Store download of {model_id} failed: {data.get('error', 'unknown')}"
-                        )
+                    if resp.status == 200:
+                        data = await resp.json()
+                        if isinstance(data, dict):
+                            status = data.get("status", "")
+                            progress = float(data.get("progress", 0.0))
+                            if on_progress is not None:
+                                await on_progress(progress)
+                            if status == "complete":
+                                return True
+                            if status == "failed":
+                                raise RuntimeError(
+                                    f"Store download of {model_id} failed: {data.get('error', 'unknown')}"
+                                )
+                            if progress > last_progress:
+                                last_progress = progress
+                                advanced = True
             except RuntimeError:
                 raise
             except Exception as exc:
                 logger.debug(f"ModelStoreClient: download status poll failed: {exc}")
+            stalled_for = 0.0 if advanced else stalled_for + poll_interval
 
-        raise TimeoutError(f"Store download of {model_id} timed out after {timeout}s")
+        raise TimeoutError(
+            f"Store download of {model_id} made no progress for {timeout}s "
+            f"(last progress {last_progress:.1%})"
+        )
 
     # ------------------------------------------------------------------
     # Local copy path (store host → same filesystem)

--- a/src/skulk/store/tests/test_download_wait_progress_aware.py
+++ b/src/skulk/store/tests/test_download_wait_progress_aware.py
@@ -1,0 +1,86 @@
+"""The worker's wait for a store download is progress-aware, not a total cap.
+
+With the store host's uncapped file-body transfer, a very large model can take
+hours. ``request_and_wait_for_download`` must not give up on a live,
+still-progressing download (which would make the master tear the placement
+down); it fails only on a genuine stall (no progress for ``timeout`` seconds).
+"""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from skulk.store import model_store_client
+from skulk.store.model_store_client import ModelStoreClient
+
+
+class _FakeResp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.status = 200
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeSession:
+    """Returns the POST ack once, then walks a scripted list of status polls."""
+
+    def __init__(self, polls: Iterator[dict[str, Any]]) -> None:
+        self._polls = polls
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+    def post(self, *_: object, **__: object) -> _FakeResp:
+        return _FakeResp({"status": "pending", "progress": 0.0})
+
+    def get(self, *_: object, **__: object) -> _FakeResp:
+        return _FakeResp(next(self._polls))
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, polls: list[dict[str, Any]]) -> None:
+    it = iter(polls)
+
+    def _fake(*_: object, **__: object) -> _FakeSession:
+        return _FakeSession(it)
+
+    monkeypatch.setattr(model_store_client, "create_http_session", _fake)
+
+
+async def test_wait_does_not_time_out_while_progress_advances(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Progress creeps up over many polls, far more than `timeout`/`poll_interval`
+    # would allow if the wait were a fixed total. It must still complete.
+    polls = [{"status": "downloading", "progress": p / 100} for p in range(1, 40)]
+    polls.append({"status": "complete", "progress": 1.0})
+    _install(monkeypatch, polls)
+    client = ModelStoreClient(store_host="h", store_port=1)
+    ok = await client.request_and_wait_for_download(
+        "org/big", timeout=0.05, poll_interval=0.0
+    )
+    assert ok is True
+
+
+async def test_wait_times_out_on_a_genuine_stall(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Progress never advances: this is a real stall and must time out.
+    polls = [{"status": "downloading", "progress": 0.5} for _ in range(1000)]
+    _install(monkeypatch, polls)
+    client = ModelStoreClient(store_host="h", store_port=1)
+    with pytest.raises(TimeoutError):
+        await client.request_and_wait_for_download(
+            "org/stuck", timeout=0.02, poll_interval=0.01
+        )


### PR DESCRIPTION
## What

Large model downloads (multi-GB GGUFs) could fail mid-transfer with an **empty error string**, then recover only on a later retry.

## Root cause

`create_http_session(timeout_profile="long")` — used for the actual file-body download in `_download_file` — set `total=1800` (30 min) on the aiohttp `ClientTimeout`. A `total` timeout caps the **entire** transfer by wall-clock, regardless of whether data is still flowing. So a 17 GB GGUF at ~7.5 MB/s hit the cap at **~80%** and raised a `TimeoutError` (which stringifies to `""`, hence the empty error). Bigger models fail sooner in percentage terms — the 62 GB gpt-oss-120B and 42 GB Llama-70B GGUFs would be worse.

Observed in the e2e mtp-served cell on `froggeric/Qwen3.6-27B-MTP-GGUF` (failed at 80.6%, empty error, recovered on retry).

## Fix

- The `long` profile now sets **`total=None`** and relies on `sock_read` (60 s per-read inactivity) and `sock_connect`/`connect`. A genuinely stalled connection still times out and retries (resuming from the `.partial` — resume was already implemented), while a slow-but-alive transfer of any size completes. The `short` profile (metadata/HEAD) keeps its 30 s `total`.
- `ModelStore` download-failure status/log now records the **exception type**, so a `TimeoutError` no longer leaves an empty, useless error field.

## Why it matters for this release

The AMD/Strix audience pulls large MTP/GGUF models as their first action. A big download failing partway through (with no error message) is a bad first impression. It self-recovered here, but on slower connections the fixed 30-min cap makes it more likely.

## Tests

`test_http_session_timeout.py`: the `long` profile has no `total` cap (and keeps `sock_read`/`sock_connect`); the `short` profile keeps its 30 s total.

## Gates

`uv run basedpyright` 0 errors · `uv run ruff check` clean · new + `test_re_download` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)