### PR TITLE
fix(dashboard): side panels become overlay drawers at the phone breakpoint

### DIFF
--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -49,6 +49,10 @@ const ContentRow = styled.div`
   min-height: 0;
   display: flex;
   flex-direction: row;
+  /* Positioning anchor for the mobile panel drawers: absolute children
+   * cover the content area only, so the header (and the toggles that
+   * opened a drawer) stays visible and interactive above them. */
+  position: relative;
 `;
 
 /*
@@ -65,11 +69,15 @@ const PanelOverlay = styled.div<{ $side: 'left' | 'right' }>`
 
   @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
     display: block;
-    position: fixed;
+    /* Absolute within ContentRow (not fixed over the viewport): the drawer
+     * covers content only, leaving the header and its panel toggles
+     * interactive, so keyboard/screen-reader users can dismiss via the
+     * same aria-pressed toggle that opened it. */
+    position: absolute;
     top: 0;
     bottom: 0;
     ${({ $side }) => ($side === 'left' ? 'left: 0;' : 'right: 0;')}
-    z-index: 30;
+    z-index: 5;
     max-width: 88vw;
     box-shadow: ${({ $side }) => ($side === 'left' ? '18px' : '-18px')} 0 48px
       ${({ theme }) => theme.colors.shadowStrong};
@@ -86,9 +94,9 @@ const PanelBackdrop = styled.div`
 
   @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
     display: block;
-    position: fixed;
+    position: absolute;
     inset: 0;
-    z-index: 29;
+    z-index: 4;
     background: ${({ theme }) => theme.colors.shadowStrong};
     backdrop-filter: blur(2px);
   }
@@ -567,11 +575,18 @@ export function App() {
           onToggleMobileMenu={() => setMobileMenuOpen((v) => !v)}
           showSidebarToggle={activeRoute === 'chat' && allConversations.length > 0}
           sidebarVisible={historyPanelOpen}
-          onToggleSidebar={toggleHistoryPanel}
+          onToggleSidebar={() => {
+            // Phone width fits one drawer: opening History closes Instances.
+            if (isMobile && !historyPanelOpen && panelOpen) togglePanel();
+            toggleHistoryPanel();
+          }}
           instanceCount={instanceCards.length}
           instancesHealthy={instanceCards.every((c) => c.status !== 'failed')}
           mobileRightOpen={panelOpen}
-          onToggleMobileRight={togglePanel}
+          onToggleMobileRight={() => {
+            if (isMobile && !panelOpen && historyPanelOpen) toggleHistoryPanel();
+            togglePanel();
+          }}
         />
         {isMobile && (
           <MobileMenuSheet
@@ -587,10 +602,16 @@ export function App() {
           {isMobile && ((activeRoute === 'chat' && allConversations.length > 0 && historyPanelOpen) || (hasInstances && panelOpen)) && (
             <PanelBackdrop
               onClick={() => {
-                if (historyPanelOpen) toggleHistoryPanel();
-                if (panelOpen) togglePanel();
+                // Only flip flags whose drawer is actually rendered: the
+                // persisted flags can be true while the drawer is absent
+                // (history off the chat route), and blind toggling would
+                // invert that hidden state. Dismissal is also available via
+                // the header's aria-pressed panel toggles; this layer is
+                // pointer convenience.
+                if (activeRoute === 'chat' && allConversations.length > 0 && historyPanelOpen) toggleHistoryPanel();
+                if (hasInstances && panelOpen) togglePanel();
               }}
-              aria-hidden
+              role="presentation"
             />
           )}
           {activeRoute === 'chat' && allConversations.length > 0 && historyPanelOpen && (

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -78,12 +78,16 @@ const PanelOverlay = styled.div<{ $side: 'left' | 'right' }>`
     bottom: 0;
     ${({ $side }) => ($side === 'left' ? 'left: 0;' : 'right: 0;')}
     z-index: 5;
