### PR TITLE
fix(master): download-failure recovery consumes the terminal failure record

### DIFF
--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -58,6 +58,7 @@ from skulk.shared.types.events import (
     InputChunkReceived,
     InstanceDeleted,
     LocalForwarderEvent,
+    NodeDownloadProgress,
     NodeGatheredInfo,
     NodeTimedOut,
     StagedModelEvicted,
@@ -92,7 +93,7 @@ from skulk.shared.types.tasks import (
     TextGeneration as TextGenerationTask,
 )
 from skulk.shared.types.telemetry import TelemetryView
-from skulk.shared.types.worker.downloads import DownloadFailed
+from skulk.shared.types.worker.downloads import DownloadFailed, DownloadPending
 from skulk.shared.types.worker.instances import Instance, InstanceId
 from skulk.shared.types.worker.runners import RunnerReady, RunnerRunning
 from skulk.shared.types.worker.shards import RpcDonorShardMetadata
@@ -1213,6 +1214,41 @@ class Master:
                 )
             for event in transition_events:
                 await self.event_sender.send(event)
+            # Recovery CONSUMES the terminal failure record: reset each failed
+            # node's download status for this model back to Pending. Without
+            # this, the stale DownloadFailed lingers in session state and this
+            # same scan condemns EVERY future placement of the model that
+            # touches the node, long after the cause (disk full, network blip)
+            # is gone -- one transient failure permanently poisoned the model
+            # on that node until a whole-fleet restart (observed live: an
+            # ENOSPC during a pooled placement kept killing fresh placements
+            # an hour after the disk was freed). This recovery pass already
+            # acted on the failure (teardown + re-place excluding the node);
+            # if the cause persists, the next download fails afresh and
+            # recovery repeats, so nothing is lost by clearing history.
+            for node_id in failed_nodes:
+                runner_id = instance.shard_assignments.node_to_runner.get(node_id)
+                shard = (
+                    instance.shard_assignments.runner_to_shard.get(runner_id)
+                    if runner_id is not None
+                    else None
+                )
+                if shard is None:
+                    continue
+                await self.event_sender.send(
+                    NodeDownloadProgress(
+                        download_progress=DownloadPending(
+                            node_id=node_id,
+                            shard_metadata=shard,
+                            model_directory="",
+                        )
+                    )
+                )
+                logger.info(
+                    f"Reset stale DownloadFailed for "
+                    f"{shard.model_card.model_id} on {node_id} (consumed by "
+                    "recovery)"
+                )
 
     async def _event_processor(self) -> None:
         with self.local_event_receiver as local_events:

--- a/src/skulk/master/tests/test_download_failure_recovery.py
+++ b/src/skulk/master/tests/test_download_failure_recovery.py
@@ -183,6 +183,81 @@ def test_multiple_failed_ranks_all_reported() -> None:
     assert failed_nodes == frozenset({node_a, node_b})
 
 
+async def test_recovery_consumes_the_terminal_failure_record() -> None:
+    """Recovery must reset the failed node's download status to Pending.
+
+    Without the reset, the stale terminal DownloadFailed lingers in session
+    state and the wedge scan condemns EVERY future placement of the model
+    touching that node, long after the cause is gone (observed live: an
+    ENOSPC during a pooled placement kept killing fresh placements an hour
+    after the disk was freed, until a whole-fleet restart).
+    """
+    from anyio import WouldBlock
+
+    from skulk.master.main import Master
+    from skulk.routing.router import get_node_id_keypair
+    from skulk.shared.types.commands import (
+        ForwarderCommand,
+        ForwarderDownloadCommand,
+    )
+    from skulk.shared.types.common import SessionId
+    from skulk.shared.types.events import (
+        Event,
+        GlobalForwarderEvent,
+        LocalForwarderEvent,
+        NodeDownloadProgress,
+    )
+    from skulk.shared.types.state_sync import StateSyncMessage
+    from skulk.shared.types.worker.downloads import DownloadPending
+    from skulk.utils.channels import channel
+
+    master_node = NodeId(get_node_id_keypair().to_node_id())
+    session_id = SessionId(master_node_id=master_node, election_clock=0)
+    ge_sender, _ = channel[GlobalForwarderEvent]()
+    _, co_receiver = channel[ForwarderCommand]()
+    _, le_receiver = channel[LocalForwarderEvent]()
+    ss_sender, ss_receiver = channel[StateSyncMessage]()
+    fcds, _ = channel[ForwarderDownloadCommand]()
+    ev_send, ev_recv = channel[Event]()
+    master = Master(
+        master_node,
+        session_id,
+        event_sender=ev_send,
+        global_event_sender=ge_sender,
+        local_event_receiver=le_receiver,
+        command_receiver=co_receiver,
+        state_sync_receiver=ss_receiver,
+        state_sync_sender=ss_sender,
+        download_command_sender=fcds,
+    )
+
+    iid = InstanceId()
+    node_a, node_b = NodeId("a"), NodeId("b")
+    instance, runner_a, runner_b = _two_node_instance(iid, node_a, node_b)
+    master.state = _state(
+        instance,
+        {runner_a: RunnerConnected(), runner_b: RunnerConnected()},
+        {node_a: [_failed(node_a)], node_b: [_completed(node_b)]},
+    )
+
+    await master._recover_download_failed_instances()  # pyright: ignore[reportPrivateUsage]
+
+    resets: list[NodeDownloadProgress] = []
+    while True:
+        try:
+            event = ev_recv.receive_nowait()
+        except WouldBlock:
+            break
+        if isinstance(event, NodeDownloadProgress):
+            resets.append(event)
+    assert any(
+        isinstance(reset.download_progress, DownloadPending)
+        and reset.download_progress.node_id == node_a
+        and reset.download_progress.shard_metadata.model_card.model_id == _MODEL
+        for reset in resets
+    ), "recovery must emit a DownloadPending reset for the failed node"
+
+
 def test_stale_donor_download_failure_does_not_wedge_rpc_instance() -> None:
     # RPC donors never download the model (#328). A stale terminal
     # DownloadFailed for the same model on the DONOR node (from an earlier


### PR DESCRIPTION
One transient download failure (disk full, network blip) permanently poisoned a model on a node: the terminal DownloadFailed stayed in session state, and the #381 wedge scan condemned every future placement of that model touching the node until a whole-fleet restart. Observed live tonight: an ENOSPC during a pooled placement kept killing fresh, correct placements an hour after the disk was freed.

Fix: the recovery pass now CONSUMES the failure it acts on, emitting a DownloadPending reset for each failed node's model entry after teardown + re-place-excluding. apply() replaces per (node, model), so the stale record is gone; a persisting cause fails afresh and recovery repeats, bounded as before.

Test: drives `_recover_download_failed_instances` on a constructed Master and asserts the reset event for the failed node. Gates: basedpyright 0, ruff clean, full suite green.

Found and fixed under the standing goal: run the full e2e, fix every bug found, repeat until green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)