### PR TITLE
fix(engine-wheel): link the CUDA build against driver stubs on GPU-less runners

### DIFF
--- a/.github/workflows/engine-wheel.yml
+++ b/.github/workflows/engine-wheel.yml
@@ -96,6 +96,12 @@ jobs:
             https://github.com/ggml-org/llama.cpp /tmp/llama-cpp-src
           if [ "${{ matrix.variant }}" = "cuda" ]; then
             BACKEND_FLAGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES"
+            # ggml-cuda links CUDA driver-API symbols (cuMem* VMM); a GPU-less
+            # build container has no libcuda, so link against the toolkit's
+            # driver stubs. Runtime resolves the real libcuda.so.1 from the
+            # target machine's driver, which is the wheel's one OS
+            # prerequisite regardless.
+            export LIBRARY_PATH="/usr/local/cuda/lib64/stubs:${LIBRARY_PATH:-}"
           else
             BACKEND_FLAGS="-DGGML_VULKAN=ON"
           fi


### PR DESCRIPTION
The re-dispatched publish run got further after #617: the Vulkan build succeeded, but the CUDA build failed at the final link with undefined references to `cuMemRelease` / `cuMemGetAllocationGranularity` — CUDA driver-API symbols (ggml's VMM allocator). GPU-less build containers have no `libcuda`; the earlier pod build only worked because RunPod injects the driver.

Standard fix: put the CUDA toolkit's driver stubs (`/usr/local/cuda/lib64/stubs`) on `LIBRARY_PATH` for the link. Runtime resolves the real `libcuda.so.1` from the target machine's driver, which is the wheel's one OS prerequisite regardless.

Note on the skipped `publish-vulkan`: both publish jobs deliberately require the whole build matrix, so the two wheels can only ever publish in version lockstep — that behavior is intended and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)