### PR TITLE
feat(deployment): prebaked CUDA pod image built on GHCR

### DIFF
--- a/.github/workflows/cuda-image.yml
+++ b/.github/workflows/cuda-image.yml
@@ -13,6 +13,11 @@ on:
       - 'deployment/cuda/pod-start.sh'
       - 'deployment/cuda/pod-bootstrap.sh'
       - '.github/workflows/cuda-image.yml'
+      # Image inputs that live outside deployment/: the prebaked wheel is
+      # version-pinned from uv.lock and built for .python-version, so a bump
+      # to either must republish the image or bootstrap installs a stale tag.
+      - 'uv.lock'
+      - '.python-version'
 
 jobs:
   build-and-push:

--- a/.github/workflows/cuda-image.yml
+++ b/.github/workflows/cuda-image.yml
@@ -1,0 +1,52 @@
+# Builds and publishes the prebaked CUDA pod image (deployment/cuda/Dockerfile)
+# to GHCR. Standard amd64 runners suffice: nvcc compiles CUDA kernels without a
+# GPU present. Triggered manually, and on dev pushes that touch the image
+# inputs, so the published image tracks the recipe.
+name: cuda-pod-image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [dev]
+    paths:
+      - 'deployment/cuda/Dockerfile'
+      - 'deployment/cuda/pod-start.sh'
+      - 'deployment/cuda/pod-bootstrap.sh'
+      - '.github/workflows/cuda-image.yml'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # The CUDA devel base plus two CUDA compiles overflow the runner's free
+      # disk; drop the preinstalled toolchains we never touch.
+      - name: Free runner disk
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
+
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deployment/cuda/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/foxlight-foundation/skulk-cuda-pod:latest
+            ghcr.io/foxlight-foundation/skulk-cuda-pod:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/cuda-image.yml
+++ b/.github/workflows/cuda-image.yml
@@ -19,6 +19,13 @@ on:
       - 'uv.lock'
       - '.python-version'
 
+# One build at a time, newest wins: without this, two quick dev pushes can
+# race and leave :latest pointing at the older commit if its build finishes
+# last.
+concurrency:
+  group: cuda-pod-image
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Added
 
+- Prebaked CUDA pod image (`deployment/cuda/Dockerfile`, published to GHCR as
+  `skulk-cuda-pod` by the `cuda-image` workflow): carries the CUDA
+  llama-cpp-python wheel, `llama-server` + `ggml-rpc-server` binaries, uv,
+  and the Rust toolchain, so a rented GPU pod goes from create to serving in
+  minutes (`/opt/skulk/pod-bootstrap.sh <ref>`) instead of the ~1 hour
+  install recipe. The recipe (`install-deps.sh`) remains the from-scratch
+  path for arbitrary driver-equipped machines.
+
 - NVIDIA / CUDA node support (platform plumbing): a passive NVML telemetry
   collector (`utils/info_gatherer/nvidia_gpu.py`) fills the normalized
   accelerator profile on NVIDIA nodes (the Linux GPU monitor tries AMD

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -39,9 +39,9 @@ RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /opt/llama.cpp \
 # CUDA llama-cpp-python wheel for the in-process llama_cpp engine. Built as a
 # wheel (not installed) so the session's `uv sync`-managed venv can install it
 # after syncing, which is what defeats the uv-sync-restores-CPU-wheel trap.
-# Built with uv-provisioned Python 3.13 to match Skulk's .python-version:
-# Ubuntu 22.04's system python is 3.10, and a cp310 wheel would be rejected by
-# the 3.13 environment pod-bootstrap.sh syncs (PR #538 review, P1).
+# Built with a uv-provisioned Python at the version pinned in the repo's
+# .python-version (Ubuntu 22.04's system python is 3.10, whose wheel tag the
+# synced environment would reject).
 # --no-binary pins the CUDA source build even if PyPI ever starts shipping
 # prebuilt (CPU-only) wheels for this package. Both the package version and
 # the Python version come from the repo's own pins (uv.lock and
@@ -69,11 +69,16 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # build-essential + cmake stay: `uv sync` compiles Skulk's Rust bindings at
 # session time (the Skulk checkout is per-session, so it cannot be prebaked).
+# The host keys openssh-server generates at install time are deleted: this
+# image is public, so baked-in keys would be shared by every pod pulled from
+# it (and readable by anyone), enabling host impersonation. pod-start.sh
+# regenerates per-pod keys before starting sshd.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential cmake git curl pkg-config python3-dev \
       ca-certificates openssh-server rsync tmux \
     && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /run/sshd
+    && mkdir -p /run/sshd \
+    && rm -f /etc/ssh/ssh_host_*
 
 # Rust toolchain for the skulk-pyo3-bindings build during `uv sync`.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -43,13 +43,20 @@ RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /opt/llama.cpp \
 # Ubuntu 22.04's system python is 3.10, and a cp310 wheel would be rejected by
 # the 3.13 environment pod-bootstrap.sh syncs (PR #538 review, P1).
 # --no-binary pins the CUDA source build even if PyPI ever starts shipping
-# prebuilt (CPU-only) wheels for this package.
+# prebuilt (CPU-only) wheels for this package. The version comes from the
+# repo's uv.lock so pod-bootstrap.sh reinstalls exactly the pinned release
+# with CUDA enabled, never a drifted newer one (PR #538 review round 3).
 ARG PYTHON_VERSION=3.13
+COPY uv.lock /tmp/uv.lock
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && LLAMA_CPP_PYTHON_VERSION="$(grep -A1 'name = "llama-cpp-python"' /tmp/uv.lock | sed -n 's/^version = "\(.*\)"$/\1/p')" \
+    && test -n "${LLAMA_CPP_PYTHON_VERSION}" \
+    && echo "building llama-cpp-python==${LLAMA_CPP_PYTHON_VERSION}" \
     && /root/.local/bin/uv venv --seed --python "${PYTHON_VERSION}" /opt/wheelbuild \
     && CMAKE_ARGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}" \
       /opt/wheelbuild/bin/python -m pip wheel --no-cache-dir \
-        --no-binary llama-cpp-python --wheel-dir /opt/wheels llama-cpp-python
+        --no-binary llama-cpp-python --wheel-dir /opt/wheels \
+        "llama-cpp-python==${LLAMA_CPP_PYTHON_VERSION}"
 
 # ---- runtime stage: everything a session needs except Skulk itself ----------
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
@@ -73,8 +80,11 @@ ENV PATH="/root/.cargo/bin:/root/.local/bin:/usr/local/cuda/bin:${PATH}"
 # uv: the canonical Skulk runtime path.
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
-COPY --from=build /opt/llama.cpp/build/bin/llama-server /opt/llama.cpp/build/bin/llama-server
-COPY --from=build /opt/llama.cpp/build/bin/ggml-rpc-server /opt/llama.cpp/build/bin/ggml-rpc-server
+# The whole bin directory, not just the two executables: upstream llama.cpp
+# builds shared on Linux (BUILD_SHARED_LIBS defaults on), so llama-server and
+# ggml-rpc-server need their sibling .so files or they die at loader time
+# (PR #538 review round 3, P1).
+COPY --from=build /opt/llama.cpp/build/bin /opt/llama.cpp/build/bin
 COPY --from=build /opt/wheels /opt/wheels
 
 COPY deployment/cuda/pod-bootstrap.sh /opt/skulk/pod-bootstrap.sh

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -43,15 +43,18 @@ RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /opt/llama.cpp \
 # Ubuntu 22.04's system python is 3.10, and a cp310 wheel would be rejected by
 # the 3.13 environment pod-bootstrap.sh syncs (PR #538 review, P1).
 # --no-binary pins the CUDA source build even if PyPI ever starts shipping
