### PR TITLE
feat(cards): vLLM starter set: Qwen2.5 Instruct 1.5B/7B/14B (#630)

### DIFF
--- a/resources/inference_model_cards/Qwen--Qwen2.5-1.5B-Instruct.toml
+++ b/resources/inference_model_cards/Qwen--Qwen2.5-1.5B-Instruct.toml
@@ -2,7 +2,7 @@
 # vllm served engine (#630): the small smoke-test card of the vLLM starter
 # set, sized so any vLLM-capable GPU can place it. Qwen2.5 is an INSTRUCT
 # model, NOT a thinking model (no <think> mode before Qwen3); text-only, no
-# [reasoning] section. Tool calling follows the qwen family default.
+# [reasoning] section. Tool calling is declared off: see the [tooling] note below.
 # context_length is the config.json max_position_embeddings (32768).
 # `supports_tensor = false`: vLLM runs single-node in Skulk. Architecture from
 # config.json (qwen2: 28 layers, hidden 1536, 2 KV heads, bf16). storage_size
@@ -20,9 +20,14 @@ capabilities = ["text"]
 context_length = 32768
 trust_remote_code = false
 
+# PLATFORM truth override: Qwen2.5 the MODEL supports OpenAI tool calling
+# (the qwen family default would advertise it), but these cards serve
+# exclusively on the vllm engine, whose runner does not implement tool
+# dispatch yet (#638). Advertising tools here would promise a guaranteed
+# runtime error. Flip this back to the family default when the vllm runner
+# gains tool calling.
 [tooling]
-supports_tool_calling = true
-tool_call_format = "generic"
+supports_tool_calling = false
 
 [placement]
 compatible_backends = ["vllm-cuda", "vllm-rocm"]

--- a/resources/inference_model_cards/Qwen--Qwen2.5-1.5B-Instruct.toml
+++ b/resources/inference_model_cards/Qwen--Qwen2.5-1.5B-Instruct.toml
@@ -1,0 +1,32 @@
+# Qwen2.5-1.5B-Instruct (official Qwen safetensors release, bf16) for the
+# vllm served engine (#630): the small smoke-test card of the vLLM starter
+# set, sized so any vLLM-capable GPU can place it. Qwen2.5 is an INSTRUCT
+# model, NOT a thinking model (no <think> mode before Qwen3); text-only, no
+# [reasoning] section. Tool calling follows the qwen family default.
+# context_length is the config.json max_position_embeddings (32768).
+# `supports_tensor = false`: vLLM runs single-node in Skulk. Architecture from
+# config.json (qwen2: 28 layers, hidden 1536, 2 KV heads, bf16). storage_size
+# is the full repo staging set (safetensors + tokenizer/config).
+model_id = "Qwen/Qwen2.5-1.5B-Instruct"
+n_layers = 28
+hidden_size = 1536
+num_key_value_heads = 2
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "bf16"
+base_model = "Qwen2.5 1.5B Instruct"
+capabilities = ["text"]
+context_length = 32768
+trust_remote_code = false
+
+[tooling]
+supports_tool_calling = true
+tool_call_format = "generic"
+
+[placement]
+compatible_backends = ["vllm-cuda", "vllm-rocm"]
+backend_preference = ["vllm-cuda", "vllm-rocm"]
+
+[storage_size]
+in_bytes = 3098955668

--- a/resources/inference_model_cards/Qwen--Qwen2.5-14B-Instruct.toml
+++ b/resources/inference_model_cards/Qwen--Qwen2.5-14B-Instruct.toml
@@ -2,7 +2,7 @@
 # served engine (#630): the mid-size card of the vLLM starter set (~29.6 GB of
 # weights, fits 48 GB-class GPUs with KV headroom). Qwen2.5 is an INSTRUCT
 # model, NOT a thinking model (no <think> mode before Qwen3); text-only, no
-# [reasoning] section. Tool calling follows the qwen family default.
+# [reasoning] section. Tool calling is declared off: see the [tooling] note below.
 # context_length is the config.json max_position_embeddings (32768).
 # `supports_tensor = false`: vLLM runs single-node in Skulk. Architecture from
 # config.json (qwen2: 48 layers, hidden 5120, 8 KV heads, bf16). storage_size
@@ -20,9 +20,14 @@ capabilities = ["text"]
 context_length = 32768
 trust_remote_code = false
 
+# PLATFORM truth override: Qwen2.5 the MODEL supports OpenAI tool calling
+# (the qwen family default would advertise it), but these cards serve
+# exclusively on the vllm engine, whose runner does not implement tool
+# dispatch yet (#638). Advertising tools here would promise a guaranteed
+# runtime error. Flip this back to the family default when the vllm runner
+# gains tool calling.
 [tooling]
-supports_tool_calling = true
-tool_call_format = "generic"
+supports_tool_calling = false
 
 [placement]
 compatible_backends = ["vllm-cuda", "vllm-rocm"]

--- a/resources/inference_model_cards/Qwen--Qwen2.5-14B-Instruct.toml
+++ b/resources/inference_model_cards/Qwen--Qwen2.5-14B-Instruct.toml
@@ -1,0 +1,32 @@
+# Qwen2.5-14B-Instruct (official Qwen safetensors release, bf16) for the vllm
+# served engine (#630): the mid-size card of the vLLM starter set (~29.6 GB of
+# weights, fits 48 GB-class GPUs with KV headroom). Qwen2.5 is an INSTRUCT
+# model, NOT a thinking model (no <think> mode before Qwen3); text-only, no
+# [reasoning] section. Tool calling follows the qwen family default.
+# context_length is the config.json max_position_embeddings (32768).
+# `supports_tensor = false`: vLLM runs single-node in Skulk. Architecture from
+# config.json (qwen2: 48 layers, hidden 5120, 8 KV heads, bf16). storage_size
+# is the full repo staging set (safetensors shards + tokenizer/config).
+model_id = "Qwen/Qwen2.5-14B-Instruct"
+n_layers = 48
+hidden_size = 5120
+num_key_value_heads = 8
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "bf16"
+base_model = "Qwen2.5 14B Instruct"
+capabilities = ["text"]
+context_length = 32768
+trust_remote_code = false
+
+[tooling]
+supports_tool_calling = true
+tool_call_format = "generic"
+
+[placement]
+compatible_backends = ["vllm-cuda", "vllm-rocm"]
+backend_preference = ["vllm-cuda", "vllm-rocm"]
+
+[storage_size]
+in_bytes = 29551669999

--- a/resources/inference_model_cards/Qwen--Qwen2.5-7B-Instruct.toml
+++ b/resources/inference_model_cards/Qwen--Qwen2.5-7B-Instruct.toml
@@ -3,8 +3,7 @@
 # installed with --with-vllm can serve without hand-authoring a card. Qwen2.5
 # is an INSTRUCT model, NOT a thinking model (no <think> mode before Qwen3),
 # so capabilities are text-only and no [reasoning] section is declared. Tool
-# calling follows the qwen family default; [tooling] is stated explicitly for
-# clarity. context_length is the config.json max_position_embeddings (32768);
+# calling is declared off: see the [tooling] platform-truth note below. context_length is the config.json max_position_embeddings (32768);
 # the GGUF sibling card's 131072 comes from YaRN extension, which this card
 # does not claim because vLLM serves the config default. `supports_tensor =
 # false`: vLLM runs single-node in Skulk (its internal tensor parallelism is
@@ -25,9 +24,14 @@ capabilities = ["text"]
 context_length = 32768
 trust_remote_code = false
 
+# PLATFORM truth override: Qwen2.5 the MODEL supports OpenAI tool calling
+# (the qwen family default would advertise it), but these cards serve
+# exclusively on the vllm engine, whose runner does not implement tool
+# dispatch yet (#638). Advertising tools here would promise a guaranteed
+# runtime error. Flip this back to the family default when the vllm runner
+# gains tool calling.
 [tooling]
-supports_tool_calling = true
-tool_call_format = "generic"
+supports_tool_calling = false
 
 [placement]
 compatible_backends = ["vllm-cuda", "vllm-rocm"]

--- a/resources/inference_model_cards/Qwen--Qwen2.5-7B-Instruct.toml
+++ b/resources/inference_model_cards/Qwen--Qwen2.5-7B-Instruct.toml
@@ -1,0 +1,37 @@
+# Qwen2.5-7B-Instruct (official Qwen safetensors release, bf16) for the vllm
+# served engine (#630): the first shipped cards reaching vLLM, so a node
+# installed with --with-vllm can serve without hand-authoring a card. Qwen2.5
+# is an INSTRUCT model, NOT a thinking model (no <think> mode before Qwen3),
+# so capabilities are text-only and no [reasoning] section is declared. Tool
+# calling follows the qwen family default; [tooling] is stated explicitly for
+# clarity. context_length is the config.json max_position_embeddings (32768);
+# the GGUF sibling card's 131072 comes from YaRN extension, which this card
+# does not claim because vLLM serves the config default. `supports_tensor =
+# false`: vLLM runs single-node in Skulk (its internal tensor parallelism is
+# not cluster sharding). Architecture from config.json (qwen2: 28 layers,
+# hidden 3584, 4 KV heads, bf16). storage_size is the full repo staging set
+# (safetensors shards + tokenizer/config); serving live-validated on an A100
+# 80GB during the 1.5.0 CUDA hardware matrix.
+model_id = "Qwen/Qwen2.5-7B-Instruct"
+n_layers = 28
+hidden_size = 3584
+num_key_value_heads = 4
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "bf16"
+base_model = "Qwen2.5 7B Instruct"
+capabilities = ["text"]
+context_length = 32768
+trust_remote_code = false
+
+[tooling]
+supports_tool_calling = true
+tool_call_format = "generic"
+
+[placement]
+compatible_backends = ["vllm-cuda", "vllm-rocm"]
+backend_preference = ["vllm-cuda", "vllm-rocm"]
+
+[storage_size]
+in_bytes = 15242788168

--- a/src/skulk/shared/tests/test_bundled_model_cards.py
+++ b/src/skulk/shared/tests/test_bundled_model_cards.py
@@ -31,9 +31,11 @@ _CARD_DIRS = {
 
 # Mirrors _ENGINES x _COMPUTE_BACKENDS in skulk.shared.backends. If an engine
 # or compute backend is added there, extend this and the assertions below.
-_VALID_TAGS = frozenset({"mlx", "mlx_audio", "llama_cpp", "llama_server"}) | frozenset(
+_VALID_TAGS = frozenset(
+    {"mlx", "mlx_audio", "llama_cpp", "llama_server", "vllm"}
+) | frozenset(
     f"{engine}-{compute}"
-    for engine in ("mlx", "mlx_audio", "llama_cpp", "llama_server")
+    for engine in ("mlx", "mlx_audio", "llama_cpp", "llama_server", "vllm")
     for compute in ("metal", "vulkan", "rocm", "cuda", "cpu")
 )
 


### PR DESCRIPTION
Fixes #630.

## Problem

\`install.sh --with-vllm\` wires the vllm engine and the node advertises \`vllm-cuda\`, but no shipped inference card declared a vllm backend, so vLLM was unreachable without hand-authoring a custom card. Found during the 1.5.0 CUDA hardware matrix.

## Change

Three new inference cards for official Qwen safetensors releases (bf16), the vLLM starter set:

- \`Qwen/Qwen2.5-1.5B-Instruct\` (~3.1 GB): smoke-test size, places on any vLLM-capable GPU
- \`Qwen/Qwen2.5-7B-Instruct\` (~15.2 GB): the mid-size default
- \`Qwen/Qwen2.5-14B-Instruct\` (~29.6 GB): fits 48 GB-class GPUs with KV headroom

Card facts sourced from each repo's config.json (layers, hidden size, KV heads, 32768 context: the config value, deliberately not the GGUF sibling's 131072 YaRN-extended claim). \`storage_size\` is the full staging set from the HF file listing. \`compatible_backends = ["vllm-cuda", "vllm-rocm"]\` per model truth: the artifacts run on vLLM on either vendor; node capability decides eligibility.

## Validation

- Card suite passes (56 tests); all three cards load through the card cache and keep their vllm tags through \`platform_compatible_backends\`.
- The 7B serve path was live-validated end-to-end on an A100 80GB during the matrix run (vllm 0.11.0, coherent chat output, 8/32-way concurrency) using an equivalent hand-authored card; the release-candidate battery should include one vLLM cell exercising these shipped cards on a fresh pod.