### PR TITLE
docs: served-engine + native MTP on AMD; 1.3.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-01
+
 ### Fixed
 
 - **Large model downloads no longer time out mid-transfer.** The download session's

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Documentation](https://img.shields.io/badge/docs-documentation-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/)
 [![Build & Runtime Paths](https://img.shields.io/badge/docs-build_%26_runtime-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/build-and-runtime/)
-[![Release Notes](https://img.shields.io/badge/release_notes-v1.3.0-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/release-notes/1.3.0/)
+[![Release Notes](https://img.shields.io/badge/release_notes-v1.3.1-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/release-notes/1.3.1/)
 [![Architecture](https://img.shields.io/badge/docs-architecture-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/architecture/)
 
   <br>
@@ -611,7 +611,7 @@ Highlights:
 - [Thunderbolt clustering](https://foxlight-foundation.github.io/Skulk/thunderbolt-clustering) and [RDMA on macOS](https://foxlight-foundation.github.io/Skulk/build-and-runtime)
 - [Speculative decoding](https://foxlight-foundation.github.io/Skulk/speculative-decoding)
 - [API guide](https://foxlight-foundation.github.io/Skulk/api-guide) and [architecture](https://foxlight-foundation.github.io/Skulk/architecture)
-- [Release notes](https://foxlight-foundation.github.io/Skulk/release-notes/1.3.0/)
+- [Release notes](https://foxlight-foundation.github.io/Skulk/release-notes/1.3.1/)
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ Build/runtime note:
 | macOS on Apple Silicon | Primary target. Best experience today. Serves MLX models. |
 | Multi-Mac clusters | Supported. Best results on matched macOS versions and fast networking. |
 | RDMA over Thunderbolt 5 | Supported on eligible macOS 26.2+ hardware after OS-level setup. |
-| AMD / Linux GPU (for example Strix Halo) | Supported. Joins a cluster and serves GGUF models on a llama.cpp engine (Vulkan or ROCm), alongside Apple Silicon nodes. See the [AMD / Strix Halo node guide](https://foxlight-foundation.github.io/Skulk/amd-strix-halo-nodes). |
+| AMD / Linux GPU (for example Strix Halo) | Supported. Joins a cluster and serves GGUF models on its GPU, alongside Apple Silicon nodes, through two engines: in-process `llama_cpp` (Vulkan or ROCm), and a served `llama_server` engine that unlocks llama.cpp's **native multi-token prediction** (`--spec-type draft-mtp`) so speculative decoding runs on AMD too. See the [AMD / Strix Halo node guide](https://foxlight-foundation.github.io/Skulk/amd-strix-halo-nodes). |
 | Linux (CPU only) | Supported as a control/API node; GGUF serving on CPU is possible but slow. |
 
 ## Core Features
 
 - **Distributed inference**: split work across devices instead of treating each machine as an island.
-- **Heterogeneous engines**: Apple Silicon nodes serve MLX models and AMD or other Linux GPU nodes serve GGUF models on a llama.cpp engine (Vulkan or ROCm), in one cluster, with each model routed to a node that can run it.
-- **Speculative decoding**: measured 1.16–2.2× decode speedups via multi-token prediction, on by default for supported model cards, including multi-node placements on mixed hardware.
+- **Heterogeneous engines**: Apple Silicon nodes serve MLX models; AMD or other Linux GPU nodes serve GGUF models through an in-process `llama_cpp` engine (Vulkan or ROCm) and a served `llama_server` engine; all in one cluster, with each model routed to a node that can run it.
+- **Speculative decoding**: measured 1.16–2.2× decode speedups via multi-token prediction, on by default for supported model cards, including multi-node placements on mixed hardware. On AMD/GPU nodes, llama.cpp's native MTP (`--spec-type draft-mtp`) runs through the served engine.
 - **Skulk Dashboard**: React dashboard for topology, model store, chat, settings, and placement workflows.
 - **Model Store**: centralize model files on one node and stage them to the rest of the cluster over the LAN; for GGUF repos it downloads only the quantization a model card pins, and the store host advertises a routable address so downloads work on a Thunderbolt-meshed fleet.
 - **Cluster-wide config sync**: update config from the dashboard and sync it across nodes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skulk"
-version = "1.3.0"
+version = "1.3.1"
 description = "Skulk: distributed AI inference across heterogeneous clusters (Apple Silicon MLX and AMD/Linux GPU)"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -2862,7 +2862,7 @@ wheels = [
 
 [[package]]
 name = "skulk"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },

--- a/website/docs/amd-strix-halo-nodes.md
+++ b/website/docs/amd-strix-halo-nodes.md
@@ -1,13 +1,23 @@
 # AMD Strix Halo nodes (Linux / ROCm)
 
 Skulk clusters are not Mac-only. An AMD Ryzen AI Max (Strix Halo, `gfx1151`) box
-running Linux can join a cluster as a worker that serves **GGUF models through
-llama.cpp on its integrated Radeon GPU**, alongside Apple Silicon nodes serving
-MLX models. The cluster is heterogeneous: each model is placed on the nodes that
-can actually run it.
+running Linux can join a cluster as a worker that serves **GGUF models on its
+integrated Radeon GPU**, alongside Apple Silicon nodes serving MLX models. The
+cluster is heterogeneous: each model is placed on the nodes that can actually run
+it.
 
-This page covers what such a node needs, how to bring one up, and how the
-cluster decides what to run where.
+An AMD node can run GGUF models through **two engines**:
+
+- **`llama_cpp`** (in-process): the default GGUF path. Skulk loads the model with
+  `llama-cpp-python` and decodes on the Radeon GPU via Vulkan. Single-node.
+- **`llama_server`** (served): Skulk launches an external `llama-server` process
+  and proxies its OpenAI API. This is the only path to llama.cpp's **native
+  multi-token prediction** (`--spec-type draft-mtp`), so it is how you get
+  speculative-decoding speedups on an AMD node. Single-node; enabled per node by
+  pointing `SKULK_LLAMA_SERVER_BIN` at a `llama-server` binary.
+
+This page covers what such a node needs, how to bring one up, both engines, and
+how the cluster decides what to run where.
 
 ## What runs where
 
@@ -17,6 +27,9 @@ A Skulk node advertises the compute **backends** it can serve, written as
 - A macOS node advertises `mlx` and `mlx-metal`.
 - A Linux node with llama.cpp built for the Radeon GPU advertises `llama_cpp`
   and `llama_cpp-vulkan`.
+- If that node also has a `llama-server` binary (`SKULK_LLAMA_SERVER_BIN`), it
+  additionally advertises the served backend for its GPU, e.g.
+  `llama_server-vulkan` (and `llama_server-cpu` as a floor).
 
 Each model card declares which backends can run it. A GGUF model card lists
 llama.cpp backends as compatible; an MLX/safetensors model lists MLX. When you
@@ -132,19 +145,42 @@ llama.cpp's multimodal chat handler, so image chat requests (OpenAI `image_url`
 content) work. A repo is recognized as a vision model from its `config.json`
 vision section, or, when it ships none, from the presence of the `mmproj` file.
 
-One thing is deliberately not on the AMD path today:
+## Native MTP on the AMD node (served engine)
 
-- **Multi-token prediction (MTP) / speculative decoding is MLX-only.** Those
-  speedups come from MLX-specific drafting (model-native prediction heads or a
-  sidecar drafter) and cross-rank coordination, which the llama.cpp engine does
-  not implement, so an AMD node runs plain autoregressive decoding. GGUF models
-  advertise no MTP capability, so it is never shown as available for them (there
-  is no promise to fall short of); the AMD node serves at its native decode speed.
+Speculative decoding (multi-token prediction) **does** run on an AMD node,
+through the served `llama_server` engine. llama.cpp's native MTP lives in the
+`llama-server` application, not in the in-process `llama-cpp-python` binding, so
+Skulk reaches it by launching `llama-server` with `--spec-type draft-mtp` and
+proxying its OpenAI API. A model whose card declares `served_spec_type =
+draft_mtp` and lists `llama_server-*` backends is placed on a node that has a
+`llama-server` binary and served with MTP on.
 
-## Scope
+There are two MTP shapes, both served this way:
 
-A single AMD node serves GGUF models on its own GPU. Sharding one model across an
-AMD node and a Mac is not supported (the two engines do not share a runtime);
-multi-node GGUF inference across several llama.cpp nodes is tracked separately.
+- **Baked-in heads**: a GGUF that ships MTP prediction tensors (for example the
+  Qwen3.5 / Qwen3.6 MTP GGUFs). No separate draft model is needed.
+- **Draft-model MTP**: a base GGUF plus a small separate draft GGUF passed as
+  `--model-draft` (for example Gemma 4 31B with a published draft). The card
+  co-fetches both through the store.
+
+To enable it on a node, install a `llama-server` build with MTP support and point
+`SKULK_LLAMA_SERVER_BIN` at it before launching Skulk. On a Ryzen AI Max the
+Vulkan `llama-server` serves an MTP-capable GGUF on the Radeon GPU and generates
+with speculation active, streaming reasoning and tool calls through the same
+`/v1` endpoints as any other model. Acceptance is per-model: a pairing that does
+not pay is turned off in that model's card, the same discipline MLX MTP uses. See
+[Speculative Decoding](speculative-decoding.md) for how MTP works and what
+speedups to expect.
+
+## What is not on the AMD path today
+
+- **MTP across the in-process `llama_cpp` engine.** The in-process binding does
+  not expose native MTP; use the served `llama_server` engine (above) for MTP.
+  A GGUF served through `llama_cpp` runs plain autoregressive decoding.
+- **Sharding one model across an AMD node and a Mac** (the two engines do not
+  share a runtime), and **multi-node GGUF inference** across several llama.cpp
+  nodes (tracked separately). A single AMD node serves each GGUF model on its own
+  GPU.
+
 The interconnect doctrine still applies: the cluster fabric is trusted, so put
 untrusted segments behind your own network controls.

--- a/website/docs/release-notes/1.0.2.md
+++ b/website/docs/release-notes/1.0.2.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.0.2
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.0.3.md
+++ b/website/docs/release-notes/1.0.3.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.0.3
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.1.0.md
+++ b/website/docs/release-notes/1.1.0.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.1.0
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.2.0.md
+++ b/website/docs/release-notes/1.2.0.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.2.0
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.3.0.md
+++ b/website/docs/release-notes/1.3.0.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.3.0
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.3.1.md
+++ b/website/docs/release-notes/1.3.1.md
@@ -33,7 +33,7 @@ deployments hit.
   [Speculative Decoding](../speculative-decoding.md).
 
 - **Store-delete evicts staged copies cluster-wide.** Deleting a model from the
-  store (`DELETE /store/models/{id}`) now removes the store host's canonical copy
+  store (`DELETE /store/models/{model_id}`) now removes the store host's canonical copy
   **and** evicts the model's staged copy from every node, instead of leaving each
   worker's disk to reclaim it lazily under memory pressure. See the
   [model store guide](../model-store.md).

--- a/website/docs/release-notes/1.3.1.md
+++ b/website/docs/release-notes/1.3.1.md
@@ -1,0 +1,62 @@
+---
+title: Release Notes 1.3.1
+sidebar_position: 1
+---
+
+<!-- Copyright 2025 Foxlight Foundation -->
+
+Release date: 2026-07-01
+
+Skulk 1.3.1 brings **speculative decoding to AMD and other GPU nodes**. 1.3.0 let
+a Linux GPU box join the cluster and serve GGUF models through an in-process
+llama.cpp engine; 1.3.1 adds a second, served engine that unlocks llama.cpp's
+native multi-token prediction, so the speculative-decoding speedups that were
+Apple-Silicon-only now run on a Strix Halo too. It also hardens the model store
+against a few download and re-provisioning edge cases that large-model
+deployments hit.
+
+## Highlights
+
+- **Native MTP on GPU nodes (served `llama_server` engine).** A new
+  inference-engine class launches an external `llama-server` process and proxies
+  its OpenAI API, coexisting with the in-process `mlx` and `llama_cpp` engines.
+  It is the only path to llama.cpp's native multi-token-prediction speculative
+  decoding (`--spec-type draft-mtp`), which is not reachable from the in-process
+  binding. Enable it on a node by pointing `SKULK_LLAMA_SERVER_BIN` at a
+  `llama-server` binary; route a model to it with `compatible_backends` and
+  configure speculation with the card's `served_spec_type` / `served_spec_n_max`
+  runtime fields. Two MTP shapes are supported: GGUFs with baked-in MTP heads
+  (Qwen3.5 / Qwen3.6) and a base plus a separate `--model-draft` GGUF (Gemma 4
+  31B, co-fetched through the store). Measured 2.19x on a dense Qwen3.6-27B on a
+  Strix Halo (Radeon / Vulkan). See the
+  [AMD / Strix Halo node guide](../amd-strix-halo-nodes.md) and
+  [Speculative Decoding](../speculative-decoding.md).
+
+- **Store-delete evicts staged copies cluster-wide.** Deleting a model from the
+  store (`DELETE /store/models/{id}`) now removes the store host's canonical copy
+  **and** evicts the model's staged copy from every node, instead of leaving each
+  worker's disk to reclaim it lazily under memory pressure. See the
+  [model store guide](../model-store.md).
+
+## Fixes
+
+- **Large model downloads no longer time out mid-transfer.** The store's
+  file-body download applied a fixed 30-minute total timeout that capped a
+  transfer by wall-clock regardless of progress, so a multi-GB GGUF could fail
+  partway through (a 17 GB model at ~7.5 MB/s failed at ~80%, with an empty
+  error). Large downloads are now bounded by read-inactivity, not total time, so
+  a slow-but-progressing transfer of any size completes and resumes from its
+  partial on retry. The worker's wait for a store download is likewise
+  progress-aware, so it no longer gives up on a live, still-progressing
+  multi-hour download.
+
+- **Store re-download after a delete no longer silently no-ops.** A stale
+  in-memory "complete" status could make a re-download short-circuit after a
+  delete, leaving a model that reported complete while absent from the store and
+  unstageable ("not found in store"). Re-provisioning a model after a
+  store-delete now works.
+
+## Upgrading
+
+All nodes in a cluster must run the same Skulk version. Upgrade the whole fleet
+together; mixed-version clusters are unsupported.

--- a/website/docs/speculative-decoding.md
+++ b/website/docs/speculative-decoding.md
@@ -38,6 +38,30 @@ pipeline (sharded) placements through one shared decode loop. You do not
 enable it, size it, or tune it for normal use: if a model ships with a
 drafter and the placement supports it, it activates on its own.
 
+## Two Engines: MLX and Served (llama.cpp)
+
+MTP runs on both of Skulk's speculative-capable engines, and placement routes
+each model to the right one from its card:
+
+- **MLX** (Apple Silicon, in-process): the drafters and models in the table
+  below. Skulk owns the generation loop, the multi-node ring, and the
+  speculative decode across sharded placements. This is the engine the speedup
+  numbers and multi-node discussion on this page describe.
+- **Served / `llama_server`** (GPU nodes, including AMD): llama.cpp's **native**
+  MTP, reached by launching `llama-server --spec-type draft-mtp` and proxying it
+  (native MTP lives in the server app, not the in-process binding). This is how
+  speculative decoding works on an AMD node. It is single-node and applies to
+  GGUF models whose card declares `served_spec_type = draft_mtp`, in two shapes:
+  baked-in MTP heads (Qwen3.5 / Qwen3.6 MTP GGUFs) and a base plus a separate
+  `--model-draft` GGUF (Gemma 4 31B). See
+  [AMD Strix Halo nodes](amd-strix-halo-nodes.md) for enabling it
+  (`SKULK_LLAMA_SERVER_BIN`) and the served MTP cards.
+
+Everything below (the MLX drafter table, the multi-node speedups, and the
+turn-itself-off cases) is about the MLX engine. The served engine's speculation
+is configured on the model card (`served_spec_type`, `served_spec_n_max`) and,
+like MLX MTP, is carded off per model when a pairing does not pay.
+
 ## Which Models Ship With It
 
 These models carry a drafter in their model card and use speculative

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -51,7 +51,7 @@ const sidebars: SidebarsConfig = {
         {
           type: "category",
           label: "Release Notes",
-          items: ["release-notes/1.3.0", "release-notes/1.2.0", "release-notes/1.1.0", "release-notes/1.0.3", "release-notes/1.0.2"],
+          items: ["release-notes/1.3.1", "release-notes/1.3.0", "release-notes/1.2.0", "release-notes/1.1.0", "release-notes/1.0.3", "release-notes/1.0.2"],
         },
         "cluster-communication",
         "architecture",


### PR DESCRIPTION
## What

Documents the served-backend engine (`llama_server`) and **native MTP on AMD**, and cuts the 1.3.1 release notes. Before this, the served engine + AMD MTP existed only in the architecture fact-sheets, and `amd-strix-halo-nodes.md` still told readers **"MTP is MLX-only"** — the exact opposite of the release headline.

## Doc changes

- **`amd-strix-halo-nodes.md`**: now describes both AMD engines (in-process `llama_cpp` and served `llama_server`); adds a **"Native MTP on the AMD node (served engine)"** section covering `SKULK_LLAMA_SERVER_BIN`, `--spec-type draft-mtp`, and the two MTP shapes (baked-in heads vs a separate `--model-draft` GGUF); replaces the stale "MTP is MLX-only" section with an accurate "what is / isn't on the AMD path."
- **`speculative-decoding.md`**: adds a **"Two Engines: MLX and Served (llama.cpp)"** section so the previously MLX-only guide names the served/native-MTP path.
- **`README.md`**: the AMD platform row and the heterogeneous/speculative-decoding bullets now name the served engine and native MTP on AMD.
- **`release-notes/1.3.1.md`** (new): served MTP on GPU nodes as the headline, plus store-delete cluster-wide eviction and the large-download + re-download fixes. Older notes' `sidebar_position` cascaded.
- **`CHANGELOG.md`**: `[Unreleased]` → `[1.3.1]`. **`pyproject.toml`**: `1.3.0` → `1.3.1` (uv.lock follows).

`architecture.md` / `architecture-reference.md` already carry current served-engine coverage (verified, unchanged).

## Notes

- All prose is em-dash-free per project style.
- This is docs + release-notes + version bump; the actual dev→main promotion (the release cut) is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)