### PR TITLE
fix(install): refuse network-filesystem install targets with the fix named (#627)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -145,7 +145,10 @@ cd "$INSTALL_DIR"
 # cryptically minutes later; SKULK_INSTALL_ALLOW_NETWORK_FS=1 overrides for
 # network mounts known to behave.
 if [[ "$OS" == "Linux" ]] && command -v findmnt >/dev/null 2>&1; then
-    FS_TYPE="$(findmnt -n -o FSTYPE --target "$INSTALL_DIR" 2>/dev/null || true)"
+    # $PWD, not $INSTALL_DIR: after the cd above, a relative --dir would
+    # resolve against the new working directory and silently skip the guard
+    # (PR #640 review).
+    FS_TYPE="$(findmnt -n -o FSTYPE --target "$PWD" 2>/dev/null || true)"
     case "$FS_TYPE" in
         nfs|nfs4|cifs|smb3|9p|lustre|ceph|glusterfs|fuse.*|moosefs|mfs)
             if [[ "${SKULK_INSTALL_ALLOW_NETWORK_FS:-}" == "1" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -137,6 +137,26 @@ else
 fi
 cd "$INSTALL_DIR"
 
+# --- filesystem sanity -------------------------------------------------------
+
+# Network filesystems break uv's installer mid-sync ('Stale file handle',
+# reproduced on RunPod's /workspace MooseFS volume, #627) and are slow homes
+# for a venv regardless. Refuse loudly with the fix instead of failing
+# cryptically minutes later; SKULK_INSTALL_ALLOW_NETWORK_FS=1 overrides for
+# network mounts known to behave.
+if [[ "$OS" == "Linux" ]] && command -v findmnt >/dev/null 2>&1; then
+    FS_TYPE="$(findmnt -n -o FSTYPE --target "$INSTALL_DIR" 2>/dev/null || true)"
+    case "$FS_TYPE" in
+        nfs|nfs4|cifs|smb3|9p|lustre|ceph|glusterfs|fuse.*|moosefs|mfs)
+            if [[ "${SKULK_INSTALL_ALLOW_NETWORK_FS:-}" == "1" ]]; then
+                warn "installing on a network filesystem ($FS_TYPE) because SKULK_INSTALL_ALLOW_NETWORK_FS=1; uv sync may fail with stale file handles"
+            else
+                die "install directory $INSTALL_DIR sits on a network filesystem ($FS_TYPE), which breaks uv's installer (stale file handles) and slows the node. Re-run with --dir on a local disk (container/cloud boxes: e.g. --dir \$HOME/skulk on the container disk, not /workspace), or set SKULK_INSTALL_ALLOW_NETWORK_FS=1 to proceed anyway."
+            fi
+            ;;
+    esac
+fi
+
 # --- environment -----------------------------------------------------------
 
 # An existing-but-old uv rejects this project's configuration; upgrade it to

--- a/website/docs/nvidia-cuda-nodes.md
+++ b/website/docs/nvidia-cuda-nodes.md
@@ -99,6 +99,14 @@ runs through the CUDA paths: the CUDA engine wheel for GGUF, and **vLLM as the
 served path for high-concurrency workloads** (neither needs Vulkan; both need
 only the driver the pod image already carries).
 
+**Install on the container disk, not the network volume.** Pod network
+volumes (RunPod's `/workspace`) break the Python installer mid-sync with
+stale-file-handle errors and make a slow home for the environment. The
+installer detects a network-filesystem target and refuses with the fix;
+pass `--dir "$HOME/skulk"` (or any container-local path) instead. Network
+mounts you know to behave can be forced with
+`SKULK_INSTALL_ALLOW_NETWORK_FS=1`.
+
 For repeated rented-GPU sessions there is a **prebaked pod image** on GHCR:
 
 ```


### PR DESCRIPTION
Fixes #627.

## Problem

\`uv sync\` fails mid-install with \`Stale file handle (os error 116)\` when the install directory sits on a network filesystem; reproduced on two independent fresh RunPod pods whose default working directory (\`/workspace\`, MooseFS) is exactly where a new user lands. The failure surfaces minutes in, deep inside uv output, with no hint of the cause.

## Fix

- \`install.sh\` resolves the target's filesystem type (\`findmnt\`, Linux only) before syncing and refuses known network filesystems (nfs/nfs4, cifs/smb3, 9p, lustre, ceph, glusterfs, fuse.*, moosefs/mfs) with a message naming the remediation: re-run with \`--dir\` on a local disk (container boxes: the container disk, not \`/workspace\`).
- \`SKULK_INSTALL_ALLOW_NETWORK_FS=1\` overrides for network mounts known to behave, downgrading the refusal to a warning.
- The NVIDIA/CUDA nodes page's container-cloud section documents the behavior.

Deliberately NOT included: a doctor check for a network-FS install root. By the time a node runs, its environment already synced successfully, so the check would fire only on boxes the guard already served; low value against the doctor-registry surface it would add.

## Validation

\`bash -n\` clean; the case-pattern match verified against \`findmnt -n -o FSTYPE\` outputs for local (ext4/xfs/overlay pass through) and network types. The real-pod proof rides the release-candidate battery's fresh-box row, which should include one deliberate \`--dir /workspace\` attempt asserting the refusal message.