### PR TITLE
fix(dashboard): pooled (LlamaRpc) instances never render as cards

### DIFF
--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -442,8 +442,16 @@ export function App() {
   const instanceCards = useMemo<InstanceCardData[]>(() => {
     const cards: InstanceCardData[] = [];
     for (const [iid, inst] of Object.entries(instances)) {
-      const isRing = !!inst.MlxRingInstance;
-      const inner = inst.MlxRingInstance ?? inst.MlxJacclInstance;
+      // Instance is a tagged union: MlxRing / MlxJaccl (in-process) and
+      // LlamaRpc (pooled multi-node GGUF, #328). Handling only the first two
+      // silently dropped every pooled instance from the Active Instances panel.
+      const instanceType: InstanceCardData['instanceType'] = inst.MlxRingInstance
+        ? 'MlxRing'
+        : inst.MlxJacclInstance
+          ? 'MlxJaccl'
+          : 'LlamaRpc';
+      const inner =
+        inst.MlxRingInstance ?? inst.MlxJacclInstance ?? inst.LlamaRpcInstance;
       if (!inner) continue;
       const sa = inner.shardAssignments;
       const modelId = sa?.modelId;
@@ -457,7 +465,10 @@ export function App() {
       // Derive sharding and model type from shard metadata
       const runnerToShard = sa?.runnerToShard;
       let sharding: 'Pipeline' | 'Tensor' = 'Pipeline';
-      let engine: InstanceCardData['engine'] = 'mlx';
+      // A pooled instance is always served by llama-server across the RPC pair,
+      // so default its engine to 'served' regardless of shard-card ordering;
+      // the backend read below only refines the in-process MLX/llama_cpp split.
+      let engine: InstanceCardData['engine'] = instanceType === 'LlamaRpc' ? 'served' : 'mlx';
       let isEmbedding = false;
       let speculation: InstanceCardData['speculation'];
       if (runnerToShard) {
@@ -539,7 +550,7 @@ export function App() {
         instanceId,
         modelId,
         sharding,
-        instanceType: isRing ? 'MlxRing' : 'MlxJaccl',
+        instanceType,
         engine,
         nodeStatuses,
         status: derived.status,

--- a/dashboard-react/src/components/cluster/ClusterCard.tsx
+++ b/dashboard-react/src/components/cluster/ClusterCard.tsx
@@ -29,7 +29,7 @@ export interface ClusterCardProps {
   modelName?: string;
   sizeBytes?: number;
   sharding: 'Pipeline' | 'Tensor';
-  instanceType: 'MlxRing' | 'MlxJaccl';
+  instanceType: 'MlxRing' | 'MlxJaccl' | 'LlamaRpc';
   nodes: ClusterCardNode[];
   isReady?: boolean;
   downloads?: ClusterCardDownload[];

--- a/dashboard-react/src/components/cluster/PlacementManager.tsx
+++ b/dashboard-react/src/components/cluster/PlacementManager.tsx
@@ -57,7 +57,8 @@ function comboKey(sharding: string, meta: string): keyof NodeCountOptions {
 function extractNodeCount(preview: PlacementPreview): number {
   if (!preview.instance || typeof preview.instance !== 'object') return 1;
   const inner = (preview.instance as Record<string, unknown>).MlxRingInstance
-    ?? (preview.instance as Record<string, unknown>).MlxJacclInstance;
+    ?? (preview.instance as Record<string, unknown>).MlxJacclInstance
+    ?? (preview.instance as Record<string, unknown>).LlamaRpcInstance;
   if (!inner || typeof inner !== 'object') return 1;
   const sa = (inner as Record<string, unknown>).shardAssignments;
   if (!sa || typeof sa !== 'object') return 1;

--- a/dashboard-react/src/components/cluster/RunningInstanceCard.tsx
+++ b/dashboard-react/src/components/cluster/RunningInstanceCard.tsx
@@ -30,7 +30,7 @@ export interface RunningInstanceCardProps {
   instanceId: string;
   modelId: string;
   sharding: 'Pipeline' | 'Tensor';
-  instanceType: 'MlxRing' | 'MlxJaccl';
+  instanceType: 'MlxRing' | 'MlxJaccl' | 'LlamaRpc';
   /** Serving engine: MLX (in-process), in-process llama.cpp, or the served
    *  llama-server. Drives the type label so a GGUF/served instance is not
    *  mislabelled as an MLX ring. */
@@ -81,10 +81,16 @@ function formatInstanceId(id: string): string {
 function formatEngineLabel(
   engine: 'mlx' | 'llama_cpp' | 'served',
   sharding: 'Pipeline' | 'Tensor',
-  instanceType: 'MlxRing' | 'MlxJaccl',
+  instanceType: 'MlxRing' | 'MlxJaccl' | 'LlamaRpc',
   t: SkulkTranslate,
 ): string {
-  if (engine === 'served') return t('placement.served', 'Served (llama.cpp)');
+  if (engine === 'served') {
+    // A pooled instance is served across the RPC pair; distinguish it from a
+    // single-node served instance so the multi-node nature is legible.
+    return instanceType === 'LlamaRpc'
+      ? t('placement.servedPooled', 'Served (pooled)')
+      : t('placement.served', 'Served (llama.cpp)');
+  }
   if (engine === 'llama_cpp') return t('placement.llamaCpp', 'llama.cpp');
   const shard = sharding === 'Pipeline' ? t('common.pipeline', 'Pipeline') : t('common.tensor', 'Tensor');
   const transport = instanceType === 'MlxRing' ? t('placement.mlxRing', 'MLX Ring') : t('placement.mlxJaccl', 'MLX Jaccl');

--- a/dashboard-react/src/components/layout/InstancePanel.tsx
+++ b/dashboard-react/src/components/layout/InstancePanel.tsx
@@ -8,7 +8,7 @@ export interface InstanceCardData {
   instanceId: string;
   modelId: string;
   sharding: 'Pipeline' | 'Tensor';
-  instanceType: 'MlxRing' | 'MlxJaccl';
+  instanceType: 'MlxRing' | 'MlxJaccl' | 'LlamaRpc';
   /** Serving engine, derived from the card's placement backends. Drives the
    *  type label (MLX vs served llama.cpp) since the wire wraps every instance
    *  as an MLX instance. */

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -363,7 +363,8 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
     const ids: string[] = [];
     const mapping: Record<string, string> = {};
     for (const [iid, inst] of Object.entries(instances)) {
-      const inner = inst.MlxRingInstance ?? inst.MlxJacclInstance;
+      const inner =
+        inst.MlxRingInstance ?? inst.MlxJacclInstance ?? inst.LlamaRpcInstance;
       const modelId = inner?.shardAssignments?.modelId;
       if (modelId) {
         ids.push(modelId);
@@ -378,7 +379,8 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
     const cards: Record<string, Omit<ClusterCardProps, 'onLaunch'>> = {};
     for (const [, inst] of Object.entries(instances)) {
       const isRing = !!inst.MlxRingInstance;
-      const inner = inst.MlxRingInstance ?? inst.MlxJacclInstance;
+      const inner =
+        inst.MlxRingInstance ?? inst.MlxJacclInstance ?? inst.LlamaRpcInstance;
       if (!inner) continue;
       const sa = inner.shardAssignments;
       const modelId = sa?.modelId;
@@ -425,7 +427,11 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
         modelId,
         sizeBytes: storeEntry?.total_bytes,
         sharding,
-        instanceType: isRing ? 'MlxRing' : 'MlxJaccl',
+        instanceType: isRing
+          ? 'MlxRing'
+          : inst.MlxJacclInstance
+            ? 'MlxJaccl'
+            : 'LlamaRpc',
         nodes: cardNodes,
         isReady,
       };

--- a/dashboard-react/src/hooks/useClusterState.ts
+++ b/dashboard-react/src/hooks/useClusterState.ts
@@ -261,7 +261,14 @@ export interface RawInstanceInner {
 
 export type RawInstances = Record<
   string,
-  { MlxRingInstance?: RawInstanceInner; MlxJacclInstance?: RawInstanceInner }
+  {
+    MlxRingInstance?: RawInstanceInner;
+    MlxJacclInstance?: RawInstanceInner;
+    // Pooled multi-node GGUF (llama.cpp RPC driver+donor, #328). A third
+    // instance variant; consumers that only knew MlxRing/MlxJaccl silently
+    // dropped every pooled instance.
+    LlamaRpcInstance?: RawInstanceInner;
+  }
 >;
 
 export type RawRunners = Record<string, Record<string, unknown>>;


### PR DESCRIPTION
**Confirmed bug Tom hit:** placing a model across two nodes (multi-node GGUF pooling, #328) produces a `LlamaRpcInstance`, but the dashboard only ever knew the two original instance variants (`MlxRingInstance` / `MlxJacclInstance`). Every consumer that unwrapped instances did `MlxRingInstance ?? MlxJacclInstance` and dropped the third variant, so pooled instances silently vanished from:

- the **Active Instances** panel (App.tsx early-`continue`d)
- the **topology** running-instance data (`useClusterState` RawInstances type omitted it)
- the **Downloads page** active-model list and cluster cards
- **placement previews** (node-count read skipped it)
- the `instanceType` type unions in RunningInstanceCard / ClusterCard / InstancePanel had no `'LlamaRpc'`

The stale comment in App.tsx even claimed 'every instance is wrapped as an MlxRing/Jaccl instance' — untrue since #328 added the pooling variant.

**Fix:** all six sites now handle `LlamaRpcInstance`. It unwraps identically (same `shardAssignments` shape: modelId / nodeToRunner / runnerToShard), reports engine `served` (a pooled instance is always llama-server across the RPC pair), and shows a **'Served (pooled)'** label so the multi-node nature is legible on the card.

Verified against a real pooled instance's `/state` JSON (captured live during the multi-node cost benchmark). Dashboard `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)