-# prebuilt (CPU-only) wheels for this package. The version comes from the
-# repo's uv.lock so pod-bootstrap.sh reinstalls exactly the pinned release
-# with CUDA enabled, never a drifted newer one (PR #538 review round 3).
-ARG PYTHON_VERSION=3.13
+# prebuilt (CPU-only) wheels for this package. Both the package version and
+# the Python version come from the repo's own pins (uv.lock and
+# .python-version), so the wheel can never drift from what pod-bootstrap.sh's
+# `uv sync` will demand (PR #538 review rounds 3-4).
 COPY uv.lock /tmp/uv.lock
+COPY .python-version /tmp/python-version
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && LLAMA_CPP_PYTHON_VERSION="$(grep -A1 'name = "llama-cpp-python"' /tmp/uv.lock | sed -n 's/^version = "\(.*\)"$/\1/p')" \
     && test -n "${LLAMA_CPP_PYTHON_VERSION}" \
-    && echo "building llama-cpp-python==${LLAMA_CPP_PYTHON_VERSION}" \
+    && PYTHON_VERSION="$(tr -d '[:space:]' < /tmp/python-version)" \
+    && test -n "${PYTHON_VERSION}" \
+    && echo "building llama-cpp-python==${LLAMA_CPP_PYTHON_VERSION} for python ${PYTHON_VERSION}" \
     && /root/.local/bin/uv venv --seed --python "${PYTHON_VERSION}" /opt/wheelbuild \
     && CMAKE_ARGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}" \
       /opt/wheelbuild/bin/python -m pip wheel --no-cache-dir \

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1
+# Prebaked CUDA pod image for rented-GPU Skulk sessions (RunPod and similar).
+#
+# Motivation: provisioning a fresh pod through deployment/cuda/install-deps.sh
+# takes about an hour, dominated by two CUDA compiles (llama.cpp's llama-server
+# and the llama-cpp-python wheel). Baking those artifacts into an image cuts a
+# session's setup to cloning Skulk and running /opt/skulk/pod-bootstrap.sh
+# (minutes). Built by .github/workflows/cuda-image.yml on standard amd64
+# runners: nvcc compiles CUDA kernels without a GPU present.
+#
+# CUDA_ARCHS pins the compiled GPU architectures. Default covers the rental
+# fleet we actually use: 86 (A40/A5000/3090) and 89 (4090/L40S). Add 80 (A100)
+# or 90 (H100) when renting those tiers; every extra arch lengthens the build.
+
+ARG CUDA_VERSION=12.4.1
+ARG UBUNTU_VERSION=22.04
+
+# ---- build stage: the two expensive CUDA compiles ---------------------------
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS build
+ARG CUDA_ARCHS="86;89"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential cmake git curl pkg-config python3-dev python3-pip \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# llama-server + ggml-rpc-server: the served-backend engine binaries (native
+# MTP via --spec-type, RPC pooling). Mirrors install-deps.sh's cmake flags.
+RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /opt/llama.cpp \
+    && cmake -S /opt/llama.cpp -B /opt/llama.cpp/build \
+         -DGGML_CUDA=ON -DGGML_RPC=ON -DCMAKE_BUILD_TYPE=Release \
+         -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
+    && cmake --build /opt/llama.cpp/build \
+         --target llama-server ggml-rpc-server -j"$(nproc)"
+
+# CUDA llama-cpp-python wheel for the in-process llama_cpp engine. Built as a
+# wheel (not installed) so the session's `uv sync`-managed venv can install it
+# after syncing, which is what defeats the uv-sync-restores-CPU-wheel trap.
+RUN CMAKE_ARGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}" \
+      python3 -m pip wheel --no-cache-dir --wheel-dir /opt/wheels llama-cpp-python
+
+# ---- runtime stage: everything a session needs except Skulk itself ----------
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
+
+# build-essential + cmake stay: `uv sync` compiles Skulk's Rust bindings at
+# session time (the Skulk checkout is per-session, so it cannot be prebaked).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential cmake git curl pkg-config python3-dev \
+      ca-certificates openssh-server rsync tmux \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /run/sshd
+
+# Rust toolchain for the skulk-pyo3-bindings build during `uv sync`.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --profile minimal --default-toolchain stable
+ENV PATH="/root/.cargo/bin:/root/.local/bin:/usr/local/cuda/bin:${PATH}"
+
+# uv: the canonical Skulk runtime path.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+COPY --from=build /opt/llama.cpp/build/bin/llama-server /opt/llama.cpp/build/bin/llama-server
+COPY --from=build /opt/llama.cpp/build/bin/ggml-rpc-server /opt/llama.cpp/build/bin/ggml-rpc-server
+COPY --from=build /opt/wheels /opt/wheels
+
+COPY deployment/cuda/pod-bootstrap.sh /opt/skulk/pod-bootstrap.sh
+COPY deployment/cuda/pod-start.sh /opt/skulk/pod-start.sh
+RUN chmod +x /opt/skulk/pod-bootstrap.sh /opt/skulk/pod-start.sh
+
+# RunPod runs the image command as pid 1; pod-start.sh installs PUBLIC_KEY for
+# sshd and then idles so the pod stays up for SSH sessions.
+CMD ["/opt/skulk/pod-start.sh"]

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -50,7 +50,7 @@ RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /opt/llama.cpp \
 COPY uv.lock /tmp/uv.lock
 COPY .python-version /tmp/python-version
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && LLAMA_CPP_PYTHON_VERSION="$(grep -A1 'name = "llama-cpp-python"' /tmp/uv.lock | sed -n 's/^version = "\(.*\)"$/\1/p')" \
+    && LLAMA_CPP_PYTHON_VERSION="$(sed -n '/^name = "llama-cpp-python"$/{n;s/^version = "\(.*\)"$/\1/p;}' /tmp/uv.lock | head -1)" \
     && test -n "${LLAMA_CPP_PYTHON_VERSION}" \
     && PYTHON_VERSION="$(tr -d '[:space:]' < /tmp/python-version)" \
     && test -n "${PYTHON_VERSION}" \

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -36,8 +36,17 @@ RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /opt/llama.cpp \
 # CUDA llama-cpp-python wheel for the in-process llama_cpp engine. Built as a
 # wheel (not installed) so the session's `uv sync`-managed venv can install it
 # after syncing, which is what defeats the uv-sync-restores-CPU-wheel trap.
