### PR TITLE
chore: bump dev to 1.5.0 (mobile dashboard support = minor)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skulk"
-version = "1.4.1"
+version = "1.5.0"
 description = "Skulk: distributed AI inference across heterogeneous clusters (Apple Silicon MLX and AMD/Linux GPU)"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -2862,7 +2862,7 @@ wheels = [
 
 [[package]]
 name = "skulk"
-version = "1.4.1"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
Tom's call: the dashboard TLC wave (responsive mobile support, phases 1-5, plus the observability fixes) is new user-facing functionality, so the next release is a semver minor. Dev carried 1.4.1 from #481's post-release bump; this re-bumps to 1.5.0 before the cut, exactly the re-bump case the version doctrine anticipated.

No release-notes changes, per the rule scoped in #481: notes and the CHANGELOG roll happen at the actual cut.

Changes: `pyproject.toml` 1.4.1 -> 1.5.0, `uv.lock` refreshed via `uv lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)