### PR TITLE
fix(master): stop the guaranteed NodeConfig rejection; rejected-event warnings name the payload (#633)

### DIFF
--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -1751,9 +1751,25 @@ class Master:
                         type(local_event.event),
                         now=time.monotonic(),
                     ):
+                        # Envelope events (NodeGatheredInfo and friends) all
+                        # share one event name; without the payload type the
+                        # warning cannot identify WHICH reading keeps landing
+                        # on the wrong plane (#633).
+                        rejected = local_event.event
+                        payload: object | None = None
+                        if isinstance(rejected, NodeGatheredInfo):
+                            payload = rejected.info
+                        elif isinstance(rejected, NodeDownloadProgress):
+                            payload = rejected.download_progress
+                        payload_note = (
+                            f" carrying {type(payload).__name__}"
+                            if payload is not None
+                            else ""
+                        )
                         logger.warning(
                             "Rejected non-control event before ordering/indexing: "
-                            f"{type(local_event.event).__name__}"
+                            f"{type(local_event.event).__name__}{payload_note} "
+                            f"from {local_event.origin}"
                         )
                     self._multi_buffer.skip(
                         local_event.origin_idx, local_event.origin

--- a/src/skulk/utils/info_gatherer/info_gatherer.py
+++ b/src/skulk/utils/info_gatherer/info_gatherer.py
@@ -615,10 +615,12 @@ class InfoGatherer:
                 tg.start_soon(self._monitor_disk_usage)
                 tg.start_soon(self._monitor_capabilities)
                 tg.start_soon(self._monitor_heartbeat)
-
-                nc = await NodeConfig.gather()
-                if nc is not None:
-                    await self.info_sender.send(nc)
+                # NodeConfig is deliberately NOT sent: it is neither a
+                # telemetry-plane reading nor a durable control event, so the
+                # master rejects it before ordering and nothing consumes it
+                # (apply() no-ops it). Sending it only produced a guaranteed
+                # rejected-event warning at every startup (#633). The type
+                # stays in the GatheredInfo union for wire decode.
         except BaseExceptionGroup as exception_group:
             # A closed/broken info channel means our consumer is gone — the
             # worker is shutting down or being replaced on a master

--- a/src/skulk/utils/info_gatherer/tests/test_consumer_gone.py
+++ b/src/skulk/utils/info_gatherer/tests/test_consumer_gone.py
@@ -65,18 +65,20 @@ async def test_consumer_closing_mid_run_stops_cleanly():
 
 
 async def test_real_errors_still_propagate(monkeypatch: pytest.MonkeyPatch):
-    # The consumer-gone handling must not swallow genuine faults. The fault
-    # is injected through the static-info monitor (the one-shot NodeConfig
-    # send this test originally used no longer exists, #633).
+    # The consumer-gone handling must not swallow genuine faults. Monitor
+    # LOOPS deliberately catch per-iteration gather errors, so the fault is
+    # injected at the task level: a monitor coroutine that dies outright,
+    # which is exactly what run()'s group handling must re-raise (the
+    # one-shot NodeConfig send this test originally rode was removed in
+    # #633).
     from skulk.utils.info_gatherer import info_gatherer as module
 
-    async def explode():
+    async def explode(self: InfoGatherer) -> None:
         raise ValueError("genuine gatherer fault")
 
-    monkeypatch.setattr(module.StaticNodeInformation, "gather", explode)
+    monkeypatch.setattr(module.InfoGatherer, "_monitor_static_info", explode)
     info_send, _info_recv = channel[GatheredInfo]()
     gatherer = _quiet_gatherer(info_send)
-    gatherer.static_info_poll_interval = 0.05
     with pytest.raises(BaseExceptionGroup) as exc_info:
         with anyio.fail_after(30):
             await gatherer.run()

--- a/src/skulk/utils/info_gatherer/tests/test_consumer_gone.py
+++ b/src/skulk/utils/info_gatherer/tests/test_consumer_gone.py
@@ -16,8 +16,11 @@ from skulk.utils.info_gatherer.info_gatherer import GatheredInfo, InfoGatherer
 
 
 def _quiet_gatherer(info_send: Sender[GatheredInfo]) -> InfoGatherer:
-    """A gatherer whose periodic monitors are all disabled, so the only
-    send is the startup NodeConfig — the exact line that crashed in #266."""
+    """A gatherer whose periodic monitors are all disabled.
+
+    Each test enables exactly the monitor it needs (the startup NodeConfig
+    send that originally crashed in #266, and that these tests first drove
+    their sends through, was removed in #633: it had no consumer)."""
     return InfoGatherer(
         info_sender=info_send,
         heartbeat_poll_interval=None,
@@ -62,15 +65,18 @@ async def test_consumer_closing_mid_run_stops_cleanly():
 
 
 async def test_real_errors_still_propagate(monkeypatch: pytest.MonkeyPatch):
-    # The consumer-gone handling must not swallow genuine faults.
+    # The consumer-gone handling must not swallow genuine faults. The fault
+    # is injected through the static-info monitor (the one-shot NodeConfig
+    # send this test originally used no longer exists, #633).
     from skulk.utils.info_gatherer import info_gatherer as module
 
     async def explode():
         raise ValueError("genuine gatherer fault")
 
-    monkeypatch.setattr(module.NodeConfig, "gather", explode)
+    monkeypatch.setattr(module.StaticNodeInformation, "gather", explode)
     info_send, _info_recv = channel[GatheredInfo]()
     gatherer = _quiet_gatherer(info_send)
+    gatherer.static_info_poll_interval = 0.05
     with pytest.raises(BaseExceptionGroup) as exc_info:
         with anyio.fail_after(30):
             await gatherer.run()

--- a/src/skulk/utils/info_gatherer/tests/test_consumer_gone.py
+++ b/src/skulk/utils/info_gatherer/tests/test_consumer_gone.py
@@ -31,8 +31,11 @@ def _quiet_gatherer(info_send: Sender[GatheredInfo]) -> InfoGatherer:
         mactop_interval=None,
         thunderbolt_bridge_poll_interval=None,
         static_info_poll_interval=None,
+        node_resources_poll_interval=None,
         rdma_ctl_poll_interval=None,
         disk_poll_interval=None,
+        gpu_linux_poll_interval=None,
+        capabilities_poll_interval=None,
     )
 
 


### PR DESCRIPTION
Fixes #633.

## Problem

Fresh nodes log \`Rejected non-control event before ordering/indexing: NodeGatheredInfo\` warnings on a healthy box (found during the 1.5.0 CUDA hardware matrix). Two defects behind it:

1. The worker's InfoGatherer sends a one-shot \`NodeConfig\` reading onto the event path at every startup. \`NodeConfig\` is in neither the telemetry plane nor the durable control-event allowlist, so the master is guaranteed to reject it, and \`apply()\` no-ops it even when delivered: a send with no consumer whose only effect is the warning.
2. The warning names only the envelope event type. Every gathered reading shares the \`NodeGatheredInfo\` name, so the message cannot identify which reading landed on the wrong plane; the matrix agents could observe the noise but not attribute it.

## Fix

- The \`NodeConfig\` send is removed, with a comment explaining why (the type stays in the \`GatheredInfo\` union for wire decode).
- The rejected-event warning now names the envelope's payload type and origin (typed isinstance dispatch for \`NodeGatheredInfo\` / \`NodeDownloadProgress\`), so any residual repeater self-identifies in operator logs.

## Validation

Local headless node runs, unpatched dev vs this branch, identical teardown noise aside: exactly one rejection at startup before, zero after. basedpyright 0 errors, ruff clean, 626 master+shared tests pass.