-RUN CMAKE_ARGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}" \
-      python3 -m pip wheel --no-cache-dir --wheel-dir /opt/wheels llama-cpp-python
+# Built with uv-provisioned Python 3.13 to match Skulk's .python-version:
+# Ubuntu 22.04's system python is 3.10, and a cp310 wheel would be rejected by
+# the 3.13 environment pod-bootstrap.sh syncs (PR #538 review, P1).
+# --no-binary pins the CUDA source build even if PyPI ever starts shipping
+# prebuilt (CPU-only) wheels for this package.
+ARG PYTHON_VERSION=3.13
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && /root/.local/bin/uv venv --seed --python "${PYTHON_VERSION}" /opt/wheelbuild \
+    && CMAKE_ARGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}" \
+      /opt/wheelbuild/bin/python -m pip wheel --no-cache-dir \
+        --no-binary llama-cpp-python --wheel-dir /opt/wheels llama-cpp-python
 
 # ---- runtime stage: everything a session needs except Skulk itself ----------
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -57,7 +57,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && echo "building llama-cpp-python==${LLAMA_CPP_PYTHON_VERSION} for python ${PYTHON_VERSION}" \
     && /root/.local/bin/uv venv --seed --python "${PYTHON_VERSION}" /opt/wheelbuild \
     && CMAKE_ARGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}" \
-      /opt/wheelbuild/bin/python -m pip wheel --no-cache-dir \
+      /opt/wheelbuild/bin/python -m pip wheel --no-cache-dir --no-deps \
         --no-binary llama-cpp-python --wheel-dir /opt/wheels \
         "llama-cpp-python==${LLAMA_CPP_PYTHON_VERSION}"
 

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -18,6 +18,9 @@ ARG UBUNTU_VERSION=22.04
 # ---- build stage: the two expensive CUDA compiles ---------------------------
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS build
 ARG CUDA_ARCHS="86;89"
+# pipefail: a curl|sh installer whose download dies must fail the build, not
+# publish an image that is missing its toolchain.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential cmake git curl pkg-config python3-dev python3-pip \
@@ -50,6 +53,9 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 
 # ---- runtime stage: everything a session needs except Skulk itself ----------
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
+# SHELL does not survive FROM; re-assert pipefail for this stage's curl|sh
+# installers (rustup, uv).
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # build-essential + cmake stay: `uv sync` compiles Skulk's Rust bindings at
 # session time (the Skulk checkout is per-session, so it cannot be prebaked).

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -49,7 +49,10 @@ RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /opt/llama.cpp \
 # `uv sync` will demand (PR #538 review rounds 3-4).
 COPY uv.lock /tmp/uv.lock
 COPY .python-version /tmp/python-version
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+# UV_VERSION pins the installer for reproducible rebuilds of the same commit;
+# bump deliberately alongside fleet uv upgrades.
+ARG UV_VERSION=0.11.6
+RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh \
     && LLAMA_CPP_PYTHON_VERSION="$(sed -n '/^name = "llama-cpp-python"$/{n;s/^version = "\(.*\)"$/\1/p;}' /tmp/uv.lock | head -1)" \
     && test -n "${LLAMA_CPP_PYTHON_VERSION}" \
     && PYTHON_VERSION="$(tr -d '[:space:]' < /tmp/python-version)" \
@@ -80,13 +83,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && mkdir -p /run/sshd \
     && rm -f /etc/ssh/ssh_host_*
 
