### PR TITLE
fix(deployment): link CUDA builds against driver stubs on GPU-less runners

### DIFF
--- a/deployment/cuda/Dockerfile
+++ b/deployment/cuda/Dockerfile
@@ -21,6 +21,12 @@ ARG CUDA_ARCHS="86;89"
 # pipefail: a curl|sh installer whose download dies must fail the build, not
 # publish an image that is missing its toolchain.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# The CUDA Driver API library (libcuda.so: cuMemMap, cuGetErrorString, ...)
+# ships with the DRIVER, which a GPU-less CI runner does not have; the devel
+# image provides link-time stubs for exactly this case. Without this, the
+# llama.cpp link fails with undefined cu* references (maiden build). Runtime
+# resolution uses the pod's real driver; the stub never leaves this stage.
+ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       build-essential cmake git curl pkg-config python3-dev python3-pip \


### PR DESCRIPTION
## Problem

The maiden `cuda-pod-image` build (run 29204374828) failed at the `llama-server` link step with undefined `cu*` references (`cuMemMap`, `cuGetErrorString`, `cuDeviceGetAttribute`, ...). Those are CUDA **Driver API** symbols from `libcuda.so`, which ships with the NVIDIA driver — present on every real GPU machine (which is why the identical build recipe worked on the rented pod) but absent on GitHub's GPU-less runners.

## Fix

NVIDIA's devel base images ship link-time stubs at `/usr/local/cuda/lib64/stubs/` for exactly this case. The build stage now sets `LIBRARY_PATH` to that directory, which covers both CUDA compiles (the llama.cpp cmake link and the `llama-cpp-python` wheel build). At runtime the pod's real driver provides `libcuda.so`; the stub never leaves the build stage (the runtime stage copies only `build/bin` and `/opt/wheels`).

One line plus the why-comment. Validation is the workflow itself: merging re-fires the image build (Dockerfile is in its path triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)