### PR TITLE
docs(deployment): USB4/TB networking guide + thunderbolt-preference regression tests

### DIFF
--- a/deployment/networking/usb4-thunderbolt.md
+++ b/deployment/networking/usb4-thunderbolt.md
@@ -1,0 +1,129 @@
+# USB4 / Thunderbolt networking between Linux nodes
+
+USB4 (Thunderbolt) host-to-host networking gives a Skulk pair a direct
+high-bandwidth link that placement automatically prefers over ethernet for
+multi-node (RPC) tensor traffic. This guide is the bring-up and tuning recipe
+for a Linux pair (validated on two AMD Strix Halo nodes, kernel 7.x), plus how
+to verify Skulk is actually using the link.
+
+## What the link buys (measured, Strix Halo pair, 2026-07)
+
+| Metric | 2.5GbE LAN | USB4 (20G link) |
+|---|---:|---:|
+| TCP throughput (iperf3) | 2.36 Gbit/s | 9.4 Gbit/s |
+| Ping RTT (avg) | 0.99 ms | 0.72 ms |
+| Pooled 63GB model load (driver launch to ready) | 96 s | 81 s |
+| Pooled decode tok/s | 44.3 | 44.0 |
+
+Bandwidth-bound phases (model load, donor tensor push, long-prompt prefill)
+benefit. Per-token decode does not: its multi-node overhead is dominated by
+the llama.cpp RPC protocol, not the wire, and is the same on both transports.
+
+## Requirements
+
+- A USB4/Thunderbolt cable rated for the speed you want. **Cable
+  certification decides the negotiated rate**: 40 Gbit/s needs a
+  USB4-40Gbps-certified cable (passive, 0.8 m or shorter is the safe
+  choice); a 20 Gbps-rated cable silently negotiates the link down to
+  20 Gbit/s even between 40G-capable ports. Check the negotiated rate after
+  connecting (below).
+- `thunderbolt` and `thunderbolt_net` kernel modules (present in stock
+  Ubuntu kernels). The `thunderbolt0` interface appears when the two hosts
+  establish their XDomain connection; no pairing/authorization step is
+  needed in the default `user` security mode for host-to-host links.
+
+## Bring-up
+
+### 1. Static subnet (required, not cosmetic)
+
+Give the link a dedicated static subnet. Do NOT rely on the 169.254/16
+link-local addresses the interface gets by default: Skulk's donor-endpoint
+selection rejects link-local addresses by contract, because a host with two
+Thunderbolt ports routes all of 169.254/16 out whichever port has the lower
+metric, so TCP breaks asymmetrically while ping appears to work (observed on
+the reference pair, which has a second TB port cabled to another machine).
+
+With NetworkManager (Ubuntu desktop/server default), on the first node:
+
+```bash
+nmcli connection modify "Wired connection 1" \
+  ipv4.method manual ipv4.addresses 10.99.0.1/30 \
+  802-3-ethernet.mtu 65520
+```
+
+and on the second node (adjust the profile name to whichever one owns
+`thunderbolt0`; `nmcli -t -f NAME,DEVICE connection show` lists them):
+
+```bash
+nmcli connection modify "Wired connection 1" \
+  ipv4.method manual ipv4.addresses 10.99.0.2/30 \
+  802-3-ethernet.mtu 65520
+```
+
+MTU 65520 is the thunderbolt-net maximum (it is a virtual interface, not
+ethernet; jumbo-frame conventions like 9000 leave packet-count savings on
+the table for bulk transfers).
+
+### 2. Queueing discipline
+
+`fq_codel` measurably reduces TCP retransmits on thunderbolt-net links.
+Persist it as the default qdisc:
+
+```bash
+echo "net.core.default_qdisc = fq_codel" | sudo tee /etc/sysctl.d/90-skulk-tb.conf
+sudo sysctl --system
+sudo tc qdisc replace dev thunderbolt0 root fq_codel
+```
+
+### 3. Verify the link
+
+```bash
+# Negotiated rate (per direction, per lane; 20.0 Gb/s x2 = a 20G cable):
+cat /sys/bus/thunderbolt/devices/*/tx_speed /sys/bus/thunderbolt/devices/*/tx_lanes
+# Reachability + latency:
+ping -c 5 10.99.0.2
+# Throughput (iperf3 -s on the peer):
+iperf3 -c 10.99.0.2 -t 5
+```
+
+If the peer's `thunderbolt0` never appears, check `dmesg | grep -i
+thunderbolt` for retimer connect/disconnect churn (reseat the cable or use
+the other port) and confirm the XDomain peer shows up under
+`/sys/bus/thunderbolt/devices/` (a `<domain>-<port>` entry named after the
+peer host).
+
+## How Skulk uses the link
+
+No Skulk configuration is needed. Placement selects multi-node addresses
+from the observed peer connections, ranked by the gossiped interface type
+with Thunderbolt first and VPN/overlay last; RPC donor endpoints
+additionally require a routable (non-link-local) address, which is what the
+static subnet provides. When both the LAN and the TB path are observed, the
+donor endpoint is stamped on the TB address (regression-tested in
+`src/skulk/master/tests/test_multinode_gguf_placement.py`).
+
+Verify on a live pooled instance:
+
+```bash
+curl -s http://localhost:52415/state | jq \
+  '.instances[].LlamaRpcInstance.donorEndpoints'
+# expect the TB subnet address, e.g. {"<donor-node-id>": "10.99.0.2:28890"}
+```
+
+One ordering caveat: candidates are the OBSERVED peer connections, and the
+workers' connection probes discover a newly-up TB path within a probe cycle
+(seconds). An instance placed while the link was down keeps its LAN endpoint
+for its lifetime; delete and re-place it after the link is up if you want
+the tensor path moved. Control-plane traffic (gossip, telemetry, Zenoh data
+plane endpoints) stays on the LAN by configuration, which keeps the TB lane
+clear for tensor traffic.
+
+## Do NOT pin CPU C-states on APU nodes
+
+Holding `/dev/cpu_dma_latency` at 0 (or capping C-states) is a standard
+small-packet latency tuning trick, and it does cut this link's RTT by an
+order of magnitude. But on a unified-memory APU (Strix Halo) the CPU and
+GPU share one package power budget, and cores held in C0 steal enough of it
+to throttle the GPU: measured ~20% decode throughput loss on the reference
+pair. Inference decode is not RTT-bound, so this trade is all cost and no
+benefit on APU inference nodes.

--- a/deployment/networking/usb4-thunderbolt.md
+++ b/deployment/networking/usb4-thunderbolt.md
@@ -8,7 +8,7 @@ to verify Skulk is actually using the link.
 
 ## What the link buys (measured, Strix Halo pair, 2026-07)
 
-| Metric | 2.5GbE LAN | USB4 (20G link) |
+| Metric | 2.5GbE LAN | USB4 (Gen3 x2, 40 Gbit/s link) |
 |---|---:|---:|
 | TCP throughput (iperf3) | 2.36 Gbit/s | 9.4 Gbit/s |
 | Ping RTT (avg) | 0.99 ms | 0.72 ms |
@@ -24,9 +24,8 @@ the llama.cpp RPC protocol, not the wire, and is the same on both transports.
 - A USB4/Thunderbolt cable rated for the speed you want. **Cable
   certification decides the negotiated rate**: 40 Gbit/s needs a
   USB4-40Gbps-certified cable (passive, 0.8 m or shorter is the safe
-  choice); a 20 Gbps-rated cable silently negotiates the link down to
-  20 Gbit/s even between 40G-capable ports. Check the negotiated rate after
-  connecting (below).
+  choice); a lesser cable silently negotiates the link down even between
+  40G-capable ports. Check the negotiated rate after connecting (below).
 - `thunderbolt` and `thunderbolt_net` kernel modules (present in stock
   Ubuntu kernels). The `thunderbolt0` interface appears when the two hosts
   establish their XDomain connection; no pairing/authorization step is
@@ -89,7 +88,9 @@ sudo tc qdisc replace dev thunderbolt0 root fq_codel
 ### 3. Verify the link
 
 ```bash
