### PR TITLE
fix(stats): served per-stream rates are wall-honest under batching

### DIFF
--- a/src/skulk/worker/runner/generation_stats.py
+++ b/src/skulk/worker/runner/generation_stats.py
@@ -188,6 +188,46 @@ def stats_from_llama_server_timings(
     )
 
 
+def served_stream_stats(
+    clock: StreamStatsClock,
+    timings: dict[str, object] | None,
+    *,
+    batching: bool,
+) -> GenerationStats:
+    """Resolve a served stream's final statistics honestly under batching.
+
+    Single-stream serving keeps the engine's own phase timings: they measure
+    prefill and decode inside the engine and beat any proxy wall clock. Under
+    multi-slot batching (``--parallel``) the engine's per-slot eval timings
+    count only the slot's ACTIVE time, not wall time per stream, so the
+    derived per-stream rates overstate reality by roughly the batch width
+    (measured ~4x at 64 slots); consumers (stats surfaces, performance
+    envelopes, the results ledger) read them as wall rates. In that mode the
+    proxy's wall clock provides the rates while the engine's exact token
+    counts are kept.
+
+    Args:
+        clock: The proxy-side stream clock (one piece marked per token).
+        timings: The engine's final ``timings`` object, when it sent one.
+        batching: Whether the serving engine decodes concurrent requests
+            together (configured max concurrency above one).
+
+    Returns:
+        Statistics whose rates are wall-honest for the serving mode.
+    """
+    from_timings = (
+        stats_from_llama_server_timings(timings) if timings is not None else None
+    )
+    if from_timings is not None and not batching:
+        return from_timings
+    if from_timings is not None:
+        return clock.stats(
+            prompt_tokens=from_timings.prompt_tokens,
+            generation_tokens=from_timings.generation_tokens,
+        )
+    return clock.stats(prompt_tokens=0, generation_tokens=clock.pieces)
+
+
 def blocking_call_stats(
     usage: object, wall_seconds: float
 ) -> GenerationStats | None:

