### PR TITLE
feat(dashboard): observability panel becomes a full-viewport sheet on phones

### DIFF
--- a/dashboard-react/src/components/observability/ObservabilityPanel.tsx
+++ b/dashboard-react/src/components/observability/ObservabilityPanel.tsx
@@ -71,7 +71,7 @@ const Aside = styled.aside<{ $width: number }>`
   animation: ${slideIn} 0.25s cubic-bezier(0.33, 1, 0.68, 1);
 
   /* Phone width: the drawer becomes a full-viewport sheet. The persisted
-   * desktop width (which can exceed a phone viewport and clipped the
+   * desktop width (which can exceed a phone viewport and clip the
    * header/tabs) is ignored; !important beats the drag-resize inline
    * style if one was left behind by a desktop session. */
   @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {

--- a/dashboard-react/src/components/observability/ObservabilityPanel.tsx
+++ b/dashboard-react/src/components/observability/ObservabilityPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
+import { MOBILE_BREAKPOINT_PX } from '../../hooks/useMediaQuery';
 import styled, { keyframes } from 'styled-components';
 import { FiX } from 'react-icons/fi';
 import { Button } from '../common/Button';
@@ -68,6 +69,15 @@ const Aside = styled.aside<{ $width: number }>`
   flex-direction: column;
   z-index: 50;
   animation: ${slideIn} 0.25s cubic-bezier(0.33, 1, 0.68, 1);
+
+  /* Phone width: the drawer becomes a full-viewport sheet. The persisted
+   * desktop width (which can exceed a phone viewport and clipped the
+   * header/tabs) is ignored; !important beats the drag-resize inline
+   * style if one was left behind by a desktop session. */
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    width: 100vw !important;
+    border-left: none;
+  }
 `;
 
 /**
@@ -86,6 +96,11 @@ const ResizeHandle = styled.div`
   &:hover {
     background: ${({ theme }) => theme.colors.goldDim};
     opacity: 0.4;
+  }
+
+  /* No drag-resize on a full-viewport phone sheet. */
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    display: none;
   }
 `;
 


### PR DESCRIPTION
## Summary

Dashboard TLC phase 4, closing the last P1 audit finding: the observability drawer's persisted desktop width can exceed a phone viewport, clipping the panel's own header and tab strip ("Traces" rendered as "ces"). At the phone breakpoint the panel now spans the full viewport (overriding the drag-resize inline width) and the resize handle hides. Desktop keeps the persisted-width drag behavior.

## Validation

- `npm run build` green
- Screenshot-verified against the live cluster at 390x844 (full title, all three tabs, close button) and 1280x800 (drag-resize drawer unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)