-# Negotiated rate (per direction, per lane; 20.0 Gb/s x2 = a 20G cable):
+# Negotiated rate. tx_speed is PER LANE (kernel Thunderbolt sysfs ABI), so
+# multiply by tx_lanes for the aggregate: 20.0 Gb/s x 2 lanes = a full
+# 40 Gbit/s Gen3 link; 10.0 Gb/s x 2 = Gen2 (20G aggregate, cable-limited).
 cat /sys/bus/thunderbolt/devices/*/tx_speed /sys/bus/thunderbolt/devices/*/tx_lanes
 # Reachability + latency:
 ping -c 5 10.99.0.2

--- a/deployment/networking/usb4-thunderbolt.md
+++ b/deployment/networking/usb4-thunderbolt.md
@@ -64,6 +64,17 @@ MTU 65520 is the thunderbolt-net maximum (it is a virtual interface, not
 ethernet; jumbo-frame conventions like 9000 leave packet-count savings on
 the table for bulk transfers).
 
+`nmcli connection modify` edits the stored profile only; an already-active
+`thunderbolt0` keeps its old address and MTU until the profile is
+re-applied. Reactivate it on both nodes before verifying:
+
+```bash
+nmcli connection up "Wired connection 1"
+```
+
+(`nmcli device reapply thunderbolt0` also works for address changes, but an
+MTU change needs the full reactivation on some NetworkManager versions.)
+
 ### 2. Queueing discipline
 
 `fq_codel` measurably reduces TCP retransmits on thunderbolt-net links.