-    max-width: 88vw;
+    /* Deterministic drawer width: the panels' own 340px would overflow the
+     * cap on narrow phones (320px viewports), so the overlay owns the width
+     * and the aside fills it. */
+    width: min(340px, 88vw);
     box-shadow: ${({ $side }) => ($side === 'left' ? '18px' : '-18px')} 0 48px
       ${({ theme }) => theme.colors.shadowStrong};
 
     > aside {
       height: 100%;
+      width: 100%;
     }
   }
 `;
@@ -214,6 +218,14 @@ export function App() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   useEffect(() => {
     if (!isMobile) setMobileMenuOpen(false);
+  }, [isMobile]);
+  // Drawer exclusivity must also hold for PERSISTED state, not just the
+  // toggle handlers: both flags can arrive true from a desktop session, and
+  // independent render predicates would stack both drawers over a phone
+  // viewport. Instances yields to History (the user is mid-conversation).
+  useEffect(() => {
+    if (isMobile && historyPanelOpen && panelOpen) dispatch(uiActions.togglePanel());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMobile]);
   const [storeDownloads, setStoreDownloads] = useState<StoreDownload[]>([]);
   // Observability panel state lives on the global UI store so any component (toolbar

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -16,7 +16,7 @@ import { darkTheme, lightTheme, GlobalStyle } from './theme';
 import { useClusterState } from './hooks/useClusterState';
 import { HeaderNav } from './components/layout/HeaderNav';
 import { MobileMenuSheet } from './components/layout/MobileMenuSheet';
-import { useIsMobile } from './hooks/useMediaQuery';
+import { useIsMobile, MOBILE_BREAKPOINT_PX } from './hooks/useMediaQuery';
 import { TopologyGraph } from './components/topology/TopologyGraph';
 // ClusterWarnings replaced by inline header warning indicator
 import { ConnectionBanner } from './components/status/ConnectionBanner';
@@ -49,6 +49,49 @@ const ContentRow = styled.div`
   min-height: 0;
   display: flex;
   flex-direction: row;
+`;
+
+/*
+ * Side-panel presentation switch (#474). On desktop the wrapper is
+ * display: contents, so the panel participates in ContentRow's flex layout
+ * exactly as before. At the phone breakpoint the panel becomes a fixed
+ * overlay drawer instead of a column: the desktop side-by-side split left
+ * chat's conversation area with no room at all (History + Instances
+ * consumed the whole viewport) and crushed the topology graph into a
+ * sliver whenever the instance panel opened.
+ */
+const PanelOverlay = styled.div<{ $side: 'left' | 'right' }>`
+  display: contents;
+
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    display: block;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    ${({ $side }) => ($side === 'left' ? 'left: 0;' : 'right: 0;')}
+    z-index: 30;
+    max-width: 88vw;
+    box-shadow: ${({ $side }) => ($side === 'left' ? '18px' : '-18px')} 0 48px
+      ${({ theme }) => theme.colors.shadowStrong};
+
+    > aside {
+      height: 100%;
+    }
+  }
+`;
+
+/* Dismiss layer behind an open mobile panel drawer; standard flyover blur. */
+const PanelBackdrop = styled.div`
+  display: none;
+
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 29;
+    background: ${({ theme }) => theme.colors.shadowStrong};
+    backdrop-filter: blur(2px);
+  }
 `;
 
 const Main = styled.main`
@@ -541,7 +584,17 @@ export function App() {
         )}
         </HeaderAnchor>
         <ContentRow>