-# Rust toolchain for the skulk-pyo3-bindings build during `uv sync`.
+# Rust toolchain for the skulk-pyo3-bindings build during `uv sync`. Pinned
+# (not `stable`) so rebuilding this published image later cannot silently
+# change the compiler under older Skulk refs; bump deliberately.
+ARG RUST_VERSION=1.94.1
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-      | sh -s -- -y --profile minimal --default-toolchain stable
+      | sh -s -- -y --profile minimal --default-toolchain "${RUST_VERSION}"
 ENV PATH="/root/.cargo/bin:/root/.local/bin:/usr/local/cuda/bin:${PATH}"
 
-# uv: the canonical Skulk runtime path.
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+# uv: the canonical Skulk runtime path. Same pin rationale as the build stage.
+ARG UV_VERSION=0.11.6
+RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
 
 # The whole bin directory, not just the two executables: upstream llama.cpp
 # builds shared on Linux (BUILD_SHARED_LIBS defaults on), so llama-server and

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -81,7 +81,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates openssh-server rsync tmux \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /run/sshd \
-    && rm -f /etc/ssh/ssh_host_*
+    && rm -f /etc/ssh/ssh_host_* \
+    && printf '%s\n' \
+         'PasswordAuthentication no' \
+         'KbdInteractiveAuthentication no' \
+         'PermitRootLogin prohibit-password' \
+         > /etc/ssh/sshd_config.d/90-skulk-pod.conf
+# Key-only auth is pinned explicitly rather than trusted from base-image
+# defaults: this image is public and runs sshd as its entrypoint, so a future
+# base change must not be able to ship password auth silently.
 
 # Rust toolchain for the skulk-pyo3-bindings build during `uv sync`. Pinned
 # (not `stable`) so rebuilding this published image later cannot silently

--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -28,10 +28,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # llama-server + ggml-rpc-server: the served-backend engine binaries (native
-# MTP via --spec-type, RPC pooling). Mirrors install-deps.sh's cmake flags.
-RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /opt/llama.cpp \
+# MTP via --spec-type, RPC pooling). Mirrors install-deps.sh's cmake flags,
+# plus two portability requirements of a prebuilt image:
+# - LLAMA_CPP_REF pins the upstream revision so re-running the workflow for
+#   the same Skulk commit republishes identical engine behavior; bump
+#   deliberately.
+# - GGML_NATIVE=OFF: default builds tune for the connected (builder) CPU, and
+#   AVX-512/AMX code from a GitHub runner would die with illegal-instruction
+#   on a rented pod with a different CPU.
+ARG LLAMA_CPP_REF=b9969
+RUN git clone --branch "${LLAMA_CPP_REF}" --depth 1 \
+         https://github.com/ggml-org/llama.cpp /opt/llama.cpp \
     && cmake -S /opt/llama.cpp -B /opt/llama.cpp/build \
-         -DGGML_CUDA=ON -DGGML_RPC=ON -DCMAKE_BUILD_TYPE=Release \
+         -DGGML_CUDA=ON -DGGML_RPC=ON -DGGML_NATIVE=OFF \
+         -DCMAKE_BUILD_TYPE=Release \
          -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
     && cmake --build /opt/llama.cpp/build \
          --target llama-server ggml-rpc-server -j"$(nproc)"
@@ -59,7 +69,7 @@ RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh \
     && test -n "${PYTHON_VERSION}" \
     && echo "building llama-cpp-python==${LLAMA_CPP_PYTHON_VERSION} for python ${PYTHON_VERSION}" \
     && /root/.local/bin/uv venv --seed --python "${PYTHON_VERSION}" /opt/wheelbuild \
-    && CMAKE_ARGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}" \
+    && CMAKE_ARGS="-DGGML_CUDA=ON -DGGML_NATIVE=OFF -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}" \
       /opt/wheelbuild/bin/python -m pip wheel --no-cache-dir --no-deps \
         --no-binary llama-cpp-python --wheel-dir /opt/wheels \
         "llama-cpp-python==${LLAMA_CPP_PYTHON_VERSION}"

--- a/deployment/cuda/pod-bootstrap.sh
+++ b/deployment/cuda/pod-bootstrap.sh
@@ -54,11 +54,21 @@ fi
 # llama-cpp-python would otherwise end up silently un-locked, and a
 # different .python-version fails later with a confusing wheel-tag error;
 # both mismatches stop here with instructions instead.
+for pin_file in uv.lock .python-version; do
+  if [ ! -f "${pin_file}" ]; then
+    echo "[bootstrap] ERROR: ${pin_file} missing from this checkout; the ref predates (or is incompatible with) the prebaked-image flow. Provision with deployment/cuda/install-deps.sh instead." >&2
+    exit 1
+  fi
+done
 WHEEL_NAME="$(basename "${WHEELS[0]}")"
 WHEEL_VERSION="$(printf '%s' "${WHEEL_NAME}" | cut -d- -f2)"
 WHEEL_PY_TAG="$(printf '%s' "${WHEEL_NAME}" | cut -d- -f3)"
 LOCKED_VERSION="$(sed -n '/^name = "llama-cpp-python"$/{n;s/^version = "\(.*\)"$/\1/p;}' uv.lock | head -1)"
 EXPECTED_PY_TAG="cp$(tr -d '[:space:].' < .python-version | cut -c1-3)"
+if [ -z "${LOCKED_VERSION}" ] || [ "${EXPECTED_PY_TAG}" = "cp" ]; then
+  echo "[bootstrap] ERROR: could not parse llama-cpp-python pin (got version '${LOCKED_VERSION:-}', tag '${EXPECTED_PY_TAG}') from this ref's uv.lock/.python-version." >&2
+  exit 1
+fi
 if [ "${WHEEL_VERSION}" != "${LOCKED_VERSION}" ] || [ "${WHEEL_PY_TAG}" != "${EXPECTED_PY_TAG}" ]; then
   echo "[bootstrap] ERROR: prebaked wheel ${WHEEL_NAME} does not match this ref's pins" >&2
   echo "[bootstrap]   ref locks llama-cpp-python==${LOCKED_VERSION} on ${EXPECTED_PY_TAG}" >&2

