### PR TITLE
Enable low-latency TTS streaming DATA delivery

### DIFF
--- a/resources/speech_model_cards/mlx-community--Qwen3-TTS-12Hz-0.6B-Base-4bit.toml
+++ b/resources/speech_model_cards/mlx-community--Qwen3-TTS-12Hz-0.6B-Base-4bit.toml
@@ -1,0 +1,27 @@
+model_id = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-4bit"
+n_layers = 5
+hidden_size = 1024
+supports_tensor = false
+tasks = ["TextToSpeech"]
+family = "qwen3_tts"
+quantization = "4bit"
+base_model = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+capabilities = ["tts"]
+context_length = 65536
+
+[audio]
+kind = "tts"
+default_response_format = "wav"
+response_formats = ["wav", "mp3"]
+supports_streaming = true
+supports_realtime = false
+supports_voice_listing = false
+supports_reference_audio = false
+sample_rates = [24000]
+
+[placement]
+compatible_backends = ["mlx_audio", "mlx_audio-metal"]
+backend_preference = ["mlx_audio-metal", "mlx_audio"]
+
+[storage_size]
+in_bytes = 1711328624

--- a/src/skulk/routing/router.py
+++ b/src/skulk/routing/router.py
@@ -39,12 +39,14 @@ from .topics import CONNECTION_MESSAGES, DATA, PublishPolicy, TypedTopic
 # egress task inside zenoh_publish. With an unbounded channel the producer (the
 # rank-0 worker's per-token emit) would keep enqueueing chunks during a long
 # generation and grow memory without limit until the node OOMs. A bounded channel
-# instead backpressures the producer (TopicRouter._send_out awaits the send), so
-# generation throttles to subscriber speed. We backpressure rather than drop on
-# purpose: the Zenoh plane is Reliable+ordered, which is exactly what lets the
-# app-layer reorder buffer be skipped (#311), so dropping chunks here would break
-# that no-loss assumption and corrupt output. The buffer is sized to absorb
-# ordinary subscriber jitter without throttling steady-state streaming.
+# instead backpressures cross-node DATA producers (TopicRouter._send_out awaits
+# the send), so generation throttles to subscriber speed. Same-node DATA is
+# delivered locally without egress because the owning API node is already local.
+# We backpressure rather than drop cross-node chunks on purpose: the Zenoh plane
+# is Reliable+ordered, which is exactly what lets the app-layer reorder buffer be
+# skipped (#311), so dropping chunks here would break that no-loss assumption and
+# corrupt output. The buffer is sized to absorb ordinary subscriber jitter
+# without throttling steady-state streaming.
 _ZENOH_DATA_OUTBOUND_BUFFER = 2048
 
 
@@ -58,6 +60,7 @@ class TopicRouter[T: CamelCaseModel]:
         topic: TypedTopic[T],
         networking_sender: Sender[tuple[str, str | None, bytes]],
         max_buffer_size: float = inf,
+        local_routing_key: str | None = None,
     ):
         self.topic: TypedTopic[T] = topic
         self.senders: set[Sender[T]] = set()
@@ -68,6 +71,7 @@ class TopicRouter[T: CamelCaseModel]:
         self.networking_sender: Sender[tuple[str, str | None, bytes]] = (
             networking_sender
         )
+        self.local_routing_key = local_routing_key
 
     async def run(self):
         logger.debug(f"Topic Router {self.topic} ready to send")
@@ -82,6 +86,8 @@ class TopicRouter[T: CamelCaseModel]:
                     # Publish locally before any outbound backpressure can hold a
                     # same-node stream and collapse it into a late burst.
                     await self.publish(item, origin=None)
+                    if self._routes_to_local_node(item):
+                        continue
                     await self._send_out(item)
                     continue
                 # Check if we should send to network
@@ -147,6 +153,11 @@ class TopicRouter[T: CamelCaseModel]:
 
     def new_sender(self) -> Sender[T]:
         return self._sender.clone()
+
+    def _routes_to_local_node(self, item: T) -> bool:
+        if self.local_routing_key is None or self.topic.routing_key is None:
+            return False
+        return self.topic.routing_key(item) == self.local_routing_key
 
     async def _send_out(self, item: T):
         logger.trace(f"TopicRouter {self.topic.topic} sending {item}")
@@ -258,7 +269,8 @@ class Router:
                 self._tmp_networking_sender = None
             else:
                 send = self.networking_receiver.clone_sender()
