### PR TITLE
Fix GGUF filename discovery and pinning

### DIFF
--- a/dashboard-react/src/components/models/HuggingFaceResultItem.tsx
+++ b/dashboard-react/src/components/models/HuggingFaceResultItem.tsx
@@ -52,6 +52,9 @@ const ModelName = styled.div`
 const Author = styled.div`
   font-size: ${({ theme }) => theme.fontSizes.label};
   color: ${({ theme }) => theme.colors.textMuted};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const StatBadge = styled.span`
@@ -91,7 +94,6 @@ export function HuggingFaceResultItem({
 }: HuggingFaceResultItemProps) {
   const { t } = useSkulkTranslation();
   const theme = useTheme() as Theme;
-  const CheckIcon = () => <FiCheck size={16} color={theme.colors.accent} strokeWidth={2.5} />;
   const shortName = model.id.startsWith('mlx-community/')
     ? model.id.replace('mlx-community/', '')
     : model.id;
@@ -126,6 +128,12 @@ export function HuggingFaceResultItem({
         <span>{formatCount(model.likes)}</span>
         <span style={{ color: theme.colors.textMuted }}>{t('huggingFaceResult.updated', 'Updated')}</span>
         <span>{new Date(model.last_modified).toLocaleDateString()}</span>
+        {model.matched_file && (
+          <>
+            <span style={{ color: theme.colors.textMuted }}>{t('huggingFaceResult.matchedFile', 'Matched file')}</span>
+            <span style={{ overflowWrap: 'anywhere' }}>{model.matched_file}</span>
+          </>
+        )}
       </div>
       {sizeTags.length > 0 && (
         <div style={{ marginTop: 8, borderTop: `1px solid ${theme.colors.borderLight}`, paddingTop: 6 }}>
@@ -146,7 +154,9 @@ export function HuggingFaceResultItem({
     <Row>
       <Info>
         <ModelName>{shortName}</ModelName>
-        <Author>{model.author}</Author>
+        <Author title={model.matched_file ?? model.author}>
+          {model.matched_file ?? model.author}
+        </Author>
       </Info>
 
       {/* Info tooltip */}
@@ -158,7 +168,7 @@ export function HuggingFaceResultItem({
 
       {/* Action */}
       {isInStore ? (
-        <AddedBadge><CheckIcon /> {t('huggingFaceResult.inStore', 'In Store')}</AddedBadge>
+        <AddedBadge><FiCheck size={16} color={theme.colors.accent} strokeWidth={2.5} /> {t('huggingFaceResult.inStore', 'In Store')}</AddedBadge>
       ) : isAdded ? (
         <SelectBtn variant="primary" size="sm" onClick={onSelect}>
           <StoreDownloadIcon /> {t('huggingFaceResult.download', 'Download')}

--- a/dashboard-react/src/components/models/ModelBrowser.tsx
+++ b/dashboard-react/src/components/models/ModelBrowser.tsx
@@ -25,10 +25,10 @@ export interface ModelBrowserProps {
   existingModelIds?: Set<string>;
   canModelFit: (modelId: string) => boolean;
   getModelFitStatus: (modelId: string) => ModelFitStatus;
-  onSelect: (modelId: string) => void;
+  onSelect: (modelId: string, ggufFile?: string | null) => void;
   onToggleFavorite: (groupId: string) => void;
   onShowInfo?: (group: ModelGroup) => void;
-  onAddModel?: (modelId: string) => Promise<void>;
+  onAddModel?: (modelId: string, ggufFile?: string | null) => Promise<boolean>;
   downloadStatusMap?: Map<string, DownloadAvailability>;
   instanceStatuses?: Record<string, InstanceStatus>;
   mode?: PickerMode;
@@ -238,13 +238,19 @@ export function ModelBrowser({
                   key={m.id}
                   model={m}
                   isAdded={models.some((mod) => mod.id === m.id)}
-                  isInStore={existingModelIds.has(m.id)}
+                  isInStore={existingModelIds.has(m.id) && !m.matched_file}
                   isAdding={false}
                   onAdd={async () => {
-                    await onAddModel?.(m.id);
-                    onSelect(m.id);
+                    const added = await onAddModel?.(m.id, m.matched_file);
+                    if (added !== false) onSelect(m.id, m.matched_file);
                   }}
-                  onSelect={() => onSelect(m.id)}
+                  onSelect={async () => {
+                    if (m.matched_file) {
+                      const updated = await onAddModel?.(m.id, m.matched_file);
+                      if (updated === false) return;
+                    }
+                    onSelect(m.id, m.matched_file);
+                  }}
                 />
               ))}
             </>

--- a/dashboard-react/src/components/pages/ModelSearchModal.tsx
+++ b/dashboard-react/src/components/pages/ModelSearchModal.tsx
@@ -163,10 +163,14 @@ export function ModelSearchModal({
     }, 500);
   }, [mlxOnly]);
 
-  const handleSelect = useCallback(async (modelId: string) => {
+  const handleSelect = useCallback(async (modelId: string, ggufFile?: string | null) => {
     try {
       const res = await fetch(`/store/models/${encodeURIComponent(modelId)}/download`, {
         method: 'POST',
+        ...(ggufFile ? {
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ gguf_file: ggufFile }),
+        } : {}),
       });
       if (res.ok) {
         addToast({
@@ -186,12 +190,12 @@ export function ModelSearchModal({
     }
   }, [onDownloadStarted, t]);
 
-  const handleAddModel = useCallback(async (modelId: string) => {
+  const handleAddModel = useCallback(async (modelId: string, ggufFile?: string | null): Promise<boolean> => {
     try {
       const res = await fetch('/models/add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model_id: modelId }),
+        body: JSON.stringify({ model_id: modelId, gguf_file: ggufFile ?? null }),
       });
       if (res.ok) {
         addToast({ type: 'success', message: t('modelSearch.toasts.addedModel', 'Added {modelId}', { modelId }) });
@@ -201,8 +205,13 @@ export function ModelSearchModal({
           const data = await listRes.json();
           setModels(data.data ?? []);
         }
+        return true;
       }
-    } catch { /* ignore */ }
+      addToast({ type: 'error', message: t('modelSearch.toasts.addModelFailed', 'Failed to add {modelId}', { modelId }) });
+    } catch {
+      addToast({ type: 'error', message: t('modelSearch.toasts.addModelFailed', 'Failed to add {modelId}', { modelId }) });
+    }
+    return false;
   }, [t]);
 
   const handleToggleMlxOnly = useCallback(() => {

--- a/dashboard-react/src/types/models.ts
+++ b/dashboard-react/src/types/models.ts
@@ -137,6 +137,8 @@ export interface HuggingFaceModel {
   likes: number;
   last_modified: string;
   tags: string[];
+  /** Exact repo-relative GGUF path matched by a filename search. */
+  matched_file?: string | null;
 }
 
 /** Progress snapshot for a download shown in the dashboard. */

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -65,6 +65,7 @@ from skulk.api.adapters.responses import (
     responses_request_to_text_generation,
 )
 from skulk.api.keepalive import with_sse_keepalive
+from skulk.api.model_search import search_hugging_face_models
 from skulk.api.node_health import compute_node_health
 from skulk.api.types import (
     AddCustomModelParams,
@@ -122,6 +123,7 @@ from skulk.api.types import (
     RuntimeCapabilitySection,
     StartDownloadParams,
     StartDownloadResponse,
+    StoreDownloadRequest,
     ToolCall,
     ToolingCapabilitySection,
     TraceCategoryStats,
@@ -1332,7 +1334,11 @@ class API:
             "/models/add",
             tags=["Models"],
             summary="Fetch and add a custom model card",
-            description="Add a custom model card to Skulk's model catalog so it becomes searchable and launchable through the API or dashboard.",
+            description=(
+                "Add a custom model card to Skulk's model catalog so it becomes "
+                "searchable and launchable. An optional gguf_file pins one exact "
+                "weight file from a multi-quant GGUF repository."
+            ),
         )(self.add_custom_model)
         self.app.delete(
             "/models/custom/{model_id:path}",
@@ -1346,7 +1352,9 @@ class API:
             summary="Search Hugging Face for models",
             description=(
                 "Search for models to add or launch. Pass mlx_only=true to restrict results "
-                "to mlx-community; omit or pass false to search all of Hugging Face."
+                "to mlx-community; omit or pass false to search all of Hugging Face. "
+                "Exact GGUF filename queries also inspect bounded candidate repository "
+                "manifests and return the matched repo-relative file path."
             ),
         )(self.search_models)
         self.app.post(
@@ -1793,7 +1801,10 @@ class API:
             "/store/models/{model_id:path}/download",
             tags=["Store"],
             summary="Request a store download",
-            description="Ask the shared model store to download and register a model by model ID.",
+            description=(
+                "Ask the shared model store to download and register a model by model ID. "
+                "An optional gguf_file request field pins one exact quant file."
+            ),
         )(self.request_store_download)
         self.app.get(
             "/store/models/{model_id:path}/download/status",
@@ -3022,7 +3033,7 @@ class API:
             async with httpx.AsyncClient(timeout=timeout, verify=False) as client:
                 response = await client.get(f"{base_url}/v1/capabilities")
                 response.raise_for_status()
-                payload_raw: object = response.json()
+                payload_raw = cast("object", response.json())
         except (httpx.HTTPError, ValueError) as exc:
             logger.warning(
                 f"describe_node: peer {node_id} capabilities fetch failed: {exc}"
@@ -4074,9 +4085,12 @@ class API:
         return ModelList(data=[self._model_list_entry(card) for card in cards])
 
     async def add_custom_model(self, payload: AddCustomModelParams) -> ModelListModel:
-        """Fetch a model from HuggingFace and save as a custom model card, then sync across the cluster."""
+        """Fetch a Hugging Face model card, optionally pinning one GGUF file."""
         try:
-            card = await ModelCard.fetch_from_hf(payload.model_id)
+            card = await ModelCard.fetch_from_hf(
+                payload.model_id,
+                gguf_file=payload.gguf_file,
+            )
         except Exception as exc:
             raise HTTPException(
                 status_code=400, detail=f"Failed to fetch model: {exc}"
@@ -4111,29 +4125,12 @@ class API:
     async def search_models(
         self, query: str = "", limit: int = 20, mlx_only: bool = False
     ) -> list[HuggingFaceSearchResult]:
-        """Search HuggingFace Hub. When mlx_only=True, restricts to mlx-community."""
-        from huggingface_hub import ModelInfo, list_models
-
-        def _to_results(models: Iterable[ModelInfo]) -> list[HuggingFaceSearchResult]:
-            return [
-                HuggingFaceSearchResult(
-                    id=m.id,
-                    author=m.author or "",
-                    downloads=m.downloads or 0,
-                    likes=m.likes or 0,
-                    last_modified=str(m.last_modified or ""),
-                    tags=list(m.tags or []),
-                )
-                for m in models
-            ]
-
-        return _to_results(
-            list_models(
-                search=query or None,
-                author="mlx-community" if mlx_only else None,
-                sort="downloads",
-                limit=limit,
-            )
+        """Search Hugging Face repositories and exact GGUF filenames."""
+        return await to_thread.run_sync(
+            search_hugging_face_models,
+            query,
+            limit,
+            mlx_only,
         )
 
     async def run(self):
@@ -6342,10 +6339,18 @@ class API:
         downloads = await self._store_client.list_active_downloads()
         return JSONResponse({"downloads": downloads})
 
-    async def request_store_download(self, model_id: str) -> JSONResponse:
+    async def request_store_download(
+        self,
+        model_id: str,
+        payload: StoreDownloadRequest | None = None,
+    ) -> JSONResponse:
+        """Request a store download, optionally pinning an exact GGUF file."""
         if self._store_client is None:
             raise HTTPException(status_code=503, detail="Store not configured")
-        result = await self._store_client.request_store_download(model_id)
+        result = await self._store_client.request_store_download(
+            model_id,
+            gguf_file=payload.gguf_file if payload is not None else None,
+        )
         return JSONResponse(result)
 
     async def get_store_download_status(self, model_id: str) -> JSONResponse:

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -1336,8 +1336,8 @@ class API:
             summary="Fetch and add a custom model card",
             description=(
                 "Add a custom model card to Skulk's model catalog so it becomes "
-                "searchable and launchable. An optional gguf_file pins one exact "
-                "weight file from a multi-quant GGUF repository."
+                "searchable and launchable. An optional gguf_file selects one exact "
+                "quant from a multi-quant GGUF repository."
             ),
         )(self.add_custom_model)
         self.app.delete(

--- a/src/skulk/api/model_search.py
+++ b/src/skulk/api/model_search.py
@@ -1,0 +1,141 @@
+"""Hugging Face repository and GGUF filename search helpers."""
+
+import re
+from pathlib import PurePosixPath
+
+from huggingface_hub import ModelInfo, list_models
+
+from skulk.api.types import HuggingFaceSearchResult
+
+_GGUF_EXTENSION = ".gguf"
+_GGUF_SHARD_SUFFIX = re.compile(r"-\d{5}-of-\d{5}$", re.IGNORECASE)
+_MIN_FILENAME_SEARCH_TERM_LENGTH = 4
+_MAX_FILENAME_SEARCH_CANDIDATES = 100
+
+
+def _to_search_result(
+    model: ModelInfo, *, matched_file: str | None = None
+) -> HuggingFaceSearchResult:
+    return HuggingFaceSearchResult(
+        id=model.id,
+        author=model.author or "",
+        downloads=model.downloads or 0,
+        likes=model.likes or 0,
+        last_modified=str(model.last_modified or ""),
+        tags=list(model.tags or []),
+        matched_file=matched_file,
+    )
+
+
+def _gguf_filename(query: str) -> str | None:
+    normalized = query.strip().replace("\\", "/")
+    filename = PurePosixPath(normalized).name
+    if not filename.casefold().endswith(_GGUF_EXTENSION):
+        return None
+    return filename
+
+
+def _gguf_repository_search_terms(filename: str) -> tuple[str, ...]:
+    stem = filename[: -len(_GGUF_EXTENSION)]
+    stem = _GGUF_SHARD_SUFFIX.sub("", stem)
+    parts = tuple(part for part in stem.split("-") if part)
+
+    terms: list[str] = []
+    for end in range(len(parts), 0, -1):
+        term = "-".join(parts[:end])
+        if len(term) < _MIN_FILENAME_SEARCH_TERM_LENGTH or term in terms:
+            continue
+        terms.append(term)
+    return tuple(terms)
+
+
+def _matching_file(model: ModelInfo, requested_filename: str) -> str | None:
+    requested = requested_filename.casefold()
+    for sibling in model.siblings or ():
+        repo_path = sibling.rfilename
+        if PurePosixPath(repo_path).name.casefold() == requested:
+            return repo_path
+    return None
+
+
+def search_hugging_face_models(
+    query: str, limit: int, mlx_only: bool
+) -> list[HuggingFaceSearchResult]:
+    """Search repositories and resolve exact GGUF filenames when requested.
+
+    Hugging Face's model search indexes repository metadata, not repository file
+    manifests. A pasted GGUF filename can therefore return no results even when
+    the file exists. Filename-shaped queries get a bounded fallback: progressively
+    broaden the model-name prefix, fetch full metadata only for those candidate
+    repositories, and retain repositories whose manifest contains the exact
+    basename. Ordinary text searches keep the single upstream repository query.
+
+    Args:
+        query: User-entered repository text or GGUF filename.
+        limit: Maximum number of repositories to return.
+        mlx_only: Restrict both search paths to the ``mlx-community`` author.
+
+    Returns:
+        Search results, with ``matched_file`` set for exact GGUF filename matches.
+    """
+    if limit <= 0:
+        return []
+
+    author = "mlx-community" if mlx_only else None
+    primary_models = list(
+        list_models(
+            search=query or None,
+            author=author,
+            sort="downloads",
+            limit=limit,
+        )
+    )
+
+    filename = _gguf_filename(query)
+    if filename is None:
+        return [_to_search_result(model) for model in primary_models]
+
+    candidate_limit = min(
+        max(limit * 2, 20),
+        _MAX_FILENAME_SEARCH_CANDIDATES,
+    )
+    inspected_repositories: set[str] = set()
+    exact_matches: dict[str, tuple[ModelInfo, str]] = {}
+    for term in _gguf_repository_search_terms(filename):
+        remaining_candidates = (
+            _MAX_FILENAME_SEARCH_CANDIDATES - len(inspected_repositories)
+        )
+        if remaining_candidates <= 0:
+            break
+        candidates = list_models(
+            search=term,
+            author=author,
+            sort="downloads",
+            limit=min(candidate_limit, remaining_candidates),
+            full=True,
+        )
+        for model in candidates:
+            if model.id in inspected_repositories:
+                continue
+            inspected_repositories.add(model.id)
+            matched_file = _matching_file(model, filename)
+            if matched_file is not None:
+                exact_matches[model.id] = (model, matched_file)
+        # The first tier that produces an exact manifest match is the most
+        # specific useful repository query. Stop there instead of broadening to
+        # short, high-cardinality terms after the requested file is already found.
+        if exact_matches:
+            break
+
+    if exact_matches:
+        ordered_matches = sorted(
+            exact_matches.values(),
+            key=lambda match: match[0].downloads or 0,
+            reverse=True,
+        )
+        return [
+            _to_search_result(model, matched_file=matched_file)
+            for model, matched_file in ordered_matches[:limit]
+        ]
+
+    return [_to_search_result(model) for model in primary_models]

--- a/src/skulk/api/tests/test_model_search.py
+++ b/src/skulk/api/tests/test_model_search.py
@@ -1,0 +1,160 @@
+# pyright: reportPrivateUsage=false
+"""Hugging Face repository and GGUF filename search behavior."""
+
+from collections.abc import Iterable
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from huggingface_hub import ModelInfo
+
+from skulk.api import model_search
+
+
+def _model(
+    model_id: str,
+    *,
+    files: tuple[str, ...] = (),
+    downloads: int = 0,
+) -> ModelInfo:
+    return cast(
+        ModelInfo,
+        cast(
+            object,
+            SimpleNamespace(
+                id=model_id,
+                author=model_id.split("/", 1)[0],
+                downloads=downloads,
+                likes=0,
+                last_modified=None,
+                tags=["gguf"],
+                siblings=[SimpleNamespace(rfilename=path) for path in files],
+            ),
+        ),
+    )
+
+
+def test_repository_search_uses_the_standard_hub_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_list_models(**kwargs: object) -> Iterable[ModelInfo]:
+        calls.append(kwargs)
+        return [_model("org/Qwen-GGUF", downloads=12)]
+
+    monkeypatch.setattr(model_search, "list_models", fake_list_models)
+
+    results = model_search.search_hugging_face_models("qwen", 5, mlx_only=False)
+
+    assert [result.id for result in results] == ["org/Qwen-GGUF"]
+    assert results[0].matched_file is None
+    assert calls == [
+        {"search": "qwen", "author": None, "sort": "downloads", "limit": 5}
+    ]
+
+
+def test_exact_gguf_filename_finds_owning_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested = "hy3-1M-MTP-IQ3_XXS.gguf"
+    calls: list[dict[str, object]] = []
+
+    def fake_list_models(**kwargs: object) -> Iterable[ModelInfo]:
+        calls.append(kwargs)
+        search = kwargs.get("search")
+        if search == "hy3-1M":
+            return [
+                _model(
+                    "satgeze/Hy3-1M-GGUF",
+                    files=("README.md", requested),
+                    downloads=50,
+                )
+            ]
+        return []
+
+    monkeypatch.setattr(model_search, "list_models", fake_list_models)
+
+    results = model_search.search_hugging_face_models(requested, 20, mlx_only=False)
+
+    assert [(result.id, result.matched_file) for result in results] == [
+        ("satgeze/Hy3-1M-GGUF", requested)
+    ]
+    assert any(
+        call.get("search") == "hy3-1M" and call.get("full") is True
+        for call in calls
+    )
+    assert not any(call.get("search") == "hy3" for call in calls)
+
+
+def test_filename_match_preserves_nested_repo_path_and_author_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested = "Qwen-Q4_K_M-00001-of-00002.gguf"
+    repo_path = f"Q4_K_M/{requested}"
+    authors: list[object] = []
+
+    def fake_list_models(**kwargs: object) -> Iterable[ModelInfo]:
+        authors.append(kwargs.get("author"))
+        if kwargs.get("full") is True:
+            return [_model("mlx-community/Qwen-GGUF", files=(repo_path,))]
+        return []
+
+    monkeypatch.setattr(model_search, "list_models", fake_list_models)
+
+    results = model_search.search_hugging_face_models(requested, 5, mlx_only=True)
+
+    assert results[0].matched_file == repo_path
+    assert set(authors) == {"mlx-community"}
+
+
+def test_filename_fallback_rejects_repositories_without_exact_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_list_models(**kwargs: object) -> Iterable[ModelInfo]:
+        if kwargs.get("full") is True:
+            return [
+                _model(
+                    "org/similar",
+                    files=("hy3-1M-MTP-IQ2_M.gguf",),
+                )
+            ]
+        return []
+
+    monkeypatch.setattr(model_search, "list_models", fake_list_models)
+
+    assert (
+        model_search.search_hugging_face_models(
+            "hy3-1M-MTP-IQ3_XXS.gguf", 20, mlx_only=False
+        )
+        == []
+    )
+
+
+def test_filename_fallback_caps_unique_manifest_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inspected: set[str] = set()
+
+    def fake_list_models(**kwargs: object) -> Iterable[ModelInfo]:
+        if kwargs.get("full") is not True:
+            return []
+        search = str(kwargs["search"])
+        limit = int(cast(int, kwargs["limit"]))
+        models = [
+            _model(f"org/{search}-{index}", files=("other.gguf",))
+            for index in range(limit)
+        ]
+        inspected.update(model.id for model in models)
+        return models
+
+    monkeypatch.setattr(model_search, "list_models", fake_list_models)
+
+    results = model_search.search_hugging_face_models(
+        "long-model-name-with-many-parts-IQ3_XXS.gguf",
+        20,
+        mlx_only=False,
+    )
+
+    assert results == []
+    assert len(inspected) == model_search._MAX_FILENAME_SEARCH_CANDIDATES

--- a/src/skulk/api/types/__init__.py
+++ b/src/skulk/api/types/__init__.py
@@ -64,6 +64,7 @@ from .api import ResolvedModelCapabilities as ResolvedModelCapabilities
 from .api import RuntimeCapabilitySection as RuntimeCapabilitySection
 from .api import StartDownloadParams as StartDownloadParams
 from .api import StartDownloadResponse as StartDownloadResponse
+from .api import StoreDownloadRequest as StoreDownloadRequest
 from .api import StreamingChoiceResponse as StreamingChoiceResponse
 from .api import ToolCall as ToolCall
 from .api import ToolCallItem as ToolCallItem

--- a/src/skulk/api/types/api.py
+++ b/src/skulk/api/types/api.py
@@ -700,10 +700,22 @@ class BenchChatCompletionRequest(ChatCompletionRequest):
 
 class AddCustomModelParams(BaseModel):
     model_config = ConfigDict(
-        json_schema_extra={"example": {"model_id": "mlx-community/my-custom-model"}}
+        json_schema_extra={
+            "example": {
+                "model_id": "bartowski/my-custom-model-GGUF",
+                "gguf_file": "my-custom-model-Q4_K_M.gguf",
+            }
+        }
     )
 
     model_id: ModelId
+    gguf_file: str | None = Field(
+        default=None,
+        description=(
+            "Exact repo-relative GGUF file to pin when adding a multi-quant "
+            "repository. Omit for non-GGUF repositories or default selection."
+        ),
+    )
 
 
 class HuggingFaceSearchResult(BaseModel):
@@ -713,6 +725,27 @@ class HuggingFaceSearchResult(BaseModel):
     likes: int = 0
     last_modified: str = ""
     tags: list[str] = Field(default_factory=list)
+    matched_file: str | None = Field(
+        default=None,
+        description=(
+            "Exact repo-relative GGUF path matched by a filename search, or null "
+            "for ordinary repository search results."
+        ),
+    )
+
+
+class StoreDownloadRequest(BaseModel):
+    """Optional file selection for a shared-store model download."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    gguf_file: str | None = Field(
+        default=None,
+        description=(
+            "Exact repo-relative GGUF file whose shard group the store should "
+            "download. Omit to use the repository's default quant selection."
+        ),
+    )
 
 
 class PlaceInstanceParams(BaseModel):

--- a/src/skulk/api/types/api.py
+++ b/src/skulk/api/types/api.py
@@ -712,8 +712,10 @@ class AddCustomModelParams(BaseModel):
     gguf_file: str | None = Field(
         default=None,
         description=(
-            "Exact repo-relative GGUF file to pin when adding a multi-quant "
-            "repository. Omit for non-GGUF repositories or default selection."
+            "Exact repo-relative GGUF file identifying the quant to select when "
+            "adding a multi-quant repository. Split weights are normalized to "
+            "their first shard for backend loading. Omit for non-GGUF "
+            "repositories or default selection."
         ),
     )
 

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -792,14 +792,30 @@ class ModelCard(CamelCaseModel):
         return mc
 
     @staticmethod
-    async def fetch_from_hf(model_id: ModelId) -> "ModelCard":
-        """Fetches storage size and number of layers for a Hugging Face model, returns Pydantic ModelMeta.
+    async def fetch_from_hf(
+        model_id: ModelId,
+        gguf_file: str | None = None,
+    ) -> "ModelCard":
+        """Build a model card from Hugging Face metadata.
 
         This is a pure fetch — it does NOT save to disk or update the cache.
         Persistence is handled by the event-sourcing layer (worker event handler).
 
         Detects GGUF repos (which `mlx-lm` cannot load) and builds a llama.cpp
-        card for them instead of the default MLX/safetensors card.
+        card for them instead of the default MLX/safetensors card. When
+        ``gguf_file`` is supplied, the resulting card pins that exact repository
+        file instead of applying the default quant preference.
+
+        Args:
+            model_id: Hugging Face repository identifier.
+            gguf_file: Optional exact repo-relative GGUF path to pin.
+
+        Returns:
+            A custom model card derived from repository metadata.
+
+        Raises:
+            ValueError: The requested GGUF path is not a weight file in the repo,
+                or a GGUF path is supplied for a non-GGUF repository.
         """
         # GGUF detection is a best-effort probe: it hits the HF model-info API,
         # which the safetensors path below does NOT require (it has its own retry
@@ -812,7 +828,15 @@ class ModelCard(CamelCaseModel):
             logger.debug(f"GGUF probe for {model_id} failed ({exc}); assuming non-GGUF")
             gguf_files = []
         if gguf_files:
-            return await ModelCard._fetch_gguf_from_hf(model_id, gguf_files)
+            return await ModelCard._fetch_gguf_from_hf(
+                model_id,
+                gguf_files,
+                gguf_file=gguf_file,
+            )
+        if gguf_file is not None:
+            raise ValueError(
+                f"Requested GGUF file {gguf_file!r}, but {model_id} has no GGUF weights"
+            )
 
         # TODO: failure if files do not exist
         config_data = await fetch_config_data(model_id)
@@ -835,7 +859,10 @@ class ModelCard(CamelCaseModel):
 
     @staticmethod
     async def _fetch_gguf_from_hf(
-        model_id: ModelId, gguf_files: "list[tuple[str, int]]"
+        model_id: ModelId,
+        gguf_files: "list[tuple[str, int]]",
+        *,
+        gguf_file: str | None = None,
     ) -> "ModelCard":
         """Build a llama.cpp model card for a GGUF repo.
 
@@ -849,7 +876,11 @@ class ModelCard(CamelCaseModel):
         Stamps the llama.cpp backend tags so placement routes the model only to
         nodes with a llama.cpp engine and prefers a GPU backend.
         """
-        selected = select_preferred_gguf(gguf_files)
+        selected = (
+            select_requested_gguf(gguf_file, gguf_files)
+            if gguf_file is not None
+            else select_preferred_gguf(gguf_files)
+        )
         selected_size = gguf_shard_group_size(selected, gguf_files)
 
         # Structural metadata comes from config.json, which most community GGUF
@@ -1198,6 +1229,28 @@ def select_preferred_gguf(gguf_files: "list[tuple[str, int]]") -> str:
         (name for name, _ in gguf_files),
         key=lambda name: (gguf_quant_rank(name), name.rsplit("/", 1)[-1]),
     )
+
+
+def select_requested_gguf(
+    requested: str,
+    gguf_files: "list[tuple[str, int]]",
+) -> str:
+    """Return an exact requested GGUF path after verifying repository membership.
+
+    Args:
+        requested: Repo-relative GGUF path supplied by the caller.
+        gguf_files: Weight-file inventory returned by :func:`gguf_weight_siblings`.
+
+    Returns:
+        The exact requested path from the repository inventory.
+
+    Raises:
+        ValueError: The requested path is not one of the repository's GGUF weights.
+    """
+    available = {name for name, _ in gguf_files}
+    if requested not in available:
+        raise ValueError(f"Requested GGUF file {requested!r} was not found in the repo")
+    return requested
 
 
 # Glob for the multimodal projector a vision GGUF repo ships alongside the LM

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -1235,14 +1235,15 @@ def select_requested_gguf(
     requested: str,
     gguf_files: "list[tuple[str, int]]",
 ) -> str:
-    """Return an exact requested GGUF path after verifying repository membership.
+    """Validate a requested GGUF path and return its loadable entrypoint.
 
     Args:
         requested: Repo-relative GGUF path supplied by the caller.
         gguf_files: Weight-file inventory returned by :func:`gguf_weight_siblings`.
 
     Returns:
-        The exact requested path from the repository inventory.
+        The requested path for a single-file quant, or the first file in the
+        requested shard group for split weights.
 
     Raises:
         ValueError: The requested path is not one of the repository's GGUF weights.
@@ -1250,7 +1251,16 @@ def select_requested_gguf(
     available = {name for name, _ in gguf_files}
     if requested not in available:
         raise ValueError(f"Requested GGUF file {requested!r} was not found in the repo")
-    return requested
+    requested_group = _gguf_shard_base(requested)
+    if requested_group is None:
+        return requested
+
+    # Backends open the first shard and discover the remaining files from it.
+    # Preserve the selected quant group while normalizing a pasted later shard
+    # to the same entrypoint used by automatic GGUF selection.
+    return min(
+        name for name in available if _gguf_shard_base(name) == requested_group
+    )
 
 
 # Glob for the multimodal projector a vision GGUF repo ships alongside the LM

--- a/src/skulk/shared/models/tests/test_gguf_cards.py
+++ b/src/skulk/shared/models/tests/test_gguf_cards.py
@@ -13,6 +13,7 @@ from skulk.shared.models.model_cards import (
     ModelId,
     _gguf_shard_base,
     gguf_weight_siblings,
+    select_requested_gguf,
 )
 
 # --- GGUF binary header builders (for #327 header-parse tests) --------------
@@ -137,6 +138,43 @@ async def test_fetch_gguf_card_stamps_llama_cpp_backends(
     assert card.supports_tensor is False  # single-node engine
     assert card.n_layers == 32 and card.hidden_size == 4096
     assert card.storage_size.in_bytes == 100  # the single selected gguf
+
+
+async def test_fetch_gguf_card_honors_requested_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested = "model-IQ3_XXS.gguf"
+    monkeypatch.setattr(
+        model_cards,
+        "model_info",
+        _fake_model_info(["model-Q4_K_M.gguf", requested]),
+    )
+
+    async def _fake_config(_model_id: object) -> object:
+        return SimpleNamespace(
+            layer_count=32,
+            hidden_size=4096,
+            num_key_value_heads=8,
+            max_position_embeddings=8192,
+        )
+
+    monkeypatch.setattr(model_cards, "fetch_config_data", _fake_config)
+
+    card = await ModelCard.fetch_from_hf(
+        ModelId("some/multi-quant-repo"),
+        gguf_file=requested,
+    )
+
+    assert card.gguf_file == requested
+    assert card.quantization == "IQ3"
+
+
+def test_requested_gguf_must_exist_in_repository() -> None:
+    with pytest.raises(ValueError, match="was not found"):
+        select_requested_gguf(
+            "model-IQ3_XXS.gguf",
+            [("model-Q4_K_M.gguf", 100)],
+        )
 
 
 async def test_fetch_gguf_card_reads_header_when_no_config(

--- a/src/skulk/shared/models/tests/test_gguf_cards.py
+++ b/src/skulk/shared/models/tests/test_gguf_cards.py
@@ -177,6 +177,22 @@ def test_requested_gguf_must_exist_in_repository() -> None:
         )
 
 
+def test_requested_sharded_gguf_uses_first_shard_as_entrypoint() -> None:
+    files = [
+        ("weights/model-IQ3_XXS-00001-of-00002.gguf", 100),
+        ("weights/model-IQ3_XXS-00002-of-00002.gguf", 120),
+        ("weights/model-Q4_K_M.gguf", 200),
+    ]
+
+    assert (
+        select_requested_gguf(
+            "weights/model-IQ3_XXS-00002-of-00002.gguf",
+            files,
+        )
+        == "weights/model-IQ3_XXS-00001-of-00002.gguf"
+    )
+
+
 async def test_fetch_gguf_card_reads_header_when_no_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -540,6 +540,10 @@ class ModelStore:
         # holding the download lock across network I/O would serialize unrelated
         # requests.
         missing_projector = await self.vision_entry_missing_projector(model_id)
+        missing_pinned_gguf = self.entry_missing_files(
+            model_id,
+            [pinned_gguf] if pinned_gguf is not None else [],
+        )
         missing_companion = self.entry_missing_files(model_id, extra_pinned_gguf or [])
         async with self._download_lock:
             existing = self._active_downloads.get(model_id)
@@ -562,6 +566,7 @@ class ModelStore:
                 # concurrent requests.
                 stale_complete = existing.status == "complete" and (
                     missing_projector
+                    or missing_pinned_gguf
                     or missing_companion
                     or not self.is_in_store(model_id)
                 )
@@ -572,6 +577,7 @@ class ModelStore:
             if (
                 self.is_in_store(model_id)
                 and not missing_projector
+                and not missing_pinned_gguf
                 and not missing_companion
             ):
                 return StoreDownloadStatus(
@@ -582,6 +588,12 @@ class ModelStore:
                     f"ModelStore: {model_id} is in the store but its entry is "
                     "missing the mmproj projector for a vision GGUF; "
                     "re-downloading to recover it (existing weights are reused)."
+                )
+            if missing_pinned_gguf:
+                logger.warning(
+                    f"ModelStore: {model_id} is in the store but its entry is "
+                    f"missing requested GGUF {pinned_gguf!r}; re-downloading to "
+                    "recover it (existing weights are reused)."
                 )
             if missing_companion:
                 logger.warning(

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -208,6 +208,55 @@ def _staged_vision_projector_missing(
     )
 
 
+def _staged_pinned_gguf_missing(shard: ShardMetadata, directory: Path) -> bool:
+    """Return whether a staged directory lacks the card-selected GGUF group.
+
+    The generic completeness probe accepts any complete GGUF quant in the
+    directory. A card can later select another quant from the same repository,
+    so staged-cache reuse must verify that exact file and, for split weights,
+    every sibling shard required by the backend entrypoint.
+
+    Args:
+        shard: Shard whose model card may pin a GGUF file.
+        directory: Canonical store or node-local staging directory to inspect.
+
+    Returns:
+        ``True`` when a selected GGUF path is unsafe, absent, or incomplete.
+    """
+    pinned = shard.model_card.gguf_file
+    if not pinned:
+        return False
+
+    relative_path = Path(pinned)
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        return True
+    selected_path = directory.joinpath(*relative_path.parts)
+    if not selected_path.is_file():
+        return True
+
+    stem_parts = selected_path.stem.rsplit("-", 3)
+    if not (
+        len(stem_parts) == 4
+        and stem_parts[1].isdigit()
+        and stem_parts[2] == "of"
+        and stem_parts[3].isdigit()
+    ):
+        return False
+
+    base, index_token, _, total_token = stem_parts
+    total_shards = int(total_token)
+    return any(
+        not (
+            selected_path.parent
+            / (
+                f"{base}-{index:0{len(index_token)}d}-of-"
+                f"{total_token}.gguf"
+            )
+        ).is_file()
+        for index in range(1, total_shards + 1)
+    )
+
+
 def _same_repo_draft_files(card: "ModelCard") -> list[str]:
     """Repo-relative GGUFs that ride the base repo's store entry but aren't the base.
 
@@ -1039,6 +1088,7 @@ class ModelStoreDownloader(ShardDownloader):
                 if (
                     direct_path.exists()
                     and _staged_directory_looks_complete(direct_path)
+                    and not _staged_pinned_gguf_missing(shard, direct_path)
                     and not _staged_vision_projector_missing(shard, direct_path)
                     and not _staged_same_repo_draft_missing(shard, direct_path)
                 ):
@@ -1060,6 +1110,7 @@ class ModelStoreDownloader(ShardDownloader):
         if (
             dest_path.exists()
             and _staged_directory_looks_complete(dest_path)
+            and not _staged_pinned_gguf_missing(shard, dest_path)
             and not _staged_vision_projector_missing(shard, dest_path)
             and not _staged_same_repo_draft_missing(shard, dest_path)
         ):

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -1124,13 +1124,12 @@ class ModelStoreDownloader(ShardDownloader):
         same_repo_drafts = _same_repo_draft_files(shard.model_card)
 
         if available:
-            if same_repo_drafts:
-                # A stale base-only store entry (registered before this card
-                # declared a same-repo draft) would stage without the draft and
-                # the served runner's --model-draft path would 404. Ensure the
-                # canonical entry carries the draft before staging; idempotent
-                # (a draft-complete entry returns immediately). The store host
-                # performs any needed HF fetch (workers never download directly).
+            if shard.model_card.gguf_file or same_repo_drafts:
+                # A canonical entry may hold a different GGUF quant or predate a
+                # same-repo draft declaration. Ensure the store has every file
+                # selected by this card before staging; the request is idempotent
+                # when the entry is already complete. Workers never fetch these
+                # files directly from Hugging Face.
                 await self._store_client.request_and_wait_for_download(
                     model_id,
                     pinned_gguf=shard.model_card.gguf_file,

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -477,22 +477,29 @@ class ModelStoreClient:
             logger.debug(f"ModelStoreClient: list_active_downloads failed: {exc}")
             return []
 
-    async def request_store_download(self, model_id: str) -> dict[str, object]:
-        """Request the store host start downloading a model. Non-blocking."""
+    async def request_store_download(
+        self,
+        model_id: str,
+        gguf_file: str | None = None,
+    ) -> dict[str, object]:
+        """Request a non-blocking store download, optionally pinning a GGUF."""
         url = _make_store_url(
             self._store_host,
             self._store_port,
             f"/models/{quote(model_id, safe='')}/download",
         )
         try:
-            async with (
-                create_http_session(timeout_profile="short") as session,
-                session.post(url) as resp,
-            ):
-                if resp.status not in (200, 201):
-                    return {"status": "error", "error": f"HTTP {resp.status}"}
-                data: object = await resp.json()
-                return data if isinstance(data, dict) else {"status": "unknown"}
+            async with create_http_session(timeout_profile="short") as session:
+                request = (
+                    session.post(url, json={"gguf_file": gguf_file})
+                    if gguf_file is not None
+                    else session.post(url)
+                )
+                async with request as resp:
+                    if resp.status not in (200, 201):
+                        return {"status": "error", "error": f"HTTP {resp.status}"}
+                    data: object = await resp.json()
+                    return data if isinstance(data, dict) else {"status": "unknown"}
         except Exception as exc:
             return {"status": "error", "error": str(exc)}
 

--- a/src/skulk/store/tests/test_model_store_download_request.py
+++ b/src/skulk/store/tests/test_model_store_download_request.py
@@ -1,0 +1,77 @@
+"""Store-client download requests preserve a selected GGUF file."""
+
+from types import TracebackType
+from typing import Self
+
+import pytest
+
+from skulk.store import model_store_client
+from skulk.store.model_store_client import ModelStoreClient
+
+
+class _Response:
+    status = 200
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def json(self) -> object:
+        return {"status": "pending"}
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, object | None]] = []
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    def post(self, url: str, *, json: object | None = None) -> _Response:
+        self.requests.append((url, json))
+        return _Response()
+
+
+@pytest.mark.anyio
+async def test_store_client_sends_requested_gguf_pin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _Session()
+
+    def fake_session_factory(**_kwargs: object) -> _Session:
+        return session
+
+    monkeypatch.setattr(
+        model_store_client,
+        "create_http_session",
+        fake_session_factory,
+    )
+    client = ModelStoreClient(store_host="store.local", store_port=58080)
+
+    result = await client.request_store_download(
+        "org/model",
+        gguf_file="model-IQ3_XXS.gguf",
+    )
+
+    assert result == {"status": "pending"}
+    assert session.requests == [
+        (
+            "http://store.local:58080/models/org%2Fmodel/download",
+            {"gguf_file": "model-IQ3_XXS.gguf"},
+        )
+    ]

--- a/src/skulk/store/tests/test_staged_pinned_gguf.py
+++ b/src/skulk/store/tests/test_staged_pinned_gguf.py
@@ -1,0 +1,123 @@
+# pyright: reportPrivateUsage=false
+"""Pinned-GGUF completeness checks for node-local staging reuse."""
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from skulk.download.download_utils import RepoDownloadProgress
+from skulk.download.shard_downloader import ShardDownloader
+from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from skulk.shared.types.memory import Memory
+from skulk.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
+from skulk.store.config import StagingNodeConfig
+from skulk.store.model_store_client import (
+    ModelStoreClient,
+    ModelStoreDownloader,
+    _staged_pinned_gguf_missing,
+)
+
+_MODEL_ID = "org/multi-quant-GGUF"
+
+
+class _UnusedInnerDownloader(ShardDownloader):
+    async def ensure_shard(
+        self, shard: ShardMetadata, config_only: bool = False
+    ) -> Path:
+        raise AssertionError("store-backed test must not use the inner downloader")
+
+    def on_progress(
+        self,
+        callback: Callable[[ShardMetadata, RepoDownloadProgress], Awaitable[None]],
+    ) -> None:
+        pass
+
+    async def get_shard_download_status(
+        self,
+    ) -> AsyncIterator[tuple[Path, RepoDownloadProgress]]:
+        if False:
+            yield (Path("/unused"), cast(RepoDownloadProgress, object()))
+
+    async def get_shard_download_status_for_shard(
+        self, shard: ShardMetadata
+    ) -> RepoDownloadProgress:
+        raise AssertionError("status queries are not used in this test")
+
+
+class _RecordingStoreClient:
+    def __init__(self) -> None:
+        self.availability_checks = 0
+        self.stage_calls = 0
+
+    async def is_model_available(self, model_id: str) -> bool:
+        assert model_id == _MODEL_ID
+        self.availability_checks += 1
+        return True
+
+    async def stage_shard(
+        self,
+        model_id: str,
+        dest_path: Path,
+        on_progress: Callable[[int, int], Awaitable[None]] | None = None,
+    ) -> Path:
+        assert model_id == _MODEL_ID
+        self.stage_calls += 1
+        dest_path.mkdir(parents=True, exist_ok=True)
+        (dest_path / "model-IQ3_XXS.gguf").write_bytes(b"selected")
+        return dest_path
+
+
+def _shard(gguf_file: str) -> PipelineShardMetadata:
+    return PipelineShardMetadata(
+        model_card=ModelCard(
+            model_id=ModelId(_MODEL_ID),
+            storage_size=Memory.from_bytes(8),
+            n_layers=1,
+            hidden_size=1,
+            supports_tensor=False,
+            tasks=[ModelTask.TextGeneration],
+            gguf_file=gguf_file,
+        ),
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=1,
+        n_layers=1,
+    )
+
+
+def test_pinned_shard_group_requires_every_sibling(tmp_path: Path) -> None:
+    shard = _shard("weights/model-IQ3-00001-of-00002.gguf")
+    weights = tmp_path / "weights"
+    weights.mkdir()
+    (weights / "model-IQ3-00001-of-00002.gguf").write_bytes(b"one")
+
+    assert _staged_pinned_gguf_missing(shard, tmp_path) is True
+
+    (weights / "model-IQ3-00002-of-00002.gguf").write_bytes(b"two")
+    assert _staged_pinned_gguf_missing(shard, tmp_path) is False
+
+
+@pytest.mark.anyio
+async def test_different_staged_quant_is_replaced_from_store(tmp_path: Path) -> None:
+    staged = tmp_path / "org--multi-quant-GGUF"
+    staged.mkdir()
+    (staged / "model-Q4_K_M.gguf").write_bytes(b"old")
+    store = _RecordingStoreClient()
+    downloader = ModelStoreDownloader(
+        inner=_UnusedInnerDownloader(),
+        store_client=cast(ModelStoreClient, cast(object, store)),
+        staging_config=StagingNodeConfig(
+            enabled=True,
+            node_cache_path=str(tmp_path),
+        ),
+    )
+
+    path = await downloader.ensure_shard(_shard("model-IQ3_XXS.gguf"))
+
+    assert path == staged
+    assert store.availability_checks == 1
+    assert store.stage_calls == 1
+    assert (staged / "model-IQ3_XXS.gguf").is_file()

--- a/src/skulk/store/tests/test_staged_pinned_gguf.py
+++ b/src/skulk/store/tests/test_staged_pinned_gguf.py
@@ -49,11 +49,23 @@ class _UnusedInnerDownloader(ShardDownloader):
 class _RecordingStoreClient:
     def __init__(self) -> None:
         self.availability_checks = 0
+        self.download_requests: list[tuple[str, str | None]] = []
         self.stage_calls = 0
 
     async def is_model_available(self, model_id: str) -> bool:
         assert model_id == _MODEL_ID
         self.availability_checks += 1
+        return True
+
+    async def request_and_wait_for_download(
+        self,
+        model_id: str,
+        *,
+        pinned_gguf: str | None = None,
+        extra_pinned_gguf: list[str] | None = None,
+    ) -> bool:
+        assert not extra_pinned_gguf
+        self.download_requests.append((model_id, pinned_gguf))
         return True
 
     async def stage_shard(
@@ -119,5 +131,6 @@ async def test_different_staged_quant_is_replaced_from_store(tmp_path: Path) -> 
 
     assert path == staged
     assert store.availability_checks == 1
+    assert store.download_requests == [(_MODEL_ID, "model-IQ3_XXS.gguf")]
     assert store.stage_calls == 1
     assert (staged / "model-IQ3_XXS.gguf").is_file()

--- a/src/skulk/store/tests/test_store_download_stale_complete.py
+++ b/src/skulk/store/tests/test_store_download_stale_complete.py
@@ -85,3 +85,19 @@ async def test_request_download_keeps_cached_complete_when_still_in_store(
     status = await store.request_download("org/present", "base-Q4_K_M.gguf", None)
 
     assert status.status == "complete"
+
+
+async def test_request_download_recovers_missing_requested_quant(
+    tmp_path: Path,
+) -> None:
+    store = ModelStore(tmp_path)
+    _register(store, "org/present", ["base-Q4_K_M.gguf", "config.json"])
+    _seed_complete(store, "org/present")
+
+    status = await store.request_download(
+        "org/present",
+        "base-IQ3_XXS.gguf",
+        None,
+    )
+
+    assert status.status in ("pending", "downloading")

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -691,7 +691,9 @@ Behavior note:
 Fetches metadata and adds a custom model card to the cluster catalog. The
 `model_id` field is required. `gguf_file` is optional; when supplied it must be
 an exact repo-relative GGUF weight path and the card pins that quant instead of
-using Skulk's default GGUF preference.
+using Skulk's default GGUF preference. If the selected quant is split, Skulk
+stores its first shard as the backend entrypoint while downloading the full
+shard group.
 
 ### Per-node storage breakdown
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -661,7 +661,7 @@ This returns known model cards, not just running instances.
 
 ### Search Hugging Face
 
-**GET** `/models/search?query=...&limit=...`
+**GET** `/models/search?query=...&limit=...&mlx_only=...`
 
 ```bash
 curl "http://localhost:52415/models/search?query=qwen3&limit=5"
