### PR TITLE
fix(dashboard): UI version reads pyproject.toml (single version source)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 This project records release notes here and mirrors public-facing notes in
 `website/docs/release-notes/`.
 
+## [Unreleased]
+
+### Fixed
+
+- **The dashboard header shows the real Skulk version.** The UI version was
+  baked at build time from the dashboard's own `package.json`, which had
+  silently drifted (it still said 1.3.0 through two releases). The build now
+  reads the version from the repo root `pyproject.toml`, the single source
+  of truth the release process bumps, so the UI can never drift again. The
+  dashboard `package.json` version is no longer read by anything.
+
 ## [1.4.0] - 2026-07-05
 
 ### Added

--- a/dashboard-react/package-lock.json
+++ b/dashboard-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard-react",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard-react",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@reduxjs/toolkit": "^2.11.2",

--- a/dashboard-react/package.json
+++ b/dashboard-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard-react",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard-react/vite.config.ts
+++ b/dashboard-react/vite.config.ts
@@ -1,19 +1,33 @@
 /// <reference types="vitest/config" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import pkg from './package.json' with { type: 'json' };
 
 // https://vite.dev/config/
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
 const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * The Skulk version shown in the dashboard header. Read from the repo root
+ * pyproject.toml at build time so there is exactly ONE version source of
+ * truth: the release process bumps pyproject and the UI follows. (The
+ * dashboard package.json version was the source before and drifted
+ * silently through two releases.)
+ */
+function skulkVersion(): string {
+  const pyproject = readFileSync(path.resolve(dirname, '../pyproject.toml'), 'utf8');
+  const match = pyproject.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!match) throw new Error('could not read version from ../pyproject.toml');
+  return match[1];
+}
+
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_VERSION__: JSON.stringify(skulkVersion()),
   },
   plugins: [react()],
   server: {


### PR DESCRIPTION
## Summary

Tom caught the deployed dashboard reporting **1.3.0** on the freshly-released 1.4.0 fleet. Root cause: the UI version (`__APP_VERSION__`) was baked at build time from `dashboard-react/package.json`, a second version field the release process never bumps; it had silently drifted through both 1.3.1 and 1.4.0.

Fix kills the drift class rather than patching the value: `vite.config.ts` now reads the version from the repo root `pyproject.toml` at build time, so the single bump the release process already makes drives the UI too. The dashboard `package.json` version is bumped once for hygiene but is no longer read by anything.

## Validation

- `npm run build` succeeds and the emitted bundle contains `1.4.0` (verified by grep on `dist/assets`)
- Build fails loudly if the pyproject version cannot be parsed

## Deployment note

Nodes serve their locally-built `dist/`; this fix reaches the fleet on the next dashboard rebuild per node (planned post-battery so builds do not skew the running benchmark cells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)