-        router = TopicRouter[T](topic, send)
+        local_routing_key = self._node_id if topic.topic == DATA.topic else None
+        router = TopicRouter[T](topic, send, local_routing_key=local_routing_key)
         self.topic_routers[topic.topic] = cast(TopicRouter[CamelCaseModel], router)
         if self._tg.is_running():
             await self._networking_subscribe(topic.topic)

--- a/src/skulk/routing/router.py
+++ b/src/skulk/routing/router.py
@@ -73,6 +73,17 @@ class TopicRouter[T: CamelCaseModel]:
         logger.debug(f"Topic Router {self.topic} ready to send")
         with self.receiver as items:
             async for item in items:
+                if (
+                    self.topic.topic == DATA.topic
+                    and self.topic.publish_policy is PublishPolicy.Always
+                ):
+                    # DATA output is latency-sensitive and the local API consumer
+                    # already dedupes Zenoh self-loopback duplicates by sequence.
+                    # Publish locally before any outbound backpressure can hold a
+                    # same-node stream and collapse it into a late burst.
+                    await self.publish(item, origin=None)
+                    await self._send_out(item)
+                    continue
                 # Check if we should send to network
                 if (
                     len(self.senders) == 0

--- a/src/skulk/routing/tests/test_topic_router.py
+++ b/src/skulk/routing/tests/test_topic_router.py
@@ -1,7 +1,12 @@
 """Tests for TopicRouter wire-format robustness."""
 
+import anyio
+
 from skulk.routing.router import TopicRouter
-from skulk.routing.topics import PublishPolicy, TypedTopic
+from skulk.routing.topics import DATA, PublishPolicy, TypedTopic
+from skulk.shared.models.model_cards import ModelId
+from skulk.shared.types.chunks import DataChunk, TokenChunk
+from skulk.shared.types.common import CommandId, NodeId
 from skulk.utils.channels import channel
 from skulk.utils.pydantic_ext import CamelCaseModel
 
@@ -46,3 +51,51 @@ async def test_publish_bytes_drops_unknown_field_payload_without_raising():
     # After dropping the bad message, the router must remain functional for
     # the next valid message.
     await router_v1.publish_bytes(valid_payload, origin=None)
+
+
+async def test_data_topic_publishes_locally_before_blocked_network_egress() -> None:
+    """DATA chunks must reach local API receivers before network backpressure.
+
+    Same-node serving publishes DATA through the same TopicRouter as cross-node
+    output. If the router awaits outbound DATA egress before local publish, a
+    blocked egress channel can hold every audio/token chunk and make a stream
+    appear as one late burst. The API's DATA consumer already dedupes the later
+    Zenoh self-loopback copy by sequence, so local-first DATA delivery is safe.
+    """
+
+    networking_send, networking_recv = channel[tuple[str, str | None, bytes]](
+        max_buffer_size=1
+    )
+    await networking_send.send(("occupied", None, b"held"))
+
+    router = TopicRouter[DataChunk](DATA, networking_send)
+    local_send, local_recv = channel[DataChunk]()
+    router.senders.add(local_send)
+    input_send = router.new_sender()
+
+    chunk = DataChunk(
+        command_id=CommandId("local-first-data"),
+        sequence=0,
+        owner_node=NodeId("api-node"),
+        chunk=TokenChunk(
+            model=ModelId("mlx-community/test"),
+            text="hello",
+            token_id=1,
+            usage=None,
+        ),
+    )
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(router.run)
+        await input_send.send(chunk)
+
+        with anyio.fail_after(0.5):
+            assert await local_recv.receive() == chunk
+
+        assert await networking_recv.receive() == ("occupied", None, b"held")
+        with anyio.fail_after(0.5):
+            topic, routing_key, payload = await networking_recv.receive()
+        assert topic == DATA.topic
+        assert routing_key == "api-node"
+        assert DATA.deserialize(payload) == chunk
+        task_group.cancel_scope.cancel()

--- a/src/skulk/routing/tests/test_topic_router.py
+++ b/src/skulk/routing/tests/test_topic_router.py
@@ -53,14 +53,28 @@ async def test_publish_bytes_drops_unknown_field_payload_without_raising():
     await router_v1.publish_bytes(valid_payload, origin=None)
 
 
-async def test_data_topic_publishes_locally_before_blocked_network_egress() -> None:
+def _data_chunk(sequence: int, owner_node: str) -> DataChunk:
+    return DataChunk(
+        command_id=CommandId("local-first-data"),
+        sequence=sequence,
+        owner_node=NodeId(owner_node),
+        chunk=TokenChunk(
+            model=ModelId("mlx-community/test"),
+            text=f"chunk-{sequence}",
+            token_id=sequence,
+            usage=None,
+        ),
+    )
+
+
+async def test_local_data_topic_does_not_wait_for_blocked_network_egress() -> None:
     """DATA chunks must reach local API receivers before network backpressure.
 
     Same-node serving publishes DATA through the same TopicRouter as cross-node
-    output. If the router awaits outbound DATA egress before local publish, a
-    blocked egress channel can hold every audio/token chunk and make a stream
-    appear as one late burst. The API's DATA consumer already dedupes the later
-    Zenoh self-loopback copy by sequence, so local-first DATA delivery is safe.
+    output. Local DATA does not need a network self-loopback copy because the
+    owning API node is already local. If the router awaits outbound DATA egress,
+    a blocked egress channel can hold subsequent audio/token chunks and make a
+    stream appear as one late burst.
     """
 
     networking_send, networking_recv = channel[tuple[str, str | None, bytes]](
@@ -68,22 +82,45 @@ async def test_data_topic_publishes_locally_before_blocked_network_egress() -> N
     )
     await networking_send.send(("occupied", None, b"held"))
 
-    router = TopicRouter[DataChunk](DATA, networking_send)
+    router = TopicRouter[DataChunk](
+        DATA, networking_send, local_routing_key="api-node"
+    )
     local_send, local_recv = channel[DataChunk]()
     router.senders.add(local_send)
     input_send = router.new_sender()
 
-    chunk = DataChunk(
-        command_id=CommandId("local-first-data"),
-        sequence=0,
-        owner_node=NodeId("api-node"),
-        chunk=TokenChunk(
-            model=ModelId("mlx-community/test"),
-            text="hello",
-            token_id=1,
-            usage=None,
-        ),
+    first_chunk = _data_chunk(sequence=0, owner_node="api-node")
+    second_chunk = _data_chunk(sequence=1, owner_node="api-node")
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(router.run)
+        await input_send.send(first_chunk)
+        await input_send.send(second_chunk)
+
+        with anyio.fail_after(0.5):
+            assert await local_recv.receive() == first_chunk
+            assert await local_recv.receive() == second_chunk
+
+        assert await networking_recv.receive() == ("occupied", None, b"held")
+        with anyio.move_on_after(0.1) as scope:
+            await networking_recv.receive()
+        assert scope.cancel_called
+        task_group.cancel_scope.cancel()
+
+
+async def test_remote_data_topic_still_egresses_to_owner_key() -> None:
+    """Cross-node DATA must still preserve ordered network delivery."""
+
+    networking_send, networking_recv = channel[tuple[str, str | None, bytes]]()
+
+    router = TopicRouter[DataChunk](
+        DATA, networking_send, local_routing_key="api-node"
     )
+    local_send, local_recv = channel[DataChunk]()
+    router.senders.add(local_send)
+    input_send = router.new_sender()
+
+    chunk = _data_chunk(sequence=0, owner_node="remote-node")
 
     async with anyio.create_task_group() as task_group:
         task_group.start_soon(router.run)
@@ -91,11 +128,8 @@ async def test_data_topic_publishes_locally_before_blocked_network_egress() -> N
 
         with anyio.fail_after(0.5):
             assert await local_recv.receive() == chunk
-
-        assert await networking_recv.receive() == ("occupied", None, b"held")
-        with anyio.fail_after(0.5):
             topic, routing_key, payload = await networking_recv.receive()
         assert topic == DATA.topic
-        assert routing_key == "api-node"
+        assert routing_key == "remote-node"
         assert DATA.deserialize(payload) == chunk
         task_group.cancel_scope.cancel()


### PR DESCRIPTION
## Summary
- Add the Qwen3 TTS 12Hz 0.6B 4-bit speech model card with streaming audio capability metadata.
- Deliver local-owner DATA chunks directly to local receivers without sending a redundant network self-loopback, so same-node API streams are not coupled to outbound DATA backpressure.
- Preserve cross-node DATA egress to the owner routing key, and add regression tests for both same-node backpressure and remote-owner network delivery.

## Root Cause
Qwen3 TTS and the speech runner can emit progressive audio chunks, but the topic router previously tied DATA delivery to outbound network publication. That could turn a progressive same-node stream into an end-of-response burst when DATA egress was delayed or saturated.

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest`
- Live speech streaming harness: passed with 57 chunks, first byte at 0.250s, stream span 3.179s.