### PR TITLE
fix(engine-wheel): disable ggml's VMM allocator instead of stub-linking libcuda

### DIFF
--- a/.github/workflows/engine-wheel.yml
+++ b/.github/workflows/engine-wheel.yml
@@ -95,13 +95,16 @@ jobs:
           git clone --depth 1 --branch "$LLAMA_CPP_PIN" \
             https://github.com/ggml-org/llama.cpp /tmp/llama-cpp-src
           if [ "${{ matrix.variant }}" = "cuda" ]; then
-            BACKEND_FLAGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES"
-            # ggml-cuda links CUDA driver-API symbols (cuMem* VMM); a GPU-less
-            # build container has no libcuda, so link against the toolkit's
-            # driver stubs. Runtime resolves the real libcuda.so.1 from the
-            # target machine's driver, which is the wheel's one OS
-            # prerequisite regardless.
-            export LIBRARY_PATH="/usr/local/cuda/lib64/stubs:${LIBRARY_PATH:-}"
+            # GGML_CUDA_NO_VMM: the VMM allocator references CUDA driver-API
+            # symbols (cuMem*), and a GPU-less builder cannot satisfy the
+            # transitive libcuda.so.1 NEEDED resolution at the executable
+            # link (the toolkit stubs ship only libcuda.so, and LIBRARY_PATH
+            # cannot influence transitive SONAME resolution at all, which is
+            # why the stubs approach failed). Disabling VMM removes every
+            # driver-API reference; llama-server commits its KV window up
+            # front at a fixed -c, so the VMM pool allocator's benefit is
+            # marginal for this serving shape.
+            BACKEND_FLAGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES -DGGML_CUDA_NO_VMM=ON"
           else
             BACKEND_FLAGS="-DGGML_VULKAN=ON"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,10 @@ otherwise; no upstream Linux CUDA prebuilt exists, vLLM is the CUDA path);
 `SKULK_LLAMA_SERVER_BIN` overrides, `SKULK_NO_ENGINE_AUTOPROVISION=1` opts
 out. The CUDA engine also ships as the pip wheel `skulk-llama-server-cuda`
 (packaging/, built+published by `.github/workflows/engine-wheel.yml`), which
-outranks tarball provisioning on NVIDIA nodes. ADVANCING THE ENGINE PIN IS A
+outranks tarball provisioning on NVIDIA nodes. The CUDA wheel builds with
+`GGML_CUDA_NO_VMM=ON`: GPU-less CI cannot satisfy the driver API's transitive
+libcuda.so.1 link (stubs ship only libcuda.so), so never reintroduce
+driver-API-dependent flags to that build. ADVANCING THE ENGINE PIN IS A
 CHECKLIST (architecture-reference.md "Engine pin advancement"): bump pin +
 re-record checksums + bump wheel version + republish + fresh-box gauntlet;
 never advance casually. `install.sh` is the one-command fresh-box installer


### PR DESCRIPTION
Attempt 3 failed at the same CUDA link despite the stubs LIBRARY_PATH from #618: the undefined `cuMem*` symbols live in `libggml-cuda.so`, and the executable link then requires `libcuda.so.1` by SONAME for transitive NEEDED resolution — the toolkit stubs directory only ships `libcuda.so`, and LIBRARY_PATH has no effect on transitive resolution anyway.

Deterministic fix: `-DGGML_CUDA_NO_VMM=ON` removes every driver-API reference, so the build links cleanly on GPU-less runners and the smoke test needs no stub shim. Trade-off: ggml uses its pool allocator instead of VMM; llama-server commits its KV window up front at a fixed `-c`, so the difference is marginal for this serving shape.

Housekeeping note: #618 was merged before its second review commit (00071a21) landed on the branch, so that commit is orphaned; its conditional-expansion nit is moot here since the stubs export is removed entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)