### PR TITLE
feat: add realtime dashboard voice conversations

### DIFF
--- a/dashboard-react/src/audio/realtimeTranscription.test.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.test.ts
@@ -343,6 +343,49 @@ describe('RealtimeConversationSocket', () => {
     expect(transcripts).toEqual(['still connected']);
   });
 
+  it('rejects connection immediately when the server returns an error', async () => {
+    const socket = new FakeWebSocket();
+    const errors: Error[] = [];
+    const client = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => socket as unknown as WebSocket,
+      onError: (error) => errors.push(error),
+    });
+
+    const connected = client.connect();
+    socket.serverEvent({
+      type: 'error',
+      error: { code: 'provider_error', message: 'provider admission failed' },
+    });
+
+    await expect(connected).rejects.toThrow('provider admission failed');
+    expect(errors.map((error) => error.message)).toEqual(['provider admission failed']);
+    expect(socket.closeCode).toBe(1011);
+  });
+
+  it('ignores server events after the conversation is closed', async () => {
+    const socket = new FakeWebSocket();
+    const transcripts: string[] = [];
+    const client = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => socket as unknown as WebSocket,
+      onTranscript: (text) => transcripts.push(text),
+    });
+
+    const connected = client.connect();
+    socket.serverEvent({ type: 'session.created' });
+    await connected;
+    client.close();
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.completed',
+      transcript: 'late transcript',
+    });
+
+    expect(transcripts).toEqual([]);
+  });
+
   it('drops a partial microphone frame at a server VAD turn boundary', async () => {
     const socket = new FakeWebSocket();
     const client = new RealtimeConversationSocket({

--- a/dashboard-react/src/audio/realtimeTranscription.test.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.test.ts
@@ -342,4 +342,32 @@ describe('RealtimeConversationSocket', () => {
     expect(errors).toEqual([]);
     expect(transcripts).toEqual(['still connected']);
   });
+
+  it('drops a partial microphone frame at a server VAD turn boundary', async () => {
+    const socket = new FakeWebSocket();
+    const client = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => socket as unknown as WebSocket,
+    });
+
+    const connected = client.connect();
+    socket.serverEvent({ type: 'session.created' });
+    await connected;
+    client.append(new Float32Array(1_000).fill(1), 24_000);
+    socket.serverEvent({ type: 'input_audio_buffer.speech_stopped' });
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.completed',
+      transcript: 'first turn',
+    });
+    client.append(new Float32Array(2_401), 24_000);
+
+    const append = socket.sent
+      .map((message) => JSON.parse(message))
+      .find((message) => message.type === 'input_audio_buffer.append');
+    expect(append).toBeDefined();
+    expect(Array.from(atob(append.audio), (char) => char.charCodeAt(0))).toEqual(
+      new Array(4_800).fill(0),
+    );
+  });
 });

--- a/dashboard-react/src/audio/realtimeTranscription.test.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.test.ts
@@ -309,4 +309,37 @@ describe('RealtimeConversationSocket', () => {
     expect(transcripts.at(-1)).toEqual(['second', false]);
     expect(responses.at(-1)).toEqual(['two', false]);
   });
+
+  it('keeps the conversation open after a late-frame turn error', async () => {
+    const socket = new FakeWebSocket();
+    const errors: Error[] = [];
+    const transcripts: string[] = [];
+    const client = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => socket as unknown as WebSocket,
+      onTranscript: (text, final) => {
+        if (final) transcripts.push(text);
+      },
+      onError: (error) => errors.push(error),
+    });
+
+    const connected = client.connect();
+    socket.serverEvent({ type: 'session.created' });
+    await connected;
+    socket.serverEvent({
+      type: 'error',
+      error: {
+        code: 'turn_in_progress',
+        message: 'audio cannot be appended until the committed turn completes',
+      },
+    });
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.completed',
+      transcript: 'still connected',
+    });
+
+    expect(errors).toEqual([]);
+    expect(transcripts).toEqual(['still connected']);
+  });
 });

--- a/dashboard-react/src/audio/realtimeTranscription.test.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   finalizeRealtimeCaptureStartup,
+  RealtimeConversationSocket,
   RealtimeTranscriptionSocket,
   StreamingLinearResampler,
   realtimeTranscriptionUrl,
@@ -198,6 +199,77 @@ describe('RealtimeTranscriptionSocket', () => {
     client.cancel();
 
     await expect(result).rejects.toThrow('Realtime transcription was cancelled.');
+    expect(socket.closeCode).toBe(1000);
+  });
+});
+
+describe('RealtimeConversationSocket', () => {
+  it('maps server VAD transcript and assistant events across multiple turns', async () => {
+    const socket = new FakeWebSocket();
+    const transcripts: Array<[string, boolean]> = [];
+    const responses: Array<[string, boolean]> = [];
+    const statuses: string[] = [];
+    const client = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      responseModelId: 'org/chat',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => socket as unknown as WebSocket,
+      onTranscript: (text, final) => transcripts.push([text, final]),
+      onAssistantText: (text, final) => responses.push([text, final]),
+      onResponseDone: (status) => statuses.push(status),
+    });
+
+    const connected = client.connect();
+    socket.serverEvent({ type: 'session.created' });
+    await connected;
+    expect(JSON.parse(socket.sent[0])).toMatchObject({
+      type: 'session.update',
+      session: {
+        audio: { input: { turn_detection: { type: 'server_vad' } } },
+        response: { model: 'org/chat' },
+      },
+    });
+
+    client.append(Float32Array.from([0, 0.25, 0.5, 0.75, 1]), 48_000);
+    client.commitTurn();
+    expect(JSON.parse(socket.sent.at(-1)!)).toEqual({ type: 'input_audio_buffer.commit' });
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.delta',
+      item_id: 'input-1',
+      delta: 'hello ',
+    });
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.delta',
+      item_id: 'input-1',
+      delta: 'world',
+    });
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'input-1',
+      transcript: 'hello world',
+    });
+    socket.serverEvent({
+      type: 'response.output_text.delta',
+      item_id: 'output-1',
+      delta: 'hi ',
+    });
+    socket.serverEvent({
+      type: 'response.output_text.done',
+      item_id: 'output-1',
+      text: 'hi there',
+    });
+    socket.serverEvent({ type: 'response.done', response: { status: 'completed' } });
+
+    expect(transcripts).toEqual([
+      ['hello ', false],
+      ['hello world', false],
+      ['hello world', true],
+    ]);
+    expect(responses).toEqual([['hi ', false], ['hi there', true]]);
+    expect(statuses).toEqual(['completed']);
+    client.cancelResponse();
+    expect(JSON.parse(socket.sent.at(-1)!)).toEqual({ type: 'response.cancel' });
+    client.close();
     expect(socket.closeCode).toBe(1000);
   });
 });

