### PR TITLE
chore: complete the [Unreleased] changelog for the dashboard TLC wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,39 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Added
+
+- **The dashboard works from a phone.** At phone widths (480px and below)
+  every view adapts to a single-column layout: the header collapses into an
+  animated hamburger menu carrying the navigation, observability, settings,
+  and theme controls; the model store table becomes stacked cards; the
+  conversation-history and active-instances panels open as drawers over the
+  content (one at a time, fully opaque, dismissed by tapping the dimmed
+  backdrop); observability takes over the full screen and sizes itself to the
+  real visible area on iOS Safari; the cluster topology scales its node cards
+  and thins the background mesh for the smaller canvas; and the chat input
+  reflows with the model selector on its own line. Verified with headless
+  sweeps at 360px, 390px, and 414px showing no horizontal overflow on any
+  view. A new docs page covers managing a cluster from a phone, including
+  Tailscale as the recommended remote-access shape.
+
 ### Fixed
+
+- **The chat scroll-to-bottom button works.** In any fresh session, the
+  scroll-position restore logic re-armed itself off the user's own scrolling
+  and yanked the pane back, cancelling in-flight smooth scrolls; the button
+  visibly did nothing. It also passed its click event where a scroll behavior
+  belongs, and stacked above the mobile drawers instead of beneath them. All
+  three fixed; smooth scrolling in chat is reliable again generally.
+
+- **The observability Node tab reports each node's own Tailscale state.** It
+  previously queried the dashboard-serving node's local Tailscale status and
+  displayed it for every node in the cluster. The reading now rides each
+  node's diagnostics bundle. The Tailscale probe is TTL-cached on the API
+  node, and a probe child that outlives its timeout is killed and reaped
+  instead of leaking one stuck subprocess per poll. A spurious "current
+  master is not a placement node" warning that fired on normal topologies
+  was removed.
 
 - **GGUF engines now report runner phases to observability.** The `llama_cpp`,
   `llama_server`, and RPC-donor runners emitted no runner-phase diagnostics at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ This project records release notes here and mirrors public-facing notes in
   and thins the background mesh for the smaller canvas; and the chat input
   reflows with the model selector on its own line. Verified with headless
   sweeps at 360px, 390px, and 414px showing no horizontal overflow on any
-  view. A new docs page covers managing a cluster from a phone, including
-  Tailscale as the recommended remote-access shape.
+  view. A new documentation page, "Manage Your Cluster from a Phone"
+  (`website/docs/mobile-dashboard.md`), covers the mobile layout and
+  remote access, with Tailscale as the recommended remote-access shape.
 
 ### Fixed
 


### PR DESCRIPTION
Pre-cut hygiene: several recent dashboard PRs (#468, #469, #470, #472, #475, #476, #477, #478, #480, #485) landed without CHANGELOG entries. This adds the missing `[Unreleased]` entries, text only, no code:

- **Added: the dashboard works from a phone.** At widths of 480px and below, every view adapts to a single-column layout: the header collapses into a hamburger menu, the model store table becomes stacked cards, side panels open as drawers, observability becomes a full-screen sheet sized to the real visible area on iOS Safari, the topology view scales down its node cards, and the chat input reflows. Includes a pointer to the new mobile documentation page.
- **Fixed: the chat scroll-to-bottom button did nothing.** Clicking the button that jumps a long chat back to the newest message had no effect in fresh sessions, because the scroll-position restore logic kept re-firing off the user's own scrolling and cancelled the scroll animation. The button also rendered on top of the mobile side drawers instead of underneath them. Both are described in the entry.
- **Fixed: observability accuracy on the Node tab.** Every node previously displayed the dashboard-serving node's Tailscale status instead of its own; the reading now comes from each node's diagnostics. The Tailscale probe result is cached with a TTL, a probe subprocess that hangs past its timeout is killed instead of leaked, and a warning that incorrectly flagged normal cluster topologies ("current master is not a placement node") was removed.

Entries for the dashboard version display fix (#467) and the GGUF runner-phase instrumentation (#483) were already present. These all roll into `[1.4.1]` at the cut.