### PR TITLE
Add Parakeet STT model card

### DIFF
--- a/resources/speech_model_cards/mlx-community--parakeet-tdt-0.6b-v3.toml
+++ b/resources/speech_model_cards/mlx-community--parakeet-tdt-0.6b-v3.toml
@@ -1,0 +1,24 @@
+model_id = "mlx-community/parakeet-tdt-0.6b-v3"
+n_layers = 24
+hidden_size = 1024
+supports_tensor = false
+tasks = ["SpeechToText"]
+family = "parakeet"
+quantization = "fp16"
+base_model = "nvidia/parakeet-tdt-0.6b-v3"
+capabilities = ["stt"]
+context_length = 0
+
+[audio]
+kind = "stt"
+supports_streaming = false
+supports_realtime = false
+supports_translation = false
+sample_rates = [16000]
+
+[placement]
+compatible_backends = ["mlx_audio", "mlx_audio-metal"]
+backend_preference = ["mlx_audio-metal", "mlx_audio"]
+
+[storage_size]
+in_bytes = 2509044141

--- a/src/skulk/worker/runner/speech/runner.py
+++ b/src/skulk/worker/runner/speech/runner.py
@@ -23,7 +23,7 @@ import numpy as np
 from anyio import WouldBlock
 
 from skulk.shared.constants import SKULK_MAX_CHUNK_SIZE