--- a/deployment/cuda/pod-bootstrap.sh
+++ b/deployment/cuda/pod-bootstrap.sh
@@ -15,17 +15,19 @@ SKULK_DIR="${SKULK_DIR:-/root/skulk}"
 
 log() { printf '[bootstrap] %s\n' "$*"; }
 
+# One ref-resolution path for fresh and reused checkouts: clone the default
+# branch shallow, then fetch/checkout the requested ref. `git clone --branch`
+# cannot take a commit SHA, and pinning a session to an exact commit (a PR
+# head, a workflow SHA) is a primary use of this script.
 if [ ! -d "${SKULK_DIR}/.git" ]; then
-  log "cloning Skulk (${REF})"
-  git clone --branch "${REF}" --depth 1 \
-    https://github.com/Foxlight-Foundation/Skulk "${SKULK_DIR}"
-else
-  log "reusing checkout at ${SKULK_DIR} (fetching ${REF})"
-  # Branches and SHAs fetch bare; tags need the qualified refspec on re-runs.
-  git -C "${SKULK_DIR}" fetch --depth 1 origin "${REF}" \
-    || git -C "${SKULK_DIR}" fetch --depth 1 origin "refs/tags/${REF}:refs/tags/${REF}"
-  git -C "${SKULK_DIR}" checkout FETCH_HEAD
+  log "cloning Skulk"
+  git clone --depth 1 https://github.com/Foxlight-Foundation/Skulk "${SKULK_DIR}"
 fi
+log "fetching ${REF}"
+# Branches and SHAs fetch bare; tags need the qualified refspec.
+git -C "${SKULK_DIR}" fetch --depth 1 origin "${REF}" \
+  || git -C "${SKULK_DIR}" fetch --depth 1 origin "refs/tags/${REF}:refs/tags/${REF}"
+git -C "${SKULK_DIR}" checkout FETCH_HEAD
 
 cd "${SKULK_DIR}"
 log "uv sync (builds the Rust bindings)"

--- a/deployment/cuda/pod-bootstrap.sh
+++ b/deployment/cuda/pod-bootstrap.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Per-session Skulk setup on the prebaked CUDA pod image.
+#
+# The image carries everything slow (CUDA llama-cpp-python wheel at
+# /opt/wheels, llama-server + ggml-rpc-server at /opt/llama.cpp/build/bin,
+# uv, the Rust toolchain); this script does only the per-session parts:
+# clone the requested Skulk ref, sync its environment, and swap in the
+# prebaked CUDA wheel. Minutes instead of the recipe's ~1 hour.
+#
+# Usage: /opt/skulk/pod-bootstrap.sh [git-ref]   (default: dev)
+set -euo pipefail
+
+REF="${1:-dev}"
+SKULK_DIR="${SKULK_DIR:-/root/skulk}"
+
+log() { printf '[bootstrap] %s\n' "$*"; }
+
+if [ ! -d "${SKULK_DIR}/.git" ]; then
+  log "cloning Skulk (${REF})"
+  git clone --branch "${REF}" --depth 1 \
+    https://github.com/Foxlight-Foundation/Skulk "${SKULK_DIR}"
+else
+  log "reusing checkout at ${SKULK_DIR} (fetching ${REF})"
+  git -C "${SKULK_DIR}" fetch --depth 1 origin "${REF}"
+  git -C "${SKULK_DIR}" checkout FETCH_HEAD
+fi
+
+cd "${SKULK_DIR}"
+log "uv sync (builds the Rust bindings)"
+uv sync
+
+# AFTER uv sync: a plain sync restores the CPU-only PyPI llama-cpp-python
+# wheel, so the CUDA wheel must be (re)installed last, exactly like
+# install-deps.sh --with-skulk-env does.
+log "installing prebaked CUDA llama-cpp-python wheel"
+uv pip install --force-reinstall /opt/wheels/llama_cpp_python-*.whl
+uv pip install --quiet nvidia-ml-py
+
+log "verifying GPU offload support in the installed binding"
+uv run --no-sync python - <<'PY'
+import llama_cpp
+
+if not llama_cpp.llama_supports_gpu_offload():
+    raise SystemExit("llama-cpp-python build has NO GPU offload; wheel/arch mismatch?")
+print("[bootstrap] llama-cpp-python: GPU offload OK")
+PY
+
+log "done. Launch example:"
+log "  cd ${SKULK_DIR} && SKULK_LLAMA_CPP_BACKENDS=cuda \\"
+log "  SKULK_LLAMA_SERVER_BIN=/opt/llama.cpp/build/bin/llama-server uv run skulk"

--- a/deployment/cuda/pod-bootstrap.sh
+++ b/deployment/cuda/pod-bootstrap.sh
@@ -44,7 +44,10 @@ if [ "${#WHEELS[@]}" -ne 1 ] || [ ! -f "${WHEELS[0]}" ]; then
   echo "[bootstrap] ERROR: expected exactly one prebaked wheel, found: ${WHEELS[*]}" >&2
   exit 1
 fi
-uv pip install --force-reinstall "${WHEELS[0]}"
+# --no-deps: uv sync already installed llama-cpp-python's dependencies at
+# their locked versions; this step only swaps the wheel artifact and must
+# not let pip drift the rest of the environment away from uv.lock.
+uv pip install --force-reinstall --no-deps "${WHEELS[0]}"
 uv pip install --quiet nvidia-ml-py
 
 log "verifying GPU offload support in the installed binding"

--- a/deployment/cuda/pod-bootstrap.sh
+++ b/deployment/cuda/pod-bootstrap.sh
@@ -30,8 +30,13 @@ git -C "${SKULK_DIR}" fetch --depth 1 origin "${REF}" \
 git -C "${SKULK_DIR}" checkout FETCH_HEAD
 
 cd "${SKULK_DIR}"
