### PR TITLE
fix(api): placement previews report the minted instance meta

### DIFF
--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -267,7 +267,7 @@ from skulk.shared.types.worker.instances import (
     Instance,
     InstanceId,
     InstanceMeta,
-    LlamaRpcInstance,
+    instance_meta_of,
 )
 from skulk.shared.types.worker.runners import RunnerId
 from skulk.shared.types.worker.shards import Sharding
@@ -1788,16 +1788,14 @@ class API:
                     extra = 1 if index < remainder else 0
                     memory_delta_by_node[str(node_id)] = per_node + extra
 
-            # Report the MINTED instance's meta, not the requested one: shape
-            # selection is cycle-driven, so a Pipeline/MlxRing request over an
-            # AMD pair can mint a LlamaRpcInstance (#328). Consumers (dashboard,
-            # test harness) match previews by instance_meta, so the preview
-            # must be truthful about the shape a real placement would produce.
-            minted_meta = (
-                InstanceMeta.LlamaRpc
-                if isinstance(instance, LlamaRpcInstance)
-                else instance_meta
-            )
+            # Report the MINTED instance's meta, not the requested one:
+            # placement normalizes shapes (single-node cycles become rings
+            # regardless of requested meta; an RPC-capable cycle mints a
+            # LlamaRpcInstance from a ring request, #328). Consumers
+            # (dashboard, test harness) match previews by instance_meta, so
+            # the preview must be truthful about the shape a real placement
+            # would produce.
+            minted_meta = instance_meta_of(instance)
             if (
                 model_card.model_id,
                 sharding,

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -263,7 +263,12 @@ from skulk.shared.types.telemetry import (
 )
 from skulk.shared.types.text_generation import TextGenerationTaskParams
 from skulk.shared.types.worker.downloads import DownloadCompleted
-from skulk.shared.types.worker.instances import Instance, InstanceId, InstanceMeta
+from skulk.shared.types.worker.instances import (
+    Instance,
+    InstanceId,
+    InstanceMeta,
+    LlamaRpcInstance,
+)
 from skulk.shared.types.worker.runners import RunnerId
 from skulk.shared.types.worker.shards import Sharding
 from skulk.shared.version import get_skulk_version, get_skulk_version_label
@@ -1783,17 +1788,27 @@ class API:
                     extra = 1 if index < remainder else 0
                     memory_delta_by_node[str(node_id)] = per_node + extra
 
+            # Report the MINTED instance's meta, not the requested one: shape
+            # selection is cycle-driven, so a Pipeline/MlxRing request over an
+            # AMD pair can mint a LlamaRpcInstance (#328). Consumers (dashboard,
+            # test harness) match previews by instance_meta, so the preview
+            # must be truthful about the shape a real placement would produce.
+            minted_meta = (
+                InstanceMeta.LlamaRpc
+                if isinstance(instance, LlamaRpcInstance)
+                else instance_meta
+            )
             if (
                 model_card.model_id,
                 sharding,
-                instance_meta,
+                minted_meta,
                 len(placement_node_ids),
             ) not in seen:
                 previews.append(
                     PlacementPreview(
                         model_id=model_card.model_id,
                         sharding=sharding,
-                        instance_meta=instance_meta,
+                        instance_meta=minted_meta,
                         instance=instance,
                         memory_delta_by_node=memory_delta_by_node or None,
                         error=None,
@@ -1803,7 +1818,7 @@ class API:
                 (
                     model_card.model_id,
                     sharding,
-                    instance_meta,
+                    minted_meta,
                     len(placement_node_ids),
                 )
             )

--- a/src/skulk/master/placement.py
+++ b/src/skulk/master/placement.py
@@ -60,6 +60,7 @@ from skulk.shared.types.worker.instances import (
     LlamaRpcInstance,
     MlxJacclInstance,
     MlxRingInstance,
+    instance_meta_of,
 )
 from skulk.shared.types.worker.runners import ShardAssignments
 from skulk.shared.types.worker.shards import Sharding, TensorShardMetadata
@@ -807,12 +808,7 @@ def _placement_intent_from_instance(
         if any(isinstance(shard, TensorShardMetadata) for shard in shards)
         else Sharding.Pipeline
     )
-    if isinstance(instance, MlxJacclInstance):
-        instance_meta = InstanceMeta.MlxJaccl
-    elif isinstance(instance, LlamaRpcInstance):
-        instance_meta = InstanceMeta.LlamaRpc
-    else:
-        instance_meta = InstanceMeta.MlxRing
+    instance_meta = instance_meta_of(instance)
     width = len(instance.shard_assignments.node_to_runner)
     return model_card, sharding, instance_meta, width
 

--- a/src/skulk/shared/types/worker/instances.py
+++ b/src/skulk/shared/types/worker/instances.py
@@ -101,6 +101,22 @@ class LlamaRpcInstance(BaseInstance):
 Instance = MlxRingInstance | MlxJacclInstance | LlamaRpcInstance
 
 
+def instance_meta_of(instance: Instance) -> InstanceMeta:
+    """The ``InstanceMeta`` a concrete instance actually embodies.
+
+    Placement normalizes and resolves shapes (a single-node cycle becomes a
+    ring regardless of the requested meta; an RPC-capable cycle mints a
+    ``LlamaRpcInstance`` even from a ring request), so consumers reporting or
+    recovering intent must derive the meta from the instance TYPE, never echo
+    the requested value. Single source of truth for that derivation.
+    """
+    if isinstance(instance, MlxJacclInstance):
+        return InstanceMeta.MlxJaccl
+    if isinstance(instance, LlamaRpcInstance):
+        return InstanceMeta.LlamaRpc
+    return InstanceMeta.MlxRing
+
+
 class BoundInstance(CamelCaseModel):
     instance: Instance
     bound_runner_id: RunnerId


### PR DESCRIPTION
Shape selection is cycle-driven (#328): a `Pipeline`/`MlxRing` preview request over the AMD pair mints a `LlamaRpcInstance`, but the preview reported the requested meta, so a pooled preview claimed `MlxRing`. The dashboard and the test harness both match previews by `instance_meta`, making pooled previews untruthful and unmatchable (found wiring the harness pooled cell). Successful previews now report the minted instance's actual meta.

Gates: basedpyright 0, ruff clean, 1534 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)