-from skulk.shared.models.model_cards import AudioResponseFormat
+from skulk.shared.models.model_cards import AudioCardKind, AudioResponseFormat
 from skulk.shared.tracing import (
     begin_trace_session,
     bind_trace_session,
@@ -185,11 +185,27 @@ def _encode_audio(
     return buffer.getvalue()
 
 
-def _load_speech_model(local_path: str) -> Any:
-    """Load an ``mlx_audio`` model from the staged local model directory."""
+def _load_speech_model(local_path: Path, audio_kind: AudioCardKind | None) -> Any:
+    """Load a staged ``mlx_audio`` model using the card-declared speech kind.
+
+    The generic upstream loader infers the category from repo/config names. That
+    breaks for some staged Skulk paths because ``owner--repo`` normalization can
+    bias the inference toward a TTS package before the STT family token is tried.
+    The card already declares the serving kind, so prefer the category-specific
+    loader and keep the generic path only for legacy cards without ``[audio]``.
+    """
+    if audio_kind == AudioCardKind.SpeechToText:
+        from mlx_audio.stt.utils import load_model
+
+        return load_model(local_path)
+    if audio_kind == AudioCardKind.TextToSpeech:
+        from mlx_audio.tts.utils import load_model
+
+        return load_model(local_path)
+
     from mlx_audio.utils import load_model
 
-    return load_model(local_path)
+    return load_model(str(local_path))
 
 
 def _resolve_staged_voice_path(
@@ -565,7 +581,9 @@ class Runner:
         local_path = build_model_path(ModelId(model_id))
         self.local_model_path = local_path
         logger.info(f"loading speech model from local path: {local_path}")
-        self.model = _load_speech_model(str(local_path))
+        audio_config = self.shard_metadata.model_card.audio
+        audio_kind = audio_config.kind if audio_config is not None else None
+        self.model = _load_speech_model(local_path, audio_kind)
         self.current_status = RunnerReady()
         logger.info(
             f"speech runner ready in {time.time() - self.setup_start_time:.1f}s"

--- a/src/skulk/worker/runner/speech/tests/test_speech_runner.py
+++ b/src/skulk/worker/runner/speech/tests/test_speech_runner.py
@@ -3,16 +3,17 @@
 
 import base64
 import hashlib
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import cast
 
 import numpy as np
 import pytest
 from anyio import WouldBlock
 
-from skulk.shared.models.model_cards import AudioResponseFormat, ModelId
+from skulk.shared.models.model_cards import AudioCardKind, AudioResponseFormat, ModelId
 from skulk.shared.types.audio import (
     AudioTranscriptionTaskParams,
     SpeechSynthesisTaskParams,
@@ -37,6 +38,7 @@ from skulk.worker.runner.speech import runner as speech_runner
 from skulk.worker.runner.speech.runner import (
     Runner,
     _filter_kwargs,
+    _load_speech_model,
     _resolve_staged_voice_path,
 )
 
@@ -200,6 +202,42 @@ def test_filter_kwargs_drops_unsupported_and_none_values() -> None:
             "reference_audio": None,
         },
     ) == {"voice": "af_heart", "stream": False}
+
+
+def test_load_speech_model_uses_stt_loader(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """STT cards should bypass upstream generic TTS/STT name inference."""
+    stt_utils = ModuleType("mlx_audio.stt.utils")
+    calls: list[Path] = []
+
+    def _fake_load_model(model_path: Path) -> object:
+        calls.append(model_path)
+        return "stt-model"
+
+    stt_utils.__dict__["load_model"] = _fake_load_model
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", stt_utils)
+
+    assert _load_speech_model(tmp_path, AudioCardKind.SpeechToText) == "stt-model"
+    assert calls == [tmp_path]
+
+
+def test_load_speech_model_uses_tts_loader(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """TTS cards should use the TTS loader directly."""
+    tts_utils = ModuleType("mlx_audio.tts.utils")
+    calls: list[Path] = []
+
+    def _fake_load_model(model_path: Path) -> object:
+        calls.append(model_path)
+        return "tts-model"
+
+    tts_utils.__dict__["load_model"] = _fake_load_model
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts.utils", tts_utils)
+
+    assert _load_speech_model(tmp_path, AudioCardKind.TextToSpeech) == "tts-model"
+    assert calls == [tmp_path]
 
 
 def test_resolve_staged_voice_path_uses_default_voice_from_model_store(

--- a/src/skulk/worker/runner/speech/tests/test_speech_runner.py
+++ b/src/skulk/worker/runner/speech/tests/test_speech_runner.py
@@ -204,19 +204,35 @@ def test_filter_kwargs_drops_unsupported_and_none_values() -> None:
     ) == {"voice": "af_heart", "stream": False}
 
 
+def _stub_mlx_audio_loader(
+    monkeypatch: pytest.MonkeyPatch,
+    category: str,
+    load_model: object,
+) -> None:
+    """Install an importable ``mlx_audio.<category>.utils`` stub."""
+    root = ModuleType("mlx_audio")
+    root.__dict__["__path__"] = []
+    category_module = ModuleType(f"mlx_audio.{category}")
+    category_module.__dict__["__path__"] = []
+    utils_module = ModuleType(f"mlx_audio.{category}.utils")
+    utils_module.__dict__["load_model"] = load_model
+
+    monkeypatch.setitem(sys.modules, "mlx_audio", root)
+    monkeypatch.setitem(sys.modules, f"mlx_audio.{category}", category_module)
+    monkeypatch.setitem(sys.modules, f"mlx_audio.{category}.utils", utils_module)
+
+
 def test_load_speech_model_uses_stt_loader(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """STT cards should bypass upstream generic TTS/STT name inference."""
-    stt_utils = ModuleType("mlx_audio.stt.utils")
     calls: list[Path] = []
 
     def _fake_load_model(model_path: Path) -> object:
         calls.append(model_path)
         return "stt-model"
 
-    stt_utils.__dict__["load_model"] = _fake_load_model
-    monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", stt_utils)
+    _stub_mlx_audio_loader(monkeypatch, "stt", _fake_load_model)
 
     assert _load_speech_model(tmp_path, AudioCardKind.SpeechToText) == "stt-model"
     assert calls == [tmp_path]
@@ -226,15 +242,13 @@ def test_load_speech_model_uses_tts_loader(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """TTS cards should use the TTS loader directly."""
-    tts_utils = ModuleType("mlx_audio.tts.utils")
     calls: list[Path] = []
 
     def _fake_load_model(model_path: Path) -> object:
         calls.append(model_path)
         return "tts-model"
 
-    tts_utils.__dict__["load_model"] = _fake_load_model
-    monkeypatch.setitem(sys.modules, "mlx_audio.tts.utils", tts_utils)
+    _stub_mlx_audio_loader(monkeypatch, "tts", _fake_load_model)
 
     assert _load_speech_model(tmp_path, AudioCardKind.TextToSpeech) == "tts-model"
     assert calls == [tmp_path]


### PR DESCRIPTION
## Summary
- Add a bundled speech model card for `mlx-community/parakeet-tdt-0.6b-v3`.
- Declare Parakeet as a non-streaming STT model served through `mlx_audio` on Metal-capable speech nodes.
- Use HF repo metadata/config for storage size, layer count, hidden size, base model, and 16 kHz input metadata.

## Validation
- `uv run pytest src/skulk/shared/tests/test_bundled_model_cards.py`
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest`
