### PR TITLE
fix(gatherer): classify Linux interface types via sysfs (unblocks TB-first addressing)

### DIFF
--- a/src/skulk/utils/info_gatherer/system_info.py
+++ b/src/skulk/utils/info_gatherer/system_info.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import socket
 import sys
@@ -156,17 +157,78 @@ async def _get_interface_types_from_networksetup() -> dict[str, InterfaceType]:
     return parse_hardware_port_types(result.stdout.decode())
 
 
+def classify_linux_interface(
+    interface_name: str, sysfs_net_root: str = "/sys/class/net"
+) -> InterfaceType:
+    """Classify a Linux network interface's transport type via sysfs.
+
+    macOS interface types come from ``networksetup``, which does not exist on
+    Linux, so before this classifier every Linux interface was labeled
+    ``unknown`` -- which meant the ring/RPC address prioritiser (thunderbolt
+    first, #265) could never distinguish a USB4/Thunderbolt point-to-point link
+    from the ordinary LAN between two Linux nodes and the preference was dead
+    code off-macOS.
+
+    Detection order (most reliable signal first):
+
+    1. ``<sysfs>/<iface>/wireless`` directory present -> ``wifi`` (kernel
+       creates it for any wireless interface regardless of name).
+    2. Device driver symlink resolving to a thunderbolt driver
+       (``thunderbolt-net``) -> ``thunderbolt``.
+    3. Interface name prefix ``thunderbolt``/``tb`` -> ``thunderbolt``
+       (fallback when the driver symlink is unreadable).
+    4. A physical device backing (``<sysfs>/<iface>/device`` exists) with a
+       conventional wired name (``en*``/``eth*``) -> ``ethernet``. Virtual
+       interfaces (veth, bridges, tunnels such as Tailscale's) have no device
+       backing and stay ``unknown``; VPN deprioritisation is address-based
+       elsewhere and unaffected.
+
+    Args:
+        interface_name: Kernel interface name (e.g. ``enp92s0``).
+        sysfs_net_root: Root of the sysfs net class; injectable for tests.
+
+    Returns:
+        The classified :data:`InterfaceType`, ``unknown`` when no signal
+        matches.
+    """
+    interface_root = os.path.join(sysfs_net_root, interface_name)
+    if os.path.isdir(os.path.join(interface_root, "wireless")):
+        return "wifi"
+    driver_link = os.path.join(interface_root, "device", "driver")
+    try:
+        driver_name = os.path.basename(os.path.realpath(driver_link))
+    except OSError:
+        driver_name = ""
+    if "thunderbolt" in driver_name:
+        return "thunderbolt"
+    if interface_name.startswith(("thunderbolt", "tb")):
+        return "thunderbolt"
+    if interface_name.startswith(("en", "eth")) and os.path.exists(
+        os.path.join(interface_root, "device")
+    ):
+        return "ethernet"
+    return "unknown"
+
+
 async def get_network_interfaces() -> list[NetworkInterfaceInfo]:
     """
-    Retrieves detailed network interface information on macOS.
-    Parses output from 'networksetup -listallhardwareports' and 'ifconfig'
-    to determine interface names, IP addresses, and types (ethernet, wifi, vpn, other).
+    Retrieves detailed network interface information.
+    On macOS, parses 'networksetup -listallhardwareports' output to determine
+    interface types (ethernet, wifi, thunderbolt); on Linux, classifies via
+    sysfs (wireless dir, thunderbolt driver, physical device backing).
     Returns a list of NetworkInterfaceInfo objects.
     """
     interfaces_info: list[NetworkInterfaceInfo] = []
     interface_types = await _get_interface_types_from_networksetup()
 
     for iface, services in psutil.net_if_addrs().items():
+        interface_type = interface_types.get(iface)
+        if interface_type is None:
+            interface_type = (
+                classify_linux_interface(iface)
+                if sys.platform == "linux"
+                else "unknown"
+            )
         for service in services:
             match service.family:
                 case socket.AF_INET | socket.AF_INET6:
@@ -174,7 +236,7 @@ async def get_network_interfaces() -> list[NetworkInterfaceInfo]:
                         NetworkInterfaceInfo(
                             name=iface,
                             ip_address=service.address,
-                            interface_type=interface_types.get(iface, "unknown"),
+                            interface_type=interface_type,
                         )
                     )
                 case _:

--- a/src/skulk/utils/info_gatherer/tests/test_linux_interface_classify.py
+++ b/src/skulk/utils/info_gatherer/tests/test_linux_interface_classify.py
@@ -1,0 +1,82 @@
+"""Linux interface-type classification via sysfs.
+
+Before `classify_linux_interface`, every Linux interface was labeled
+``unknown`` (interface types came only from macOS ``networksetup``), so the
+ring/RPC address prioritiser's thunderbolt-first ranking (#265) could never
+fire between two Linux nodes: a USB4/TB point-to-point link and the ordinary
+LAN tied at "unknown" priority. These tests exercise the classifier against a
+synthetic sysfs tree; no hardware or privileged reads involved.
+"""
+
+import os
+from pathlib import Path
+
+from skulk.utils.info_gatherer.system_info import classify_linux_interface
+
+
+def _make_iface(
+    sysfs_root: Path,
+    name: str,
+    *,
+    wireless: bool = False,
+    device: bool = False,
+    driver: str | None = None,
+) -> None:
+    iface_dir = sysfs_root / name
+    iface_dir.mkdir(parents=True)
+    if wireless:
+        (iface_dir / "wireless").mkdir()
+    if device or driver is not None:
+        (iface_dir / "device").mkdir()
+    if driver is not None:
+        # Mirror the kernel layout: device/driver is a symlink into
+        # /sys/bus/<bus>/drivers/<name>; only the basename matters here.
+        drivers_dir = sysfs_root / "_drivers"
+        drivers_dir.mkdir(exist_ok=True)
+        target = drivers_dir / driver
+        target.mkdir(exist_ok=True)
+        os.symlink(target, iface_dir / "device" / "driver")
+
+
+def test_wireless_dir_wins_regardless_of_name(tmp_path: Path) -> None:
+    # Kernel creates the wireless dir for any Wi-Fi interface; name-agnostic.
+    _make_iface(tmp_path, "wlp2s0", wireless=True, device=True, driver="ath11k_pci")
+    assert classify_linux_interface("wlp2s0", str(tmp_path)) == "wifi"
+
+
+def test_thunderbolt_by_driver_symlink(tmp_path: Path) -> None:
+    # thunderbolt-net interfaces are the USB4/TB point-to-point links the
+    # address prioritiser must rank first.
+    _make_iface(tmp_path, "thunderbolt0", device=True, driver="thunderbolt-net")
+    assert classify_linux_interface("thunderbolt0", str(tmp_path)) == "thunderbolt"
+
+
+def test_thunderbolt_by_name_when_driver_unreadable(tmp_path: Path) -> None:
+    _make_iface(tmp_path, "tb0", device=True)
+    assert classify_linux_interface("tb0", str(tmp_path)) == "thunderbolt"
+
+
+def test_ethernet_needs_physical_device_backing(tmp_path: Path) -> None:
+    _make_iface(tmp_path, "enp92s0", device=True, driver="r8169")
+    assert classify_linux_interface("enp92s0", str(tmp_path)) == "ethernet"
+
+
+def test_virtual_en_named_interface_stays_unknown(tmp_path: Path) -> None:
+    # A veth/bridge can carry an en-ish name but has no device backing; it must
+    # not masquerade as wired transport for the prioritiser.
+    _make_iface(tmp_path, "enveth0")
+    assert classify_linux_interface("enveth0", str(tmp_path)) == "unknown"
+
+
+def test_tunnels_and_loopback_stay_unknown(tmp_path: Path) -> None:
+    # Tailscale/tun devices are handled by address-based VPN detection
+    # downstream; the classifier must not give them a transport label.
+    _make_iface(tmp_path, "tailscale0")
+    _make_iface(tmp_path, "lo")
+    assert classify_linux_interface("tailscale0", str(tmp_path)) == "unknown"
+    assert classify_linux_interface("lo", str(tmp_path)) == "unknown"
+
+
+def test_missing_sysfs_entry_is_unknown(tmp_path: Path) -> None:
+    # Interface disappeared between enumeration and classification.
+    assert classify_linux_interface("enp99s0", str(tmp_path)) == "unknown"


### PR DESCRIPTION
Interface types come only from macOS `networksetup`, so every Linux interface is labeled `unknown` and the address prioritiser's thunderbolt-first ranking (#265) is dead code between two Linux nodes: a USB4/TB point-to-point link and the ordinary 2.5GbE LAN tie at `unknown` priority. This matters now that the AMD pair (kite4/kite5) is the target for multi-node GGUF inference over a TB interconnect (#328, #329) — donor/ring address selection should automatically prefer the TB link once it exists.

## Change
`classify_linux_interface()` in `system_info.py`, used as the fallback when `networksetup` yields nothing (i.e. off-macOS). Detection order, most reliable signal first:
1. `<sysfs>/<iface>/wireless` dir present → `wifi` (kernel-created, name-agnostic)
2. device driver symlink resolving to `thunderbolt-net` → `thunderbolt`
3. `thunderbolt*`/`tb*` name prefix → `thunderbolt` (fallback when the symlink is unreadable)
4. physical device backing + `en*`/`eth*` name → `ethernet`
5. else `unknown` — virtual interfaces (veth, bridges, `tailscale0`/tun) have no device backing and keep their VPN handling address-based, unchanged

macOS behavior is unchanged (the `networksetup` map still wins when present). Sysfs root is injectable for tests.

## Validation
- 7 new unit tests against a synthetic sysfs tree (wifi wins over name, driver symlink, name fallback, virtual-`en*` stays unknown, tunnels/lo unknown, missing entry unknown).
- Checked against the live boxes' real inventories: kite4 `eno1` (r8169) → ethernet, `thunderbolt1` (thunderbolt-net) → thunderbolt, `wlp195s0` → wifi, `docker0`/`tailscale0`/`lo` → unknown; kite5 equivalent.
- Full suite 1508 passed; basedpyright 0 errors; ruff clean.

Design context: `foxlight-docs/initiatives/skulk-amd-nodes/multi-node-gguf-design.md` §3.5 (Track A of the multi-node GGUF plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)