### PR TITLE
fix: reject speech-only models from text generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- Text-generation compatibility endpoints now reject mounted TTS-only and
+  STT-only model cards before command dispatch, preventing modality mistakes
+  from reaching or restarting speech runners.
+
 - **Pooled (multi-node) GGUF placement no longer caps unified-memory nodes at
   their BIOS VRAM carve.** Admission for RPC placements previously sized each
   node against a VRAM-carve-only figure, which falsely refused pooled models

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -1615,7 +1615,8 @@ class API:
             summary="OpenAI Chat Completions-compatible text generation",
             description=(
                 "Generate text with an OpenAI Chat Completions-compatible payload. The requested "
-                "model must already be placed and running or Skulk will return a not-found error."
+                "model must already be placed, running, and declare TextGeneration; speech-only "
+                "models are rejected before command dispatch."
             ),
         )(self.chat_completions)
         self.app.post(
@@ -1676,6 +1677,10 @@ class API:
             "/bench/chat/completions",
             tags=["Compatibility APIs"],
             summary="Benchmark chat completions",
+            description=(
+                "Benchmark text generation for a placed model that declares "
+                "TextGeneration. Speech-only models are rejected before dispatch."
+            ),
         )(self.bench_chat_completions)
         self.app.post(
             "/v1/images/generations",
@@ -1712,7 +1717,7 @@ class API:
             summary="Anthropic Claude Messages-compatible endpoint",
             description=(
                 "Claude Messages-compatible text generation endpoint. As with chat completions, "
-                "the target model must already be placed and ready."
+                "the target model must already be placed, ready, and declare TextGeneration."
             ),
         )(self.claude_messages)
         self.app.post(
@@ -1722,7 +1727,7 @@ class API:
             summary="OpenAI Responses-compatible endpoint",
             description=(
                 "OpenAI Responses-compatible endpoint for text generation and reasoning-style "
-                "workflows backed by a placed Skulk model."
+                "workflows backed by a placed Skulk model that declares TextGeneration."
             ),
         )(self.openai_responses)
         self.app.post(
@@ -1773,7 +1778,10 @@ class API:
             response_model=None,
             tags=["Compatibility APIs"],
             summary="Ollama chat",
-            description="Ollama-compatible chat endpoint backed by Skulk model placement and routing.",
+            description=(
+                "Ollama-compatible chat endpoint backed by a placed model that "
+                "declares TextGeneration."
+            ),
             openapi_extra=_json_request_body(OllamaChatRequest.model_json_schema()),
         )(self.ollama_chat)
         self.app.post(
@@ -1793,7 +1801,10 @@ class API:
             response_model=None,
             tags=["Compatibility APIs"],
             summary="Ollama generate",
-            description="Ollama-compatible prompt-completion endpoint backed by a placed Skulk model.",
+            description=(
+                "Ollama-compatible prompt completion backed by a placed model "
+                "that declares TextGeneration."
+            ),
             openapi_extra=_json_request_body(OllamaGenerateRequest.model_json_schema()),
         )(self.ollama_generate)
         self.app.get(
@@ -3059,9 +3070,10 @@ class API:
         return await self._collect_text_generation_with_stats(command.command_id)
 
     async def _resolve_and_validate_text_model(self, model_id: ModelId) -> ModelId:
-        """Validate a text model exists and return the resolved model ID.
+        """Validate a mounted model supports text generation.
 
-        Raises HTTPException 404 if no instance is found for the model.
+        Raises HTTPException 404 if no instance is found for the model, or 400
+        when the mounted model does not declare ``TextGeneration``.
         """
         if not any(
             instance.shard_assignments.model_id == model_id
@@ -3071,6 +3083,12 @@ class API:
             raise HTTPException(
                 status_code=404,
                 detail=f"No instance found for model {model_id}",
+            )
+        model_card = await self._get_running_model_card(model_id)
+        if ModelTask.TextGeneration not in model_card.tasks:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Model {model_card.model_id} is not a text-generation model",
             )
         return model_id
 

--- a/src/skulk/api/tests/test_model_validation_order.py
+++ b/src/skulk/api/tests/test_model_validation_order.py
@@ -22,14 +22,19 @@ from skulk.api.types.ollama_api import (
     OllamaMessage,
 )
 from skulk.api.types.openai_responses import ResponsesRequest
-from skulk.shared.models.model_cards import ModelCard, ModelTask
+from skulk.shared.models.model_cards import (
+    AudioCardConfig,
+    AudioCardKind,
+    ModelCard,
+    ModelTask,
+)
 from skulk.shared.types.commands import TextGeneration
 from skulk.shared.types.common import CommandId, ModelId, NodeId
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.state import State
 from skulk.shared.types.text_generation import InputMessage, TextGenerationTaskParams
 from skulk.shared.types.worker.instances import InstanceId, MlxRingInstance
-from skulk.shared.types.worker.runners import RunnerId, ShardAssignments
+from skulk.shared.types.worker.runners import RunnerId, RunnerReady, ShardAssignments
 from skulk.shared.types.worker.shards import PipelineShardMetadata
 
 
@@ -66,7 +71,23 @@ def _build_running_state(running_card: ModelCard) -> State:
                 hosts_by_node={node_id: []},
                 ephemeral_port=52415,
             )
-        }
+        },
+        runners={runner_id: RunnerReady()},
+    )
+
+
+def _speech_card(task: ModelTask, kind: AudioCardKind) -> ModelCard:
+    """Build a mounted speech-only card for text-admission tests."""
+
+    return ModelCard(
+        model_id=ModelId(f"test/{kind.value}-only"),
+        storage_size=Memory.from_mb(100),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[task],
+        capabilities=[kind.value],
+        audio=AudioCardConfig(kind=kind),
     )
 
 
@@ -174,6 +195,46 @@ async def test_running_text_requests_use_in_memory_model_card(monkeypatch: pytes
     resolved = await _get_running_model_card_fn(api)(running_card.model_id)
 
     assert resolved == running_card
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("task", "kind"),
+    [
+        (ModelTask.TextToSpeech, AudioCardKind.TextToSpeech),
+        (ModelTask.SpeechToText, AudioCardKind.SpeechToText),
+    ],
+)
+async def test_chat_rejects_speech_only_models_before_dispatch(
+    task: ModelTask,
+    kind: AudioCardKind,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A modality mismatch must not emit text work or disturb the speech runner."""
+
+    card = _speech_card(task, kind)
+    api = object.__new__(API)
+    api.state = _build_running_state(card)
+
+    async def _fail_if_called(*_args: object, **_kwargs: object) -> Never:
+        raise AssertionError("speech-only models must fail before text dispatch")
+
+    monkeypatch.setattr("skulk.api.main.chat_request_to_text_generation", _fail_if_called)
+    monkeypatch.setattr(api, "_send_text_generation_with_images", _fail_if_called)
+
+    payload = ChatCompletionRequest(
+        model=card.model_id,
+        messages=[ChatCompletionMessage(role="user", content="hello")],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await api.chat_completions(payload)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == (
+        f"Model {card.model_id} is not a text-generation model"
+    )
+    assert all(isinstance(runner, RunnerReady) for runner in api.state.runners.values())
 
 
 @pytest.mark.anyio

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -15,6 +15,11 @@ That API has two jobs:
 
 A model must be placed and running before chat requests for it succeed; calling
 `/v1/chat/completions` for an unplaced model returns a 404 `No instance found`.
+Text-generation endpoints require the mounted card to declare `TextGeneration`;
+targeting a TTS-only or STT-only model returns **400 Bad Request** before any
+runner command is dispatched. This applies to Chat Completions, Responses,
+Claude, Ollama chat/generate, and benchmark adapters through their shared
+admission path.
 The [First Success Flow](#first-success-flow) below walks from placement to first
 token.
 
@@ -169,6 +174,8 @@ Requests are validated before dispatch: an empty `messages` array or a
 non-positive `max_tokens` returns **400 Bad Request** rather than being
 accepted and failing during generation. (This applies across the Claude,
 Ollama, and Responses wire formats too, which share the same dispatch path.)
+The mounted model must also declare `TextGeneration`; speech-only cards return
+**400 Bad Request** without affecting their speech runner.
 
 ### Context-length limits
 


### PR DESCRIPTION
## Summary
- require mounted models to declare `TextGeneration` before compatibility endpoints dispatch text work
- reject TTS-only and STT-only cards with a 400 while leaving speech runners untouched
- document the shared admission behavior across OpenAI, Claude, Ollama, and benchmark adapters

Closes #519

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `NIX_CONFIG="experimental-features = nix-command flakes" nix fmt`
- `uv run pytest` (2327 passed, 1 skipped)
- `uv run python scripts/export_openapi.py`