--- a/src/skulk/worker/runner/generation_stats.py
+++ b/src/skulk/worker/runner/generation_stats.py
@@ -243,7 +243,9 @@ def served_stream_stats(
 
 
 def blocking_call_stats(
-    usage: object, wall_seconds: float
+    usage: object,
+    wall_seconds: float,
+    processed_prompt_tokens: int | None = None,
 ) -> GenerationStats | None:
     """Statistics for a non-streamed (blocking) completion from its ``usage``.
 
@@ -252,6 +254,14 @@ def blocking_call_stats(
     (necessarily under-reporting each phase's true speed - still honest, and
     far better than the null that hid llama.cpp throughput entirely, #532).
     Returns ``None`` when ``usage`` lacks integer token counts.
+
+    Args:
+        usage: The response ``usage`` object with integer token counts.
+        wall_seconds: Whole-request wall time.
+        processed_prompt_tokens: When known (the engine's ``prompt_n``), the
+            prompt RATE covers only these newly processed tokens so a
+            slot-cache hit's cached prefix cannot inflate it; the reported
+            prompt COUNT stays the request's true size from ``usage``.
     """
     if not isinstance(usage, dict):
         return None
@@ -261,8 +271,13 @@ def blocking_call_stats(
     if not isinstance(prompt_tokens, int) or not isinstance(completion_tokens, int):
         return None
     rate_window = wall_seconds if wall_seconds > 0 else 0.0
+    rate_prompt = (
+        processed_prompt_tokens
+        if processed_prompt_tokens is not None
+        else prompt_tokens
+    )
     return GenerationStats(
-        prompt_tps=prompt_tokens / rate_window if rate_window else 0.0,
+        prompt_tps=rate_prompt / rate_window if rate_window else 0.0,
         generation_tps=completion_tokens / rate_window if rate_window else 0.0,
         prompt_tokens=prompt_tokens,
         generation_tokens=completion_tokens,

--- a/src/skulk/worker/runner/generation_stats.py
+++ b/src/skulk/worker/runner/generation_stats.py
@@ -221,9 +221,23 @@ def served_stream_stats(
     if from_timings is not None and not batching:
         return from_timings
     if from_timings is not None:
-        return clock.stats(
-            prompt_tokens=from_timings.prompt_tokens,
+        # The prompt RATE covers only newly processed tokens (a slot-cache
+        # hit's cached prefix cost no prefill work and would inflate the wall
+        # rate), while the reported prompt COUNT stays the request's true
+        # prompt size, matching stats_from_llama_server_timings' convention.
+        raw_processed = timings.get("prompt_n") if timings is not None else None
+        processed_prompt = (
+            int(raw_processed)
+            if isinstance(raw_processed, (int, float))
+            and not isinstance(raw_processed, bool)
+            else from_timings.prompt_tokens
+        )
+        wall = clock.stats(
+            prompt_tokens=processed_prompt,
             generation_tokens=from_timings.generation_tokens,
+        )
+        return wall.model_copy(
+            update={"prompt_tokens": from_timings.prompt_tokens}
         )
     return clock.stats(prompt_tokens=0, generation_tokens=clock.pieces)
 

--- a/src/skulk/worker/runner/llama_server/runner.py
+++ b/src/skulk/worker/runner/llama_server/runner.py
@@ -73,6 +73,7 @@ from skulk.worker.runner.diagnostics import record_runner_phase, runner_phase
 from skulk.worker.runner.generation_stats import (
     StreamStatsClock,
     blocking_call_stats,
+    served_stream_stats,
     stats_from_llama_server_timings,
     subprocess_peak_memory,
 )
@@ -878,18 +879,12 @@ class Runner(ServedConcurrentDispatch):
         admission_in_flight = self._admission_concurrency(task.task_id)
 
         def final_stats() -> GenerationStats:
-            # Prefer the engine's own measurements; fall back to proxy-side
-            # wall clocks (prompt count unknowable from here, reported as 0).
+            # Engine timings win single-stream; under --parallel batching the
+            # per-slot eval rates are not wall rates, so the proxy clock
+            # provides the rates and the engine keeps the token counts (#611).
             # Peak memory always comes from the server child, never this proxy.
-            if last_timings is not None:
-                from_timings = stats_from_llama_server_timings(last_timings)
-                if from_timings is not None:
-                    base = from_timings.model_copy(
-                        update={"peak_memory_usage": self._server_peak_memory()}
-                    )
-                    return self.stamp_runner_stats(base, admission_in_flight)
-            base = clock.stats(
-                prompt_tokens=0, generation_tokens=clock.pieces
+            base = served_stream_stats(
+                clock, last_timings, batching=self._max_concurrency > 1
             ).model_copy(update={"peak_memory_usage": self._server_peak_memory()})
             return self.stamp_runner_stats(base, admission_in_flight)
 
@@ -996,9 +991,12 @@ class Runner(ServedConcurrentDispatch):
         # Engine-side timings when the server includes them, usage-derived
         # effective rates otherwise (#532).
         raw_timings = result.get("timings")
+        # Same wall-honesty rule as the streaming path (#611): engine timings
+        # only when serving single-stream; under batching the usage-derived
+        # whole-request wall rates are the honest ones.
         stats = (
             stats_from_llama_server_timings(raw_timings)
-            if isinstance(raw_timings, dict)
+            if isinstance(raw_timings, dict) and self._max_concurrency <= 1
             else None
         ) or blocking_call_stats(result.get("usage"), request_seconds)
         if stats is not None:

--- a/src/skulk/worker/runner/llama_server/runner.py
+++ b/src/skulk/worker/runner/llama_server/runner.py
@@ -34,7 +34,7 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Final, Literal, NamedTuple
+from typing import Any, Final, Literal, NamedTuple, cast
 
 import httpx
 
@@ -993,12 +993,23 @@ class Runner(ServedConcurrentDispatch):
         raw_timings = result.get("timings")
         # Same wall-honesty rule as the streaming path (#611): engine timings
         # only when serving single-stream; under batching the usage-derived
-        # whole-request wall rates are the honest ones.
+        # whole-request wall rates are the honest ones, with the prompt RATE
+        # over the engine's processed count so a slot-cache hit's cached
+        # prefix cannot inflate it.
+        processed_prompt: int | None = None
+        if isinstance(raw_timings, dict):
+            raw_prompt_n = cast("dict[str, object]", raw_timings).get("prompt_n")
+            if isinstance(raw_prompt_n, (int, float)) and not isinstance(
+                raw_prompt_n, bool
+            ):
+                processed_prompt = int(raw_prompt_n)
         stats = (
             stats_from_llama_server_timings(raw_timings)
             if isinstance(raw_timings, dict) and self._max_concurrency <= 1
             else None
-        ) or blocking_call_stats(result.get("usage"), request_seconds)
+        ) or blocking_call_stats(
+            result.get("usage"), request_seconds, processed_prompt
+        )
         if stats is not None:
             # The model lives in the server child; never report proxy RSS.
             stats = stats.model_copy(

--- a/src/skulk/worker/runner/tests/test_generation_stats.py
+++ b/src/skulk/worker/runner/tests/test_generation_stats.py
@@ -12,9 +12,9 @@ from skulk.worker.runner.generation_stats import (
     parse_vm_hwm,
     process_peak_memory,
     resolve_stream_token_counts,
+    served_stream_stats,
     stats_from_llama_server_timings,
     subprocess_peak_memory,
-    served_stream_stats,
 )
 
 
@@ -183,7 +183,12 @@ def test_served_stream_stats_single_stream_keeps_engine_timings() -> None:
     clock = _ticking_clock([0.0, 1.0, 2.0])
     clock.mark_piece()
     clock.mark_piece()
-    timings = {"prompt_n": 10.0, "prompt_ms": 100.0, "predicted_n": 50.0, "predicted_ms": 500.0}
+    timings: dict[str, object] = {
+        "prompt_n": 10.0,
+        "prompt_ms": 100.0,
+        "predicted_n": 50.0,
+        "predicted_ms": 500.0,
+    }
     stats = served_stream_stats(clock, timings, batching=False)
     assert stats.generation_tps == 100.0  # 50 tokens / 0.5s engine-measured
     assert stats.prompt_tokens == 10
@@ -198,7 +203,12 @@ def test_served_stream_stats_batching_uses_wall_rates_with_engine_tokens() -> No
     clock.mark_piece()
     clock.mark_piece()
     # Engine claims 100 tok/s slot-active; wall truth is 50 tokens over 10s.
-    timings = {"prompt_n": 10.0, "prompt_ms": 100.0, "predicted_n": 50.0, "predicted_ms": 500.0}
+    timings: dict[str, object] = {
+        "prompt_n": 10.0,
+        "prompt_ms": 100.0,
+        "predicted_n": 50.0,
+        "predicted_ms": 500.0,
+    }
     stats = served_stream_stats(clock, timings, batching=True)
     assert stats.generation_tps == 5.0  # 50 engine tokens / 10s wall decode
     assert stats.prompt_tps == 10.0  # 10 tokens / 1s wall prefill

--- a/src/skulk/worker/runner/tests/test_generation_stats.py
+++ b/src/skulk/worker/runner/tests/test_generation_stats.py
@@ -14,6 +14,7 @@ from skulk.worker.runner.generation_stats import (
     resolve_stream_token_counts,
     stats_from_llama_server_timings,
     subprocess_peak_memory,
+    served_stream_stats,
 )
 
 
@@ -169,3 +170,46 @@ def test_resolve_stream_token_counts_fallbacks() -> None:
     assert resolve_stream_token_counts(120, None, 20) == (100, 20)
     # No position signal at all: only the piece count is trustworthy.
     assert resolve_stream_token_counts(0, None, 7) == (0, 7)
+
+
+def _ticking_clock(moments: list[float]) -> StreamStatsClock:
+    """A clock fed a fixed sequence of perf-counter readings."""
+    it = iter(moments)
+    return StreamStatsClock(now=lambda: next(it))
+
+
+def test_served_stream_stats_single_stream_keeps_engine_timings() -> None:
+    # Engine phase timings beat proxy wall clocks when serving one stream.
+    clock = _ticking_clock([0.0, 1.0, 2.0])
+    clock.mark_piece()
+    clock.mark_piece()
+    timings = {"prompt_n": 10.0, "prompt_ms": 100.0, "predicted_n": 50.0, "predicted_ms": 500.0}
+    stats = served_stream_stats(clock, timings, batching=False)
+    assert stats.generation_tps == 100.0  # 50 tokens / 0.5s engine-measured
+    assert stats.prompt_tokens == 10
+    assert stats.generation_tokens == 50
+
+
+def test_served_stream_stats_batching_uses_wall_rates_with_engine_tokens() -> None:
+    # Under --parallel, per-slot eval timings count only slot-active time and
+    # overstate per-stream rates by roughly the batch width (#611): rates must
+    # come from the proxy wall clock while token counts stay engine-exact.
+    clock = _ticking_clock([0.0, 1.0, 11.0])  # start, first piece, last piece
+    clock.mark_piece()
+    clock.mark_piece()
+    # Engine claims 100 tok/s slot-active; wall truth is 50 tokens over 10s.
+    timings = {"prompt_n": 10.0, "prompt_ms": 100.0, "predicted_n": 50.0, "predicted_ms": 500.0}
+    stats = served_stream_stats(clock, timings, batching=True)
+    assert stats.generation_tps == 5.0  # 50 engine tokens / 10s wall decode
+    assert stats.prompt_tps == 10.0  # 10 tokens / 1s wall prefill
+    assert stats.prompt_tokens == 10
+    assert stats.generation_tokens == 50
+
+
+def test_served_stream_stats_no_timings_falls_back_to_pieces() -> None:
+    clock = _ticking_clock([0.0, 1.0, 2.0])
+    clock.mark_piece()
+    clock.mark_piece()
+    stats = served_stream_stats(clock, None, batching=True)
+    assert stats.generation_tokens == 2
+    assert stats.generation_tps == 2.0  # 2 pieces over 1s decode span

--- a/src/skulk/worker/runner/tests/test_generation_stats.py
+++ b/src/skulk/worker/runner/tests/test_generation_stats.py
@@ -223,3 +223,22 @@ def test_served_stream_stats_no_timings_falls_back_to_pieces() -> None:
     stats = served_stream_stats(clock, None, batching=True)
     assert stats.generation_tokens == 2
     assert stats.generation_tps == 2.0  # 2 pieces over 1s decode span
+
+
+def test_served_stream_stats_batching_cache_hit_rate_over_processed_only() -> None:
+    # A slot-cache hit reports the cached prefix in cache_n; the wall prompt
+    # rate must cover only the newly processed suffix while the reported
+    # prompt count keeps the request's true size (PR #626 review).
+    clock = _ticking_clock([0.0, 2.0, 4.0])
+    clock.mark_piece()
+    clock.mark_piece()
+    timings: dict[str, object] = {
+        "prompt_n": 10.0,
+        "prompt_ms": 100.0,
+        "predicted_n": 50.0,
+        "predicted_ms": 500.0,
+        "cache_n": 990.0,
+    }
+    stats = served_stream_stats(clock, timings, batching=True)
+    assert stats.prompt_tokens == 1000  # true request prompt size
+    assert stats.prompt_tps == 5.0  # 10 processed tokens over 2s wall prefill

--- a/src/skulk/worker/runner/tests/test_generation_stats.py
+++ b/src/skulk/worker/runner/tests/test_generation_stats.py
@@ -105,6 +105,20 @@ def test_blocking_call_stats_uses_exact_counts_and_wall_rates() -> None:
     assert stats.generation_tps == 10.0
 
 
+def test_blocking_call_stats_cache_hit_rate_over_processed_only() -> None:
+    # A slot-cache hit: 1000-token prompt but only 10 newly processed. The
+    # prompt RATE covers the processed tokens; the COUNT stays the true size.
+    stats = blocking_call_stats(
+        {"prompt_tokens": 1000, "completion_tokens": 40},
+        wall_seconds=2.0,
+        processed_prompt_tokens=10,
+    )
+    assert stats is not None
+    assert stats.prompt_tokens == 1000
+    assert stats.prompt_tps == 5.0
+    assert stats.generation_tps == 20.0
+
+
 def test_blocking_call_stats_rejects_missing_or_non_dict_usage() -> None:
     assert blocking_call_stats(None, 1.0) is None
     assert blocking_call_stats({"prompt_tokens": 80}, 1.0) is None


### PR DESCRIPTION
Fixes #611.

Under `--parallel` batching, llama-server's per-slot eval timings count only the slot's ACTIVE time, so per-stream rates derived from them overstated wall reality by roughly the batch width (measured ~4x at 64 slots on the A100 session) and flowed into stats surfaces, performance envelopes, and the results ledger as if they were wall rates.

`served_stream_stats()` now resolves final stream statistics by serving mode: single-stream keeps the engine's strictly-better phase timings (unchanged behavior); batching derives both rates from the proxy wall clock while keeping the engine's exact token counts. The blocking tool-call path applies the same rule. vLLM's runner already measured wall-clock and is unchanged. Unit tests cover both modes and the no-timings fallback with an injected clock.

This is the Skulk half of the measurement-honesty gate before the CUDA hardware matrix; the harness half (#69/#70/#71) is in flight in the harness repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)