### PR TITLE
fix(doctor): plain doctor recognizes dormant wheel/managed engines (#628)

### DIFF
--- a/src/skulk/doctor/checks.py
+++ b/src/skulk/doctor/checks.py
@@ -161,30 +161,55 @@ def _check_engine_available(facts: NodeFacts) -> Sequence[CheckResult]:
     # tags until node startup exports its path; without this read-only lookup
     # plain doctor reports FAIL on exactly the box the installer just set up
     # (#628). --fix and startup share the same discovery via
-    # ensure_llama_server. The candidate is validated with the same device
-    # probe derivation applies at startup: a shim whose runtime is broken
-    # (dead Vulkan ICD, missing CUDA loader) would be disabled at startup, so
-    # reporting it OK here would trade #628's false negative for a false
-    # positive (PR #634 review).
+    # ensure_llama_server. The candidate is judged by REPLAYING the real
+    # derivation over a hypothetical facts snapshot with the binary wired:
+    # any candidate startup would disable (failed device probe from a dead
+    # Vulkan ICD or missing CUDA loader, a CPU-only build on a GPU node's
+    # gpu_serving_disabled, ...) must not read as available, or #628's false
+    # negative becomes a false positive (PR #634 review, both rounds).
     from skulk.facts.probe import probe_llama_server_devices
     from skulk.provisioning import dormant_llama_server
+    from skulk.shared.backends import LLAMA_SERVER_BIN_ENV
+    from skulk.shared.types.node_facts import EngineBinaryFact
 
     dormant = dormant_llama_server(facts)
     broken_dormant_detail: str | None = None
     if dormant is not None:
-        probe = probe_llama_server_devices(str(dormant))
-        if probe.outcome != "failed":
+        hypothetical = facts.model_copy(
+            update={
+                "llama_server_binary": EngineBinaryFact(
+                    env_var=LLAMA_SERVER_BIN_ENV,
+                    configured_path=str(dormant),
+                    state="ok",
+                ),
+                "llama_server_device_probe": probe_llama_server_devices(
+                    str(dormant)
+                ),
+            }
+        )
+        replay = derive_node_backends(hypothetical)
+        if "llama_server" in replay.backends:
+            # Derivation can advertise the engine AND raise conflicts (the
+            # #609 cpu-only-on-GPU shape keeps llama_server-cpu with an
+            # error-level gpu_serving_disabled); those stay visible here
+            # because the capability-conflicts check reads the unwired facts
+            # and cannot see them before startup.
+            flagged = "; ".join(c.message for c in replay.conflicts)
             return [
                 _ok(
                     check_id,
                     title,
                     f"llama_server ({dormant}) is installed and wires "
-                    "automatically at node startup",
+                    "automatically at node startup"
+                    + (f" (startup will flag: {flagged})" if flagged else ""),
                 )
             ]
+        reason = "; ".join(c.message for c in replay.conflicts) or (
+            "the binary derives no usable backend on this hardware"
+        )
         broken_dormant_detail = (
-            f"an installed managed llama-server at {dormant} failed its "
-            f"device probe ({probe.detail}); startup would disable it"
+            f"an installed managed llama-server at {dormant} would be "
+            f"disabled at startup: {reason}"
         )
     return [
         CheckResult(

--- a/src/skulk/doctor/checks.py
+++ b/src/skulk/doctor/checks.py
@@ -157,6 +157,23 @@ def _check_engine_available(facts: NodeFacts) -> Sequence[CheckResult]:
         engines.append(f"vllm ({facts.vllm_binary.configured_path})")
     if engines:
         return [_ok(check_id, title, "available: " + ", ".join(engines))]
+    # A wheel-provisioned or previously provisioned managed engine derives no
+    # tags until node startup exports its path; without this read-only lookup
+    # plain doctor reports FAIL on exactly the box the installer just set up
+    # (#628). --fix and startup share the same discovery via
+    # ensure_llama_server.
+    from skulk.provisioning import dormant_llama_server
+
+    dormant = dormant_llama_server(facts)
+    if dormant is not None:
+        return [
+            _ok(
+                check_id,
+                title,
+                f"llama_server ({dormant}) is installed and wires "
+                "automatically at node startup",
+            )
+        ]
     return [
         CheckResult(
             check_id=check_id,

--- a/src/skulk/doctor/checks.py
+++ b/src/skulk/doctor/checks.py
@@ -191,19 +191,37 @@ def _check_engine_available(facts: NodeFacts) -> Sequence[CheckResult]:
         if "llama_server" in replay.backends:
             # Derivation can advertise the engine AND raise conflicts (the
             # #609 cpu-only-on-GPU shape keeps llama_server-cpu with an
-            # error-level gpu_serving_disabled); those stay visible here
-            # because the capability-conflicts check reads the unwired facts
-            # and cannot see them before startup.
-            flagged = "; ".join(c.message for c in replay.conflicts)
-            return [
+            # error-level gpu_serving_disabled). The capability-conflicts
+            # check reads the unwired facts and cannot see them before
+            # startup, so each replayed conflict becomes its own verdict here
+            # with the same error->fail mapping; the audit's exit code then
+            # matches what startup will flag instead of reading healthy.
+            results = [
                 _ok(
                     check_id,
                     title,
                     f"llama_server ({dormant}) is installed and wires "
-                    "automatically at node startup"
-                    + (f" (startup will flag: {flagged})" if flagged else ""),
+                    "automatically at node startup",
                 )
             ]
+            for conflict in replay.conflicts:
+                conflict_verdict: CheckVerdict = (
+                    "fail" if conflict.code in CONFLICT_ERROR_CODES else "degraded"
+                )
+                results.append(
+                    CheckResult(
+                        check_id=check_id,
+                        title=f"Startup capability conflict: {conflict.code}",
+                        verdict=conflict_verdict,
+                        detail=conflict.message,
+                        consequence=(
+                            "node startup will wire this engine and raise "
+                            "this conflict into nodeHealth"
+                        ),
+                        remediation=conflict.remediation,
+                    )
+                )
+            return results
         reason = "; ".join(c.message for c in replay.conflicts) or (
             "the binary derives no usable backend on this hardware"
         )

--- a/src/skulk/doctor/checks.py
+++ b/src/skulk/doctor/checks.py
@@ -161,25 +161,38 @@ def _check_engine_available(facts: NodeFacts) -> Sequence[CheckResult]:
     # tags until node startup exports its path; without this read-only lookup
     # plain doctor reports FAIL on exactly the box the installer just set up
     # (#628). --fix and startup share the same discovery via
-    # ensure_llama_server.
+    # ensure_llama_server. The candidate is validated with the same device
+    # probe derivation applies at startup: a shim whose runtime is broken
+    # (dead Vulkan ICD, missing CUDA loader) would be disabled at startup, so
+    # reporting it OK here would trade #628's false negative for a false
+    # positive (PR #634 review).
+    from skulk.facts.probe import probe_llama_server_devices
     from skulk.provisioning import dormant_llama_server
 
     dormant = dormant_llama_server(facts)
+    broken_dormant_detail: str | None = None
     if dormant is not None:
-        return [
-            _ok(
-                check_id,
-                title,
-                f"llama_server ({dormant}) is installed and wires "
-                "automatically at node startup",
-            )
-        ]
+        probe = probe_llama_server_devices(str(dormant))
+        if probe.outcome != "failed":
+            return [
+                _ok(
+                    check_id,
+                    title,
+                    f"llama_server ({dormant}) is installed and wires "
+                    "automatically at node startup",
+                )
+            ]
+        broken_dormant_detail = (
+            f"an installed managed llama-server at {dormant} failed its "
+            f"device probe ({probe.detail}); startup would disable it"
+        )
     return [
         CheckResult(
             check_id=check_id,
             title=title,
             verdict="fail",
-            detail="no inference engine is importable or configured on this node",
+            detail=broken_dormant_detail
+            or "no inference engine is importable or configured on this node",
             consequence=(
                 "the node advertises no backends and will never be selected to "
                 "serve a model; it participates in the cluster as management "

--- a/src/skulk/doctor/tests/test_checks.py
+++ b/src/skulk/doctor/tests/test_checks.py
@@ -92,7 +92,36 @@ def test_engine_available_fails_when_dormant_engine_is_broken(
     results = _check_engine_available(make_facts(gpus=(NVIDIA_A40,)))
     assert [r.verdict for r in results] == ["fail"]
     assert str(shim) in results[0].detail
-    assert "failed its device probe" in results[0].detail
+    assert "would be disabled at startup" in results[0].detail
+
+
+def test_engine_available_flags_cpu_only_dormant_on_gpu_node(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A CPU-only build on a GPU node: derivation ADVERTISES llama_server-cpu
+    # with an error-level gpu_serving_disabled conflict (#609), so the engine
+    # is available but the doctor detail must surface the conflict, because
+    # the capability-conflicts check reads unwired facts and cannot see it
+    # before startup (PR #634 review round 2).
+    shim = tmp_path / "llama-server-cpu"
+
+    def _dormant(facts: NodeFacts) -> Path:
+        return shim
+
+    monkeypatch.setattr("skulk.provisioning.dormant_llama_server", _dormant)
+
+    def _probe_cpu_only(binary: str) -> object:
+        from skulk.shared.types.node_facts import LlamaServerDeviceProbe
+
+        return LlamaServerDeviceProbe(outcome="devices", computes=())
+
+    monkeypatch.setattr(
+        "skulk.facts.probe.probe_llama_server_devices", _probe_cpu_only
+    )
+    results = _check_engine_available(make_facts(gpus=(NVIDIA_A40,)))
+    assert [r.verdict for r in results] == ["ok"]
+    assert "startup will flag" in results[0].detail
+    assert "fraction of hardware speed" in results[0].detail
 
 
 def test_engine_available_ok_with_served_binary() -> None:

--- a/src/skulk/doctor/tests/test_checks.py
+++ b/src/skulk/doctor/tests/test_checks.py
@@ -29,11 +29,42 @@ def test_engine_available_ok_on_darwin() -> None:
     assert "mlx" in results[0].detail
 
 
-def test_engine_available_fails_on_bare_linux() -> None:
+def test_engine_available_fails_on_bare_linux(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Hermetic: the dormant-engine lookup must not see a real managed install
+    # or wheel on the developer machine.
+    monkeypatch.setattr(
+        "skulk.provisioning.llama_server.SKULK_ENGINES_DIR", tmp_path
+    )
+
+    def _no_wheel(vendor: str, facts: NodeFacts) -> tuple[Path, Path | None] | None:
+        return None
+
+    monkeypatch.setattr(
+        "skulk.provisioning.llama_server.wheel_llama_server", _no_wheel
+    )
     results = _check_engine_available(make_facts())
     assert [r.verdict for r in results] == ["fail"]
     assert "management" in results[0].consequence
     assert results[0].remediation != ""
+
+
+def test_engine_available_ok_with_dormant_wheel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The #628 shape: engine wheel installed, no override exported yet. Plain
+    # doctor must report the engine that startup will wire, not FAIL.
+    shim = tmp_path / "llama-server-cuda"
+
+    def _dormant(facts: NodeFacts) -> Path:
+        return shim
+
+    monkeypatch.setattr("skulk.provisioning.dormant_llama_server", _dormant)
+    results = _check_engine_available(make_facts(gpus=(NVIDIA_A40,)))
+    assert [r.verdict for r in results] == ["ok"]
+    assert str(shim) in results[0].detail
+    assert "startup" in results[0].detail
 
 
 def test_engine_available_ok_with_served_binary() -> None:

--- a/src/skulk/doctor/tests/test_checks.py
+++ b/src/skulk/doctor/tests/test_checks.py
@@ -119,9 +119,10 @@ def test_engine_available_flags_cpu_only_dormant_on_gpu_node(
         "skulk.facts.probe.probe_llama_server_devices", _probe_cpu_only
     )
     results = _check_engine_available(make_facts(gpus=(NVIDIA_A40,)))
-    assert [r.verdict for r in results] == ["ok"]
-    assert "startup will flag" in results[0].detail
-    assert "fraction of hardware speed" in results[0].detail
+    assert [r.verdict for r in results] == ["ok", "fail"]
+    assert "gpu_serving_disabled" in results[1].title
+    assert "fraction of hardware speed" in results[1].detail
+    assert results[1].remediation != ""
 
 
 def test_engine_available_ok_with_served_binary() -> None:

--- a/src/skulk/doctor/tests/test_checks.py
+++ b/src/skulk/doctor/tests/test_checks.py
@@ -61,10 +61,38 @@ def test_engine_available_ok_with_dormant_wheel(
         return shim
 
     monkeypatch.setattr("skulk.provisioning.dormant_llama_server", _dormant)
+
+    def _probe_ok(binary: str) -> object:
+        from skulk.shared.types.node_facts import LlamaServerDeviceProbe
+
+        return LlamaServerDeviceProbe(outcome="devices", computes=("cuda",))
+
+    monkeypatch.setattr(
+        "skulk.facts.probe.probe_llama_server_devices", _probe_ok
+    )
     results = _check_engine_available(make_facts(gpus=(NVIDIA_A40,)))
     assert [r.verdict for r in results] == ["ok"]
     assert str(shim) in results[0].detail
     assert "startup" in results[0].detail
+
+
+def test_engine_available_fails_when_dormant_engine_is_broken(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A shim whose runtime probe fails (dead Vulkan ICD, missing CUDA loader)
+    # would be disabled at startup; doctor must not claim it as available
+    # (PR #634 review). The nonexistent tmp path makes the real probe fail
+    # with a launch error, exercising the same outcome as a broken loader.
+    shim = tmp_path / "llama-server-vulkan"
+
+    def _dormant(facts: NodeFacts) -> Path:
+        return shim
+
+    monkeypatch.setattr("skulk.provisioning.dormant_llama_server", _dormant)
+    results = _check_engine_available(make_facts(gpus=(NVIDIA_A40,)))
+    assert [r.verdict for r in results] == ["fail"]
+    assert str(shim) in results[0].detail
+    assert "failed its device probe" in results[0].detail
 
 
 def test_engine_available_ok_with_served_binary() -> None:

--- a/src/skulk/provisioning/__init__.py
+++ b/src/skulk/provisioning/__init__.py
@@ -6,6 +6,7 @@ llama-server logic in :mod:`skulk.provisioning.llama_server`.
 """
 
 from skulk.provisioning.llama_server import (
+    dormant_llama_server,
     ensure_llama_server,
     managed_llama_server_path,
     provision_llama_server,
@@ -16,6 +17,7 @@ from skulk.provisioning.manifest import LLAMA_SERVER_PIN, EngineVariant
 __all__ = [
     "LLAMA_SERVER_PIN",
     "EngineVariant",
+    "dormant_llama_server",
     "ensure_llama_server",
     "managed_llama_server_path",
     "provision_llama_server",

--- a/src/skulk/provisioning/llama_server.py
+++ b/src/skulk/provisioning/llama_server.py
@@ -325,6 +325,51 @@ def _binary_in(target_dir: Path) -> Path | None:
     return None
 
 
+def dormant_llama_server(facts: NodeFacts) -> Path | None:
+    """The managed llama-server that node startup would wire, without wiring it.
+
+    Read-only twin of :func:`ensure_llama_server`'s no-network paths, for
+    diagnostics: ``skulk doctor`` without ``--fix`` must not export
+    environment variables or download anything, but it also must not report
+    an engine-less node when startup will wire an already-installed managed
+    engine (#628). Same gates and the same preference order (engine wheel
+    shim first, then an already-provisioned managed install on disk); no
+    environment mutation, no network.
+
+    Args:
+        facts: The current facts snapshot (decides applicability and variant).
+
+    Returns:
+        The managed binary startup would adopt, or ``None`` when nothing on
+        disk would wire (override present, opted out, non-Linux, or no
+        installed wheel/build).
+    """
+    if os.environ.get(AUTOPROVISION_OPT_OUT_ENV, "").strip() == "1":
+        return None
+    if facts.llama_server_binary.state != "not_configured":
+        return None
+    if not select_variant_chain(facts):
+        return None
+    vendor = (
+        "nvidia"
+        if facts.gpus_of("nvidia")
+        else "amd"
+        if facts.gpus_of("amd")
+        else None
+    )
+    if vendor is not None:
+        wheel = wheel_llama_server(vendor, facts)
+        if wheel is not None:
+            return wheel[0]
+    for variant in select_variant_chain(facts):
+        existing = _binary_in(
+            SKULK_ENGINES_DIR / "llama-server" / LLAMA_SERVER_PIN / variant
+        )
+        if existing is not None and os.access(existing, os.X_OK):
+            return existing
+    return None
+
+
 def ensure_llama_server(
     facts: NodeFacts, *, allow_download: bool = True
 ) -> Path | None:

--- a/src/skulk/provisioning/tests/test_llama_server.py
+++ b/src/skulk/provisioning/tests/test_llama_server.py
@@ -350,8 +350,15 @@ def test_dormant_matches_ensure_offline_adoption(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     # Drift guard: the diagnostic answer must be the binary offline startup
-    # actually wires.
+    # actually wires. Hermetic against the developer/CI environment: a real
+    # installed engine wheel would outrank the provisioned tarball for BOTH
+    # functions, silently weakening the comparison (PR #634 review).
     _isolate_engines_dir(monkeypatch, tmp_path)
+
+    def _no_wheel(vendor: str, facts: object) -> tuple[Path, Path | None] | None:
+        return None
+
+    monkeypatch.setattr(provisioning, "wheel_llama_server", _no_wheel)
     _pin_fake_artifact(monkeypatch, _fake_archive())
     provisioned = provision_llama_server("vulkan")
     monkeypatch.delenv(provisioning.AUTOPROVISION_OPT_OUT_ENV, raising=False)

--- a/src/skulk/provisioning/tests/test_llama_server.py
+++ b/src/skulk/provisioning/tests/test_llama_server.py
@@ -326,6 +326,79 @@ def test_tarball_fallback_when_no_wheel_installed(
     assert "vulkan" in str(wired)
 
 
+def test_dormant_reports_wheel_without_wiring(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The read-only diagnostics twin (#628): reports the shim startup would
+    # adopt, but never exports environment.
+    _isolate_engines_dir(monkeypatch, tmp_path)
+    shim = _fake_wheel(tmp_path, "llama-server-cuda")
+
+    def _fake_lookup(
+        vendor: str, facts: object
+    ) -> tuple[Path, Path | None] | None:
+        return (shim, None) if vendor == "nvidia" else None
+
+    monkeypatch.setattr(provisioning, "wheel_llama_server", _fake_lookup)
+    monkeypatch.delenv(provisioning.AUTOPROVISION_OPT_OUT_ENV, raising=False)
+    monkeypatch.delenv(LLAMA_SERVER_BIN_ENV, raising=False)
+    assert provisioning.dormant_llama_server(make_facts(gpus=(NVIDIA_A40,))) == shim
+    assert LLAMA_SERVER_BIN_ENV not in os.environ
+
+
+def test_dormant_matches_ensure_offline_adoption(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Drift guard: the diagnostic answer must be the binary offline startup
+    # actually wires.
+    _isolate_engines_dir(monkeypatch, tmp_path)
+    _pin_fake_artifact(monkeypatch, _fake_archive())
+    provisioned = provision_llama_server("vulkan")
+    monkeypatch.delenv(provisioning.AUTOPROVISION_OPT_OUT_ENV, raising=False)
+    monkeypatch.delenv(LLAMA_SERVER_BIN_ENV, raising=False)
+    facts = make_facts(gpus=(NVIDIA_A40,))
+    dormant = provisioning.dormant_llama_server(facts)
+    assert dormant == provisioned
+    assert LLAMA_SERVER_BIN_ENV not in os.environ
+    wired = ensure_llama_server(facts, allow_download=False)
+    assert wired == dormant
+
+
+def test_dormant_honors_override_and_opt_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _isolate_engines_dir(monkeypatch, tmp_path)
+    shim = _fake_wheel(tmp_path, "llama-server-cuda")
+
+    def _cuda_wheel(
+        vendor: str, facts: object
+    ) -> tuple[Path, Path | None] | None:
+        return (shim, None)
+
+    monkeypatch.setattr(provisioning, "wheel_llama_server", _cuda_wheel)
+    # Explicit override wins: nothing dormant to report.
+    override_facts = make_facts(
+        gpus=(NVIDIA_A40,), llama_server_bin=ok_bin(LLAMA_SERVER_BIN_ENV)
+    )
+    assert provisioning.dormant_llama_server(override_facts) is None
+    # Opt-out disables adoption, so the diagnostic must not promise it.
+    monkeypatch.setenv(provisioning.AUTOPROVISION_OPT_OUT_ENV, "1")
+    assert provisioning.dormant_llama_server(make_facts(gpus=(NVIDIA_A40,))) is None
+
+
+def test_dormant_none_when_nothing_on_disk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _isolate_engines_dir(monkeypatch, tmp_path)
+
+    def _no_wheel(vendor: str, facts: object) -> tuple[Path, Path | None] | None:
+        return None
+
+    monkeypatch.setattr(provisioning, "wheel_llama_server", _no_wheel)
+    monkeypatch.delenv(provisioning.AUTOPROVISION_OPT_OUT_ENV, raising=False)
+    assert provisioning.dormant_llama_server(make_facts(gpus=(NVIDIA_A40,))) is None
+
+
 def test_cuda_capability_gate() -> None:
     # The CUDA wheel is compiled for SM >= 8.0: a T4 (7.5) or a
     # capability-unknown NVML-degraded GPU must not select it (it would fail


### PR DESCRIPTION
Fixes #628.

## Problem

On a node with an engine wheel installed (skulk-llama-server-cuda / -vulkan) but no explicit \`SKULK_LLAMA_SERVER_BIN\`, plain \`skulk doctor\` reported \`engine-available\` FAIL ("no inference engine is importable or configured") and exited 1, while the node in fact serves fine: wheel adoption happens inside \`ensure_llama_server\`, which only \`doctor --fix\` and node startup invoke. The installer's recommended audit command therefore reported failure on exactly the box the installer had just set up. Reproduced on every row of the 1.5.0 CUDA hardware matrix (A100, RTX 6000 Ada, H100, RTX 5090).

## Fix

- New \`dormant_llama_server(facts)\` in \`skulk.provisioning\`: a read-only twin of \`ensure_llama_server\`'s no-network paths. Same gates (opt-out env, explicit override wins, variant chain) and the same preference order (installed wheel shim first, then an already-provisioned managed install on disk), but no environment export and no download.
- The doctor \`engine-available\` check consults it when no backend derives, and reports ok with the path startup will wire ("installed and wires automatically at node startup") instead of FAIL.

## Tests

- Provisioning: dormant reports the wheel without exporting env; drift guard asserting dormant equals what offline \`ensure_llama_server\` actually wires; override and opt-out return None; nothing-on-disk returns None.
- Doctor: the #628 shape (wheel installed, no override) now verdicts ok naming the shim; the bare-Linux FAIL case is made hermetic against real installs on the developer machine.

## Validation

basedpyright 0 errors, ruff clean, full pytest: 2698 passed with the single pre-existing #616 failure (reproduces identically on clean dev, standalone; unrelated to this change). Doctor docs regenerated with no content change (registry text untouched).