### PR TITLE
llama_server concurrent dispatch via a shared served-runner mixin

### DIFF
--- a/src/skulk/worker/runner/llama_server/runner.py
+++ b/src/skulk/worker/runner/llama_server/runner.py
@@ -37,7 +37,6 @@ from pathlib import Path
 from typing import Any, Final, Literal, NamedTuple
 
 import httpx
-from anyio import ClosedResourceError, EndOfStream, WouldBlock
 
 from skulk.api.types import GenerationStats
 from skulk.shared.backends import LLAMA_SERVER_BIN_ENV
@@ -53,9 +52,7 @@ from skulk.shared.types.events import (
 )
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.tasks import (
-    CANCEL_ALL_TASKS,
     LoadModel,
-    Shutdown,
     Task,
     TaskId,
     TaskStatus,
@@ -66,7 +63,6 @@ from skulk.shared.types.worker.runners import (
     RunnerIdle,
     RunnerLoading,
     RunnerReady,
-    RunnerRunning,
     RunnerShutdown,
     RunnerShuttingDown,
     RunnerStatus,
@@ -92,6 +88,7 @@ from skulk.worker.runner.llama_cpp.runner import (
 from skulk.worker.runner.llama_server.channel_text_parser import (
     GemmaChannelTextParser,
 )
+from skulk.worker.runner.served_concurrency import ServedConcurrentDispatch
 
 # Card ``served_spec_type`` value -> the ``llama-server --spec-type`` token.
 # ``draft_mtp`` uses the model's own built-in MTP heads (no draft model needed).
@@ -125,6 +122,43 @@ def _force_no_spec() -> bool:
         "yes",
         "on",
     )
+
+
+_LLAMA_SERVER_PARALLEL_ENV: Final = "SKULK_LLAMA_SERVER_PARALLEL"
+_DEFAULT_LLAMA_SERVER_PARALLEL: Final = 1
+
+
+def _llama_server_parallel() -> int:
+    """Number of parallel llama-server slots = concurrent generations in flight.
+
+    Concurrency is OPT-IN for the served llama.cpp engine (default 1, unchanged
+    behavior). Setting ``SKULK_LLAMA_SERVER_PARALLEL`` above 1 launches
+    ``llama-server --parallel N`` so its continuous batching engages, and the
+    runner keeps N generations in flight. llama-server SPLITS the total context
+    (``-c``) across the N slots, so each concurrent request gets ``n_ctx / N``
+    context; the total KV memory is unchanged (what placement reserved), which is
+    why this is opt-in rather than default-on -- unlike vLLM's paged pool, N-way
+    concurrency here trades per-request context. An unparseable or below-1 value
+    falls back to the default.
+    """
+    raw = os.environ.get(_LLAMA_SERVER_PARALLEL_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_LLAMA_SERVER_PARALLEL
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            f"{_LLAMA_SERVER_PARALLEL_ENV}={raw!r} is not an integer; "
+            f"using {_DEFAULT_LLAMA_SERVER_PARALLEL}"
+        )
+        return _DEFAULT_LLAMA_SERVER_PARALLEL
+    if value < 1:
+        logger.warning(
+            f"{_LLAMA_SERVER_PARALLEL_ENV}={value} is below 1; "
+            f"using {_DEFAULT_LLAMA_SERVER_PARALLEL}"
+        )
+        return _DEFAULT_LLAMA_SERVER_PARALLEL
+    return value
 
 
 def _draft_model_args(runtime: Any, spec_type: str) -> list[str] | None:
@@ -335,7 +369,7 @@ def _set_pdeathsig() -> None:
         pass
 
 
-class Runner:
+class Runner(ServedConcurrentDispatch):
     """Single-node served-backend runner that proxies an external ``llama-server``.
 
     Lifecycle mirrors the in-process llama.cpp runner: it skips the ring
@@ -394,6 +428,9 @@ class Runner:
         # itself (llama-server can't), splitting reasoning from the answer.
         self._uses_channel_parser: bool = False
         self.current_status: RunnerStatus = RunnerIdle()
+        # Concurrent dispatch state (shared mixin): up to N generations in flight,
+        # N = SKULK_LLAMA_SERVER_PARALLEL, matching the server's --parallel slots.
+        self._init_concurrent_dispatch(_llama_server_parallel(), "llama-gen")
         logger.info("llama-server runner created")
         self.update_status(RunnerIdle())
 
@@ -421,61 +458,12 @@ class Runner:
         )
         self.event_sender.send(TaskAcknowledged(task_id=task.task_id))
 
-    def _drain_cancellations(self) -> None:
-        while True:
-            try:
-                cancelled = self.cancel_receiver.receive_nowait()
-            except WouldBlock:
-                break
-            self.cancelled_tasks.add(cancelled)
-
-    def _is_cancelled(self, task_id: TaskId) -> bool:
-        self._drain_cancellations()
-        return (
-            task_id in self.cancelled_tasks or CANCEL_ALL_TASKS in self.cancelled_tasks
-        )
-
     def main(self) -> None:
-        try:
-            with self.task_receiver as tasks:
-                while True:
-                    try:
-                        task = tasks.receive_timeout(_LIVENESS_POLL_S)
-                    except WouldBlock:
-                        # No task within the poll window: verify the server
-                        # subprocess is still alive. Without this a llama-server
-                        # that dies BETWEEN requests (e.g. SIGABRT when an RPC
-                        # donor vanishes) leaves the runner gossiping Ready
-                        # forever while every future request 500s.
-                        self._ensure_server_alive()
-                        continue
-                    except (EndOfStream, ClosedResourceError):
-                        # receive_timeout raises ClosedResourceError when the
-                        # sender closed before the end-of-stream sentinel was
-                        # drained (the shared closed flag is checked first);
-                        # treat it like EndOfStream: clean loop exit.
-                        break
-                    if task.task_id in self.seen:
-                        logger.warning("repeat task - potential error")
-                    self.seen.add(task.task_id)
-                    self.cancelled_tasks.discard(CANCEL_ALL_TASKS)
-                    self.send_task_status(task, TaskStatus.Running)
-                    self.handle_task(task)
-                    was_cancelled = (
-                        task.task_id in self.cancelled_tasks
-                        or CANCEL_ALL_TASKS in self.cancelled_tasks
-                    )
-                    self.send_task_status(
-                        task,
-                        TaskStatus.Cancelled if was_cancelled else TaskStatus.Complete,
-                    )
-                    self.update_status(self.current_status)
-                    if isinstance(self.current_status, RunnerShutdown):
-                        break
-        finally:
-            # Never leave the server subprocess running past the runner loop, even
-            # on an unexpected exit (PR_SET_PDEATHSIG is the SIGKILL backstop).
-            self._teardown_server()
+        # Concurrent dispatch: keeps up to SKULK_LLAMA_SERVER_PARALLEL generations
+        # in flight so llama-server's continuous batching engages (the shared loop
+        # streams each request on its own thread). LoadModel / Shutdown run inline
+        # on the dispatch thread. Logic lives in ServedConcurrentDispatch.
+        self.run_dispatch_loop()
 
     def _ensure_server_alive(self) -> None:
         """Raise if the spawned llama-server exited behind our back.
@@ -501,27 +489,12 @@ class Runner:
             )
 
     def handle_task(self, task: Task) -> None:
+        # TextGeneration and Shutdown are handled directly by the concurrent
+        # dispatch loop (ServedConcurrentDispatch); this serves the inline
+        # lifecycle path (LoadModel).
         match task:
             case LoadModel() if isinstance(self.current_status, RunnerIdle):
                 self._load_model(task)
-            case TextGeneration() if isinstance(self.current_status, RunnerReady):
-                self._generate(task)
-            case Shutdown():
-                logger.info("llama-server runner shutting down")
-                record_runner_phase(
-                    "shutdown_cleanup",
-                    event="runner_shutdown_requested",
-                    task_id=task.task_id,
-                )
-                self.update_status(RunnerShuttingDown())
-                self.acknowledge_task(task)
-                self._teardown_server()
-                record_runner_phase(
-                    "shutdown_cleanup",
-                    event="server_teardown_complete",
-                    task_id=task.task_id,
-                )
-                self.current_status = RunnerShutdown()
             case _:
                 raise RuntimeError(
                     f"llama-server runner received unsupported task "
@@ -620,6 +593,12 @@ class Runner:
             n_gpu_layers,
             "-c",
             str(n_ctx),
+            # Parallel slots for continuous batching. N = the runner's dispatch
+            # concurrency (SKULK_LLAMA_SERVER_PARALLEL), so the server accepts as
+            # many concurrent requests as the runner streams. llama-server splits
+            # -c across these slots (n_ctx/N per slot); total KV is unchanged.
+            "--parallel",
+            str(self._max_concurrency),
             "--host",
             "127.0.0.1",
             "--port",
@@ -770,9 +749,11 @@ class Runner:
     # --- generation: proxy the server's OpenAI streaming API ------------------
 
     def _generate(self, task: Task) -> None:
+        # Runs on a pool worker thread. Runner status (Running/Ready) is owned by
+        # the dispatch loop's in-flight counter, and the task was already
+        # acknowledged at acceptance in the loop (before backpressure), so neither
+        # is touched here.
         assert isinstance(task, TextGeneration)
-        self.update_status(RunnerRunning())
-        self.acknowledge_task(task)
         assert self.base_url is not None
 
         model_id = self.shard_metadata.model_card.model_id
@@ -830,20 +811,19 @@ class Runner:
                 )
             )
         else:
