### PR TITLE
fix(worker): emit runner-phase diagnostics from the GGUF engines (#479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **GGUF engines now report runner phases to observability.** The `llama_cpp`,
+  `llama_server`, and RPC-donor runners emitted no runner-phase diagnostics at
+  all, so the dashboard's observability Live tab sat at "created" forever for
+  any placement on those engines (every GGUF placement on a GPU/Linux node).
+  All three now record the same lifecycle the MLX runner does: task
+  acknowledgement, model load (server spawn for the served and donor shapes),
+  ready, generation start, completion or cancellation, errors including a
+  server subprocess dying behind the runner, and shutdown teardown.
+
 - **The dashboard header shows the real Skulk version.** The UI version was
   baked at build time from the dashboard's own `package.json`, which had
   silently drifted (it still said 1.3.0 through two releases). The build now

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -58,6 +58,7 @@ from skulk.shared.types.worker.runners import (
 )
 from skulk.utils.channels import MpReceiver, MpSender
 from skulk.worker.runner.bootstrap import logger
+from skulk.worker.runner.diagnostics import record_runner_phase, runner_phase
 from skulk.worker.runner.llm_inference.harmony_text_parser import HarmonyTextParser
 from skulk.worker.runner.llm_inference.think_text_parser import ThinkTextParser
 from skulk.worker.runner.llm_inference.tool_text_parser import (
@@ -645,6 +646,12 @@ class Runner:
         )
 
     def acknowledge_task(self, task: Task) -> None:
+        record_runner_phase(
+            "task_submission",
+            event="task_acknowledged",
+            detail=task.__class__.__name__,
+            task_id=task.task_id,
+        )
         self.event_sender.send(TaskAcknowledged(task_id=task.task_id))
 
     def _drain_cancellations(self) -> None:
@@ -696,9 +703,19 @@ class Runner:
                 self._generate(task)
             case Shutdown():
                 logger.info("llama.cpp runner shutting down")
+                record_runner_phase(
+                    "shutdown_cleanup",
+                    event="runner_shutdown_requested",
+                    task_id=task.task_id,
+                )
                 self.update_status(RunnerShuttingDown())
                 self.acknowledge_task(task)
                 self.model = None
+                record_runner_phase(
+                    "shutdown_cleanup",
+                    event="model_released",
+                    task_id=task.task_id,
+                )
                 self.current_status = RunnerShutdown()
             case _:
                 raise RuntimeError(
@@ -770,16 +787,29 @@ class Runner:
             f"(n_ctx={n_ctx}, logits_all={logits_all}, flash_attn={flash_attn}, "
             f"vision={vision is not None})"
         )
-        self.model = Llama(
-            model_path=str(gguf_path),
-            n_gpu_layers=-1,
-            n_ctx=n_ctx,
-            logits_all=logits_all,
-            flash_attn=flash_attn,
-            verbose=False,
-            chat_handler=chat_handler,
-        )
+        with runner_phase(
+            "load_model",
+            detail="llama_cpp_construct",
+            task_id=task.task_id,
+            attrs={
+                "gguf_file": gguf_path.name,
+                "n_ctx": n_ctx,
+                "logits_all": logits_all,
+                "flash_attn": flash_attn,
+                "vision": vision is not None,
+            },
+        ):
+            self.model = Llama(
+                model_path=str(gguf_path),
+                n_gpu_layers=-1,
+                n_ctx=n_ctx,
+                logits_all=logits_all,
+                flash_attn=flash_attn,
+                verbose=False,
+                chat_handler=chat_handler,
+            )
         self.current_status = RunnerReady()
+        record_runner_phase("idle", event="runner_ready", task_id=task.task_id)
         logger.info(
             f"llama.cpp runner ready in {time.time() - self.setup_start_time:.1f}s"
         )
@@ -813,6 +843,13 @@ class Runner:
             task.task_params.logprobs, task.task_params.top_logprobs
         )
 
+        record_runner_phase(
+            "task_submission",
+            event="submit_text_generation",
+            task_id=task.task_id,
+            command_id=str(command_id),
+            attrs={"tools": bool(task.task_params.tools)},
+        )
         try:
             # Fail loud when logprobs are requested but the model was not loaded
             # with logits_all (#385): llama-cpp-python gates ALL logprobs behind
