### PR TITLE
fix(dashboard): observability panel sizes to the dynamic viewport (dvh)

### DIFF
--- a/dashboard-react/src/components/observability/ObservabilityPanel.tsx
+++ b/dashboard-react/src/components/observability/ObservabilityPanel.tsx
@@ -60,7 +60,13 @@ const Aside = styled.aside<{ $width: number }>`
   position: fixed;
   top: 0;
   right: 0;
+  /* dvh tracks the ACTUAL visible viewport on mobile browsers; 100vh
+   * includes the area behind Safari's URL/tool bars, which pushed the
+   * panel's bottom (and the scrolled list's tail) off screen and centered
+   * spinners against the wrong height. Plain vh stays as the fallback for
+   * engines without dvh. */
   height: 100vh;
+  height: 100dvh;
   width: ${({ $width }) => $width}px;
   background: ${({ theme }) => theme.colors.surfaceElevated};
   border-left: 1px solid ${({ theme }) => theme.colors.borderStrong};


### PR DESCRIPTION
## Summary

From Tom's live phone test: the observability panel used `height: 100vh`, which on mobile Safari includes the area behind the URL/tool bars — the spinner centered against the oversized height and the scrolled list's bottom was cut off behind the browser chrome. Now `height: 100dvh` with the `vh` declaration kept as the fallback for engines without dvh support. This was the only production `100vh` in the dashboard (the rest are storybook decorators); the app shell uses `height: 100%` and is unaffected.

## Validation

- `npm run build` green
- Root cause matches both captures (mis-centered spinner, clipped list tail); dvh is the standard remedy, iOS 15.4+

🤖 Generated with [Claude Code](https://claude.com/claude-code)