### PR TITLE
fix(dashboard): mobile drawers get a fully opaque base

### DIFF
--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -78,6 +78,10 @@ const PanelOverlay = styled.div<{ $side: 'left' | 'right' }>`
     bottom: 0;
     ${({ $side }) => ($side === 'left' ? 'left: 0;' : 'right: 0;')}
     z-index: 5;
+    /* The panels themselves are background: transparent (they sit against
+     * the page gradient as desktop columns); as an overlay that reads as
+     * see-through, so the wrapper supplies a fully opaque base. */
+    background: ${({ theme }) => theme.colors.surface};
     /* Deterministic drawer width: the panels' own 340px would overflow the
      * cap on narrow phones (320px viewports), so the overlay owns the width
      * and the aside fills it. */

--- a/dashboard-react/src/components/layout/MobileMenuSheet.tsx
+++ b/dashboard-react/src/components/layout/MobileMenuSheet.tsx
@@ -49,7 +49,9 @@ const Sheet = styled.nav<{ $open: boolean }>`
   right: 0;
   z-index: 19; /* under the header (20) so the sheet emerges from beneath it */
   padding: 8px 12px 12px;
-  background: ${({ theme }) => theme.colors.header};
+  /* Fully opaque: the header token is translucent by design (it sits over
+   * the page gradient), which made the menu see-through over content. */
+  background: ${({ theme }) => theme.colors.surface};
   border-bottom: 1px solid ${({ theme }) => theme.colors.border};
   box-shadow: 0 12px 32px ${({ theme }) => theme.colors.shadowStrong};
   display: flex;


### PR DESCRIPTION
## Summary

First finding from Tom's live phone test: the mobile panel drawers were see-through (the panels are `background: transparent` by design as desktop columns, which composited badly as overlays). The overlay wrapper now supplies `theme.colors.surface` as a fully opaque base at the phone breakpoint. Desktop untouched (`display: contents` path unaffected).

## Validation

- Verified against the live cluster at 390x844: the instance drawer renders solid over the store page (screenshot in thread)
- `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)