-log "uv sync (builds the Rust bindings)"
-uv sync
+# --extra llama-cpp: llama-cpp-python lives in an optional extra, so a plain
+# sync would install neither it nor its locked dependencies (diskcache and
+# friends), and the --no-deps CUDA wheel swap below would leave the import
+# broken. The extra installs the locked CPU build + deps; the swap then only
+# replaces the artifact.
+log "uv sync --extra llama-cpp (builds the Rust bindings)"
+uv sync --extra llama-cpp
 
 # AFTER uv sync: a plain sync restores the CPU-only PyPI llama-cpp-python
 # wheel, so the CUDA wheel must be (re)installed last, exactly like
@@ -48,7 +53,10 @@ fi
 # their locked versions; this step only swaps the wheel artifact and must
 # not let pip drift the rest of the environment away from uv.lock.
 uv pip install --force-reinstall --no-deps "${WHEELS[0]}"
-uv pip install --quiet nvidia-ml-py
+# Optional NVML telemetry binding: best-effort, because a transient PyPI
+# failure must not abort a session Skulk can run without it.
+uv pip install --quiet --no-deps nvidia-ml-py \
+  || log "WARNING: nvidia-ml-py install failed; NVML telemetry disabled this session"
 
 log "verifying GPU offload support in the installed binding"
 uv run --no-sync python - <<'PY'

--- a/deployment/cuda/pod-bootstrap.sh
+++ b/deployment/cuda/pod-bootstrap.sh
@@ -21,7 +21,9 @@ if [ ! -d "${SKULK_DIR}/.git" ]; then
     https://github.com/Foxlight-Foundation/Skulk "${SKULK_DIR}"
 else
   log "reusing checkout at ${SKULK_DIR} (fetching ${REF})"
-  git -C "${SKULK_DIR}" fetch --depth 1 origin "${REF}"
+  # Branches and SHAs fetch bare; tags need the qualified refspec on re-runs.
+  git -C "${SKULK_DIR}" fetch --depth 1 origin "${REF}" \
+    || git -C "${SKULK_DIR}" fetch --depth 1 origin "refs/tags/${REF}:refs/tags/${REF}"
   git -C "${SKULK_DIR}" checkout FETCH_HEAD
 fi
 
@@ -33,7 +35,14 @@ uv sync
 # wheel, so the CUDA wheel must be (re)installed last, exactly like
 # install-deps.sh --with-skulk-env does.
 log "installing prebaked CUDA llama-cpp-python wheel"
-uv pip install --force-reinstall /opt/wheels/llama_cpp_python-*.whl
+# Exactly one wheel must match: zero means the image build silently failed,
+# more than one means an ambiguous install; both should stop the session here.
+WHEELS=(/opt/wheels/llama_cpp_python-*.whl)
+if [ "${#WHEELS[@]}" -ne 1 ] || [ ! -f "${WHEELS[0]}" ]; then
+  echo "[bootstrap] ERROR: expected exactly one prebaked wheel, found: ${WHEELS[*]}" >&2
+  exit 1
+fi
+uv pip install --force-reinstall "${WHEELS[0]}"
 uv pip install --quiet nvidia-ml-py
 
 log "verifying GPU offload support in the installed binding"

--- a/deployment/cuda/pod-bootstrap.sh
+++ b/deployment/cuda/pod-bootstrap.sh
@@ -71,20 +71,25 @@ fi
 
 # ---- sync and swap ----------------------------------------------------------
 # --locked: the sync must install the ref's committed lock verbatim, never
-# re-resolve it on the pod. --extra llama-cpp: llama-cpp-python lives in an
-# optional extra, so a plain sync would install neither it nor its locked
-# dependencies (diskcache and friends), and the --no-deps CUDA wheel swap
-# below would leave the import broken.
-log "uv sync --locked --extra llama-cpp (builds the Rust bindings)"
-uv sync --locked --extra llama-cpp
+# re-resolve it on the pod. The llama-cpp extra is NOT synced: its
+# llama-cpp-python entry is sdist-only, so syncing it would compile a CPU
+# build on the pod - the exact rental-time cost this image exists to avoid.
+# Instead the extra's locked DEPENDENCIES (diskcache and friends) install
+# from an export below, and the prebaked CUDA wheel supplies the package.
+log "uv sync --locked (builds the Rust bindings)"
+uv sync --locked
 
-# AFTER uv sync: a plain sync restores the CPU-only PyPI llama-cpp-python
-# wheel, so the CUDA wheel must be (re)installed last, exactly like
-# install-deps.sh --with-skulk-env does.
+log "installing the llama-cpp extra's locked dependencies (without the sdist)"
+uv export --frozen --extra llama-cpp --no-hashes --no-emit-project --no-emit-workspace \
+  --no-emit-package llama-cpp-python -o /tmp/llama-extra-deps.txt
+uv pip install --requirement /tmp/llama-extra-deps.txt
+
 log "installing prebaked CUDA llama-cpp-python wheel"
 # --no-deps: uv sync already installed llama-cpp-python's dependencies at
 # their locked versions; this step only swaps the wheel artifact and must
 # not let pip drift the rest of the environment away from uv.lock.
+# --force-reinstall keeps re-runs honest; --no-deps because the locked
+# dependency set was installed above and must not drift.
 uv pip install --force-reinstall --no-deps "${WHEELS[0]}"
 # Optional NVML telemetry binding: best-effort, because a transient PyPI
 # failure must not abort a session Skulk can run without it.

--- a/deployment/cuda/pod-bootstrap.sh
+++ b/deployment/cuda/pod-bootstrap.sh
@@ -49,6 +49,22 @@ if [ "${#WHEELS[@]}" -ne 1 ] || [ ! -f "${WHEELS[0]}" ]; then
   echo "[bootstrap] ERROR: expected exactly one prebaked wheel, found: ${WHEELS[*]}" >&2
   exit 1
 fi
