### PR TITLE
fix(engine-wheel): container jobs need an explicit bash shell

### DIFF
--- a/.github/workflows/engine-wheel.yml
+++ b/.github/workflows/engine-wheel.yml
@@ -40,6 +40,11 @@ env:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    # Container jobs default to sh (dash), which rejects `set -o pipefail`;
+    # every run step here assumes bash.
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         include:


### PR DESCRIPTION
GitHub runs container-job steps under sh (dash), which rejects `set -o pipefail`; the first prerequisite step of both build jobs failed instantly on the first real dispatch of the publish workflow (it never ran in PR CI, since its triggers are dev pushes and manual dispatch only). One-line fix: an explicit `shell: bash` default on the build job.

Completes the wheel publish Tom already authorized (PR #615 follow-through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)