### PR TITLE
fix(dashboard): header warning tooltip caused horizontal overflow on phones

### DIFF
--- a/dashboard-react/src/components/layout/HeaderNav.tsx
+++ b/dashboard-react/src/components/layout/HeaderNav.tsx
@@ -8,6 +8,7 @@ import type { Theme } from '../../theme';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { uiActions } from '../../store/slices/uiSlice';
 import { useSkulkTranslation } from '../../i18n/tolgee';
+import { MOBILE_BREAKPOINT_PX } from '../../hooks/useMediaQuery';
 
 export type NavRoute = 'cluster' | 'model-store' | 'chat' | 'operator';
 
@@ -195,6 +196,21 @@ const WarningTooltip = styled.div`
   visibility: hidden;
   transition: opacity 0.2s, visibility 0.2s;
   z-index: 50;
+
+  /* Anchored under a pip near the left screen edge, the centered 300px box
+   * pokes past the right edge of narrow viewports. Even hidden it extends the
+   * document's scrollable area (visibility does not remove layout), giving
+   * phones a horizontal pan wiggle. Pin it inside the viewport instead:
+   * fixed placement contributes no scroll overflow. */
+  @media (max-width: ${MOBILE_BREAKPOINT_PX}px) {
+    position: fixed;
+    top: 60px;
+    left: 12px;
+    right: 12px;
+    width: auto;
+    transform: none;
+    padding-top: 0;
+  }
 `;
 
 const WarningTooltipInner = styled.div`


### PR DESCRIPTION
Found by the pre-cut small-viewport sweep (360px and 414px): every view had horizontal scroll on narrow phones (17px baseline, 43px on chat at 360px). The culprit is the cluster-warnings hover tooltip: a 300px absolutely-positioned box centered under the warning pip near the left screen edge. `visibility: hidden` keeps it out of sight but not out of layout, so it silently extended the document's scrollable width past the right edge of any viewport narrower than about 406px, including 390px iPhones.

Fix: at the mobile breakpoint the tooltip becomes `position: fixed`, pinned just below the header with 12px side insets and auto width. Fixed-position elements contribute no scroll overflow, and the tooltip now renders fully on-screen if the pip is tapped.

Verified with a headless sweep at 360x800 and 414x896 across cluster, store, chat, and the open instances drawer: `scrollWidth == viewport` everywhere (previously 377 and 403 vs 360).

🤖 Generated with [Claude Code](https://claude.com/claude-code)