--- a/dashboard-react/src/audio/realtimeTranscription.test.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.test.ts
@@ -272,4 +272,41 @@ describe('RealtimeConversationSocket', () => {
     client.close();
     expect(socket.closeCode).toBe(1000);
   });
+
+  it('clears fallback accumulators between events without item IDs', async () => {
+    const socket = new FakeWebSocket();
+    const transcripts: Array<[string, boolean]> = [];
+    const responses: Array<[string, boolean]> = [];
+    const client = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      responseModelId: 'org/chat',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => socket as unknown as WebSocket,
+      onTranscript: (text, final) => transcripts.push([text, final]),
+      onAssistantText: (text, final) => responses.push([text, final]),
+    });
+
+    const connected = client.connect();
+    socket.serverEvent({ type: 'session.created' });
+    await connected;
+
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.delta',
+      delta: 'first',
+    });
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.completed',
+      transcript: 'first',
+    });
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.delta',
+      delta: 'second',
+    });
+    socket.serverEvent({ type: 'response.output_text.delta', delta: 'one' });
+    socket.serverEvent({ type: 'response.output_text.done', text: 'one' });
+    socket.serverEvent({ type: 'response.output_text.delta', delta: 'two' });
+
+    expect(transcripts.at(-1)).toEqual(['second', false]);
+    expect(responses.at(-1)).toEqual(['two', false]);
+  });
 });

--- a/dashboard-react/src/audio/realtimeTranscription.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.ts
@@ -499,6 +499,9 @@ export class RealtimeConversationSocket {
     }
     if (payload.type === 'input_audio_buffer.speech_stopped') {
       this.acceptingAudio = false;
+      this.pendingSamples.length = 0;
+      this.resampler = null;
+      this.inputSampleRate = null;
       this.options.onSpeechStopped?.();
       return;
     }

--- a/dashboard-react/src/audio/realtimeTranscription.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.ts
@@ -8,6 +8,7 @@ type WebSocketFactory = (url: string) => WebSocket;
 export type TranscriptionCaptureMode = 'realtime' | 'batch' | null;
 
 interface RealtimeServerError {
+  code?: unknown;
   message?: unknown;
 }
 
