### PR TITLE
fix(dashboard): chat scroll-to-bottom button — dead click + drawer stacking

### DIFF
--- a/dashboard-react/src/components/chat/ChatMessages.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.tsx
@@ -296,7 +296,8 @@ const ScrollBtn = styled.button`
   position: sticky;
   bottom: 16px;
   align-self: center;
-  z-index: 10;
+  /* Above message cards, below the mobile panel drawers (z 5) and their backdrop (z 4). */
+  z-index: 3;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -665,7 +666,7 @@ export function ChatMessages({
       )}
 
       {showScrollBtn && (
-        <ScrollBtn onClick={scrollToBottom} aria-label={t('chat.messages.scrollToBottom', 'Scroll to bottom')}>
+        <ScrollBtn onClick={() => scrollToBottom()} aria-label={t('chat.messages.scrollToBottom', 'Scroll to bottom')}>
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <polyline points="6 9 12 15 18 9" />
           </svg>

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -526,7 +526,17 @@ export function ChatView({ readyInstances, className }: ChatViewProps) {
   const setChatScrollTop = (pos: number) => dispatch(uiActions.setChatScrollTop(pos));
   const scrollRestored = useRef(false);
   useEffect(() => {
-    if (scrollRestored.current || chatScrollTop <= 0) return;
+    if (scrollRestored.current) return;
+    if (chatScrollTop <= 0) {
+      // Nothing to restore, but latch anyway: the store hydrates synchronously,
+      // so a non-positive value on first run is final. Leaving the guard
+      // unlatched lets later chatScrollTop updates (echoes of the user's own
+      // scrolling, saved by handleScroll) re-enter this effect and assign a
+      // stale scrollTop — which cancels in-flight smooth scrolling and made
+      // the scroll-to-bottom button a no-op in fresh sessions.
+      scrollRestored.current = true;
+      return;
+    }
 
     // Wait for store to hydrate and DOM to render messages
     const tryRestore = () => {


### PR DESCRIPTION
Fixes Tom's couch-loop report: the chat scroll-to-bottom button did nothing at the mobile breakpoint and floated on top of the instances drawer when open.

Root causes (three compounding bugs):

1. **Dead click (the real one):** `ChatView`'s scroll-position restore effect never latched its ran-once guard when there was nothing to restore (`chatScrollTop <= 0` at mount, i.e. any fresh session). Every later scroll event re-entered the effect through the `handleScroll` → redux → dependency loop and assigned a stale `scrollTop`, cancelling the in-flight smooth scroll. Measured: a 6200px scroll advanced 9px before being yanked back. Store hydration is synchronous, so latching on a non-positive first value is safe.
2. `onClick={scrollToBottom}` passed the PointerEvent into the `behavior` parameter of `Element.scrollTo`.
3. The button's `z-index: 10` beat the mobile panel drawers (z 5) and backdrop (z 4). Now z 3: above message cards, below drawers.

Verified headless (Playwright, 390x844, production bundle against the live cluster): button appears on scroll-up, click scrolls fully to bottom and hides it, and with the instances drawer open the drawer covers the button (`elementFromPoint` assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)