### PR TITLE
feat(dashboard): model store restacks as cards at the phone breakpoint

### DIFF
--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import styled, { css, keyframes, useTheme } from 'styled-components';
+import { MOBILE_BREAKPOINT_PX } from '../../hooks/useMediaQuery';
 import type { Theme } from '../../theme';
 import { FiTrash2, FiExternalLink, FiRefreshCw } from 'react-icons/fi';
 import { MdPlayArrow, MdClose, MdTune, MdAutoFixHigh, MdExtension } from 'react-icons/md';
@@ -121,6 +122,38 @@ const HeaderRow = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  /* Phone width: the count text and the toolbar stack instead of squeezing
+   * the text into a one-word-per-line column. */
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+`;
+
+/*
+ * Phone width: rows leave the 7-column grid and restack as a card via
+ * grid-template-areas (see TRow); each cell declares which area it fills.
+ * Purely presentational: same DOM, same handlers, no behavior change.
+ */
+const mobileArea = css<{ $area?: string }>`
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    grid-area: ${({ $area }) => $area ?? 'auto'};
+  }
+`;
+
+/* Field label rendered only at phone width, where the table header row
+ * (which normally names the columns) is hidden. */
+const MobileLabel = styled.span`
+  display: none;
+
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    display: inline;
+    margin-right: 4px;
+    font-size: ${({ theme }) => theme.fontSizes.xs};
+    color: ${({ theme }) => theme.colors.textMuted};
+  }
 `;
 
 const HeaderActions = styled.div`
@@ -170,6 +203,11 @@ const Table = styled.div`
 const THead = styled.div`
   display: grid;
   grid-template-columns: 36px 32px 1fr 80px 60px 100px 100px;
+
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    /* Cards are self-labeling at phone width (MobileLabel); no header row. */
+    display: none;
+  }
   gap: 8px;
   padding: 8px 12px;
   background: ${({ theme }) => theme.colors.surfaceSunken};
@@ -191,6 +229,16 @@ const TRow = styled.div<{ $highlight?: boolean }>`
   gap: 8px;
   padding: 10px 12px;
   align-items: center;
+
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    grid-template-columns: auto auto 1fr;
+    grid-template-areas:
+      'model model model'
+      'size  files status'
+      'play  place actions';
+    row-gap: 10px;
+    padding: 12px;
+  }
   border-top: 1px solid ${({ theme }) => theme.colors.borderLight};
   transition: background 0.15s;
 
@@ -201,7 +249,8 @@ const TRow = styled.div<{ $highlight?: boolean }>`
     css`background: ${({ theme }) => theme.colors.goldBg};`}
 `;
 
-const ModelCell = styled.div`
+const ModelCell = styled.div<{ $area?: string }>`
+  ${mobileArea}
   display: flex;
   align-items: center;
   gap: 6px;
@@ -322,11 +371,16 @@ const ChatBubble = styled.button`
   }
 `;
 
-const Cell = styled.div<{ $align?: string }>`
+const Cell = styled.div<{ $align?: string; $area?: string }>`
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
   font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textSecondary};
   text-align: ${({ $align }) => $align ?? 'left'};
+  ${mobileArea}
+
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    text-align: left;
+  }
 `;
 
 const ProgressTrack = styled.div`
@@ -378,7 +432,8 @@ const RefreshBtn = styled.button<{ $spinning: boolean }>`
   }
 `;
 
-const PlayCell = styled.div`
+const PlayCell = styled.div<{ $area?: string }>`
+  ${mobileArea}
   display: flex;
   align-items: center;
   justify-content: center;
@@ -453,7 +508,12 @@ const StopBtn = styled.button`
   }
 `;
 
-const ActionsCell = styled.div`
+const ActionsCell = styled.div<{ $area?: string }>`
+  ${mobileArea}
+
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    justify-self: end;
+  }
   display: flex;
   align-items: center;
   gap: 6px;
@@ -640,14 +700,14 @@ export function StoreRegistryTable({
           {/* Pending downloads (not yet registered) */}
           {pendingDownloads.map((dl) => (
             <TRow key={dl.modelId} $highlight>
-              <Cell />
-              <Cell />
-              <ModelCell>
+              <Cell $area="play" />
+              <Cell $area="place" />
+              <ModelCell $area="model">
                 <ModelId title={dl.modelId}>{dl.modelId}</ModelId>
               </ModelCell>
-              <Cell />
-              <Cell />
-              <Cell $align="right">
+              <Cell $area="size" />
+              <Cell $area="files" />
+              <Cell $align="right" $area="status">
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
                   <ProgressTrack>
                     <ProgressFill $pct={dl.progress * 100} />
@@ -655,7 +715,7 @@ export function StoreRegistryTable({
                   <ProgressText>{(dl.progress * 100).toFixed(0)}%</ProgressText>
                 </div>
               </Cell>
-              <Cell />
+              <Cell $area="actions" />
             </TRow>
           ))}
 
@@ -674,7 +734,7 @@ export function StoreRegistryTable({
             const isGguf = /gguf/i.test(entry.model_id);
             return (
               <TRow key={entry.model_id}>
-                <PlayCell>
+                <PlayCell $area="play">
                   {active && onStop ? (
                     <StopBtn onClick={() => onStop(entry.model_id)} title={t('storeRegistry.stopModel', 'Stop model')}>
                       <MdClose size={20} />
@@ -693,7 +753,7 @@ export function StoreRegistryTable({
                     )
                   ) : null}
                 </PlayCell>
-                <PlayCell>
+                <PlayCell $area="place">
                   {!active && !dl && !companion && onPlacement ? (
                     <PlacementBtn
                       onClick={() => onPlacement(entry.model_id)}
@@ -704,7 +764,7 @@ export function StoreRegistryTable({
                     </PlacementBtn>
                   ) : null}
                 </PlayCell>
-                <ModelCell>
+                <ModelCell $area="model">
                   <ModelId title={entry.model_id}>{entry.model_id}</ModelId>
                   {companion && (
                     <InfoTooltip
@@ -758,9 +818,15 @@ export function StoreRegistryTable({
                     </>;
                   })()}
                 </ModelCell>
-                <Cell $align="right">{formatBytes(entry.total_bytes)}</Cell>
-                <Cell $align="right">{entry.files.length}</Cell>
-                <Cell $align="right">
+                <Cell $align="right" $area="size">
+                  <MobileLabel>{t('common.size', 'Size')}</MobileLabel>
+                  {formatBytes(entry.total_bytes)}
+                </Cell>
+                <Cell $align="right" $area="files">
+                  <MobileLabel>{t('common.files', 'Files')}</MobileLabel>
+                  {entry.files.length}
+                </Cell>
+                <Cell $align="right" $area="status">
                   {dl ? (
                     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
                       <ProgressTrack>
@@ -772,7 +838,7 @@ export function StoreRegistryTable({
                     timeAgo(entry.downloaded_at, t)
                   )}
                 </Cell>
-                <ActionsCell>
+                <ActionsCell $area="actions">
                   <InfoTooltip
                     content={<ModelInfoContent entry={entry} card={modelCards[entry.model_id]} />}
                     placement="left"

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -136,8 +136,12 @@ const HeaderRow = styled.div`
  * Phone width: rows leave the 7-column grid and restack as a card via
  * grid-template-areas (see TRow); each cell declares which area it fills.
  * Purely presentational: same DOM, same handlers, no behavior change.