+          {isMobile && ((activeRoute === 'chat' && allConversations.length > 0 && historyPanelOpen) || (hasInstances && panelOpen)) && (
+            <PanelBackdrop
+              onClick={() => {
+                if (historyPanelOpen) toggleHistoryPanel();
+                if (panelOpen) togglePanel();
+              }}
+              aria-hidden
+            />
+          )}
           {activeRoute === 'chat' && allConversations.length > 0 && historyPanelOpen && (
+            <PanelOverlay $side="left">
             <ConversationPanel
               conversations={allConversations}
               activeConversationId={activeConversationId}
@@ -549,6 +602,7 @@ export function App() {
               onDelete={deleteConversation}
               onNewChat={() => { if (selectedModelId) newConversation(selectedModelId); }}
             />
+            </PanelOverlay>
           )}
           <Main>
             {activeRoute === 'model-store' ? (
@@ -578,11 +632,13 @@ export function App() {
             )}
           </Main>
           {hasInstances && panelOpen && (
+            <PanelOverlay $side="right">
             <InstancePanel
               instances={instanceCards}
               onDelete={handleDeleteInstance}
               onChat={(modelId) => { dispatch(chatActions.selectModel(modelId)); setActiveRoute('chat'); }}
             />
+            </PanelOverlay>
           )}
         </ContentRow>
         <ToastContainer />

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { MOBILE_BREAKPOINT_PX } from '../../hooks/useMediaQuery';
 import styled, { css, keyframes } from 'styled-components';
 import type { ChatUploadedFile } from '../../types/chat';
 import { ChatAttachments } from './ChatAttachments';
@@ -66,6 +67,29 @@ const HeaderRow = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.xs};
   font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
+
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    flex-wrap: wrap;
+    row-gap: 4px;
+  }
+`;
+
+/*
+ * Groups the model label + name so that, at phone width, the model gets its
+ * own full line and the stats (ctx / thinking / TTFT / TPS) flow onto the
+ * next line, instead of the long model id wrapping mid-name in a narrow
+ * column. On desktop the wrapper is display: contents (layout unchanged).
+ */
+const ModelLine = styled.div`
+  display: contents;
+
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-basis: 100%;
+    min-width: 0;
+  }
 `;
 
 const ModelBtn = styled.button`
@@ -163,6 +187,18 @@ const HelperText = styled.div`
   font-family: ${({ theme }) => theme.fonts.body};
   color: ${({ theme }) => theme.colors.textMuted};
   text-align: center;
+
+  /* Keyboard hints (Enter / Shift+Enter / drag & drop) mean nothing on a
+   * phone; they and their rule hide below the breakpoint. */
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    display: none;
+  }
+`;
+
+const BottomAccentLine = styled(AccentLine)`
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    display: none;
+  }
 `;
 
 /* ---- component ---- */
@@ -327,10 +363,10 @@ export function ChatForm({
       {showHeader && (
         <HeaderRow>
           {(modelLabel || modelSelector) && (
-            <>
+            <ModelLine>
               <span>{t('chat.form.modelLabel', 'Model:')}</span>
               {modelSelector ?? <ModelBtn onClick={onOpenModelPicker}>{modelLabel}</ModelBtn>}
-            </>
+            </ModelLine>
           )}
           {contextLength > 0 && (
             <Stat>
@@ -422,7 +458,7 @@ export function ChatForm({
         )}
       </InputRow>
 
-      <AccentLine />
+      <BottomAccentLine />
       <HelperText>
         {supportsImageAttachments
           ? t(

--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -138,7 +138,8 @@ const DownloadBadge = styled.div`
   height: 28px;
 `;
 
-const IconToggle = styled.span<{ $active: boolean }>`
+const IconToggle = styled.button<{ $active: boolean }>`
+  all: unset;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -147,6 +148,12 @@ const IconToggle = styled.span<{ $active: boolean }>`
 
   &:hover {
     color: ${({ theme }) => theme.colors.text};
+  }
+
+  /* Keyboard focus: all: unset removes the browser outline (Button's pattern). */
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.goldDim};
   }
 `;
 
@@ -373,9 +380,11 @@ export function HeaderNav({
         )}
         {showSidebarToggle && (
           <IconToggle
+            type="button"
             $active={sidebarVisible}
             onClick={onToggleSidebar}
             aria-label={t('header.toggleSidebar', 'Toggle sidebar')}
+            aria-pressed={sidebarVisible}
           >
             <SidebarIcon />
           </IconToggle>


### PR DESCRIPTION
## Summary

Fixes #474 (dashboard TLC phase 5): at the phone breakpoint the History and Active Instances panels become fixed overlay drawers with a shared blur backdrop, instead of flex columns that consumed the viewport. Chat was entirely unusable on phones (no conversation area, no input); topology was crushed to a sliver whenever the instance panel opened. On desktop the wrapper is `display: contents`, so the flex layout is byte-identical.

## Validation

- `npm run build` green; lint clean
- Live-cluster verification at 390x844: placed-instance topology keeps the full viewport (drawer over it, backdrop-dismissible), and chat completes a real generation end to end (query, streamed reply with TTFT 1022ms / 16.8 TPS, input bar present)
- Desktop 1280x800 screenshot-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)