@@ -833,8 +870,21 @@ class Runner:
             # wants the assembled call), and accumulating OpenAI tool-call deltas
             # is fragile; run it non-streamed and emit one ToolCallChunk.
             if task.task_params.tools:
+                record_runner_phase(
+                    "decode_stream",
+                    event="request_started",
+                    task_id=task.task_id,
+                    command_id=str(command_id),
+                )
                 self._generate_with_tools(task, messages, kwargs, model_id, command_id)
+                record_runner_phase(
+                    "completion",
+                    event="generation_finished",
+                    task_id=task.task_id,
+                    command_id=str(command_id),
+                )
                 self.current_status = RunnerReady()
+                record_runner_phase("idle", event="runner_ready", task_id=task.task_id)
                 return
 
             # A reasoning model's markers arrive as literal text in the content
@@ -860,6 +910,12 @@ class Runner:
                     "logprobs/top_logprobs."
                 )
 
+            record_runner_phase(
+                "decode_stream",
+                event="request_started",
+                task_id=task.task_id,
+                command_id=str(command_id),
+            )
             stream = self.model.create_chat_completion(
                 messages=messages, stream=True, **kwargs
             )
@@ -935,6 +991,13 @@ class Runner:
                     )
                 )
         except Exception as exc:
+            record_runner_phase(
+                "error",
+                event="generation_failed",
+                detail=f"{type(exc).__name__}: {exc}",
+                task_id=task.task_id,
+                command_id=str(command_id),
+            )
             logger.opt(exception=exc).warning("llama.cpp generation failed")
             self.event_sender.send(
                 ChunkGenerated(
@@ -942,8 +1005,22 @@ class Runner:
                     chunk=ErrorChunk(model=model_id, error_message=str(exc)),
                 )
             )
+        else:
+            # Only cancellations OBSERVED during execution: draining the cancel
+            # pipe here would retroactively flip a finished task (see main()).
+            was_cancelled = (
+                task.task_id in self.cancelled_tasks
+                or CANCEL_ALL_TASKS in self.cancelled_tasks
+            )
+            record_runner_phase(
+                "cancel_observed" if was_cancelled else "completion",
+                event="generation_finished",
+                task_id=task.task_id,
+                command_id=str(command_id),
+            )
 
         self.current_status = RunnerReady()