@@ -546,6 +547,7 @@ export class RealtimeConversationSocket {
       return;
     }
     if (payload.type === 'error') {
+      if (payload.error?.code === 'turn_in_progress') return;
       const message = typeof payload.error?.message === 'string'
         ? payload.error.message
         : 'Realtime conversation failed.';

--- a/dashboard-react/src/audio/realtimeTranscription.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.ts
@@ -515,7 +515,7 @@ export class RealtimeConversationSocket {
       payload.type === 'conversation.item.input_audio_transcription.completed'
       && typeof payload.transcript === 'string'
     ) {
-      if (itemId) this.transcripts.delete(itemId);
+      this.transcripts.delete(itemId ?? 'current');
       this.acceptingAudio = true;
       this.turnHasAudio = false;
       this.options.onTranscript?.(payload.transcript, true, itemId);
@@ -533,7 +533,7 @@ export class RealtimeConversationSocket {
       return;
     }
     if (payload.type === 'response.output_text.done' && typeof payload.text === 'string') {
-      if (itemId) this.responses.delete(itemId);
+      this.responses.delete(itemId ?? 'current');
       this.options.onAssistantText?.(payload.text, true, itemId);
       return;
     }

--- a/dashboard-react/src/audio/realtimeTranscription.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.ts
@@ -13,8 +13,11 @@ interface RealtimeServerError {
 
 interface RealtimeServerEvent {
   type?: unknown;
+  item_id?: unknown;
   transcript?: unknown;
   delta?: unknown;
+  text?: unknown;
+  response?: { status?: unknown };
   error?: RealtimeServerError;
 }
 
@@ -305,6 +308,267 @@ export class RealtimeTranscriptionSocket {
     if (this.resultTimer !== null) window.clearTimeout(this.resultTimer);
     this.connectTimer = null;
     this.resultTimer = null;
+  }
+}
+
+/** Callbacks emitted by one multi-turn realtime voice conversation. */
+export interface RealtimeConversationCallbacks {
+  onTranscript?: (text: string, final: boolean, itemId: string | null) => void;
+  onAssistantText?: (text: string, final: boolean, itemId: string | null) => void;
+  onSpeechStarted?: () => void;
+  onSpeechStopped?: () => void;
+  onResponseDone?: (status: string) => void;
+  onError?: (error: Error) => void;
+}
+
+/** Options for a server-VAD realtime voice conversation. */
+export interface RealtimeConversationSocketOptions extends RealtimeConversationCallbacks {
+  transcriptionModelId: string;
+  responseModelId?: string | null;
+  socketFactory?: WebSocketFactory;
+  location?: Pick<Location, 'protocol' | 'host'>;
+}
+
+/** Own a bounded multi-turn server-VAD socket used by dashboard voice chat. */
+export class RealtimeConversationSocket {
+  private readonly options: RealtimeConversationSocketOptions;
+  private readonly socketFactory: WebSocketFactory;
+  private socket: WebSocket | null = null;
+  private resampler: StreamingLinearResampler | null = null;
+  private inputSampleRate: number | null = null;
+  private readonly pendingSamples: number[] = [];
+  private readonly transcripts = new Map<string, string>();
+  private readonly responses = new Map<string, string>();
+  private connected = false;
+  private acceptingAudio = true;
+  private turnHasAudio = false;
+  private responseActive = false;
+  private terminal = false;
+  private connectResolve: (() => void) | null = null;
+  private connectReject: ((error: Error) => void) | null = null;
+  private connectTimer: number | null = null;
+
+  constructor(options: RealtimeConversationSocketOptions) {
+    this.options = options;
+    this.socketFactory = options.socketFactory ?? ((url) => new WebSocket(url));
+  }
+
+  /** Open the socket and install server VAD plus optional chat response routing. */
+  connect(): Promise<void> {
+    if (this.socket) throw new Error('realtime conversation socket is already opened');
+    const socket = this.socketFactory(realtimeTranscriptionUrl(
+      this.options.transcriptionModelId,
+      this.options.location ?? window.location,
+    ));
+    this.socket = socket;
+    socket.addEventListener('message', (event) => this.handleMessage(event));
+    socket.addEventListener('error', () => this.fail(
+      new Error('Realtime conversation connection failed.'),
+    ));
+    socket.addEventListener('close', () => {
+      if (!this.terminal) this.fail(
+        new Error('Realtime conversation connection closed unexpectedly.'),
+      );
+    });
+    return new Promise<void>((resolve, reject) => {
+      this.connectResolve = resolve;
+      this.connectReject = reject;
+      this.connectTimer = window.setTimeout(() => this.fail(
+        new Error('Realtime conversation connection timed out.'),
+      ), CONNECT_TIMEOUT_MS);
+    });
+  }
+
+  /** Resample and append one ordered microphone frame to the active turn. */
+  append(samples: Float32Array, inputSampleRate: number): void {
+    const socket = this.socket;
+    if (!this.connected || !socket || socket.readyState !== 1) {
+      throw new Error('realtime conversation socket is not connected');
+    }
+    if (!this.acceptingAudio) return;
+    if (socket.bufferedAmount > MAX_SOCKET_BUFFERED_BYTES) {
+      const error = new Error('Realtime conversation cannot keep up with microphone audio.');
+      this.fail(error);
+      throw error;
+    }
+    if (this.inputSampleRate === null) {
+      this.inputSampleRate = inputSampleRate;
+      this.resampler = new StreamingLinearResampler(inputSampleRate);
+    } else if (this.inputSampleRate !== inputSampleRate) {
+      throw new Error('microphone sample rate changed during realtime conversation');
+    }
+    const resampled = this.resampler?.process(samples) ?? new Float32Array(0);
+    if (resampled.length > 0) this.turnHasAudio = true;
+    for (const sample of resampled) this.pendingSamples.push(sample);
+    while (this.pendingSamples.length >= TARGET_FRAME_SAMPLES) {
+      this.sendSamples(Float32Array.from(
+        this.pendingSamples.splice(0, TARGET_FRAME_SAMPLES),
+      ));
+    }
+  }
+
+  /** Flush microphone tail and ask the server to close the current turn. */
+  commitTurn(): boolean {
+    const socket = this.socket;
+    if (!this.connected || !socket || socket.readyState !== 1 || !this.turnHasAudio) {
+      return false;
+    }
+    if (this.pendingSamples.length > 0) {
+      this.sendSamples(Float32Array.from(this.pendingSamples.splice(0)));
+    }
+    socket.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
+    this.acceptingAudio = false;
+    return true;
+  }
+
+  /** Return whether assistant model or speech output is still draining. */
+  hasActiveResponse(): boolean {
+    return this.responseActive;
+  }
+
+  /** Cancel active assistant output while preserving the conversation socket. */
+  cancelResponse(): void {
+    if (this.connected && this.socket?.readyState === 1) {
+      this.socket.send(JSON.stringify({ type: 'response.cancel' }));
+    }
+  }
+
+  /** Close the socket and release all pending callback state. */
+  close(): void {
+    if (this.terminal) return;
+    this.terminal = true;
+    this.clearConnectTimer();
+    this.connectReject?.(new Error('Realtime conversation was cancelled.'));
+    this.connectResolve = null;
+    this.connectReject = null;
+    this.socket?.close(1000, 'client closed realtime conversation');
+  }
+
+  private sendSamples(samples: Float32Array): void {
+    const socket = this.socket;
+    if (!socket || socket.readyState !== 1) return;
+    socket.send(JSON.stringify({
+      type: 'input_audio_buffer.append',
+      audio: pcm16Base64(samples),
+    }));
+  }
+
+  private handleMessage(event: MessageEvent): void {
+    if (typeof event.data !== 'string') {
+      this.fail(new Error('Realtime conversation returned a non-JSON event.'));
+      return;
+    }
+    let payload: RealtimeServerEvent;
+    try {
+      payload = JSON.parse(event.data) as RealtimeServerEvent;
+    } catch {
+      this.fail(new Error('Realtime conversation returned invalid JSON.'));
+      return;
+    }
+    if (payload.type === 'session.created') {
+      this.connected = true;
+      this.clearConnectTimer();
+      this.socket?.send(JSON.stringify({
+        type: 'session.update',
+        session: {
+          type: 'transcription',
+          audio: {
+            input: {
+              format: { type: 'audio/pcm', rate: TARGET_SAMPLE_RATE },
+              transcription: { model: this.options.transcriptionModelId },
+              turn_detection: { type: 'server_vad' },
+              noise_reduction: null,
+            },
+          },
+          include: [],
+          ...(this.options.responseModelId
+            ? { response: { model: this.options.responseModelId } }
+            : {}),
+        },
+      }));
+      this.connectResolve?.();
+      this.connectResolve = null;
+      this.connectReject = null;
+      return;
+    }
+    const itemId = typeof payload.item_id === 'string' ? payload.item_id : null;
+    if (payload.type === 'input_audio_buffer.speech_started') {
+      this.options.onSpeechStarted?.();
+      return;
+    }
+    if (payload.type === 'input_audio_buffer.speech_stopped') {
+      this.acceptingAudio = false;
+      this.options.onSpeechStopped?.();
+      return;
+    }
+    if (
+      payload.type === 'conversation.item.input_audio_transcription.delta'
+      && typeof payload.delta === 'string'
+    ) {
+      const key = itemId ?? 'current';
+      const text = (this.transcripts.get(key) ?? '') + payload.delta;
+      this.transcripts.set(key, text);
+      this.options.onTranscript?.(text, false, itemId);
+      return;
+    }
+    if (
+      payload.type === 'conversation.item.input_audio_transcription.completed'
+      && typeof payload.transcript === 'string'
+    ) {
+      if (itemId) this.transcripts.delete(itemId);
+      this.acceptingAudio = true;
+      this.turnHasAudio = false;
+      this.options.onTranscript?.(payload.transcript, true, itemId);
+      return;
+    }
+    if (payload.type === 'response.output_text.delta' && typeof payload.delta === 'string') {
+      const key = itemId ?? 'current';
+      const text = (this.responses.get(key) ?? '') + payload.delta;
+      this.responses.set(key, text);
+      this.options.onAssistantText?.(text, false, itemId);
+      return;
+    }
+    if (payload.type === 'response.created') {
+      this.responseActive = true;
+      return;
+    }
+    if (payload.type === 'response.output_text.done' && typeof payload.text === 'string') {
+      if (itemId) this.responses.delete(itemId);
+      this.options.onAssistantText?.(payload.text, true, itemId);
+      return;
+    }
+    if (payload.type === 'response.done') {
+      this.responseActive = false;
+      const status = typeof payload.response?.status === 'string'
+        ? payload.response.status
+        : 'unknown';
+      this.options.onResponseDone?.(status);
+      return;
+    }
+    if (payload.type === 'error') {
+      const message = typeof payload.error?.message === 'string'
+        ? payload.error.message
+        : 'Realtime conversation failed.';
+      this.options.onError?.(new Error(message));
+    }
+  }
+
+  private fail(error: Error): void {
+    if (this.terminal) return;
+    this.terminal = true;
+    this.clearConnectTimer();
+    this.connectReject?.(error);
+    this.connectResolve = null;
+    this.connectReject = null;
+    this.options.onError?.(error);
+    if (this.socket?.readyState === 0 || this.socket?.readyState === 1) {
+      this.socket.close(1011, 'realtime conversation failed');
+    }
+  }
+
+  private clearConnectTimer(): void {
+    if (this.connectTimer !== null) window.clearTimeout(this.connectTimer);
+    this.connectTimer = null;
   }
 }
 

--- a/dashboard-react/src/audio/realtimeTranscription.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.ts
@@ -455,6 +455,7 @@ export class RealtimeConversationSocket {
   }
 
   private handleMessage(event: MessageEvent): void {
+    if (this.terminal) return;
     if (typeof event.data !== 'string') {
       this.fail(new Error('Realtime conversation returned a non-JSON event.'));
       return;
@@ -554,7 +555,7 @@ export class RealtimeConversationSocket {
       const message = typeof payload.error?.message === 'string'
         ? payload.error.message
         : 'Realtime conversation failed.';
-      this.options.onError?.(new Error(message));
+      this.fail(new Error(message));
     }
   }
 

--- a/dashboard-react/src/components/chat/ChatForm.stories.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.stories.tsx
@@ -85,7 +85,12 @@ export const RealtimeStt: Story = {
     transcriptionModels: [realtimeSttModel],
     selectedTranscriptionModelId: realtimeSttModel.modelId,
     realtimeTranscriptionAvailable: true,
+    realtimeVoiceEnabled: true,
+    autoSubmitVoice: true,
+    realtimeResponseModelId: 'mlx-community/Qwen3-30B-A3B-4bit',
     onTranscribeAudio: async () => 'batch fallback transcript',
+    onRealtimeVoiceEnabledChange: () => {},
+    onAutoSubmitVoiceChange: () => {},
   },
 };
 

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -1140,6 +1140,7 @@ export function ChatForm({
                 type="button"
                 disabled={isStartingRecording || isRecording || isTranscribing}
                 $active={realtimeVoiceEnabled}
+                aria-pressed={realtimeVoiceEnabled}
                 onClick={() => onRealtimeVoiceEnabledChange?.(!realtimeVoiceEnabled)}
               >
                 {t('chat.form.realtime', 'Realtime')}
@@ -1150,6 +1151,7 @@ export function ChatForm({
                 type="button"
                 disabled={isStartingRecording || isRecording || isTranscribing}
                 $active={autoSubmitVoice}
+                aria-pressed={autoSubmitVoice}
                 onClick={() => onAutoSubmitVoiceChange?.(!autoSubmitVoice)}
               >
                 {t('chat.form.autoSubmit', 'Auto-send')}
@@ -1187,6 +1189,7 @@ export function ChatForm({
               type="button"
               disabled={!speechReady}
               $active={autoSpeakAssistant}
+              aria-pressed={autoSpeakAssistant}
               onClick={() => onAutoSpeakAssistantChange?.(!autoSpeakAssistant)}
             >
               {t('chat.form.autoSpeak', 'Auto')}

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -477,6 +477,7 @@ export function ChatForm({
   const browserRecordingAvailable = captureMode !== null;
   const useRealtimeCapture = captureMode === 'realtime';
   const useRealtimeConversation = useRealtimeCapture && realtimeVoiceEnabled;
+  const submitRealtimeTranscript = autoSubmitVoice && realtimeResponseModelId !== null;
   const recordingUnavailableReason = !secureRecordingContext
     ? t('chat.form.voiceErrors.secureContextRequired', 'Microphone requires HTTPS or localhost.')
     : !browserRecordingAvailable
@@ -571,13 +572,13 @@ export function ChatForm({
         let capture: RealtimePcmCapture | null = null;
         const socket = new RealtimeConversationSocket({
           transcriptionModelId: selectedTranscriptionId,
-          responseModelId: autoSubmitVoice ? realtimeResponseModelId : null,
+          responseModelId: submitRealtimeTranscript ? realtimeResponseModelId : null,
           onSpeechStarted: onStopSpeaking,
           onTranscript: (text, final) => {
             if (realtimeConversationRef.current !== socket) return;
-            setMessage(final && autoSubmitVoice ? '' : text);
+            setMessage(final && submitRealtimeTranscript ? '' : text);
             onRealtimeTranscript?.(text, final);
-            if (final && conversationStoppingRef.current && !autoSubmitVoice) {
+            if (final && conversationStoppingRef.current && !submitRealtimeTranscript) {
               finishConversation();
             }
           },
@@ -800,7 +801,7 @@ export function ChatForm({
     t,
     transcriptionReady,
     captureMode,
-    autoSubmitVoice,
+    submitRealtimeTranscript,
     onRealtimeAssistantText,
     onRealtimeResponseDone,
     onRealtimeTranscript,

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -8,6 +8,7 @@ import { Button } from '../common/Button';
 import { useSkulkTranslation } from '../../i18n/tolgee';
 import {
   finalizeRealtimeCaptureStartup,
+  RealtimeConversationSocket,
   RealtimePcmCapture,
   RealtimeTranscriptionSocket,
   selectTranscriptionCaptureMode,
@@ -52,6 +53,12 @@ export interface ChatFormProps {
   selectedVoice?: string | null;
   /** Whether final assistant messages should be spoken automatically. */
   autoSpeakAssistant?: boolean;
+  /** Enable a persistent server-VAD conversation instead of push-to-transcribe. */
+  realtimeVoiceEnabled?: boolean;
+  /** Route final realtime transcripts directly to the selected chat model. */
+  autoSubmitVoice?: boolean;
+  /** Mounted chat model used for automatic realtime responses. */
+  realtimeResponseModelId?: string | null;
   /** Whether a dashboard-managed audio playback is active. */
   isSpeaking?: boolean;
   /** Speech-related API error surfaced from the page container. */
@@ -64,6 +71,11 @@ export interface ChatFormProps {
   onSelectedVoiceChange?: (voice: string | null) => void;
   /** Toggle automatic TTS playback for final assistant messages. */
   onAutoSpeakAssistantChange?: (enabled: boolean) => void;
+  onRealtimeVoiceEnabledChange?: (enabled: boolean) => void;
+  onAutoSubmitVoiceChange?: (enabled: boolean) => void;
+  onRealtimeTranscript?: (text: string, final: boolean) => void;
+  onRealtimeAssistantText?: (text: string, final: boolean) => void;
+  onRealtimeResponseDone?: (status: string) => void;
   /** Transcribe a browser-recorded audio blob and return transcript text. */
   onTranscribeAudio?: (audio: Blob) => Promise<string>;
   /** Speak the current draft text with the selected TTS model. */
@@ -390,12 +402,20 @@ export function ChatForm({
   selectedSpeechModelId = null,
   selectedVoice = null,
   autoSpeakAssistant = false,
+  realtimeVoiceEnabled = true,
+  autoSubmitVoice = false,
+  realtimeResponseModelId = null,
   isSpeaking = false,
   voiceError = null,
   onSelectTranscriptionModel,
   onSelectSpeechModel,
   onSelectedVoiceChange,
   onAutoSpeakAssistantChange,
+  onRealtimeVoiceEnabledChange,
+  onAutoSubmitVoiceChange,
+  onRealtimeTranscript,
+  onRealtimeAssistantText,
+  onRealtimeResponseDone,
   onTranscribeAudio,
   onSpeakText,
   onStopSpeaking,
@@ -416,11 +436,13 @@ export function ChatForm({
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
   const realtimeSocketRef = useRef<RealtimeTranscriptionSocket | null>(null);
+  const realtimeConversationRef = useRef<RealtimeConversationSocket | null>(null);
   const realtimeCommitSocketRef = useRef<RealtimeTranscriptionSocket | null>(null);
   const realtimeCaptureRef = useRef<RealtimePcmCapture | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
   const recordingCancelledRef = useRef(false);
   const recordingStartingRef = useRef(false);
+  const conversationStoppingRef = useRef(false);
   const componentMountedRef = useRef(true);
   const recordingStartedAtRef = useRef(0);
   const recordingTimerRef = useRef<number | null>(null);
@@ -454,6 +476,7 @@ export function ChatForm({
   );
   const browserRecordingAvailable = captureMode !== null;
   const useRealtimeCapture = captureMode === 'realtime';
+  const useRealtimeConversation = useRealtimeCapture && realtimeVoiceEnabled;
   const recordingUnavailableReason = !secureRecordingContext
     ? t('chat.form.voiceErrors.secureContextRequired', 'Microphone requires HTTPS or localhost.')
     : !browserRecordingAvailable
@@ -544,6 +567,88 @@ export function ChatForm({
         return;
       }
       mediaStreamRef.current = stream;
+      if (useRealtimeConversation && selectedTranscriptionId) {
+        let capture: RealtimePcmCapture | null = null;
+        const socket = new RealtimeConversationSocket({
+          transcriptionModelId: selectedTranscriptionId,
+          responseModelId: autoSubmitVoice ? realtimeResponseModelId : null,
+          onSpeechStarted: onStopSpeaking,
+          onTranscript: (text, final) => {
+            if (realtimeConversationRef.current !== socket) return;
+            setMessage(final && autoSubmitVoice ? '' : text);
+            onRealtimeTranscript?.(text, final);
+            if (final && conversationStoppingRef.current && !autoSubmitVoice) {
+              finishConversation();
+            }
+          },
+          onAssistantText: (text, final) => {
+            if (realtimeConversationRef.current === socket) {
+              onRealtimeAssistantText?.(text, final);
+            }
+          },
+          onResponseDone: (status) => {
+            if (realtimeConversationRef.current !== socket) return;
+            onRealtimeResponseDone?.(status);
+            if (conversationStoppingRef.current) finishConversation();
+          },
+          onError: (error) => {
+            if (realtimeConversationRef.current !== socket) return;
+            setMediaError(error.message);
+            finishConversation();
+            stream.getTracks().forEach((track) => track.stop());
+            void capture?.stop();
+          },
+        });
+        const finishConversation = () => {
+          if (realtimeConversationRef.current !== socket) return;
+          realtimeConversationRef.current = null;
+          mediaStreamRef.current = null;
+          conversationStoppingRef.current = false;
+          socket.close();
+          stopRecordingTimer();
+          setIsRecording(false);
+          setIsTranscribing(false);
+          setRecordingSeconds(0);
+        };
+        realtimeConversationRef.current = socket;
+        conversationStoppingRef.current = false;
+        try {
+          await socket.connect();
+          capture = await RealtimePcmCapture.start(stream, (samples, sampleRate) => {
+            try {
+              socket.append(samples, sampleRate);
+            } catch (error) {
+              if (realtimeConversationRef.current !== socket) return;
+              const messageText = error instanceof Error
+                ? error.message
+                : t('chat.form.voiceErrors.recordingFailed', 'Recording failed.');
+              setMediaError(messageText);
+              finishConversation();
+              void capture?.stop();
+            }
+          });
+          if (!await finalizeRealtimeCaptureStartup(
+            capture,
+            componentMountedRef.current,
+            realtimeConversationRef.current === socket,
+          )) return;
+        } catch (error) {
+          realtimeConversationRef.current = null;
+          mediaStreamRef.current = null;
+          socket.close();
+          stream.getTracks().forEach((track) => track.stop());
+          throw error;
+        }
+        realtimeCaptureRef.current = capture;
+        recordingStartedAtRef.current = Date.now();
+        setIsRecording(true);
+        setRecordingSeconds(0);
+        stopRecordingTimer();
+        recordingTimerRef.current = window.setInterval(() => {
+          setRecordingSeconds(Math.floor((Date.now() - recordingStartedAtRef.current) / 1000));
+        }, 250);
+        return;
+      }
       if (useRealtimeCapture && selectedTranscriptionId) {
         let capture: RealtimePcmCapture | null = null;
         const socket = new RealtimeTranscriptionSocket({
@@ -695,10 +800,43 @@ export function ChatForm({
     t,
     transcriptionReady,
     captureMode,
+    autoSubmitVoice,
+    onRealtimeAssistantText,
+    onRealtimeResponseDone,
+    onRealtimeTranscript,
+    onStopSpeaking,
+    realtimeResponseModelId,
+    useRealtimeConversation,
     useRealtimeCapture,
   ]);
 
   const stopRecording = useCallback((cancelled: boolean) => {
+    const conversationSocket = realtimeConversationRef.current;
+    if (conversationSocket) {
+      const realtimeCapture = realtimeCaptureRef.current;
+      realtimeCaptureRef.current = null;
+      mediaStreamRef.current = null;
+      stopRecordingTimer();
+      setIsRecording(false);
+      setRecordingSeconds(0);
+      void realtimeCapture?.stop();
+      if (cancelled) {
+        realtimeConversationRef.current = null;
+        conversationStoppingRef.current = false;
+        conversationSocket.close();
+        return;
+      }
+      conversationStoppingRef.current = true;
+      setIsTranscribing(true);
+      const committed = conversationSocket.commitTurn();
+      if (!committed && !conversationSocket.hasActiveResponse()) {
+        realtimeConversationRef.current = null;
+        conversationStoppingRef.current = false;
+        conversationSocket.close();
+        setIsTranscribing(false);
+      }
+      return;
+    }
     const realtimeSocket = realtimeSocketRef.current;
     if (realtimeSocket) {
       const realtimeCapture = realtimeCaptureRef.current;
@@ -758,14 +896,17 @@ export function ChatForm({
       const mediaStream = mediaStreamRef.current;
       const realtimeSocket = realtimeSocketRef.current;
       const realtimeCommitSocket = realtimeCommitSocketRef.current;
+      const realtimeConversation = realtimeConversationRef.current;
       const realtimeCapture = realtimeCaptureRef.current;
       mediaStreamRef.current = null;
       realtimeSocketRef.current = null;
       realtimeCommitSocketRef.current = null;
+      realtimeConversationRef.current = null;
       realtimeCaptureRef.current = null;
       mediaStream?.getTracks().forEach((track) => track.stop());
       realtimeSocket?.cancel();
       realtimeCommitSocket?.cancel();
+      realtimeConversation?.close();
       void realtimeCapture?.stop();
     };
   }, [stopRecordingTimer]);
@@ -990,6 +1131,26 @@ export function ChatForm({
               >
                 <FiMic size={16} />
               </VoiceIconBtn>
+            )}
+            {selectedTranscriptionModel?.supportsRealtime && realtimeTranscriptionAvailable && (
+              <VoiceToggle
+                type="button"
+                disabled={isStartingRecording || isRecording || isTranscribing}
+                $active={realtimeVoiceEnabled}
+                onClick={() => onRealtimeVoiceEnabledChange?.(!realtimeVoiceEnabled)}
+              >
+                {t('chat.form.realtime', 'Realtime')}
+              </VoiceToggle>
+            )}
+            {useRealtimeConversation && canSendMessages && (
+              <VoiceToggle
+                type="button"
+                disabled={isStartingRecording || isRecording || isTranscribing}
+                $active={autoSubmitVoice}
+                onClick={() => onAutoSubmitVoiceChange?.(!autoSubmitVoice)}
+              >
+                {t('chat.form.autoSubmit', 'Auto-send')}
+              </VoiceToggle>
             )}
           </VoiceGroup>
 

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -477,7 +477,9 @@ export function ChatForm({
   const browserRecordingAvailable = captureMode !== null;
   const useRealtimeCapture = captureMode === 'realtime';
   const useRealtimeConversation = useRealtimeCapture && realtimeVoiceEnabled;
-  const submitRealtimeTranscript = autoSubmitVoice && realtimeResponseModelId !== null;
+  const submitRealtimeTranscript = autoSubmitVoice
+    && canSendMessages
+    && realtimeResponseModelId !== null;
   const recordingUnavailableReason = !secureRecordingContext
     ? t('chat.form.voiceErrors.secureContextRequired', 'Microphone requires HTTPS or localhost.')
     : !browserRecordingAvailable

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -1443,14 +1443,14 @@ export function ChatView({
   }, [activeConversationId, expandedThinkingMap, setExpandedThinking]);
 
   const handleRealtimeTranscript = useCallback((text: string, final: boolean) => {
-    if (!final || !autoSubmitVoice || !text.trim()) return;
+    if (!final || !autoSubmitVoice || !canSendMessages || !text.trim()) return;
     addMessage({
       id: uuidv4(),
       role: 'user',
       content: text.trim(),
       timestamp: Date.now(),
     });
-  }, [addMessage, autoSubmitVoice]);
+  }, [addMessage, autoSubmitVoice, canSendMessages]);
 
   const handleRealtimeAssistantText = useCallback((text: string, final: boolean) => {
     const visibleText = text.trimStart();

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -851,6 +851,10 @@ export function ChatView({
     setIsAutoSpeaking(false);
   }, []);
 
+  useEffect(() => {
+    if (!autoSpeakAssistant) stopSpeechPlayback();
+  }, [autoSpeakAssistant, stopSpeechPlayback]);
+
   const playSpeechSegment = useCallback(async (
     text: string,
     messageId: string | null,
@@ -1499,7 +1503,7 @@ export function ChatView({
     };
     addMessage(assistantMessage);
     const queue = speechSentenceQueueRef.current;
-    if (queue && realtimeSpeechTailRef.current.trim()) {
+    if (autoSpeakAssistant && queue && realtimeSpeechTailRef.current.trim()) {
       setIsAutoSpeaking(true);
       queue.enqueue([realtimeSpeechTailRef.current.trim()]);
     } else if (autoSpeakAssistant && selectedSpeechModelId && !queue) {

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -590,6 +590,8 @@ export function ChatView({
   const selectedSpeechModelId = useAppSelector((s) => s.chat.selectedSpeechModelId);
   const selectedVoice = useAppSelector((s) => s.chat.selectedVoice);
   const autoSpeakAssistant = useAppSelector((s) => s.chat.autoSpeakAssistant);
+  const realtimeVoiceEnabled = useAppSelector((s) => s.chat.realtimeVoiceEnabled);
+  const autoSubmitVoice = useAppSelector((s) => s.chat.autoSubmitVoice);
   const activeConversationId = useAppSelector((s) => s.chat.activeConversationId);
   const messages = useAppSelector((s) =>
     s.chat.activeConversationId
@@ -605,6 +607,10 @@ export function ChatView({
     dispatch(chatActions.setSelectedVoice(voice));
   const setAutoSpeakAssistant = (enabled: boolean) =>
     dispatch(chatActions.setAutoSpeakAssistant(enabled));
+  const setRealtimeVoiceEnabled = (enabled: boolean) =>
+    dispatch(chatActions.setRealtimeVoiceEnabled(enabled));
+  const setAutoSubmitVoice = (enabled: boolean) =>
+    dispatch(chatActions.setAutoSubmitVoice(enabled));
   const addMessage = (msg: ChatMessage) => dispatch(chatActions.addMessage(msg));
   const deleteMessageAction = (id: string) => dispatch(chatActions.deleteMessage(id));
   const editMessageAction = (messageId: string, content: string) =>
@@ -634,6 +640,8 @@ export function ChatView({
   const streamingPlaybackRef = useRef<StreamingSpeechPlayback | null>(null);
   const speechAbortRef = useRef<AbortController | null>(null);
   const speechSentenceQueueRef = useRef<SpeechSentenceQueue | null>(null);
+  const realtimeSpeechTextRef = useRef('');
+  const realtimeSpeechTailRef = useRef('');
 
   // Restore scroll position after store hydration + DOM render
   const dispatch = useAppDispatch();
@@ -1434,6 +1442,89 @@ export function ChatView({
     setExpandedThinking(activeConversationId, next);
   }, [activeConversationId, expandedThinkingMap, setExpandedThinking]);
 
+  const handleRealtimeTranscript = useCallback((text: string, final: boolean) => {
+    if (!final || !autoSubmitVoice || !text.trim()) return;
+    addMessage({
+      id: uuidv4(),
+      role: 'user',
+      content: text.trim(),
+      timestamp: Date.now(),
+    });
+  }, [addMessage, autoSubmitVoice]);
+
+  const handleRealtimeAssistantText = useCallback((text: string, final: boolean) => {
+    const visibleText = text.trimStart();
+    if (!final) {
+      setStreamingContent(visibleText);
+      if (
+        autoSpeakAssistant
+        && selectedSpeechModelId
+        && selectedSpeechOption?.supportsStreaming
+        && selectedSpeechOption.responseFormats.includes('pcm')
+        && canUseStreamingSpeechPlayback()
+      ) {
+        if (!speechSentenceQueueRef.current) {
+          speechSentenceQueueRef.current = new SpeechSentenceQueue(
+            (sentence, signal) => playSpeechSegment(sentence, null, signal),
+            (error) => {
+              setSpeechError(error instanceof Error
+                ? error.message
+                : t('chat.view.errors.speechSynthesisFailed', 'Speech synthesis failed.'));
+            },
+            () => setIsAutoSpeaking(false),
+          );
+        }
+        if (visibleText.startsWith(realtimeSpeechTextRef.current)) {
+          const delta = visibleText.slice(realtimeSpeechTextRef.current.length);
+          const split = splitCompleteSpeechSentences(realtimeSpeechTailRef.current + delta);
+          realtimeSpeechTailRef.current = split.remainder;
+          if (split.sentences.length > 0) {
+            setIsAutoSpeaking(true);
+            speechSentenceQueueRef.current.enqueue(split.sentences);
+          }
+        }
+        realtimeSpeechTextRef.current = visibleText;
+      }
+      return;
+    }
+
+    const finalText = text.trim();
+    setStreamingContent(null);
+    if (!finalText) return;
+    const assistantMessage: ChatMessage = {
+      id: uuidv4(),
+      role: 'assistant',
+      content: finalText,
+      timestamp: Date.now(),
+    };
+    addMessage(assistantMessage);
+    const queue = speechSentenceQueueRef.current;
+    if (queue && realtimeSpeechTailRef.current.trim()) {
+      setIsAutoSpeaking(true);
+      queue.enqueue([realtimeSpeechTailRef.current.trim()]);
+    } else if (autoSpeakAssistant && selectedSpeechModelId && !queue) {
+      void speakText(finalText, assistantMessage.id);
+    }
+    realtimeSpeechTextRef.current = '';
+    realtimeSpeechTailRef.current = '';
+  }, [
+    addMessage,
+    autoSpeakAssistant,
+    playSpeechSegment,
+    selectedSpeechModelId,
+    selectedSpeechOption,
+    speakText,
+    t,
+  ]);
+
+  const handleRealtimeResponseDone = useCallback((status: string) => {
+    if (status === 'completed') return;
+    setStreamingContent(null);
+    realtimeSpeechTextRef.current = '';
+    realtimeSpeechTailRef.current = '';
+    stopSpeechPlayback();
+  }, [stopSpeechPlayback]);
+
   if (readyModels.length === 0 && readyTranscriptionModels.length === 0 && readySpeechModels.length === 0) {
     return (
       <NoModels>
@@ -1496,12 +1587,20 @@ export function ChatView({
           selectedSpeechModelId={selectedSpeechModelId}
           selectedVoice={selectedVoice}
           autoSpeakAssistant={autoSpeakAssistant}
+          realtimeVoiceEnabled={realtimeVoiceEnabled}
+          autoSubmitVoice={autoSubmitVoice}
+          realtimeResponseModelId={selectedModelId}
           isSpeaking={speakingMessageId !== null || isAutoSpeaking}
           voiceError={speechError}
           onSelectTranscriptionModel={selectTranscriptionModel}
           onSelectSpeechModel={selectSpeechModel}
           onSelectedVoiceChange={setSelectedVoice}
           onAutoSpeakAssistantChange={setAutoSpeakAssistant}
+          onRealtimeVoiceEnabledChange={setRealtimeVoiceEnabled}
+          onAutoSubmitVoiceChange={setAutoSubmitVoice}
+          onRealtimeTranscript={handleRealtimeTranscript}
+          onRealtimeAssistantText={handleRealtimeAssistantText}
+          onRealtimeResponseDone={handleRealtimeResponseDone}
           onTranscribeAudio={transcribeAudio}
           onSpeakText={(text) => { void speakText(text, 'draft'); }}
           onStopSpeaking={stopSpeechPlayback}

--- a/dashboard-react/src/i18n/en/skulk.json
+++ b/dashboard-react/src/i18n/en/skulk.json
@@ -36,6 +36,8 @@
   "chat.form.noSpeechModels": "No TTS",
   "chat.form.noTranscriptionModels": "No STT",
   "chat.form.placeholder": "Type a message...",
+  "chat.form.realtime": "Realtime",
+  "chat.form.autoSubmit": "Auto-send",
   "chat.form.selectSpeechModel": "Select speech model",
   "chat.form.selectTranscriptionModel": "Select transcription model",
   "chat.form.sendMessage": "Send message",

--- a/dashboard-react/src/store/slices/chatSlice.ts
+++ b/dashboard-react/src/store/slices/chatSlice.ts
@@ -46,6 +46,8 @@ export interface ChatState {
   selectedSpeechModelId: string | null;
   selectedVoice: string | null;
   autoSpeakAssistant: boolean;
+  realtimeVoiceEnabled: boolean;
+  autoSubmitVoice: boolean;
   modelToConversationId: Record<string, string>;
 }
 
@@ -54,6 +56,8 @@ interface PersistedDurable {
   modelToConversationId?: Record<string, string>;
   selectedVoice?: string | null;
   autoSpeakAssistant?: boolean;
+  realtimeVoiceEnabled?: boolean;
+  autoSubmitVoice?: boolean;
 }
 
 interface PersistedSession {
@@ -99,6 +103,8 @@ function initialState(): ChatState {
     selectedSpeechModelId: session.selectedSpeechModelId ?? null,
     selectedVoice: durable.selectedVoice ?? null,
     autoSpeakAssistant: durable.autoSpeakAssistant ?? false,
+    realtimeVoiceEnabled: durable.realtimeVoiceEnabled ?? true,
+    autoSubmitVoice: durable.autoSubmitVoice ?? false,
   };
 }
 
@@ -172,6 +178,14 @@ const slice = createSlice({
 
     setAutoSpeakAssistant(state, action: PayloadAction<boolean>) {
       state.autoSpeakAssistant = action.payload;
+    },
+
+    setRealtimeVoiceEnabled(state, action: PayloadAction<boolean>) {
+      state.realtimeVoiceEnabled = action.payload;
+    },
+
+    setAutoSubmitVoice(state, action: PayloadAction<boolean>) {
+      state.autoSubmitVoice = action.payload;
     },
 
     addMessage(state, action: PayloadAction<ChatMessage>) {
@@ -336,6 +350,8 @@ export function subscribeChatPersistence(
         modelToConversationId: chat.modelToConversationId,
         selectedVoice: chat.selectedVoice,
         autoSpeakAssistant: chat.autoSpeakAssistant,
+        realtimeVoiceEnabled: chat.realtimeVoiceEnabled,
+        autoSubmitVoice: chat.autoSubmitVoice,
       },
       version: 1,
     };

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -1597,8 +1597,10 @@ declares streaming/realtime audio and the API node currently advertises the
 stable `stt.realtime` provider. An `AudioWorklet` captures mono browser
 samples, the dashboard continuously resamples them to 24 kHz PCM16, and the
 client aggregates worklet callbacks into 100 ms transport frames before the
-existing mic control commits the socket when recording stops. If either truth
-is absent, chat retains the batch `MediaRecorder` plus
+mic control commits the socket when recording stops. Realtime mode can retain
+the socket across server-VAD turns, show partial transcripts in the editable
+draft, and optionally auto-send final transcripts through the selected mounted
+chat model. If either capability truth is absent, chat retains the batch `MediaRecorder` plus
 `POST /v1/audio/transcriptions` path.
 
 When `response` is configured, the API node that owns the WebSocket retains the

--- a/website/docs/speech-fabric-realtime.md
+++ b/website/docs/speech-fabric-realtime.md
@@ -45,8 +45,9 @@ instead of broadcasting private media through gossipsub.
 
 `WS /v1/realtime?model=<model-id>` accepts OpenAI-style base64 PCM16 append and
 commit events over a WebSocket. It emits transcript delta, final, and failure
-events from the mounted realtime STT model. The route is a transcription
-compatibility surface, not a full speech-to-speech conversation API.
+events from the mounted realtime STT model. An optional response configuration
+routes final transcripts through a mounted chat model and can stream the visible
+answer through a mounted TTS participant.
 
 See [API Guide](api-guide.md) for request fields, response formats, limits, and
 errors.
@@ -106,6 +107,11 @@ model and local node advertise the required capabilities.
 - Realtime models use an `AudioWorklet` to capture mono Float32 browser audio.
 - A stateful browser resampler produces 24 kHz PCM16.
 - Capture callbacks are aggregated into bounded 100 ms transport frames.
+- Realtime mode keeps one multi-turn socket open, uses server VAD for automatic
+  turn boundaries, and shows partial transcripts in the editable chat draft.
+- Auto-send optionally routes final transcripts to the selected chat model;
+  assistant text remains visible while it streams and barge-in cancels active
+  response playback.
 - Batch-only models retain the `MediaRecorder` upload flow.
 - Transcription results populate the chat draft for review or submission.
 - Streaming-capable TTS models use sentence-sized raw PCM requests and a bounded


### PR DESCRIPTION
## Summary
- add a persistent server-VAD dashboard conversation client with live transcript and assistant text events
- add capability-gated Realtime and Auto-send chat controls while preserving batch transcription fallback
- route realtime assistant text through existing bounded streaming TTS playback and document released dashboard behavior

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (2319 passed, 1 skipped)
- `cd dashboard-react && npm test` (27 passed)
- `cd dashboard-react && npm run build`
- Storybook desktop and mobile visual inspection