### PR TITLE
fix(master): refusal recovery falls back to excluding the refuser

### DIFF
--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -15,6 +15,7 @@ from skulk.master.placement import (
     add_instance_to_placements,
     cancel_unnecessary_downloads,
     delete_instance,
+    fallback_command_for_refused_instance,
     get_transition_events,
     place_instance,
     replacement_command_for_download_failed_instance,
@@ -904,14 +905,60 @@ class Master:
                                         f"still gossiping ({err}). Torn down."
                                     )
                                 except PlacementError as err:
-                                    final_placement = after_delete
-                                    logger.error(
-                                        "Cannot re-place "
-                                        f"{replace_command.model_card.model_id} after "
-                                        f"refusal on {command.node_id} (tried "
-                                        f"min_nodes={replace_command.min_nodes}): {err}. "
-                                        "Giving up on this placement."
+                                    # The wider width can be unsatisfiable by
+                                    # construction on a heterogeneous fleet (an
+                                    # MLX model refused at the full Mac width
+                                    # cannot add an AMD node). Fall back to
+                                    # anywhere-but-the-refuser at min_nodes=1:
+                                    # the memory fit-check, not the width,
+                                    # decides. Only a second failure is
+                                    # terminal.
+                                    fallback = fallback_command_for_refused_instance(
+                                        refused, command.node_id
                                     )
+                                    try:
+                                        final_placement = place_instance(
+                                            fallback,
+                                            self.state.topology,
+                                            after_delete,
+                                            self._telemetry_view.node_memory,
+                                            self.state.node_network,
+                                            download_status=self.state.downloads,
+                                            excluded_nodes={command.node_id},
+                                            node_resources=self._telemetry_view.node_resources,
+                                            node_vram=usable_vram_by_node(
+                                                self._telemetry_view.node_system,
+                                                self._telemetry_view.node_resources,
+                                                node_memory=self._telemetry_view.node_memory,
+                                            ),
+                                            node_vram_strict=usable_vram_by_node(
+                                                self._telemetry_view.node_system,
+                                                self._telemetry_view.node_resources,
+                                                node_memory=self._telemetry_view.node_memory,
+                                                include_uma_spill=False,
+                                            ),
+                                        )
+                                        logger.warning(
+                                            "Re-placing "
+                                            f"{fallback.model_card.model_id} "
+                                            f"excluding refusing node "
+                                            f"{command.node_id} (wider width "
+                                            f"min_nodes={replace_command.min_nodes} "
+                                            f"was unplaceable: {err})"
+                                        )
+                                    except (
+                                        PlacementError,
+                                        PlacementInfoPendingError,
+                                    ) as fallback_err:
+                                        final_placement = after_delete
+                                        logger.error(
+                                            "Cannot re-place "
+                                            f"{replace_command.model_card.model_id} after "
+                                            f"refusal on {command.node_id} (tried "
+                                            f"min_nodes={replace_command.min_nodes}, then "
+                                            f"excluding the refuser: {fallback_err}). "
+                                            "Giving up on this placement."
+                                        )
                                 transition_events = get_transition_events(
                                     self.state.instances,
                                     final_placement,

--- a/src/skulk/master/placement.py
+++ b/src/skulk/master/placement.py
@@ -813,6 +813,34 @@ def _placement_intent_from_instance(
     return model_card, sharding, instance_meta, width
 
 
+def fallback_command_for_refused_instance(
+    instance: Instance, refusing_node: NodeId
+) -> PlaceInstance:
+    """Build the anywhere-but-the-refuser fallback for a memory-refused instance.
+
+    The primary #290 recovery re-places one node WIDER so every shard shrinks,
+    but on a heterogeneous fleet the wider width can be unsatisfiable by
+    construction: an MLX model refused at the full Mac width cannot add an AMD
+    node, so the wider attempt raises and recovery used to give up even though
+    a narrower cycle EXCLUDING the memory-constrained refuser would fit
+    (observed live: a 3-Mac placement refused on the 16GB node dead-ended at
+    min_nodes=4 while the 24GB node could serve the model alone). This
+    fallback re-places at ``min_nodes=1`` with the refusing node excluded,
+    letting the planner pick the best remaining cycle; the memory fit-check,
+    not the width, decides. The caller treats a second failure as terminal.
+    """
+    model_card, sharding, instance_meta, _width = _placement_intent_from_instance(
+        instance
+    )
+    return PlaceInstance(
+        model_card=model_card,
+        sharding=sharding,
+        instance_meta=instance_meta,
+        min_nodes=1,
+        excluded_nodes=[refusing_node],
+    )
+
+
 def replacement_command_for_refused_instance(instance: Instance) -> PlaceInstance:
     """Build a *wider* placement command to recover a memory-refused instance.
 

--- a/src/skulk/master/tests/test_placement.py
+++ b/src/skulk/master/tests/test_placement.py
@@ -4,6 +4,7 @@ from skulk.master.placement import (
     PlacementError,
     PlacementInfoPendingError,
     add_instance_to_placements,
+    fallback_command_for_refused_instance,
     get_transition_events,
     place_instance,
     replacement_command_for_refused_instance,
@@ -1231,6 +1232,55 @@ def test_replacement_command_widens_refused_instance_by_one_node() -> None:
     assert replacement.model_card.model_id == card.model_id
     assert replacement.sharding == Sharding.Pipeline
     assert replacement.instance_meta == InstanceMeta.MlxRing
+
+
+def test_refusal_fallback_excludes_refuser_at_any_width() -> None:
+    """When the wider re-place is unsatisfiable, the fallback re-places
+    anywhere but the refusing node at min_nodes=1 (#290 on a heterogeneous
+    fleet: an MLX model refused at the full Mac width cannot go wider, but a
+    remaining node can hold it alone)."""
+    topology, node_memory, node_network, node_ids = _fully_connected_three_nodes(
+        (10.0, 10.0, 24.0)
+    )
+    card = ModelCard(
+        model_id=ModelId("fallback-model"),
+        storage_size=Memory.from_gb(9),
+        n_layers=12,
+        hidden_size=30,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+    )
+    three_node = PlaceInstance(
+        model_card=card,
+        sharding=Sharding.Pipeline,
+        instance_meta=InstanceMeta.MlxRing,
+        min_nodes=3,
+    )
+    placed = place_instance(three_node, topology, {}, node_memory, node_network)
+    instance = next(iter(placed.values()))
+    refusing_node = node_ids[0]
+
+    # The wider attempt is unsatisfiable by construction (only 3 nodes).
+    wider = replacement_command_for_refused_instance(instance)
+    assert wider.min_nodes == 4
+    with pytest.raises(PlacementError):
+        place_instance(wider, topology, {}, node_memory, node_network)
+
+    # The fallback places on the remaining nodes with the refuser excluded.
+    fallback = fallback_command_for_refused_instance(instance, refusing_node)
+    assert fallback.min_nodes == 1
+    assert fallback.excluded_nodes == [refusing_node]
+    assert fallback.model_card.model_id == card.model_id
+    result = place_instance(
+        fallback,
+        topology,
+        {},
+        node_memory,
+        node_network,
+        excluded_nodes={refusing_node},
+    )
+    fallback_instance = next(iter(result.values()))
+    assert refusing_node not in fallback_instance.shard_assignments.node_to_runner
 
 
 def test_refused_instance_replaces_onto_a_wider_split() -> None:


### PR DESCRIPTION
Found by the e2e goal loop (iteration 1, moe cell): a 3-Mac placement of gemma-4-26b was memory-refused on the 16GB node; the #290 wider re-place (min_nodes=4) necessarily touched a backend-ineligible AMD node and recovery gave up, even though the 24GB Mac could hold the model alone. On a heterogeneous fleet, any refusal at an engine's maximum width was an automatic dead-end.

Fix: when the wider re-place raises, retry once at min_nodes=1 with the refusing node excluded; the memory fit-check decides. Second failure is terminal, preserving the bounded-recovery property. Pure helper + placement-level test reproducing the dead-end.

Gates: basedpyright 0, ruff clean, 1536 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)