+        record_runner_phase("idle", event="runner_ready", task_id=task.task_id)
 
     def _is_harmony_model(self) -> bool:
         """Whether this runner serves a gpt-oss (harmony-format) model.

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -877,8 +877,15 @@ class Runner:
                     command_id=str(command_id),
                 )
                 self._generate_with_tools(task, messages, kwargs, model_id, command_id)
+                # Same observed-cancellation rule as the streaming path: a task
+                # cancelled during the non-streamed tool call must not be
+                # recorded as a completion.
+                tools_cancelled = (
+                    task.task_id in self.cancelled_tasks
+                    or CANCEL_ALL_TASKS in self.cancelled_tasks
+                )
                 record_runner_phase(
-                    "completion",
+                    "cancel_observed" if tools_cancelled else "completion",
                     event="generation_finished",
                     task_id=task.task_id,
                     command_id=str(command_id),

--- a/src/skulk/worker/runner/llama_server/runner.py
+++ b/src/skulk/worker/runner/llama_server/runner.py
@@ -71,6 +71,7 @@ from skulk.shared.types.worker.runners import (
 )
 from skulk.utils.channels import MpReceiver, MpSender
 from skulk.worker.runner.bootstrap import logger
+from skulk.worker.runner.diagnostics import record_runner_phase, runner_phase
 from skulk.worker.runner.llama_cpp.runner import (
     generation_kwargs,
     map_finish_reason,
@@ -365,6 +366,12 @@ class Runner:
         )
 
     def acknowledge_task(self, task: Task) -> None:
+        record_runner_phase(
+            "task_submission",
+            event="task_acknowledged",
+            detail=task.__class__.__name__,
+            task_id=task.task_id,
+        )
         self.event_sender.send(TaskAcknowledged(task_id=task.task_id))
 
     def _drain_cancellations(self) -> None:
@@ -436,6 +443,11 @@ class Runner:
         ):
             return
         if proc.poll() is not None:
+            record_runner_phase(
+                "error",
+                event="server_exited",
+                detail=f"llama-server exited unexpectedly (code {proc.returncode})",
+            )
             raise RuntimeError(
                 f"llama-server exited unexpectedly (code {proc.returncode}); "
                 f"log tail:\n{self._server_log_tail()}"
@@ -449,9 +461,19 @@ class Runner:
                 self._generate(task)
             case Shutdown():
                 logger.info("llama-server runner shutting down")
+                record_runner_phase(
+                    "shutdown_cleanup",
+                    event="runner_shutdown_requested",
+                    task_id=task.task_id,
+                )
                 self.update_status(RunnerShuttingDown())
                 self.acknowledge_task(task)
                 self._teardown_server()
+                record_runner_phase(
+                    "shutdown_cleanup",
+                    event="server_teardown_complete",
+                    task_id=task.task_id,
+                )
                 self.current_status = RunnerShutdown()
             case _:
                 raise RuntimeError(
@@ -501,12 +523,21 @@ class Runner:
         )
         n_ctx = serving_n_ctx(self.context_token_limit, logits_all=False)
         try:
-            self._spawn_server(gguf_path, n_ctx, card.runtime, reasoning_format_none)
-            self._await_health()
+            with runner_phase(
+                "load_model",
+                detail="spawn_llama_server",
+                task_id=task.task_id,
+                attrs={"gguf_file": gguf_path.name, "n_ctx": n_ctx},
+            ):
+                self._spawn_server(
+                    gguf_path, n_ctx, card.runtime, reasoning_format_none
+                )
+                self._await_health()
         except Exception:
             self._teardown_server()
             raise
         self.current_status = RunnerReady()
+        record_runner_phase("idle", event="runner_ready", task_id=task.task_id)
         logger.info(
             f"llama-server runner ready in {time.time() - self.setup_start_time:.1f}s "
             f"(url={self.base_url})"
@@ -695,6 +726,13 @@ class Runner:
         # can return empty content under a bounded budget (#428/#420).
         body.update(reasoning_request_overrides(task.task_params))
 
+        record_runner_phase(
+            "task_submission",
+            event="submit_text_generation",
+            task_id=task.task_id,
+            command_id=str(command_id),
+            attrs={"tools": bool(task.task_params.tools)},
+        )
         try:
             # Per-token logprobs are not wired over the SSE proxy yet. Fail loud
             # rather than return a successful response with logprobs silently
@@ -708,12 +746,24 @@ class Runner:
                     "(llama_server) engine: the OpenAI SSE proxy does not surface "
                     "them. Retry without logprobs/top_logprobs."
                 )
+            record_runner_phase(
+                "decode_stream",
+                event="request_started",
+                task_id=task.task_id,
+                command_id=str(command_id),
+            )
             if task.task_params.tools:
                 self._generate_with_tools(task, body, model_id, command_id)
-                self.current_status = RunnerReady()
-                return
-            self._generate_streaming(task, body, model_id, command_id)
+            else:
+                self._generate_streaming(task, body, model_id, command_id)
         except Exception as exc:  # noqa: BLE001 - surface as an ErrorChunk
+            record_runner_phase(
+                "error",
+                event="generation_failed",
+                detail=f"{type(exc).__name__}: {exc}",
+                task_id=task.task_id,
+                command_id=str(command_id),
+            )
             logger.opt(exception=exc).warning("llama-server generation failed")
             self.event_sender.send(
                 ChunkGenerated(
@@ -721,7 +771,21 @@ class Runner:
                     chunk=ErrorChunk(model=model_id, error_message=str(exc)),
                 )
             )
+        else:
+            # Only cancellations OBSERVED during execution: draining the cancel
+            # pipe here would retroactively flip a finished task (see main()).
+            was_cancelled = (
+                task.task_id in self.cancelled_tasks
+                or CANCEL_ALL_TASKS in self.cancelled_tasks
+            )
+            record_runner_phase(
+                "cancel_observed" if was_cancelled else "completion",
+                event="generation_finished",
+                task_id=task.task_id,
+                command_id=str(command_id),
+            )
         self.current_status = RunnerReady()
+        record_runner_phase("idle", event="runner_ready", task_id=task.task_id)
 
     def _generate_streaming(
         self,

--- a/src/skulk/worker/runner/rpc_donor/runner.py
+++ b/src/skulk/worker/runner/rpc_donor/runner.py
@@ -47,6 +47,7 @@ from skulk.shared.types.worker.runners import (
 from skulk.shared.types.worker.shards import RpcDonorShardMetadata
 from skulk.utils.channels import MpReceiver, MpSender
 from skulk.worker.runner.bootstrap import logger
+from skulk.worker.runner.diagnostics import record_runner_phase, runner_phase
 
 # How long the donor waits for its ggml-rpc-server to accept a TCP connection
 # before declaring the spawn failed. The server binds and listens almost
@@ -136,9 +137,18 @@ class Runner:
     def main(self) -> None:
         """Spawn the RPC server, report Ready, then wait for Shutdown."""
         try:
-            self._spawn_rpc_server()
-            self._await_listening()
+            # "load_model" is the honest mapping in the closed phase vocabulary:
+            # a donor loads no model, but spawning + health-checking the RPC
+            # server is its equivalent get-ready work.
+            with runner_phase(
+                "load_model",
+                detail="spawn_rpc_server",
+                attrs={"endpoint": f"{self.bind_host}:{self.bind_port}"},
+            ):
+                self._spawn_rpc_server()
+                self._await_listening()
             self.update_status(RunnerReady())
+            record_runner_phase("idle", event="runner_ready")
             logger.info(
                 f"rpc-donor serving on {self.bind_host}:{self.bind_port} "
                 f"(pid={self.server_proc.pid if self.server_proc else '?'})"
@@ -177,6 +187,11 @@ class Runner:
         ):
             return
         if proc.poll() is not None:
+            record_runner_phase(
+                "error",
+                event="server_exited",
+                detail=f"ggml-rpc-server exited unexpectedly (code {proc.returncode})",
+            )
             raise RuntimeError(
                 f"ggml-rpc-server exited unexpectedly (code {proc.returncode}); "
                 f"log tail:\n{self._server_log_tail()}"
@@ -186,9 +201,19 @@ class Runner:
         match task:
             case Shutdown():
                 logger.info("rpc-donor runner shutting down")
+                record_runner_phase(
+                    "shutdown_cleanup",
+                    event="runner_shutdown_requested",
+                    task_id=task.task_id,
+                )
                 self.update_status(RunnerShuttingDown())
                 self.event_sender.send(TaskAcknowledged(task_id=task.task_id))
                 self._teardown_server()
+                record_runner_phase(
+                    "shutdown_cleanup",
+                    event="server_teardown_complete",
+                    task_id=task.task_id,
+                )
                 self.event_sender.send(
                     TaskStatusUpdated(
                         task_id=task.task_id, task_status=TaskStatus.Complete

--- a/src/skulk/worker/tests/unittests/test_runner/test_gguf_runner_phases.py
+++ b/src/skulk/worker/tests/unittests/test_runner/test_gguf_runner_phases.py
@@ -1,0 +1,108 @@
+"""Runner-phase flight-recorder emission for the GGUF-engine runners (#479).
+
+The llama_cpp / llama_server / rpc_donor runners historically emitted no
+runner-phase diagnostics at all, so the observability Live tab sat at
+"created" forever for any GGUF placement. These tests capture the diagnostic
+channel directly and assert the key lifecycle emissions exist, using the RPC
+donor runner (no model, no GPU) as the cheap representative of the shared
+runner skeleton.
+"""
+
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+
+import pytest
+
+from skulk.shared.types.diagnostics import (
+    RunnerDiagnosticContext,
+    RunnerDiagnosticUpdate,
+)
+from skulk.shared.types.tasks import Shutdown, TaskId
+from skulk.utils.channels import MpReceiver, WouldBlock, mp_channel
+from skulk.worker.runner.diagnostics import configure_runner_diagnostics
+from skulk.worker.tests.unittests.test_runner.test_rpc_donor_liveness import (
+    _donor_runner,  # pyright: ignore[reportPrivateUsage]
+)
+
+
+@pytest.fixture
+def phase_updates() -> Iterator[MpReceiver[RunnerDiagnosticUpdate]]:
+    """Route runner-phase emissions into a capturable channel, then unwire."""
+    sender, receiver = mp_channel[RunnerDiagnosticUpdate]()
+    context = RunnerDiagnosticContext(
+        node_id="test-node",
+        runner_id="test-runner",
+        instance_id="test-instance",
+        model_id="test/pooled-gguf",
+        rank=1,
+        world_size=2,
+        start_layer=0,
+        end_layer=0,
+        n_layers=36,
+    )
+    configure_runner_diagnostics(sender, context)
+    try:
+        yield receiver
+    finally:
+        configure_runner_diagnostics(None, context)
+
+
+def _drain(receiver: MpReceiver[RunnerDiagnosticUpdate]) -> list[RunnerDiagnosticUpdate]:
+    """Collect every queued update, tolerating mp.Queue feeder-thread latency.
+
+    A multiprocessing queue transfers items through a background feeder
+    thread, so an immediate receive after send can spuriously report empty;
+    poll briefly and stop once the queue stays quiet.
+    """
+    updates: list[RunnerDiagnosticUpdate] = []
+    deadline = time.monotonic() + 2.0
+    quiet_until = time.monotonic() + 0.2
+    while time.monotonic() < deadline:
+        try:
+            updates.append(receiver.receive_nowait())
+            quiet_until = time.monotonic() + 0.2
+        except WouldBlock:
+            # Return only after the queue stays quiet: consecutive sends can
+            # flush through the feeder thread at different times.
+            if updates and time.monotonic() >= quiet_until:
+                return updates
+            time.sleep(0.02)
+    return updates
+
+
+def test_dead_subprocess_records_error_phase(
+    phase_updates: MpReceiver[RunnerDiagnosticUpdate],
+) -> None:
+    runner = _donor_runner()
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    _ = proc.wait(timeout=10)
+    runner.server_proc = proc
+    with pytest.raises(RuntimeError, match="exited unexpectedly"):
+        runner._ensure_server_alive()  # pyright: ignore[reportPrivateUsage]
+
+    updates = _drain(phase_updates)
+    assert any(
+        update.phase == "error" and update.event == "server_exited"
+        for update in updates
+    )
+
+
+def test_shutdown_records_cleanup_phases(
+    phase_updates: MpReceiver[RunnerDiagnosticUpdate],
+) -> None:
+    runner = _donor_runner()
+    # No server was ever spawned; teardown is a no-op, but the lifecycle
+    # phases must still be recorded for the Live tab.
+    runner._handle_task(  # pyright: ignore[reportPrivateUsage]
+        Shutdown(
+            task_id=TaskId(),
+            instance_id=runner.bound_instance.instance.instance_id,
+            runner_id=runner.runner_id,
+        )
+    )
+
+    events = [(update.phase, update.event) for update in _drain(phase_updates)]
+    assert ("shutdown_cleanup", "runner_shutdown_requested") in events
+    assert ("shutdown_cleanup", "server_teardown_complete") in events


### PR DESCRIPTION
Closes #479 (phases half — the gate for the 1.4.1 cut). The `llama_cpp`, `llama_server`, and `rpc_donor` runners emitted zero runner-phase diagnostics, so the observability Live tab sat at **created** forever for any GGUF placement — which is every placement the AMD Strix release audience runs. The flight-recorder channel was already wired for all runner types (bootstrap configures it before dispatch); the runners just never spoke on it.

**What's recorded now** (same vocabulary and seams as the MLX runner):
- `task_submission` on task acknowledge and generation submit
- `load_model` (enter/exit) around `Llama()` construction, `llama-server` spawn + health-check, and `ggml-rpc-server` spawn + listen (the donor's honest mapping in the closed phase vocabulary; detail says `spawn_rpc_server`)
- `idle` / `runner_ready` on ready and after each generation returns to ready
- `decode_stream` / `request_started` when a generation request begins
- `completion` or `cancel_observed` on finish — checking only cancellations observed during execution, NOT re-draining the cancel pipe (that would recreate the finished-task-flips-to-Cancelled race `main()` explicitly guards against)
- `error` on generation failure and when a server subprocess is found dead behind the runner
- `shutdown_cleanup` around teardown

**Not in scope:** trace sessions for these engines (the Traces tab). Phases are the visible 80% for the Live tab; traces are a follow-up on #479.

**Tests:** new `test_gguf_runner_phases.py` captures the diagnostic channel through the donor runner (cheap representative of the shared runner skeleton): dead subprocess records an `error` phase; Shutdown records both `shutdown_cleanup` phases. Full suite 1801 passed; basedpyright 0 errors; ruff clean.

Live verification on kite4 (GGUF placement showing real phases in the Live tab) queued behind the merge, with the pre-cut fleet battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)