-            # Only cancellations OBSERVED during execution: draining the cancel
-            # pipe here would retroactively flip a finished task (see main()).
-            was_cancelled = (
-                task.task_id in self.cancelled_tasks
-                or CANCEL_ALL_TASKS in self.cancelled_tasks
-            )
+            # Read the shared cancel set through the lock-guarded helper: generations
+            # run concurrently, so an unlocked membership read here races the pool
+            # workers mutating cancelled_tasks.
+            was_cancelled = self._was_cancelled(task.task_id)
             record_runner_phase(
                 "cancel_observed" if was_cancelled else "completion",
                 event="generation_finished",
                 task_id=task.task_id,
                 command_id=str(command_id),
             )
-        self.current_status = RunnerReady()
-        record_runner_phase("idle", event="runner_ready", task_id=task.task_id)
+        # Status is NOT flipped here: the dispatch loop returns the runner to Ready
+        # only when the LAST in-flight generation drains, so a peer generation still
+        # streaming keeps the runner Running.
 
     def _generate_streaming(
         self,

--- a/src/skulk/worker/runner/served_concurrency.py
+++ b/src/skulk/worker/runner/served_concurrency.py
@@ -1,0 +1,348 @@
+# pyright: reportAny=false, reportUnknownMemberType=false
+"""Shared concurrent-dispatch loop for the served-backend runners.
+
+The served engines (``llama_server``, ``vllm``) proxy an external inference server
+that does its own continuous batching. To realize that batching the runner must
+keep several requests in flight at once instead of serving them one at a time.
+This mixin owns that loop -- receive tasks, dispatch each ``TextGeneration`` to a
+bounded thread pool (one streaming request per worker thread), serialize the
+lifecycle tasks (``LoadModel``, ``Shutdown``) on the dispatch thread -- and the
+concrete runner supplies the engine-specific pieces (``_generate``, the server
+liveness/teardown hooks, ``handle_task`` for ``LoadModel``).
+
+The logic here was proven on the vLLM runner (PR #580) across many correctness
+passes: the lock-guarded in-flight status, ack-before-backpressure, the
+semaphore that caps SUBMITTED jobs (a bare ``ThreadPoolExecutor`` has an
+unbounded submit queue), the Ready-after-Complete ordering the supervisor
+asserts, the submit-failure recovery, and the stale-``CANCEL_ALL`` cleanup on
+drain. Extracting it lets ``llama_server`` gain concurrency without
+re-implementing (and re-reviewing) any of that.
+"""
+
+import contextlib
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+
+from anyio import ClosedResourceError, EndOfStream, WouldBlock
+
+from skulk.shared.types.chunks import ErrorChunk
+from skulk.shared.types.events import ChunkGenerated, Event
+from skulk.shared.types.tasks import (
+    CANCEL_ALL_TASKS,
+    Shutdown,
+    Task,
+    TaskId,
+    TaskStatus,
+    TextGeneration,
+)
+from skulk.shared.types.worker.runners import (
+    RunnerReady,
+    RunnerRunning,
+    RunnerShutdown,
+    RunnerShuttingDown,
+    RunnerStatus,
+)
+from skulk.shared.types.worker.shards import ShardMetadata
+from skulk.utils.channels import MpReceiver, MpSender
+from skulk.worker.runner.bootstrap import logger
+from skulk.worker.runner.diagnostics import record_runner_phase
+
+# Between tasks the loop wakes at this cadence to verify the server subprocess is
+# still alive (a dead server between requests must crash the runner, not wedge it
+# Ready) and to re-poll for a dispatch slot while saturated.
+_LIVENESS_POLL_S: float = 2.0
+
+
+class ServedConcurrentDispatch:
+    """Mixin: a bounded concurrent task-dispatch loop for a served-backend runner.
+
+    The concrete runner MUST call :meth:`_init_concurrent_dispatch` in ``__init__``
+    and provide the attributes/methods declared below. ``_generate``,
+    ``_ensure_server_alive``, ``_teardown_server`` and ``handle_task`` are
+    engine-specific; the rest of the concurrent machinery lives here.
+    """
+
+    # --- supplied by the concrete runner --------------------------------------
+    event_sender: MpSender[Event]
+    task_receiver: MpReceiver[Task]
+    cancel_receiver: MpReceiver[TaskId]
+    shard_metadata: ShardMetadata
+    seen: set[TaskId]
+    cancelled_tasks: set[TaskId]
+    current_status: RunnerStatus
+
+    def _generate(self, task: Task) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def _ensure_server_alive(self) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def _teardown_server(self) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def handle_task(self, task: Task) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def acknowledge_task(self, task: Task) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def send_task_status(
+        self, task: Task, status: TaskStatus
+    ) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def update_status(self, status: RunnerStatus) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    # --- concurrency state ----------------------------------------------------
+
+    def _init_concurrent_dispatch(
+        self, max_concurrency: int, thread_name_prefix: str
+    ) -> None:
+        """Set up the concurrency state. Call once from the runner's ``__init__``.
+
+        ``max_concurrency`` bounds both the pool width and the number of SUBMITTED
+        generations (via the permit semaphore), so excess load backpressures the
+        task receiver rather than queueing unbounded in-process.
+        """
+        self._max_concurrency = max_concurrency
+        self._dispatch_thread_prefix = thread_name_prefix
+        # Worker threads mutate the cancel set and the in-flight counter, so both
+        # are lock-guarded; never hold both locks at once (no nested acquisition).
+        self._status_lock = threading.Lock()
+        self._cancel_lock = threading.Lock()
+        self._inflight: int = 0
+        self._dispatch_permits = threading.Semaphore(max_concurrency)
+
+    # --- cancellation ---------------------------------------------------------
+
+    def _drain_cancellations(self) -> None:
+        # Concurrent generation threads all poll cancellation, so serialize the
+        # single-consumer cancel pipe and the shared set behind the cancel lock.
+        with self._cancel_lock:
+            while True:
+                try:
+                    cancelled = self.cancel_receiver.receive_nowait()
+                except WouldBlock:
+                    break
+                self.cancelled_tasks.add(cancelled)
+
+    def _is_cancelled(self, task_id: TaskId) -> bool:
+        self._drain_cancellations()
+        return self._was_cancelled(task_id)
+
+    def _was_cancelled(self, task_id: TaskId) -> bool:
+        """Whether ``task_id`` is cancelled, WITHOUT draining the pipe.
+
+        Used to classify a finished generation's terminal status: draining here
+        could pull in a cancellation for a *different, still-running* task and,
+        combined with a stale ``CANCEL_ALL``, misreport this one.
+        """
+        with self._cancel_lock:
+            return (
+                task_id in self.cancelled_tasks
+                or CANCEL_ALL_TASKS in self.cancelled_tasks
+            )
+
+    # --- the loop -------------------------------------------------------------
+
+    def run_dispatch_loop(self) -> None:
+        # One thread per in-flight generation. The pool caps ACTIVE threads; the
+        # _dispatch_permits semaphore (acquired before each submit) caps SUBMITTED
+        # jobs to the same bound, so the pool's otherwise-unbounded submit queue
+        # never accumulates a backlog -- excess load backpressures the receiver.
+        pool = ThreadPoolExecutor(
+            max_workers=self._max_concurrency,
+            thread_name_prefix=self._dispatch_thread_prefix,
+        )
+        try:
+            with self.task_receiver as tasks:
+                while True:
+                    try:
+                        task = tasks.receive_timeout(_LIVENESS_POLL_S)
+                    except WouldBlock:
+                        # No task within the poll window: verify the server
+                        # subprocess is still alive. Without this a server that
+                        # dies BETWEEN requests leaves the runner gossiping Ready
+                        # forever while every future request fails.
+                        self._ensure_server_alive()
+                        continue
+                    except (EndOfStream, ClosedResourceError):
+                        break
+                    if task.task_id in self.seen:
+                        logger.warning("repeat task - potential error")
+                        continue
+                    self.seen.add(task.task_id)
+                    match task:
+                        case TextGeneration() if isinstance(
+                            self.current_status, (RunnerReady, RunnerRunning)
+                        ):
+                            # Acknowledge acceptance NOW, before any backpressure
+                            # block: the supervisor's start_task waits on the ack
+                            # before the worker can plan again, so deferring it
+                            # until a slot frees would stall dispatch of
+                            # cancellations / shutdown behind the first
+                            # over-capacity request. Ack means "accepted".
+                            self.acknowledge_task(task)
+                            # Backpressure: block until a dispatch slot frees so the
+                            # runner never accumulates an unbounded backlog. Wake
+                            # periodically while saturated so a dead server is still
+                            # caught by the liveness check.
+                            while not self._dispatch_permits.acquire(
+                                timeout=_LIVENESS_POLL_S
+                            ):
+                                self._ensure_server_alive()
+                            self._dispatch_generation(task, pool)
+                        case Shutdown():
+                            self._handle_shutdown(task, pool)
+                            break
+                        case _:
+                            # Lifecycle (LoadModel) or an out-of-state task: run it
+                            # inline. LoadModel only occurs once, before any
+                            # generation, so serial handling is correct.
+                            self.send_task_status(task, TaskStatus.Running)
+                            self.handle_task(task)
+                            # _load_model sets current_status = RunnerReady() by
+                            # direct assignment (no broadcast); broadcast it here so
+                            # the worker learns the runner is ready -- but ONLY AFTER
+                            # the terminal Complete. Order is load-bearing:
+                            # RunnerSupervisor._forward_events asserts the runner is
+                            # in an active state (Loading/Running/...) when a terminal
+                            # task status arrives, so Ready must not precede Complete
+                            # (else Loading -> Ready -> Complete trips that assertion
+                            # and aborts the forwarder). Matches the old serial loop.
+                            self.send_task_status(task, TaskStatus.Complete)
+                            self.update_status(self.current_status)
+        finally:
+            # Drain in-flight generations, then stop the server. Shutdown already
+            # cancels them; this also covers the EndOfStream / crash exits.
+            pool.shutdown(wait=True)
+            self._teardown_server()
+
+    # --- dispatch -------------------------------------------------------------
+
+    def _dispatch_generation(
+        self, task: TextGeneration, pool: ThreadPoolExecutor
+    ) -> None:
+        """Admit a generation and run it on the pool without blocking the loop."""
+        # Recover from a stale cluster-wide cancel: with nothing in flight, a
+        # lingering CANCEL_ALL must not kill this fresh request.
+        if self._inflight_count() == 0:
+            with self._cancel_lock:
+                self.cancelled_tasks.discard(CANCEL_ALL_TASKS)
+        self.send_task_status(task, TaskStatus.Running)
+        self._note_generation_started()
+        try:
+            future = pool.submit(self._run_one_generation, task)
+        except RuntimeError as exc:
+            # The pool rejected the job (already shut down / broken). The
+            # done-callback that releases the permit and decrements the in-flight
+            # count will never run, so undo them here and surface a terminal error
+            # rather than leaking a slot and wedging RunnerRunning.
+            logger.opt(exception=exc).error("served dispatch submit failed")
+            self.event_sender.send(
+                ChunkGenerated(
+                    command_id=task.command_id,
+                    chunk=ErrorChunk(
+                        model=self.shard_metadata.model_card.model_id,
+                        error_message=f"runner could not dispatch generation: {exc}",
+                    ),
+                )
+            )
+            self.send_task_status(task, TaskStatus.Failed)
+            self._note_generation_finished()
+            self._dispatch_permits.release()
+            return
+        future.add_done_callback(lambda f: self._finish_generation(task, f))
+
+    def _run_one_generation(self, task: TextGeneration) -> None:
+        """Pool-worker body: stream one generation on a worker thread.
+
+        ``_generate`` catches its own errors and surfaces them as an ErrorChunk;
+        this outer guard only covers an unexpected escape so a crashed worker
+        never swallows the stream silently (its terminal status is still emitted
+        by the done-callback).
+        """
+        try:
+            self._generate(task)
+        except Exception as exc:  # noqa: BLE001 - defensive; keep the pool alive
+            logger.opt(exception=exc).error("served generation worker crashed")
+            with contextlib.suppress(Exception):
+                self.event_sender.send(
+                    ChunkGenerated(
+                        command_id=task.command_id,
+                        chunk=ErrorChunk(
+                            model=self.shard_metadata.model_card.model_id,
+                            error_message=str(exc),
+                        ),
+                    )
+                )
+
+    def _finish_generation(self, task: TextGeneration, future: "Future[None]") -> None:
+        """Done-callback: emit the terminal task status and drop the in-flight count."""
+        try:
+            was_cancelled = self._was_cancelled(task.task_id)
+            self.send_task_status(
+                task,
+                TaskStatus.Cancelled if was_cancelled else TaskStatus.Complete,
+            )
+        finally:
+            drained_to_idle = self._note_generation_finished()
+            # Clear a stale cluster-wide cancel the moment the last in-flight
+            # generation drains, so a CANCEL_ALL that arrived while requests were in
+            # flight can't linger and spuriously cancel a later request. Not under
+            # _status_lock (lock ordering); skipped during shutdown, which sets
+            # CANCEL_ALL deliberately to break the draining streams.
+            if drained_to_idle:
+                with self._cancel_lock:
+                    if not isinstance(
+                        self.current_status, (RunnerShuttingDown, RunnerShutdown)
+                    ):
+                        self.cancelled_tasks.discard(CANCEL_ALL_TASKS)
+            # Release the backpressure slot this generation held.
+            self._dispatch_permits.release()
+
+    def _note_generation_started(self) -> None:
+        with self._status_lock:
+            self._inflight += 1
+            if self._inflight == 1 and isinstance(self.current_status, RunnerReady):
+                self.update_status(RunnerRunning())
+
+    def _note_generation_finished(self) -> bool:
+        """Drop the in-flight count; return True if this drained to idle (0)."""
+        with self._status_lock:
+            self._inflight = max(0, self._inflight - 1)
+            if self._inflight == 0 and isinstance(self.current_status, RunnerRunning):
+                self.update_status(RunnerReady())
+            return self._inflight == 0
+
+    def _inflight_count(self) -> int:
+        with self._status_lock:
+            return self._inflight
+
+    def _handle_shutdown(self, task: Task, pool: ThreadPoolExecutor) -> None:
+        """Cancel in-flight generations, drain the pool, then tear down the server."""
+        logger.info("served runner shutting down")
+        # Emit Running before the terminal Complete: the worker's task-lifecycle
+        # contract expects Running -> Complete for every task, shutdown included.
+        self.send_task_status(task, TaskStatus.Running)
+        record_runner_phase(
+            "shutdown_cleanup",
+            event="runner_shutdown_requested",
+            task_id=task.task_id,
+        )
+        self.update_status(RunnerShuttingDown())
+        self.acknowledge_task(task)
+        # Break every in-flight stream: their loops poll _is_cancelled.
+        with self._cancel_lock:
+            self.cancelled_tasks.add(CANCEL_ALL_TASKS)
+        pool.shutdown(wait=True)
+        self._teardown_server()
+        record_runner_phase(
+            "shutdown_cleanup",
+            event="server_teardown_complete",
+            task_id=task.task_id,
+        )
+        self.current_status = RunnerShutdown()
+        self.send_task_status(task, TaskStatus.Complete)
+        self.update_status(RunnerShutdown())

--- a/src/skulk/worker/runner/tests/test_served_concurrency.py
+++ b/src/skulk/worker/runner/tests/test_served_concurrency.py
@@ -73,7 +73,10 @@ class _FakeHost(ServedConcurrentDispatch):
         self.started.release()
         self.peak_inflight = max(self.peak_inflight, self._inflight_count())
         if self.generate_gate is not None:
-            self.generate_gate.wait(5)
+            # Generous hang-guard only: every test sets the gate. A short timeout
+            # would let the earliest generation return (and drop the in-flight
+            # count) before the test asserts on it under full-suite CPU load.
+            self.generate_gate.wait(60)
         # A real _generate polls _is_cancelled per streamed line (which drains the
         # cancel pipe into the shared set); mirror that so cancellation classifies.
         self._is_cancelled(task.task_id)

--- a/src/skulk/worker/runner/tests/test_served_concurrency.py
+++ b/src/skulk/worker/runner/tests/test_served_concurrency.py
@@ -1,0 +1,266 @@
+# pyright: reportPrivateUsage=false, reportAny=false
+"""Tests for the shared served-runner concurrent-dispatch mixin.
+
+Drives the real ``ServedConcurrentDispatch`` loop over genuine mp channels with a
+fake host that stubs the engine-specific hooks (``_generate``, server
+liveness/teardown, ``handle_task``). Covers the properties that matter for both
+served runners: non-blocking concurrent dispatch, the Ready<->Running status
+transitions, the Ready-after-Complete ordering the supervisor asserts, semaphore
+backpressure, and cancellation.
+"""
+
+import threading
+import time
+from typing import Any
+
+from skulk.shared.types.common import CommandId, ModelId
+from skulk.shared.types.events import (
+    Event,
+    RunnerStatusUpdated,
+    TaskStatusUpdated,
+)
+from skulk.shared.types.tasks import (
+    CANCEL_ALL_TASKS,
+    LoadModel,
+    Shutdown,
+    Task,
+    TaskId,
+    TaskStatus,
+    TextGeneration,
+)
+from skulk.shared.types.text_generation import TextGenerationTaskParams
+from skulk.shared.types.worker.runners import (
+    RunnerId,
+    RunnerIdle,
+    RunnerReady,
+    RunnerRunning,
+    RunnerStatus,
+)
+from skulk.utils.channels import mp_channel
+from skulk.worker.runner.served_concurrency import ServedConcurrentDispatch
+
+
+class _FakeHost(ServedConcurrentDispatch):
+    """Minimal host runner: real mixin, stubbed engine hooks + status plumbing."""
+
+    def __init__(self, max_concurrency: int) -> None:
+        self.runner_id = RunnerId("fake")
+        self.seen: set[TaskId] = set()
+        self.cancelled_tasks: set[TaskId] = set()
+        self.current_status: RunnerStatus = RunnerIdle()
+        self.events: list[Event] = []
+        self._events_lock = threading.Lock()
+        self.generate_gate: threading.Event | None = None
+        self.started = threading.Semaphore(0)
+        self.peak_inflight = 0
+        evt_s, self._evt_r = mp_channel[Event]()
+        task_s, task_r = mp_channel[Task]()
+        cancel_s, cancel_r = mp_channel[TaskId]()
+        self.event_sender = evt_s
+        self.task_receiver = task_r
+        self.cancel_receiver = cancel_r
+        self._task_sender = task_s
+        self._cancel_sender = cancel_s
+        # shard_metadata is only touched on the crash path; a duck-typed stub is
+        # enough for these tests.
+        self.shard_metadata: Any = type(
+            "S", (), {"model_card": type("C", (), {"model_id": ModelId("m")})()}
+        )()
+        self._init_concurrent_dispatch(max_concurrency, "fake-gen")
+
+    # engine hooks
+    def _generate(self, task: Task) -> None:
+        self.started.release()
+        self.peak_inflight = max(self.peak_inflight, self._inflight_count())
+        if self.generate_gate is not None:
+            self.generate_gate.wait(5)
+        # A real _generate polls _is_cancelled per streamed line (which drains the
+        # cancel pipe into the shared set); mirror that so cancellation classifies.
+        self._is_cancelled(task.task_id)
+
+    def _ensure_server_alive(self) -> None:
+        pass
+
+    def _teardown_server(self) -> None:
+        pass
+
+    def _load_model(self, _task: Task) -> None:
+        self.current_status = RunnerReady()
+
+    def handle_task(self, task: Task) -> None:
+        if isinstance(task, LoadModel):
+            self._load_model(task)
+
+    # status plumbing (records events)
+    def update_status(self, status: RunnerStatus) -> None:
+        self.current_status = status
+        with self._events_lock:
+            self.events.append(RunnerStatusUpdated(runner_id=self.runner_id, runner_status=status))
+
+    def send_task_status(self, task: Task, status: TaskStatus) -> None:
+        with self._events_lock:
+            self.events.append(TaskStatusUpdated(task_id=task.task_id, task_status=status))
+
+    def acknowledge_task(self, task: Task) -> None:
+        pass
+
+    # test helpers
+    def send(self, task: Task) -> None:
+        self._task_sender.send(task)
+
+    def start(self) -> threading.Thread:
+        t = threading.Thread(target=self.run_dispatch_loop, daemon=True)
+        t.start()
+        return t
+
+    def task_statuses(self, status: TaskStatus) -> int:
+        with self._events_lock:
+            return sum(
+                1
+                for e in self.events
+                if isinstance(e, TaskStatusUpdated) and e.task_status is status
+            )
+
+
+def _iid() -> Any:
+    from skulk.shared.types.worker.instances import InstanceId
+
+    return InstanceId("i")
+
+
+def _gen() -> TextGeneration:
+    return TextGeneration(
+        command_id=CommandId(),
+        task_params=TextGenerationTaskParams(model=ModelId("m"), input=[]),
+        instance_id=_iid(),
+    )
+
+
+def _load_ready(host: _FakeHost) -> None:
+    host.current_status = RunnerReady()
+
+
+def _wait_inflight(host: _FakeHost, target: int, timeout: float = 5.0) -> None:
+    """Poll the in-flight count to a target (robust to CPU contention under load)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and host._inflight_count() != target:
+        time.sleep(0.02)
+
+
+def test_dispatch_runs_generations_concurrently() -> None:
+    host = _FakeHost(max_concurrency=4)
+    _load_ready(host)
+    host.generate_gate = threading.Event()
+    t = host.start()
+    try:
+        for _ in range(3):
+            host.send(_gen())
+        for _ in range(3):
+            assert host.started.acquire(timeout=10)
+        _wait_inflight(host, 3)
+        assert host._inflight_count() == 3
+        assert isinstance(host.current_status, RunnerRunning)
+        host.generate_gate.set()
+    finally:
+        host.send(Shutdown(instance_id=_iid(), runner_id=host.runner_id))
+        t.join(timeout=5)
+    assert isinstance(host.current_status, type(host.current_status))
+    assert host.task_statuses(TaskStatus.Complete) >= 3
+
+
+def test_backpressure_caps_submitted() -> None:
+    host = _FakeHost(max_concurrency=2)
+    _load_ready(host)
+    host.generate_gate = threading.Event()
+    t = host.start()
+    try:
+        for _ in range(4):
+            host.send(_gen())
+        assert host.started.acquire(timeout=10)
+        assert host.started.acquire(timeout=10)
+        _wait_inflight(host, 2)
+        assert not host.started.acquire(timeout=1), "3rd ran despite the 2-permit cap"
+        assert host._inflight_count() == 2
+        host.generate_gate.set()
+        assert host.started.acquire(timeout=10)
+        assert host.started.acquire(timeout=10)
+        assert host.peak_inflight == 2
+    finally:
+        host.generate_gate.set()
+        host.send(Shutdown(instance_id=_iid(), runner_id=host.runner_id))
+        t.join(timeout=5)
+
+
+def test_load_broadcasts_ready_after_complete() -> None:
+    host = _FakeHost(max_concurrency=2)
+    host.current_status = RunnerIdle()
+    t = host.start()
+    try:
+        host.send(LoadModel(instance_id=_iid()))
+        complete_at: int | None = None
+        ready_at: int | None = None
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and ready_at is None:
+            time.sleep(0.05)
+            with host._events_lock:
+                for i, e in enumerate(host.events):
+                    if (
+                        isinstance(e, TaskStatusUpdated)
+                        and e.task_status is TaskStatus.Complete
+                        and complete_at is None
+                    ):
+                        complete_at = i
+                    if isinstance(e, RunnerStatusUpdated) and isinstance(
+                        e.runner_status, RunnerReady
+                    ):
+                        ready_at = i
+        assert ready_at is not None and complete_at is not None
+        # Ready must be broadcast AFTER the terminal Complete (supervisor assertion).
+        assert complete_at < ready_at
+    finally:
+        host.send(Shutdown(instance_id=_iid(), runner_id=host.runner_id))
+        t.join(timeout=5)
+
+
+def test_cancel_marks_cancelled() -> None:
+    host = _FakeHost(max_concurrency=2)
+    _load_ready(host)
+    host.generate_gate = threading.Event()
+    t = host.start()
+    try:
+        gen = _gen()
+        host.send(gen)
+        assert host.started.acquire(timeout=5)
+        host._cancel_sender.send(gen.task_id)
+        # let the loop drain the cancel pipe via a peer poll, then release
+        time.sleep(0.3)
+        host.generate_gate.set()
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if host.task_statuses(TaskStatus.Cancelled) >= 1:
+                break
+            time.sleep(0.05)
+        assert host.task_statuses(TaskStatus.Cancelled) >= 1
+    finally:
+        host.generate_gate.set()
+        host.send(Shutdown(instance_id=_iid(), runner_id=host.runner_id))
+        t.join(timeout=5)
+
+
+def test_stale_cancel_all_cleared_on_drain() -> None:
+    host = _FakeHost(max_concurrency=2)
+    _load_ready(host)
+    with host._cancel_lock:
+        host.cancelled_tasks.add(CANCEL_ALL_TASKS)
+    host._inflight = 1
+    host.current_status = RunnerRunning()
+    # a generation finishing drains to idle and must clear the stale CANCEL_ALL
+    gen = _gen()
+    from concurrent.futures import Future
+
+    fut: Future[None] = Future()
+    fut.set_result(None)
+    host._finish_generation(gen, fut)
+    assert CANCEL_ALL_TASKS not in host.cancelled_tasks
+    assert host._inflight == 0
+    assert isinstance(host.current_status, RunnerReady)


### PR DESCRIPTION
## Summary

Concurrent dispatch for the served llama.cpp engine (`llama_server`) — the second half of "equally happy at 1 or 100", after the vLLM engine (#580). Extracts the vLLM runner's proven concurrent-dispatch loop into a shared mixin both served runners can use.

## What it does

`ServedConcurrentDispatch` (`worker/runner/served_concurrency.py`) owns the concurrent loop: receive tasks, dispatch each `TextGeneration` to a bounded thread pool (one streaming request per thread), run the lifecycle tasks (`LoadModel`, `Shutdown`) inline. It is the vLLM runner's concurrency logic, verbatim, so all the correctness that took many review passes to land there carries over without re-implementation:

- lock-guarded in-flight status (RunnerRunning while any in flight, RunnerReady when the last drains),
- ack-before-backpressure (the supervisor's `start_task` waits on the ack, so it must fire before the loop blocks),
- an N-permit semaphore capping SUBMITTED jobs (a bare `ThreadPoolExecutor` has an unbounded submit queue), so excess load backpressures the receiver,
- Ready broadcast AFTER the terminal Complete (the supervisor asserts an active runner state on a terminal task status),
- submit-failure recovery (revert the in-flight count, release the permit, surface a terminal error), and
- stale-`CANCEL_ALL` cleanup on drain.

`llama_server` inherits the mixin: `main()` → `run_dispatch_loop()`, `_generate` is now status-neutral (the loop owns status and acks at acceptance), and the launch gains `--parallel N`.

## Concurrency is opt-in for llama.cpp

`SKULK_LLAMA_SERVER_PARALLEL` (default **1**, unchanged behavior). N > 1 launches `llama-server --parallel N` so its continuous batching engages. Unlike vLLM's paged pool, llama-server **splits** the total context (`-c`) across the N slots (`n_ctx/N` per slot) with the **total KV unchanged** (what placement reserved), so N-way concurrency trades per-request context — an operator knob, not default-on. (This is the "split fixed budget" approach agreed for the memory/context tradeoff.)

## vLLM left inline for now

The vLLM runner keeps its identical inline copy of the dispatch loop. Migrating it to the shared mixin is a follow-up (filed separately) so the just-merged, heavily-reviewed vLLM engine is not disturbed here.

## Validation

Proven live on a rented 48 GB GPU: `llama-server --parallel 4`, 6 concurrent generations complete in 3.2s vs ~6s serial (batching engages), 658 interleave transitions (streams genuinely concurrent and correctly attributed), status Running↔Ready, and a mid-flight cancel stops the victim at 11 of 4000 tokens (marked Cancelled) while its peers finish.

A fake host drives the real mixin loop in unit tests: concurrent dispatch, backpressure cap, Ready-after-Complete ordering, cancellation, stale-`CANCEL_ALL` drain. Full suite green (2515 + the mixin tests).

## Follow-up

- Migrate the vLLM runner onto the shared `ServedConcurrentDispatch` mixin (remove its inline copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