+# The image is reusable across refs, but the wheel it carries is pinned to
+# the pins of the commit that built it. A ref with a different locked
+# llama-cpp-python would otherwise end up silently un-locked, and a
+# different .python-version fails later with a confusing wheel-tag error;
+# both mismatches stop here with instructions instead.
+WHEEL_NAME="$(basename "${WHEELS[0]}")"
+WHEEL_VERSION="$(printf '%s' "${WHEEL_NAME}" | cut -d- -f2)"
+WHEEL_PY_TAG="$(printf '%s' "${WHEEL_NAME}" | cut -d- -f3)"
+LOCKED_VERSION="$(sed -n '/^name = "llama-cpp-python"$/{n;s/^version = "\(.*\)"$/\1/p;}' uv.lock | head -1)"
+EXPECTED_PY_TAG="cp$(tr -d '[:space:].' < .python-version | cut -c1-3)"
+if [ "${WHEEL_VERSION}" != "${LOCKED_VERSION}" ] || [ "${WHEEL_PY_TAG}" != "${EXPECTED_PY_TAG}" ]; then
+  echo "[bootstrap] ERROR: prebaked wheel ${WHEEL_NAME} does not match this ref's pins" >&2
+  echo "[bootstrap]   ref locks llama-cpp-python==${LOCKED_VERSION} on ${EXPECTED_PY_TAG}" >&2
+  echo "[bootstrap]   use the image built for this ref, or rebuild via the cuda-image workflow" >&2
+  exit 1
+fi
 # --no-deps: uv sync already installed llama-cpp-python's dependencies at
 # their locked versions; this step only swaps the wheel artifact and must
 # not let pip drift the rest of the environment away from uv.lock.

--- a/deployment/cuda/pod-bootstrap.sh
+++ b/deployment/cuda/pod-bootstrap.sh
@@ -30,18 +30,11 @@ git -C "${SKULK_DIR}" fetch --depth 1 origin "${REF}" \
 git -C "${SKULK_DIR}" checkout FETCH_HEAD
 
 cd "${SKULK_DIR}"
-# --extra llama-cpp: llama-cpp-python lives in an optional extra, so a plain
-# sync would install neither it nor its locked dependencies (diskcache and
-# friends), and the --no-deps CUDA wheel swap below would leave the import
-# broken. The extra installs the locked CPU build + deps; the swap then only
-# replaces the artifact.
-log "uv sync --extra llama-cpp (builds the Rust bindings)"
-uv sync --extra llama-cpp
 
-# AFTER uv sync: a plain sync restores the CPU-only PyPI llama-cpp-python
-# wheel, so the CUDA wheel must be (re)installed last, exactly like
-# install-deps.sh --with-skulk-env does.
-log "installing prebaked CUDA llama-cpp-python wheel"
+# ---- verify this ref matches the prebaked wheel BEFORE any sync ------------
+# The checks run against the ref's COMMITTED pins: syncing first (and without
+# --locked) could regenerate uv.lock in the pod and the checks would then
+# validate against bootstrap-generated state instead of the ref.
 # Exactly one wheel must match: zero means the image build silently failed,
 # more than one means an ambiguous install; both should stop the session here.
 WHEELS=(/opt/wheels/llama_cpp_python-*.whl)
@@ -49,17 +42,17 @@ if [ "${#WHEELS[@]}" -ne 1 ] || [ ! -f "${WHEELS[0]}" ]; then
   echo "[bootstrap] ERROR: expected exactly one prebaked wheel, found: ${WHEELS[*]}" >&2
   exit 1
 fi
-# The image is reusable across refs, but the wheel it carries is pinned to
-# the pins of the commit that built it. A ref with a different locked
-# llama-cpp-python would otherwise end up silently un-locked, and a
-# different .python-version fails later with a confusing wheel-tag error;
-# both mismatches stop here with instructions instead.
 for pin_file in uv.lock .python-version; do
   if [ ! -f "${pin_file}" ]; then
     echo "[bootstrap] ERROR: ${pin_file} missing from this checkout; the ref predates (or is incompatible with) the prebaked-image flow. Provision with deployment/cuda/install-deps.sh instead." >&2
     exit 1
   fi
 done
+# The image is reusable across refs, but the wheel it carries is pinned to
+# the pins of the commit that built it. A ref with a different locked
+# llama-cpp-python would otherwise end up silently un-locked, and a
+# different .python-version fails later with a confusing wheel-tag error;
+# both mismatches stop here with instructions instead.
 WHEEL_NAME="$(basename "${WHEELS[0]}")"
 WHEEL_VERSION="$(printf '%s' "${WHEEL_NAME}" | cut -d- -f2)"
 WHEEL_PY_TAG="$(printf '%s' "${WHEEL_NAME}" | cut -d- -f3)"
