### PR TITLE
Add Fish and LongCat speech model cards

### DIFF
--- a/resources/speech_model_cards/mlx-community--LongCat-AudioDiT-1B-4bit.toml
+++ b/resources/speech_model_cards/mlx-community--LongCat-AudioDiT-1B-4bit.toml
@@ -1,0 +1,27 @@
+model_id = "mlx-community/LongCat-AudioDiT-1B-4bit"
+n_layers = 24
+hidden_size = 1536
+supports_tensor = false
+tasks = ["TextToSpeech"]
+family = "longcat_audiodit"
+quantization = "4bit"
+base_model = "meituan-longcat/LongCat-AudioDiT-1B"
+capabilities = ["tts"]
+context_length = 0
+
+[audio]
+kind = "tts"
+default_response_format = "wav"
+response_formats = ["wav"]
+supports_streaming = false
+supports_realtime = false
+supports_voice_listing = false
+supports_reference_audio = false
+sample_rates = [24000]
+
+[placement]
+compatible_backends = ["mlx_audio", "mlx_audio-metal"]
+backend_preference = ["mlx_audio-metal", "mlx_audio"]
+
+[storage_size]
+in_bytes = 1417906487

--- a/resources/speech_model_cards/mlx-community--fish-audio-s2-pro-8bit.toml
+++ b/resources/speech_model_cards/mlx-community--fish-audio-s2-pro-8bit.toml
@@ -1,0 +1,27 @@
+model_id = "mlx-community/fish-audio-s2-pro-8bit"
+n_layers = 36
+hidden_size = 2560
+supports_tensor = false
+tasks = ["TextToSpeech"]
+family = "fish_qwen3_omni"
+quantization = "8bit"
+base_model = "fishaudio/s2-pro"
+capabilities = ["tts"]
+context_length = 32768
+
+[audio]
+kind = "tts"
+default_response_format = "wav"
+response_formats = ["wav"]
+supports_streaming = false
+supports_realtime = false
+supports_voice_listing = false
+supports_reference_audio = false
+sample_rates = [44100]
+
+[placement]
+compatible_backends = ["mlx_audio", "mlx_audio-metal"]
+backend_preference = ["mlx_audio-metal", "mlx_audio"]
+
+[storage_size]
+in_bytes = 6731423034


### PR DESCRIPTION
## Summary
- Add bundled TTS model cards for mlx-community/fish-audio-s2-pro-8bit and mlx-community/LongCat-AudioDiT-1B-4bit.
- Declare the current Skulk serving contract as non-streaming WAV speech synthesis for both cards.
- Set mlx_audio / mlx_audio-metal placement preferences and persisted storage sizes from the HF repo metadata.

## Validation
- uv run pytest src/skulk/shared/tests/test_bundled_model_cards.py
- uv run basedpyright
- uv run ruff check
- nix --extra-experimental-features "nix-command flakes" fmt
- uv run pytest
- Live branch validation: pinned Fish + LongCat speech-synthesis harness run passed 2/2 with no issues.
  - Fish: audio/wav, 143404 bytes
  - LongCat: audio/wav, 139308 bytes
