### PR TITLE
fix(store): hardlink local staging instead of copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,14 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- **Store-host staging no longer doubles disk usage.** Staging a model from a
+  local store into the worker staging directory hardlinks each file instead
+  of copying when both live on the same filesystem (store files are immutable
+  once registered and staged files are never mutated in place), falling back
+  to a copy across filesystems. Previously a 26GB GGUF needed 52GB of free
+  disk to stage on a store-host node, and the staging copy could fail with
+  ENOSPC after a successful store download (#533).
+
 - **Pooled (multi-node) GGUF placement no longer caps unified-memory nodes at
   their BIOS VRAM carve.** Admission for RPC placements previously sized each
   node against a VRAM-carve-only figure, which falsely refused pooled models

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -67,6 +67,7 @@ file already exists (from a previous complete run), the file is skipped.
 from __future__ import annotations
 
 import asyncio
+import os
 import shutil
 from collections.abc import Awaitable
 from datetime import timedelta
@@ -319,8 +320,8 @@ class ModelStoreClient:
 
     Every non-store-host node holds one instance of this class.  The store
     host also holds one instance (with ``local_store_path`` set) so that the
-    staging path is unified — the store host just uses ``shutil.copy2()``
-    instead of HTTP.
+    staging path is unified — the store host hardlinks store files into
+    staging (falling back to ``shutil.copy2()``) instead of using HTTP.
 
     Args:
         store_host: Hostname or IP of the store host node.
@@ -717,6 +718,27 @@ class ModelStoreClient:
     # Local copy path (store host → same filesystem)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _link_or_copy(src_file: Path, dst_file: Path) -> None:
+        """Hardlink ``src_file`` into place, falling back to a full copy.
+
+        Store files are immutable once registered and staged files are never
+        mutated in place (staging eviction deletes whole directories, and the
+        only post-staging write is the separate ``.last_used`` marker), so a
+        hardlink is safe. It avoids doubling disk usage when store and staging
+        share a filesystem: without it a 26GB GGUF needs 52GB to stage, which
+        is exactly what killed staging on a 50GB-disk store-host node. A stale
+        destination is removed first because ``os.link`` refuses to overwrite.
+        Filesystems that cannot link (EXDEV cross-device, EPERM on some network
+        mounts) fall back to ``shutil.copy2``.
+        """
+        if dst_file.exists():
+            dst_file.unlink()
+        try:
+            os.link(src_file, dst_file)
+        except OSError:
+            shutil.copy2(src_file, dst_file)
+
     async def _stage_local(
         self,
         model_id: str,
@@ -746,7 +768,7 @@ class ModelStoreClient:
                 not dst_file.exists()
                 or dst_file.stat().st_size != src_file.stat().st_size
             ):
-                await asyncio.to_thread(shutil.copy2, src_file, dst_file)
+                await asyncio.to_thread(self._link_or_copy, src_file, dst_file)
             staged_bytes += src_file.stat().st_size
             if on_progress is not None:
                 await on_progress(staged_bytes, total_bytes)

--- a/src/skulk/store/tests/test_stage_local_hardlink.py
+++ b/src/skulk/store/tests/test_stage_local_hardlink.py
@@ -1,0 +1,82 @@
+"""Local staging must hardlink, not copy, when store and staging share a filesystem.
+
+Staging by copy doubles the disk cost of every model on a store-host node: a
+26GB GGUF needs 52GB of free disk to stage, which is exactly how a 50GB-disk
+node ended up failing staging with ENOSPC after a successful store download
+(issue #533). Store files are immutable once registered and staged files are
+never mutated in place, so a hardlink is safe and costs no additional disk.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from skulk.store.model_store_client import ModelStoreClient
+
+
+def _make_store_model(store_root: Path, sanitized_id: str) -> Path:
+    """Create a fake registered store model with two files, returning its dir."""
+    model_dir = store_root / sanitized_id
+    (model_dir / "sub").mkdir(parents=True)
+    (model_dir / "weights.gguf").write_bytes(b"g" * 4096)
+    (model_dir / "sub" / "config.json").write_bytes(b"{}")
+    return model_dir
+
+
+async def test_stage_local_hardlinks_on_same_filesystem(tmp_path: Path) -> None:
+    """Staged files share an inode with the store files (no disk doubling)."""
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    model_dir = _make_store_model(store_root, "org--model")
+    client = ModelStoreClient("localhost", local_store_path=store_root)
+
+    dest = tmp_path / "staging" / "org--model"
+    dest.mkdir(parents=True)
+    await client._stage_local("org/model", dest, on_progress=None)  # pyright: ignore[reportPrivateUsage]
+
+    staged_weights = dest / "weights.gguf"
+    staged_config = dest / "sub" / "config.json"
+    assert staged_weights.read_bytes() == b"g" * 4096
+    assert staged_config.read_bytes() == b"{}"
+    # Same inode == hardlink == zero additional data blocks on disk.
+    assert staged_weights.stat().st_ino == (model_dir / "weights.gguf").stat().st_ino
+    assert staged_config.stat().st_ino == (model_dir / "sub" / "config.json").stat().st_ino
+
+
+async def test_stage_local_falls_back_to_copy_when_link_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """EXDEV-style link failures degrade to a byte-identical copy."""
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    model_dir = _make_store_model(store_root, "org--model")
+    client = ModelStoreClient("localhost", local_store_path=store_root)
+
+    def refuse_link(src: object, dst: object, **_kwargs: object) -> None:
+        raise OSError(18, "Invalid cross-device link")
+
+    monkeypatch.setattr("skulk.store.model_store_client.os.link", refuse_link)
+
+    dest = tmp_path / "staging" / "org--model"
+    dest.mkdir(parents=True)
+    await client._stage_local("org/model", dest, on_progress=None)  # pyright: ignore[reportPrivateUsage]
+
+    staged_weights = dest / "weights.gguf"
+    assert staged_weights.read_bytes() == b"g" * 4096
+    assert staged_weights.stat().st_ino != (model_dir / "weights.gguf").stat().st_ino
+
+
+async def test_stage_local_replaces_stale_partial_destination(tmp_path: Path) -> None:
+    """A size-mismatched (stale/partial) staged file is replaced, not kept."""
+    store_root = tmp_path / "store"
+    store_root.mkdir()
+    _make_store_model(store_root, "org--model")
+    client = ModelStoreClient("localhost", local_store_path=store_root)
+
+    dest = tmp_path / "staging" / "org--model"
+    (dest / "sub").mkdir(parents=True)
+    (dest / "weights.gguf").write_bytes(b"partial")
+
+    await client._stage_local("org/model", dest, on_progress=None)  # pyright: ignore[reportPrivateUsage]
+
+    assert (dest / "weights.gguf").read_bytes() == b"g" * 4096


### PR DESCRIPTION
## Problem

On a store-host node, staging a model from the local store into the worker staging directory copies every file (`shutil.copy2`), so each model transiently needs twice its size on disk. On a 50GB-disk CUDA node, a 26GB GGUF downloaded into the store successfully and then failed staging with ENOSPC, which also tripped the event-log persistence kill switch and left the node degraded. Issue #533.

## Fix

`ModelStoreClient._stage_local` now hardlinks each store file into staging and falls back to `shutil.copy2` when the filesystem cannot link (EXDEV cross-device, EPERM on some network mounts). A stale size-mismatched destination is unlinked first because `os.link` refuses to overwrite.

Safety argument: store files are immutable once registered, and staged files are never mutated in place — staging eviction deletes whole directories, and the only post-staging write is the separate `.last_used` marker file. The HTTP staging path (non-store-host nodes) is unchanged.

## Tests

New `src/skulk/store/tests/test_stage_local_hardlink.py`:
- staged files share an inode with store files (no disk doubling)
- a refused link degrades to a byte-identical copy
- a stale partial destination is replaced

## Validation

Full gauntlet: basedpyright 0 errors, ruff clean, 2230 passed / 1 skipped.

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)