### PR TITLE
test: require dashboard speech browser coverage

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,6 +30,30 @@ jobs:
       - name: Ruff check
         run: uv run ruff check
 
+  dashboard-test:
+    name: Dashboard browser tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: dashboard-react/package-lock.json
+
+      - name: Install dashboard dependencies
+        working-directory: dashboard-react
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: dashboard-react
+        run: npx playwright install --with-deps chromium
+
+      - name: Run dashboard browser tests
+        working-directory: dashboard-react
+        run: npm run test
+
   test:
     name: Test
     runs-on: macos-26

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,8 @@ review threads remain:
 2. Verify that all new or modified API endpoints are documented in `website/docs/api-guide.md`.
 3. Verify that all new or modified API endpoints have proper FastAPI decorators (`tags`, `summary`, `description`).
 4. Verify that all new or modified public functions have docstrings.
-5. If the dashboard was changed, run `npm run build` in `dashboard-react/` to confirm it builds.
+5. If the dashboard was changed, run `npm run test` and `npm run build` in
+   `dashboard-react/` to confirm its Chromium suite and production build pass.
 6. Stage any files changed by formatters before committing.
 
 ## Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,7 +387,8 @@ review threads remain:
 2. Verify that all new or modified API endpoints are documented in `website/docs/api-guide.md`.
 3. Verify that all new or modified API endpoints have proper FastAPI decorators (`tags`, `summary`, `description`).
 4. Verify that all new or modified public functions have docstrings.
-5. If the dashboard was changed, run `npm run build` in `dashboard-react/` to confirm it builds.
+5. If the dashboard was changed, run `npm run test` and `npm run build` in
+   `dashboard-react/` to confirm its Chromium suite and production build pass.
 6. Stage any files changed by formatters before committing.
 
 ## Testing

--- a/dashboard-react/src/audio/realtimeTranscription.test.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.test.ts
@@ -1,12 +1,17 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   finalizeRealtimeCaptureStartup,
   RealtimeConversationSocket,