@@ -669,8 +669,29 @@ curl "http://localhost:52415/models/search?query=qwen3&limit=5"
 
 Behavior note:
 
-- Skulk searches `mlx-community` first.
-- If that returns nothing, it falls back to a broader Hugging Face search.
+- `mlx_only=true` restricts results to the `mlx-community` author; the default
+  searches all Hugging Face model repositories.
+- Ordinary text queries use Hugging Face repository search.
+- A query ending in `.gguf` also performs a bounded filename-aware fallback:
+  Skulk broadens the model-name prefix, inspects those candidate repositories'
+  manifests, and returns only exact filename matches. Exact matches carry a
+  `matched_file` repo-relative path so the dashboard can preserve that quant.
+
+### Add a Hugging Face model
+
+**POST** `/models/add`
+
+```json
+{
+  "model_id": "satgeze/Hy3-1M-GGUF",
+  "gguf_file": "hy3-1M-MTP-IQ3_XXS.gguf"
+}
+```
+
+Fetches metadata and adds a custom model card to the cluster catalog. The
+`model_id` field is required. `gguf_file` is optional; when supplied it must be
+an exact repo-relative GGUF weight path and the card pins that quant instead of
+using Skulk's default GGUF preference.
 
 ### Per-node storage breakdown
 
@@ -837,7 +858,9 @@ Use this when you want the store host to fetch and register a model.
 Optional JSON body `{"gguf_file": "<repo-relative path>"}` pins which GGUF quant
 the store fetches for a multi-quant GGUF repo (it downloads that file's shard
 group plus `config.json`). Omit the body to use the default quant preference.
-A pin naming a file not present in the repo falls back to the default.
+A pin naming a file not present in the repo falls back to the default at the
+store protocol layer; the `/models/add` card-building endpoint validates exact
+pins before requesting a download.
 
 ### Store download status
 


### PR DESCRIPTION
## Summary

- resolve exact `.gguf` filename queries by inspecting a bounded set of candidate Hugging Face repository manifests
- preserve the matched repo-relative file through model-card creation and shared-store download, including recovery when the requested quant is absent from an existing store entry
- show the matched file in Find Models and document/test the API contract
- include a one-line strict-typing correction exposed on the current `dev` base

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (1,998 passed, 1 skipped, 210 deselected)
- changed-file dashboard ESLint
- `npm run build`
- live Hugging Face filename resolution and mocked dashboard add/download flow verified with the exact selected GGUF path