--- a/src/skulk/master/tests/test_multinode_gguf_placement.py
+++ b/src/skulk/master/tests/test_multinode_gguf_placement.py
@@ -31,7 +31,11 @@ from skulk.shared.types.commands import PlaceInstance
 from skulk.shared.types.common import CommandId, NodeId
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.multiaddr import Multiaddr
-from skulk.shared.types.profiling import NodeResources
+from skulk.shared.types.profiling import (
+    NetworkInterfaceInfo,
+    NodeNetworkInfo,
+    NodeResources,
+)
 from skulk.shared.types.topology import Connection, Cycle, SocketConnection
 from skulk.shared.types.worker.instances import InstanceMeta, LlamaRpcInstance
 from skulk.shared.types.worker.shards import (
@@ -219,6 +223,147 @@ def test_pooled_gguf_places_rpc_shape_on_amd_pair() -> None:
     # #330 stamping applies to both roles.
     assert driver_shard.resolved_backend == "llama_server-vulkan"
     assert donor_shard.resolved_backend == "llama_server-vulkan"
+
+
+def _lan_connection(ip_octet: int) -> SocketConnection:
+    """An observed connection on the LAN (ethernet) subnet."""
+    return SocketConnection(
+        sink_multiaddr=Multiaddr(address=f"/ip4/192.168.0.{ip_octet}/tcp/1234"),
+    )
+
+
+def _dual_path_pair() -> tuple[Topology, NodeId, NodeId]:
+    """The kite4+kite5 shape with BOTH paths observed: the 2.5GbE LAN and the
+    USB4/Thunderbolt static-subnet link. This is the fixture that exercises
+    the transport CHOICE; ``_amd_pair`` only ever observes the TB path."""
+    topology = Topology()
+    big = NodeId()
+    small = NodeId()
+    topology.add_node(big)
+    topology.add_node(small)
+    for edge_to_small, edge_to_big in (
+        (_lan_connection(129), _lan_connection(123)),
+        (_routable_connection(2), _routable_connection(1)),
+    ):
+        topology.add_connection(
+            Connection(source=big, sink=small, edge=edge_to_small)
+        )
+        topology.add_connection(
+            Connection(source=small, sink=big, edge=edge_to_big)
+        )
+    return topology, big, small
+
+
+def _dual_path_network(tb_octet: int, lan_octet: int) -> NodeNetworkInfo:
+    """Gossiped interfaces for a node on both the LAN and the TB subnet."""
+    return NodeNetworkInfo(
+        interfaces=[
+            NetworkInterfaceInfo(
+                name="eno1",
+                ip_address=f"192.168.0.{lan_octet}",
+                interface_type="ethernet",
+            ),
+            NetworkInterfaceInfo(
+                name="thunderbolt0",
+                ip_address=f"10.99.0.{tb_octet}",
+                interface_type="thunderbolt",
+            ),
+        ]
+    )
+
+
+def test_rpc_donor_endpoint_prefers_thunderbolt_over_ethernet() -> None:
+    """When BOTH the LAN and the USB4/TB path are observed between driver and
+    donor, the donor endpoint must be stamped on the Thunderbolt address.
+
+    This is the operator guarantee that the pooled tensor path automatically
+    rides the fastest interconnect (proven live on the kite pair 2026-07-06:
+    re-placing pooled gpt-oss-120b after the TB link came up stamped
+    10.99.0.2 unaided, and the donor's 24GB tensor push rode thunderbolt0).
+    The other RPC tests observe only one path, so without this test the
+    LAN-vs-TB CHOICE has no regression coverage.
+    """
+    topology, big, small = _dual_path_pair()
+    node_memory = {
+        big: create_node_memory(Memory.from_gb(64).in_bytes),
+        small: create_node_memory(Memory.from_gb(32).in_bytes),
+    }
+    node_network = {
+        big: _dual_path_network(tb_octet=1, lan_octet=123),
+        small: _dual_path_network(tb_octet=2, lan_octet=129),
+    }
+    resources = {big: _amd_resources(), small: _amd_resources()}
+    node_vram = {big: Memory.from_gb(57.6), small: Memory.from_gb(28.8)}
+    command = _command(_gguf_card(storage_gb=55.0), min_nodes=1)
+    placements = place_instance(
+        command,
+        topology,
+        {},
+        node_memory,
+        node_network,
+        node_resources=resources,
+        node_vram=node_vram,
+    )
+    instance = next(iter(placements.values()))
+    assert isinstance(instance, LlamaRpcInstance)
+    ip, _, _ = instance.donor_endpoints[small].rpartition(":")
+    assert ip == "10.99.0.2"
+
+
+def test_rpc_donor_endpoint_falls_back_to_ethernet_without_thunderbolt() -> None:
+    """With only the LAN path observed (no TB link), the donor endpoint is the
+    ethernet address: preferring TB must never make LAN-only pairs unplaceable."""
+    topology = Topology()
+    big = NodeId()
+    small = NodeId()
+    topology.add_node(big)
+    topology.add_node(small)
+    topology.add_connection(
+        Connection(source=big, sink=small, edge=_lan_connection(129))
+    )
+    topology.add_connection(
+        Connection(source=small, sink=big, edge=_lan_connection(123))
+    )
+    node_memory = {
+        big: create_node_memory(Memory.from_gb(64).in_bytes),
+        small: create_node_memory(Memory.from_gb(32).in_bytes),
+    }
+    node_network = {
+        big: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="eno1",
+                    ip_address="192.168.0.123",
+                    interface_type="ethernet",
+                )
+            ]
+        ),
+        small: NodeNetworkInfo(
+            interfaces=[
+                NetworkInterfaceInfo(
+                    name="eno1",
+                    ip_address="192.168.0.129",
+                    interface_type="ethernet",
+                )
+            ]
+        ),
+    }
+    resources = {big: _amd_resources(), small: _amd_resources()}
+    node_vram = {big: Memory.from_gb(57.6), small: Memory.from_gb(28.8)}
+    command = _command(_gguf_card(storage_gb=55.0), min_nodes=1)
+    placements = place_instance(
+        command,
+        topology,
+        {},
+        node_memory,
+        node_network,
+        node_resources=resources,
+        node_vram=node_vram,
+    )
+    instance = next(iter(placements.values()))
+    assert isinstance(instance, LlamaRpcInstance)
+    ip, _, _ = instance.donor_endpoints[small].rpartition(":")
+    assert ip == "192.168.0.129"
 
 
 def test_link_local_only_path_fails_placement() -> None:


### PR DESCRIPTION
## What

Two things the USB4 interconnect work on the kite4+kite5 Strix pair surfaced as missing from the repo:

**1. The thunderbolt-over-ethernet preference had no regression coverage for the actual choice.** Placement ranks donor-endpoint candidates thunderbolt-first (`_find_ip_prioritised`), and the Linux interface labeling that makes that work between Linux boxes is merged, but every existing RPC placement test observes only ONE path between the pair. This PR adds the two missing tests:

- `test_rpc_donor_endpoint_prefers_thunderbolt_over_ethernet`: both a LAN edge (labeled `ethernet`) and a TB edge (labeled `thunderbolt`) observed between driver and donor; the donor endpoint must be stamped on the TB address.
- `test_rpc_donor_endpoint_falls_back_to_ethernet_without_thunderbolt`: LAN-only pairs stay placeable on the ethernet address.

Both encode what was proven live on the pair (2026-07-06): re-placing a pooled gpt-oss-120b after the TB link came up stamped `10.99.0.2` unaided, and the donor's 24GB tensor push rode `thunderbolt0` (interface byte counters).

**2. The link bring-up and tuning recipe lived only on the reference machines.** `deployment/networking/usb4-thunderbolt.md` now carries it: the static-subnet requirement and the two-TB-port link-local trap, NetworkManager profile commands (MTU 65520), fq_codel qdisc, the cable-certification gotcha (a 20Gbps-rated cable silently negotiates 40G-capable ports down to 20G; how to read the negotiated rate from sysfs), how to verify a live pooled instance's donor endpoint from `/state`, the placed-while-link-down caveat (endpoints are stamped at placement time; delete + re-place to move an instance's tensor path onto a newly-up link), and the APU C-state warning (pinning C-states cut small-packet RTT 12x but throttled the shared-power-budget GPU ~20%, a net loss for inference nodes).

## Measured context (kite4+kite5, 2026-07-06)

| Metric | 2.5GbE LAN | USB4 (20G link) |
|---|---:|---:|
| iperf3 | 2.36 Gbit/s | 9.4 Gbit/s |
| RTT avg | 0.99 ms | 0.72 ms |
| Pooled 63GB load (launch to ready) | 96 s | 81 s |
| Pooled decode | 44.3 tok/s | 44.0 tok/s |

Decode is transport-invariant: the multi-node per-token overhead is llama.cpp RPC protocol cost, not wire, which the doc states so nobody tunes the link chasing decode.

## Validation

- `uv run basedpyright`: 0 errors (local; CI does not run it)
- `uv run ruff check`: clean
- `uv run pytest src/skulk/master/tests/test_multinode_gguf_placement.py`: 16 passed
- Doc checked for the no-em-dash prose rule

## Notes

- No behavior change; tests + docs only.
- Written against current dev; the new tests do not touch the `node_vram_strict` parameter, so they are compatible with #491 (UMA admission) whichever merges first. Same-file textual conflict with #491 is possible but trivial (different regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)