+  RealtimePcmCapture,
   RealtimeTranscriptionSocket,
   StreamingLinearResampler,
   realtimeTranscriptionUrl,
   selectTranscriptionCaptureMode,
 } from './realtimeTranscription';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('finalizeRealtimeCaptureStartup', () => {
   it('stops a capture that finishes after its session lost ownership', async () => {
@@ -386,6 +391,39 @@ describe('RealtimeConversationSocket', () => {
     expect(transcripts).toEqual([]);
   });
 
+  it('allows a fresh conversation after an unexpected socket close', async () => {
+    const firstSocket = new FakeWebSocket();
+    const errors: string[] = [];
+    const firstClient = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => firstSocket as unknown as WebSocket,
+      onError: (error) => errors.push(error.message),
+    });
+
+    const firstConnected = firstClient.connect();
+    firstSocket.serverEvent({ type: 'session.created' });
+    await firstConnected;
+    firstSocket.close(1011);
+    expect(errors).toEqual(['Realtime conversation connection closed unexpectedly.']);
+
+    const secondSocket = new FakeWebSocket();
+    const secondClient = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => secondSocket as unknown as WebSocket,
+    });
+    const secondConnected = secondClient.connect();
+    secondSocket.serverEvent({ type: 'session.created' });
+
+    await expect(secondConnected).resolves.toBeUndefined();
+    expect(JSON.parse(secondSocket.sent[0])).toMatchObject({
+      type: 'session.update',
+      session: { audio: { input: { transcription: { model: 'org/stt' } } } },
+    });
+    secondClient.close();
+  });
+
   it('drops a partial microphone frame at a server VAD turn boundary', async () => {
     const socket = new FakeWebSocket();
     const client = new RealtimeConversationSocket({
@@ -412,5 +450,90 @@ describe('RealtimeConversationSocket', () => {
     expect(Array.from(atob(append.audio), (char) => char.charCodeAt(0))).toEqual(
       new Array(4_800).fill(0),
     );
+  });
+});
+
+describe('RealtimePcmCapture', () => {
+  it('forwards worklet frames and releases the complete microphone graph', async () => {
+    const addModule = vi.fn().mockResolvedValue(undefined);
+    const resume = vi.fn().mockResolvedValue(undefined);
+    const close = vi.fn().mockResolvedValue(undefined);
+    const sourceConnect = vi.fn();
+    const sourceDisconnect = vi.fn();
+    const captureConnect = vi.fn();
+    const captureDisconnect = vi.fn();
+    const muteConnect = vi.fn();
+    const muteDisconnect = vi.fn();
+    const stopTrack = vi.fn();
+    const source = { connect: sourceConnect, disconnect: sourceDisconnect };
+    const mute = {
+      gain: { value: 1 },
+      connect: muteConnect,
+      disconnect: muteDisconnect,
+    };
+    const destination = {};
+
+    class FakeAudioContext {
+      readonly sampleRate = 48_000;
+      readonly audioWorklet = { addModule };
+      readonly destination = destination;
+
+      createMediaStreamSource(): MediaStreamAudioSourceNode {
+        return source as unknown as MediaStreamAudioSourceNode;
+      }
+
+      createGain(): GainNode {
+        return mute as unknown as GainNode;
+      }
+
+      resume = resume;
+      close = close;
+    }
+
+    const worklets: FakeAudioWorkletNode[] = [];
+    class FakeAudioWorkletNode {
+      readonly port: { onmessage: ((event: MessageEvent<unknown>) => void) | null } = {
+        onmessage: null,
+      };
+
+      constructor(_context: AudioContext, readonly name: string) {
+        worklets.push(this);
+      }
+
+      connect = captureConnect;
+      disconnect = captureDisconnect;
+    }
+
+    vi.stubGlobal('AudioContext', FakeAudioContext);
+    vi.stubGlobal('AudioWorkletNode', FakeAudioWorkletNode);
+    const stream = {
+      getTracks: () => [{ stop: stopTrack }],
+    } as unknown as MediaStream;
+    const received: Array<[Float32Array, number]> = [];
+
+    const capture = await RealtimePcmCapture.start(
+      stream,
+      (samples, sampleRate) => received.push([samples, sampleRate]),
+    );
+    const worklet = worklets[0];
+    expect(worklet).toBeDefined();
+    const samples = Float32Array.from([0.25, -0.5]);
+    worklet.port.onmessage?.(new MessageEvent('message', { data: samples }));
+
+    expect(addModule).toHaveBeenCalledWith('/realtime-pcm-worklet.js');
+    expect(sourceConnect).toHaveBeenCalledWith(worklet);
+    expect(captureConnect).toHaveBeenCalledWith(mute);
+    expect(muteConnect).toHaveBeenCalledWith(destination);
+    expect(mute.gain.value).toBe(0);
+    expect(received).toEqual([[samples, 48_000]]);
+
+    await capture.stop();
+
+    expect(worklet.port.onmessage).toBeNull();
+    expect(sourceDisconnect).toHaveBeenCalledOnce();
+    expect(captureDisconnect).toHaveBeenCalledOnce();
+    expect(muteDisconnect).toHaveBeenCalledOnce();
+    expect(stopTrack).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/dashboard-react/src/components/chat/ChatForm.test.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.test.tsx
@@ -1,0 +1,122 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ThemeProvider } from 'styled-components';
+import { userEvent } from 'vitest/browser';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { darkTheme } from '../../theme/theme';
+import type { ChatSpeechModelOption } from '../../types/chat';
+import { ChatForm } from './ChatForm';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../i18n/tolgee', () => ({
+  useSkulkTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function renderChatForm(props: React.ComponentProps<typeof ChatForm>): Promise<void> {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <ThemeProvider theme={darkTheme}>
+        <ChatForm {...props} />
+      </ThemeProvider>,
+    );
+  });
+}
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  Reflect.deleteProperty(navigator, 'mediaDevices');
+  vi.unstubAllGlobals();
+});
+
+describe('ChatForm speech controls', () => {
+  it('hides the speech toolbar when no mounted speech capability exists', async () => {
+    await renderChatForm({ onSend: vi.fn() });
+
+    expect(container?.querySelector('[aria-label="Select transcription model"]')).toBeNull();
+    expect(container?.querySelector('[aria-label="Select speech model"]')).toBeNull();
+  });
+
+  it('gates realtime controls and speaks a typed draft through mounted models', async () => {
+    vi.stubGlobal('AudioContext', class {});
+    vi.stubGlobal('AudioWorkletNode', class {});
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn() },
+    });
+    const transcriptionModel: ChatSpeechModelOption = {
+      modelId: 'org/realtime-stt',
+      label: 'Realtime STT',
+      supportsRealtime: true,
+    };
+    const speechModel: ChatSpeechModelOption = {
+      modelId: 'org/streaming-tts',
+      label: 'Streaming TTS',
+      defaultResponseFormat: 'pcm',
+      responseFormats: ['pcm', 'mp3'],
+      supportsStreaming: true,
+    };
+    const onRealtimeVoiceEnabledChange = vi.fn();
+    const onAutoSubmitVoiceChange = vi.fn();
+    const onAutoSpeakAssistantChange = vi.fn();
+    const onSpeakText = vi.fn();
+
+    await renderChatForm({
+      onSend: vi.fn(),
+      transcriptionModels: [transcriptionModel],
+      selectedTranscriptionModelId: transcriptionModel.modelId,
+      realtimeTranscriptionAvailable: true,
+      realtimeVoiceEnabled: true,
+      autoSubmitVoice: false,
+      realtimeResponseModelId: 'org/chat',
+      speechModels: [speechModel],
+      selectedSpeechModelId: speechModel.modelId,
+      onRealtimeVoiceEnabledChange,
+      onAutoSubmitVoiceChange,
+      onAutoSpeakAssistantChange,
+      onSpeakText,
+    });
+
+    const realtime = container?.querySelector<HTMLButtonElement>('button[aria-pressed="true"]');
+    const toggles = [...(container?.querySelectorAll<HTMLButtonElement>('button') ?? [])];
+    const autoSend = toggles.find((button) => button.textContent === 'Auto-send');
+    const autoSpeak = toggles.find((button) => button.textContent === 'Auto');
+    expect(realtime?.textContent).toBe('Realtime');
+    expect(autoSend).toBeDefined();
+    expect(autoSpeak).toBeDefined();
+
+    await act(async () => {
+      await userEvent.click(realtime!);
+      await userEvent.click(autoSend!);
+      await userEvent.click(autoSpeak!);
+    });
+    expect(onRealtimeVoiceEnabledChange).toHaveBeenCalledWith(false);
+    expect(onAutoSubmitVoiceChange).toHaveBeenCalledWith(true);
+    expect(onAutoSpeakAssistantChange).toHaveBeenCalledWith(true);
+
+    const textarea = container?.querySelector<HTMLTextAreaElement>('textarea');
+    const speakDraft = container?.querySelector<HTMLButtonElement>('[aria-label="Speak draft"]');
+    expect(textarea).not.toBeNull();
+    expect(speakDraft).not.toBeNull();
+    await act(async () => {
+      await userEvent.fill(textarea!, 'Speak this response');
+    });
+    expect(speakDraft?.disabled).toBe(false);
+    await act(async () => {
+      await userEvent.click(speakDraft!);
+    });
+    expect(onSpeakText).toHaveBeenCalledWith('Speak this response');
+  });
+});

--- a/dashboard-react/vite.config.ts
+++ b/dashboard-react/vite.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
       extends: true,
       test: {
         name: 'unit',
-        include: ['src/**/*.test.ts'],
+        include: ['src/**/*.test.{ts,tsx}'],
         browser: {
           enabled: true,
           headless: true,
@@ -71,7 +71,7 @@ export default defineConfig({
       })],
       test: {
         name: 'storybook',
-        exclude: ['src/**/*.test.ts'],
+        exclude: ['src/**/*.test.{ts,tsx}'],
         browser: {
           enabled: true,
           headless: true,


### PR DESCRIPTION
## Summary
- exercise dashboard speech capability gating and typed-draft TTS controls in headless Chromium
- verify Web Audio microphone frames reach the capture callback and every graph/track resource is released
- cover starting a fresh realtime conversation after an unexpected socket closure
- run the dashboard Chromium suite as a required CI job and record the command in agent guidance

## Validation
- `npm run test` (36 passed)
- `npx tsc --noEmit`
- targeted ESLint for changed TypeScript files
- `npm run build`
- `uv run basedpyright`
- `uv run ruff check`
- Nix formatting (0 files changed)
- `uv run pytest` (2350 passed, 1 skipped)