### PR TITLE
fix(vllm): engine-exact token counts via include_usage; cache-honest prompt rate (#631)

### DIFF
--- a/src/skulk/worker/runner/vllm/runner.py
+++ b/src/skulk/worker/runner/vllm/runner.py
@@ -224,6 +224,10 @@ def build_vllm_serve_args(
         f"{gpu_memory_utilization:.2f}",
         "--tensor-parallel-size",
         "1",
+        # Off by default in vLLM; without it the include_usage final chunk
+        # carries no prompt_tokens_details, so the cache-honest prompt rate
+        # (#631) would silently never subtract cached prefix tokens.
+        "--enable-prompt-tokens-details",
     ]
     if trust_remote_code:
         args.append("--trust-remote-code")

--- a/src/skulk/worker/runner/vllm/runner.py
+++ b/src/skulk/worker/runner/vllm/runner.py
@@ -159,6 +159,7 @@ class _StreamDelta(NamedTuple):
     content: str
     finish: Literal["stop", "length", "content_filter"] | None
     done: bool  # the terminal ``data: [DONE]`` sentinel
+    usage: dict[str, Any] | None = None  # the include_usage final-chunk counts
 
 
 def _gpu_memory_utilization() -> float:
@@ -281,6 +282,20 @@ def vllm_reasoning_overrides(task_params: Any) -> dict[str, Any]:
     return overrides
 
 
+def _usage_count(usage: dict[str, Any] | None, key: str) -> int | None:
+    """A non-negative integer token count from a usage object, or ``None``.
+
+    Bool-guarded like every timings extraction: JSON ``true`` is an ``int``
+    to ``isinstance`` and must not read as a count of one.
+    """
+    if usage is None:
+        return None
+    value = usage.get(key)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
 def parse_openai_sse_line(line: str) -> _StreamDelta | None:
     """Parse one OpenAI SSE line into a ``_StreamDelta``, or ``None`` to skip it.
 
@@ -302,8 +317,15 @@ def parse_openai_sse_line(line: str) -> _StreamDelta | None:
         return None
     if not isinstance(chunk, dict):
         return None
+    raw_usage = chunk.get("usage")
+    usage = raw_usage if isinstance(raw_usage, dict) else None
     choices = chunk.get("choices")
     if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        # The stream_options include_usage final chunk carries empty choices
+        # plus the engine-exact token counts (#631); anything else choice-less
+        # stays skipped.
+        if usage is not None:
+            return _StreamDelta("", "", None, done=False, usage=usage)
         return None
     choice = choices[0]
     raw_delta = choice.get("delta")
@@ -325,6 +347,7 @@ def parse_openai_sse_line(line: str) -> _StreamDelta | None:
         content=delta.get("content") or "",
         finish=finish,
         done=False,
+        usage=usage,
     )
 
 
@@ -696,6 +719,10 @@ class Runner(ServedConcurrentDispatch):
         command_id: CommandId,
     ) -> None:
         body["stream"] = True
+        # The final pre-[DONE] chunk then carries engine-exact token counts
+        # (empty choices + usage), the only place the proxy can learn the
+        # prompt size (#631).
+        body["stream_options"] = {"include_usage": True}
         assert self.base_url is not None
         clock = StreamStatsClock()
         # In-flight captured at THIS task's admission on the dispatch loop, for
@@ -705,16 +732,41 @@ class Runner(ServedConcurrentDispatch):
         # thread, so a burst does not collapse every sample into one bucket.
         admission_in_flight = self._admission_concurrency(task.task_id)
 
+        last_usage: dict[str, Any] | None = None
+
         def final_stats() -> GenerationStats:
             # Peak memory always comes from the server child (weights + KV live
-            # there), never this proxy. Prompt count is unknowable from the SSE
-            # stream, reported as 0 (a zero reads as "unmeasured").
+            # there), never this proxy. Token counts come from the
+            # include_usage final chunk when it arrived (engine-exact); a
+            # stream that ended without one falls back to prompt 0
+            # ("unmeasured") and the piece count. The prompt RATE covers only
+            # newly processed tokens so a prefix-cache hit cannot inflate it,
+            # while the reported prompt COUNT stays the request's true size
+            # (the same cache-hit rule as the llama_server path, #611/#631).
+            prompt_total = _usage_count(last_usage, "prompt_tokens") or 0
+            generation = _usage_count(last_usage, "completion_tokens") or clock.pieces
+            processed_prompt = prompt_total
+            if last_usage is not None:
+                details = last_usage.get("prompt_tokens_details")
+                if isinstance(details, dict):
+                    cached = details.get("cached_tokens")
+                    if (
+                        isinstance(cached, int)
+                        and not isinstance(cached, bool)
+                        and 0 < cached <= prompt_total
+                    ):
+                        processed_prompt = prompt_total - cached
             base = clock.stats(
-                prompt_tokens=0, generation_tokens=clock.pieces
-            ).model_copy(update={"peak_memory_usage": self._server_peak_memory()})
+                prompt_tokens=processed_prompt, generation_tokens=generation
+            ).model_copy(
+                update={
+                    "prompt_tokens": prompt_total,
+                    "peak_memory_usage": self._server_peak_memory(),
+                }
+            )
             return self.stamp_runner_stats(base, admission_in_flight)
 
-        emitted_finish = False
+        finish_reason: Literal["stop", "length", "content_filter"] | None = None
         # No read timeout: generation can pause between tokens on a busy GPU. The
         # connection is closed (aborting server generation) when we break out.
         timeout = httpx.Timeout(connect=15.0, read=None, write=30.0, pool=None)
@@ -734,6 +786,8 @@ class Runner(ServedConcurrentDispatch):
                     continue
                 if delta.done:
                     break
+                if delta.usage is not None:
+                    last_usage = delta.usage
                 if delta.reasoning or delta.content:
                     # One SSE delta per generated token piece.
                     clock.mark_piece()
@@ -744,19 +798,20 @@ class Runner(ServedConcurrentDispatch):
                 if delta.content:
                     self._send_token(command_id, model_id, delta.content)
                 if delta.finish is not None:
-                    self._send_token(
-                        command_id,
-                        model_id,
-                        "",
-                        finish_reason=delta.finish,
-                        stats=final_stats(),
-                    )
-                    emitted_finish = True
-        # Guarantee a terminal chunk so the consumer's stream closes even if the
-        # server ended without an explicit finish_reason.
-        if not emitted_finish and not self._is_cancelled(task.task_id):
+                    # The terminal chunk is deferred past the loop: the
+                    # include_usage counts arrive AFTER the finish_reason
+                    # chunk, and stats must include them (#631).
+                    finish_reason = delta.finish
+        # One guaranteed terminal chunk (with final stats) once the stream is
+        # fully drained, whether or not the server sent an explicit
+        # finish_reason.
+        if not self._is_cancelled(task.task_id):
             self._send_token(
-                command_id, model_id, "", finish_reason="stop", stats=final_stats()
+                command_id,
+                model_id,
+                "",
+                finish_reason=finish_reason or "stop",
+                stats=final_stats(),
             )
 
     def _server_peak_memory(self) -> Memory:

--- a/src/skulk/worker/runner/vllm/runner.py
+++ b/src/skulk/worker/runner/vllm/runner.py
@@ -321,10 +321,11 @@ def parse_openai_sse_line(line: str) -> _StreamDelta | None:
     usage = raw_usage if isinstance(raw_usage, dict) else None
     choices = chunk.get("choices")
     if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
-        # The stream_options include_usage final chunk carries empty choices
-        # plus the engine-exact token counts (#631); anything else choice-less
-        # stays skipped.
-        if usage is not None:
+        # The stream_options include_usage final chunk carries exactly
+        # ``"choices": []`` plus the engine-exact token counts (#631); only
+        # that shape is accepted, so a malformed payload that happens to have
+        # a usage-shaped field stays skipped like any other stray line.
+        if usage is not None and isinstance(choices, list) and not choices:
             return _StreamDelta("", "", None, done=False, usage=usage)
         return None
     choice = choices[0]
@@ -744,7 +745,12 @@ class Runner(ServedConcurrentDispatch):
             # while the reported prompt COUNT stays the request's true size
             # (the same cache-hit rule as the llama_server path, #611/#631).
             prompt_total = _usage_count(last_usage, "prompt_tokens") or 0
-            generation = _usage_count(last_usage, "completion_tokens") or clock.pieces
+            # Explicit None check: an engine-exact completion count of 0 is a
+            # real measurement and must not fall back to the piece count.
+            usage_generation = _usage_count(last_usage, "completion_tokens")
+            generation = (
+                usage_generation if usage_generation is not None else clock.pieces
+            )
             processed_prompt = prompt_total
             if last_usage is not None:
                 details = last_usage.get("prompt_tokens_details")

--- a/src/skulk/worker/runner/vllm/tests/test_vllm_runner.py
+++ b/src/skulk/worker/runner/vllm/tests/test_vllm_runner.py
@@ -179,6 +179,11 @@ def test_parse_sse_done_sentinel() -> None:
         "event: ping",  # non-data line
         "data: {not json}",  # malformed json
         'data: {"choices":[]}',  # choice-less payload without usage
+        # usage may only ride a well-formed chunk: choices exactly [] (the
+        # include_usage final chunk) or a dict-bearing choices list.
+        'data: {"usage":{"prompt_tokens":5}}',  # no choices key at all
+        'data: {"choices":"x","usage":{"prompt_tokens":5}}',  # malformed choices
+        'data: {"choices":[42],"usage":{"prompt_tokens":5}}',  # non-dict choice
         "",  # blank
     ],
 )

--- a/src/skulk/worker/runner/vllm/tests/test_vllm_runner.py
+++ b/src/skulk/worker/runner/vllm/tests/test_vllm_runner.py
@@ -127,6 +127,9 @@ def test_build_vllm_serve_args_shape() -> None:
     assert args[args.index("--gpu-memory-utilization") + 1] == "0.90"
     # single-node in this slice.
     assert args[args.index("--tensor-parallel-size") + 1] == "1"
+    # Required for prompt_tokens_details in the include_usage final chunk;
+    # without it the cache-honest prompt rate (#631) never sees cached counts.
+    assert "--enable-prompt-tokens-details" in args
 
 
 def test_build_vllm_serve_args_trust_remote_code() -> None:

--- a/src/skulk/worker/runner/vllm/tests/test_vllm_runner.py
+++ b/src/skulk/worker/runner/vllm/tests/test_vllm_runner.py
@@ -178,12 +178,53 @@ def test_parse_sse_done_sentinel() -> None:
     [
         "event: ping",  # non-data line
         "data: {not json}",  # malformed json
-        'data: {"choices":[]}',  # choice-less payload
+        'data: {"choices":[]}',  # choice-less payload without usage
         "",  # blank
     ],
 )
 def test_parse_sse_skips_non_deltas(line: str) -> None:
     assert parse_openai_sse_line(line) is None
+
+
+def test_parse_sse_usage_final_chunk() -> None:
+    # The stream_options include_usage final chunk: empty choices, engine-exact
+    # counts (#631). Must parse into a usage-bearing delta, not be skipped.
+    line = (
+        'data: {"choices":[],"usage":{"prompt_tokens":1000,'
+        '"completion_tokens":40,"prompt_tokens_details":{"cached_tokens":990}}}'
+    )
+    delta = parse_openai_sse_line(line)
+    assert delta is not None
+    assert delta.usage == {
+        "prompt_tokens": 1000,
+        "completion_tokens": 40,
+        "prompt_tokens_details": {"cached_tokens": 990},
+    }
+    assert delta.content == "" and delta.finish is None and not delta.done
+
+
+def test_parse_sse_usage_on_choice_chunk() -> None:
+    # Some servers attach usage on the last choice-bearing chunk instead of a
+    # separate one; it must ride along with the delta.
+    line = (
+        'data: {"choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}],'
+        '"usage":{"prompt_tokens":7,"completion_tokens":2}}'
+    )
+    delta = parse_openai_sse_line(line)
+    assert delta is not None
+    assert delta.content == "hi"
+    assert delta.finish == "stop"
+    assert delta.usage == {"prompt_tokens": 7, "completion_tokens": 2}
+
+
+def test_usage_count_bool_and_shape_guards() -> None:
+    from skulk.worker.runner.vllm.runner import _usage_count
+
+    assert _usage_count({"prompt_tokens": 1000}, "prompt_tokens") == 1000
+    assert _usage_count({"prompt_tokens": True}, "prompt_tokens") is None
+    assert _usage_count({"prompt_tokens": -1}, "prompt_tokens") is None
+    assert _usage_count({"prompt_tokens": "10"}, "prompt_tokens") is None
+    assert _usage_count(None, "prompt_tokens") is None
 
 
 def test_gpu_memory_utilization_default(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #631.

## Problem

Completions served through the vllm proxy engine reported \`prompt_tps\` and \`prompt_tokens\` as 0 (found during the 1.5.0 CUDA hardware matrix): the SSE loop had no source for the prompt size and stamped zero with a "unknowable from the stream" comment. It is knowable: the OpenAI streaming protocol's \`stream_options: {"include_usage": true}\` makes the final pre-[DONE] chunk carry engine-exact token counts.

## Fix

- The streaming request sets \`stream_options.include_usage\`.
- The SSE parser carries a chunk's \`usage\` object; the include_usage final chunk (empty choices + usage) parses into a usage-bearing delta instead of being skipped.
- The terminal TokenChunk is deferred until the stream drains, because the usage chunk arrives after the finish_reason chunk and final stats must include it. The guaranteed-terminal behavior (server ends without finish_reason) and the cancellation no-terminal behavior are unchanged.
- Stats: wall-phase rates from the StreamStatsClock with engine-exact counts. The prompt RATE covers only newly processed tokens (\`prompt_tokens_details.cached_tokens\` subtracted) while the reported prompt COUNT stays the request's true size: the same cache-hit rule as the llama_server path (#611, PR #626). Streams without a usage chunk keep the previous prompt-0 ("unmeasured") and piece-count fallback.

## Tests

Parser: include_usage final chunk parses with counts; usage riding a choice chunk is preserved; \`_usage_count\` bool/negative/string/None guards. 37 vllm runner tests pass, basedpyright 0 errors, ruff clean.