### PR TITLE
fix: land the 1.4.0 release-review fixes on dev (runner poll-loop close, --check GPU groups)

### DIFF
--- a/deployment/rocm/install-deps.sh
+++ b/deployment/rocm/install-deps.sh
@@ -152,8 +152,14 @@ ensure_gpu_groups() {
   local added=0
   for grp in render video; do
     if getent group "$grp" >/dev/null 2>&1 && ! id -nG "$target_user" | tr ' ' '\n' | grep -qx "$grp"; then
-      log "adding $target_user to group $grp"
-      [ "$CHECK_ONLY" -eq 0 ] && sudo usermod -aG "$grp" "$target_user" && added=1
+      if [ "$CHECK_ONLY" -eq 1 ]; then
+        # Missing group membership means the node cannot open /dev/dri: a
+        # verify run must fail on it, not just note it.
+        check_gap "$target_user is not in group $grp (no /dev/dri access)"
+      else
+        log "adding $target_user to group $grp"
+        sudo usermod -aG "$grp" "$target_user" && added=1
+      fi
     fi
   done
   [ "$added" -eq 1 ] && warn "group membership changed: log out and back in (or reboot) before starting Skulk."

--- a/src/skulk/worker/runner/llama_server/runner.py
+++ b/src/skulk/worker/runner/llama_server/runner.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from typing import Any, Final, Literal, NamedTuple
 
 import httpx
-from anyio import EndOfStream, WouldBlock
+from anyio import ClosedResourceError, EndOfStream, WouldBlock
 
 from skulk.shared.backends import LLAMA_SERVER_BIN_ENV
 from skulk.shared.models.model_cards import OutputParserType
@@ -395,7 +395,11 @@ class Runner:
                         # forever while every future request 500s.
                         self._ensure_server_alive()
                         continue
-                    except EndOfStream:
+                    except (EndOfStream, ClosedResourceError):
+                        # receive_timeout raises ClosedResourceError when the
+                        # sender closed before the end-of-stream sentinel was
+                        # drained (the shared closed flag is checked first);
+                        # treat it like EndOfStream: clean loop exit.
                         break
                     if task.task_id in self.seen:
                         logger.warning("repeat task - potential error")

--- a/src/skulk/worker/runner/rpc_donor/runner.py
+++ b/src/skulk/worker/runner/rpc_donor/runner.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 from typing import IO, final
 
-from anyio import EndOfStream, WouldBlock
+from anyio import ClosedResourceError, EndOfStream, WouldBlock
 
 from skulk.shared.backends import RPC_SERVER_BIN_ENV, rpc_server_binary
 from skulk.shared.types.events import (
@@ -154,7 +154,12 @@ class Runner:
                         # rather than gossip Ready over a dead port.
                         self._ensure_server_alive()
                         continue
-                    except EndOfStream:
+                    except (EndOfStream, ClosedResourceError):
+                        # A sender-side close sets the channel's shared closed
+                        # flag BEFORE the end-of-stream sentinel is drained, and
+                        # receive_timeout checks that flag first, so a normal
+                        # close can surface as ClosedResourceError here. Both
+                        # mean the same thing: no more tasks, exit cleanly.
                         break
                     self._handle_task(task)
                     if isinstance(self.current_status, RunnerShutdown):


### PR DESCRIPTION
## Summary

Re-lands on dev the two code fixes that release review (#460) surfaced and that were committed directly to `release/1.4.0` — dev is the integration branch and the promotion PR should carry nothing dev does not have, so these go here first and the release branch then syncs from dev.

- **Served/donor runner poll loops treat `ClosedResourceError` as a clean exit.** `MpSender.close()` sets the shared closed flag before the end-of-stream sentinel drains, and `receive_timeout` checks the flag first, so a normal close could exit the runner via an exception and be logged as a failure. Both between-task liveness loops now handle it like `EndOfStream`. Channel semantics already pinned by `test_receive_timeout_closed_on_sender_close`.
- **`install-deps.sh --check` counts missing `render`/`video` membership as a gap** and exits non-zero; previously verify mode silently skipped the `usermod` and passed a node that cannot open `/dev/dri`.

## Validation

- basedpyright 0 errors, ruff clean, 1796 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)