@@ -75,6 +68,20 @@ if [ "${WHEEL_VERSION}" != "${LOCKED_VERSION}" ] || [ "${WHEEL_PY_TAG}" != "${EX
   echo "[bootstrap]   use the image built for this ref, or rebuild via the cuda-image workflow" >&2
   exit 1
 fi
+
+# ---- sync and swap ----------------------------------------------------------
+# --locked: the sync must install the ref's committed lock verbatim, never
+# re-resolve it on the pod. --extra llama-cpp: llama-cpp-python lives in an
+# optional extra, so a plain sync would install neither it nor its locked
+# dependencies (diskcache and friends), and the --no-deps CUDA wheel swap
+# below would leave the import broken.
+log "uv sync --locked --extra llama-cpp (builds the Rust bindings)"
+uv sync --locked --extra llama-cpp
+
+# AFTER uv sync: a plain sync restores the CPU-only PyPI llama-cpp-python
+# wheel, so the CUDA wheel must be (re)installed last, exactly like
+# install-deps.sh --with-skulk-env does.
+log "installing prebaked CUDA llama-cpp-python wheel"
 # --no-deps: uv sync already installed llama-cpp-python's dependencies at
 # their locked versions; this step only swaps the wheel artifact and must
 # not let pip drift the rest of the environment away from uv.lock.

--- a/deployment/cuda/pod-start.sh
+++ b/deployment/cuda/pod-start.sh
@@ -18,6 +18,11 @@ if [ -n "${PUBLIC_KEY:-}" ]; then
   chmod 600 /root/.ssh/authorized_keys
 fi
 
+# Host keys are generated per pod: the public image ships without any (they
+# are deleted at build time) because baked-in keys would be shared across
+# every pod and readable by anyone who pulls the image.
+ssh-keygen -A
+
 echo "[pod-start] starting sshd; bootstrap a session with /opt/skulk/pod-bootstrap.sh"
 # Foreground as pid 1: container stop signals reach sshd directly, and an
 # sshd death ends the pod instead of leaving it alive but unreachable.

--- a/deployment/cuda/pod-start.sh
+++ b/deployment/cuda/pod-start.sh
@@ -4,18 +4,21 @@
 # RunPod injects the operator's SSH public key as the PUBLIC_KEY environment
 # variable when the pod is created with it (API-created pods MUST pass it:
 # without a key sshd is unreachable and the pod is only usable through the
-# provider's interactive web terminal). This installs the key, starts sshd,
-# and idles as pid 1 so the pod stays alive between SSH sessions.
+# provider's interactive web terminal). This installs the key and then runs
+# sshd in the foreground as pid 1 for the pod's lifetime.
 set -euo pipefail
 
 if [ -n "${PUBLIC_KEY:-}" ]; then
   mkdir -p /root/.ssh
   chmod 700 /root/.ssh
-  printf '%s\n' "${PUBLIC_KEY}" >> /root/.ssh/authorized_keys
+  # Overwrite, not append: container restarts re-run this entrypoint and
+  # appending would duplicate entries. Multiple newline-separated keys are a
+  # legitimate provider convention, so the content is written as-is.
+  printf '%s\n' "${PUBLIC_KEY}" > /root/.ssh/authorized_keys
   chmod 600 /root/.ssh/authorized_keys
 fi
 
-/usr/sbin/sshd
-
-echo "[pod-start] sshd up; bootstrap a session with /opt/skulk/pod-bootstrap.sh"
-exec sleep infinity
+echo "[pod-start] starting sshd; bootstrap a session with /opt/skulk/pod-bootstrap.sh"
+# Foreground as pid 1: container stop signals reach sshd directly, and an
+# sshd death ends the pod instead of leaving it alive but unreachable.
+exec /usr/sbin/sshd -D -e

--- a/deployment/cuda/pod-start.sh
+++ b/deployment/cuda/pod-start.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Pod entrypoint for the prebaked CUDA image (RunPod and similar).
+#
+# RunPod injects the operator's SSH public key as the PUBLIC_KEY environment
+# variable when the pod is created with it (API-created pods MUST pass it:
+# without a key sshd is unreachable and the pod is only usable through the
+# provider's interactive web terminal). This installs the key, starts sshd,
+# and idles as pid 1 so the pod stays alive between SSH sessions.
+set -euo pipefail
+
+if [ -n "${PUBLIC_KEY:-}" ]; then
+  mkdir -p /root/.ssh
+  chmod 700 /root/.ssh
+  printf '%s\n' "${PUBLIC_KEY}" >> /root/.ssh/authorized_keys
+  chmod 600 /root/.ssh/authorized_keys
+fi
+
+/usr/sbin/sshd
+
+echo "[pod-start] sshd up; bootstrap a session with /opt/skulk/pod-bootstrap.sh"
+exec sleep infinity


### PR DESCRIPTION
## What

A prebaked Docker image for rented-GPU Skulk sessions (RunPod and similar), published to GHCR as `ghcr.io/foxlight-foundation/skulk-cuda-pod` by a new `cuda-image` workflow.

## Why

Provisioning a fresh pod through `deployment/cuda/install-deps.sh` takes about an hour, dominated by two CUDA compiles (`llama-server` and the CUDA `llama-cpp-python` wheel). At rental rates that is dead spend at the start of every session, and it happened twice this week. Baking the artifacts into an image cuts session setup to clone + `uv sync` + wheel install (minutes). This is the last item of the CUDA-ladder no-pod batch.

## How

- **`deployment/cuda/Dockerfile`** (multi-stage): devel stage compiles `llama-server` + `ggml-rpc-server` (`-DGGML_CUDA -DGGML_RPC`) and builds the CUDA `llama-cpp-python` wheel; runtime stage carries the binaries at `/opt/llama.cpp/build/bin`, the wheel at `/opt/wheels`, uv, the Rust toolchain (`uv sync` builds Skulk's PyO3 bindings per-session), and sshd.
- **`pod-start.sh`** (pid 1): installs the provider-injected `PUBLIC_KEY` for sshd — API-created pods are unreachable over SSH without it — then idles.
- **`pod-bootstrap.sh`**: per-session setup — clone the requested Skulk ref, `uv sync`, then install the prebaked CUDA wheel **after** sync (a plain sync restores the CPU-only PyPI wheel), and verify `llama_supports_gpu_offload()` so a CPU-silent build fails loud.
- **`.github/workflows/cuda-image.yml`**: builds on standard amd64 runners (nvcc compiles CUDA without a GPU present), pushes `:latest` + `:<sha>`, GHA layer cache, disk-free step for the CUDA base image. Triggers: manual dispatch + dev pushes touching the image inputs.

`CUDA_ARCHS` build-arg defaults to `86;89` (A40/A5000/3090 + 4090/L40S — the tiers we actually rent); 80/90 are one arg away for A100/H100 sessions.

## Validation

- `bash -n` on both scripts.
- The workflow itself is the build validation; first publish fires on merge (workflow_dispatch becomes available once the file is on dev). Live pod validation in the next rented session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)