+ * The union type guards against a typo silently breaking the layout: it
+ * must match the areas named in TRow's grid-template-areas.
  */
-const mobileArea = css<{ $area?: string }>`
+type MobileGridArea = 'model' | 'size' | 'files' | 'status' | 'play' | 'place' | 'actions';
+
+const mobileArea = css<{ $area?: MobileGridArea }>`
   @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
     grid-area: ${({ $area }) => $area ?? 'auto'};
   }
@@ -249,7 +253,7 @@ const TRow = styled.div<{ $highlight?: boolean }>`
     css`background: ${({ theme }) => theme.colors.goldBg};`}
 `;
 
-const ModelCell = styled.div<{ $area?: string }>`
+const ModelCell = styled.div<{ $area?: MobileGridArea }>`
   ${mobileArea}
   display: flex;
   align-items: center;
@@ -371,7 +375,7 @@ const ChatBubble = styled.button`
   }
 `;
 
-const Cell = styled.div<{ $align?: string; $area?: string }>`
+const Cell = styled.div<{ $align?: string; $area?: MobileGridArea }>`
   font-size: ${({ theme }) => theme.fontSizes.tableBody};
   font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textSecondary};
@@ -432,7 +436,7 @@ const RefreshBtn = styled.button<{ $spinning: boolean }>`
   }
 `;
 
-const PlayCell = styled.div<{ $area?: string }>`
+const PlayCell = styled.div<{ $area?: MobileGridArea }>`
   ${mobileArea}
   display: flex;
   align-items: center;
@@ -508,7 +512,7 @@ const StopBtn = styled.button`
   }
 `;
 
-const ActionsCell = styled.div<{ $area?: string }>`
+const ActionsCell = styled.div<{ $area?: MobileGridArea }>`
   ${mobileArea}
 
   @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
@@ -708,6 +712,7 @@ export function StoreRegistryTable({
               <Cell $area="size" />
               <Cell $area="files" />
               <Cell $align="right" $area="status">
+                <MobileLabel>{t('common.status', 'Status')}</MobileLabel>
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
                   <ProgressTrack>
                     <ProgressFill $pct={dl.progress * 100} />
@@ -827,6 +832,7 @@ export function StoreRegistryTable({
                   {entry.files.length}
                 </Cell>
                 <Cell $align="right" $area="status">
+                  <MobileLabel>{t('common.status', 'Status')}</MobileLabel>
                   {dl ? (
                     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
                       <ProgressTrack>


### PR DESCRIPTION
## Summary

Dashboard TLC phase 2 (Tom-approved scope): the model store's 7-column grid becomes a card stack at the 480px breakpoint via `grid-template-areas` — model id + capability badges full-width, a labeled Size / Files / status meta line, action buttons in a bottom row. The column header row hides at phone width; cards self-label with screen-only `MobileLabel` spans (Tolgee `t()` strings). The page header stacks count text above the toolbar. Same DOM and handlers; the change is entirely presentational.

## Validation

- `npm run build` green; lint clean on the touched file
- Screenshot-verified against the live 1.4.0 cluster at 390x844 (cards, labels, actions) and 1280x800 (desktop identical)

## Notes

The mesh background still bleeds through the cards at phone width — that's audit finding P1-4, deliberately left for its own phase per the phased-review process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)