### PR TITLE
fix(llama-cpp): keep sliding-window cache bounded

### DIFF
--- a/src/skulk/api/tests/test_capability_stream.py
+++ b/src/skulk/api/tests/test_capability_stream.py
@@ -410,12 +410,16 @@ class _ImmediateFailureInputProvider(_BidirectionalProvider):
         )
 
 
-def _build_api(provider: object) -> API:
+def _build_api(
+    provider: object, *, provider_transport_buffer: int = 256
+) -> API:
     command_sender, _ = channel[ForwarderCommand]()
     download_sender, _ = channel[ForwarderDownloadCommand]()
     _, event_receiver = channel[IndexedEvent]()
     _, election_receiver = channel[ElectionMessage]()
-    provider_sender, provider_receiver = channel[ProviderStreamPacket](256)
+    provider_sender, provider_receiver = channel[ProviderStreamPacket](
+        provider_transport_buffer
+    )
     return API(
         NodeId("api-node"),
         port=52415,
@@ -1196,7 +1200,10 @@ async def test_cancel_racing_admission_still_emits_started_first() -> None:
 
 
 async def test_caller_queue_overflow_cannot_report_truncated_stream_complete() -> None:
-    api = _build_api(_BurstProvider())
+    # The simulated transport must hold more than the caller's 256-frame queue;
+    # otherwise upstream backpressure prevents the queue under test from ever
+    # overflowing and the provider legitimately completes the whole stream.
+    api = _build_api(_BurstProvider(), provider_transport_buffer=512)
     context = api._extension_context  # pyright: ignore[reportPrivateUsage]
     opened = False
     frames: list[CapabilityStreamFrame] = []
@@ -1214,7 +1221,9 @@ async def test_caller_queue_overflow_cannot_report_truncated_stream_complete() -
             timeout_seconds=5.0,
         )
         opened = session.open_result.ok
-        await anyio.sleep(0.1)
+        with anyio.fail_after(1.0):
+            while api._provider_stream_receivers:  # pyright: ignore[reportPrivateUsage]
+                await anyio.sleep(0.01)
         frames = [frame async for frame in session.frames]
         task_group.cancel_scope.cancel()
 

--- a/src/skulk/shared/models/memory_estimate.py
+++ b/src/skulk/shared/models/memory_estimate.py
@@ -92,6 +92,18 @@ KV_DTYPE_BYTES: int = 2
 """Bytes per KV-cache element. MLX keeps the KV cache in fp16 even for 4-bit
 weights unless quantized-KV is explicitly enabled, which Skulk does not."""
 
+LLAMA_CPP_FULL_SWA_CACHE: Final = False
+"""Whether the in-process llama.cpp runner expands sliding-window attention.
+
+This is part of the memory-admission contract, not a performance preference.
+The generic GGUF estimate conservatively charges every layer for the full
+context using the card's scalar KV geometry. That safely overestimates a
+bounded sliding-window cache, but it can underestimate ``swa_full=True`` for
+architectures whose sliding layers use wider K/V tensors than their global
+layers. Keep the runner tied to this constant so a dependency default cannot
+silently invalidate the context window Skulk admitted.
+"""
+
 
 def memory_overhead_factor(model_card: ModelCard) -> float:
     """Engine-appropriate weight-overhead multiplier for a model.

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -16,8 +16,10 @@ warmup), mirroring the embeddings runner's group-less lifecycle.
 cleanly on nodes (e.g. Macs) where the binding is not installed.
 """
 
+import inspect
 import os
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Final, Literal
 
@@ -120,6 +122,29 @@ _VISION_HANDLER_BY_MODEL_TYPE: dict[str, str] = {
     "moondream": "MoondreamChatHandler",
     "nanollava": "NanoLlavaChatHandler",
 }
+
+
+def _require_bounded_swa_support(llama_class: Callable[..., object]) -> None:
+    """Fail closed when the installed binding cannot apply ``swa_full``.
+
+    Older llama-cpp-python releases accept arbitrary keyword arguments and
+    silently ignore ``swa_full``. Continuing on those builds would restore the
+    runtime/admission mismatch this runner is required to prevent.
+    """
+    try:
+        parameters = inspect.signature(llama_class).parameters
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "cannot verify llama-cpp-python bounded SWA support; install a "
+            "build whose Llama constructor explicitly declares swa_full"
+        ) from exc
+    if "swa_full" not in parameters:
+        raise RuntimeError(
+            "installed llama-cpp-python does not explicitly support swa_full; "
+            "refusing to load because full SWA cache can exceed admission"
+        )
+
+
 _DEFAULT_VISION_HANDLER: Final = "MTMDChatHandler"
 
 
@@ -758,6 +783,8 @@ class Runner:
         from llama_cpp import Llama  # pyright: ignore[reportAttributeAccessIssue]
 
         from skulk.download.download_utils import build_model_path
+
+        _require_bounded_swa_support(Llama)
 
         card = self.shard_metadata.model_card
         model_id = card.model_id

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -25,7 +25,10 @@ from anyio import WouldBlock
 
 from skulk.api.types import GenerationStats, ToolCallItem, TopLogprobItem
 from skulk.shared.models.capabilities import resolve_model_capability_profile
-from skulk.shared.models.memory_estimate import KV_CONTEXT_BUDGET_TOKENS
+from skulk.shared.models.memory_estimate import (
+    KV_CONTEXT_BUDGET_TOKENS,
+    LLAMA_CPP_FULL_SWA_CACHE,
+)
 from skulk.shared.models.model_cards import OutputParserType, ReasoningFormat
 from skulk.shared.types.chunks import ErrorChunk, TokenChunk, ToolCallChunk
 from skulk.shared.types.common import CommandId, ModelId
@@ -781,9 +784,12 @@ class Runner:
         # built with (Vulkan/ROCm/CUDA). n_ctx is bounded by the KV budget
         # placement reserved (never 0/full-context nor the larger admission
         # ceiling, either of which OOM-kills the node on a large-context model --
-        # see serving_n_ctx). logits_all (logprobs, opt-in) further bounds it
-        # because it pre-allocates an n_ctx*vocab*4 logits buffer. See
-        # _logits_all_enabled / _logits_all_n_ctx.
+        # see serving_n_ctx). Sliding-window attention must remain bounded: the
+        # shared estimator conservatively accounts for that mode, while
+        # llama-cpp-python defaults swa_full to true and can otherwise allocate a
+        # full-context cache for every sliding layer. logits_all (logprobs,
+        # opt-in) further bounds n_ctx because it pre-allocates an n_ctx*vocab*4
+        # logits buffer. See _logits_all_enabled / _logits_all_n_ctx.
         logits_all = _logits_all_enabled()
         n_ctx = serving_n_ctx(self.context_token_limit, logits_all)
         # Vision GGUF (#128): when the card declares a vision config, load the
@@ -810,7 +816,7 @@ class Runner:
         logger.info(
             f"loading GGUF {gguf_path.name} for {model_id} "
             f"(n_ctx={n_ctx}, logits_all={logits_all}, flash_attn={flash_attn}, "
-            f"vision={vision is not None})"
+            f"swa_full={LLAMA_CPP_FULL_SWA_CACHE}, vision={vision is not None})"
         )
         with runner_phase(
             "load_model",
@@ -821,6 +827,7 @@ class Runner:
                 "n_ctx": n_ctx,
                 "logits_all": logits_all,
                 "flash_attn": flash_attn,
+                "swa_full": LLAMA_CPP_FULL_SWA_CACHE,
                 "vision": vision is not None,
             },
         ):
@@ -830,6 +837,7 @@ class Runner:
                 n_ctx=n_ctx,
                 logits_all=logits_all,
                 flash_attn=flash_attn,
+                swa_full=LLAMA_CPP_FULL_SWA_CACHE,
                 verbose=False,
                 chat_handler=chat_handler,
             )

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_runner_cancel.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_runner_cancel.py
@@ -9,14 +9,19 @@ and the task ends ``Cancelled`` rather than ``Complete``. A request that is not
 cancelled still emits exactly one terminal chunk and completes.
 """
 
-from types import SimpleNamespace
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 
+import pytest
 from anyio import WouldBlock
 
+from skulk.shared.models.model_cards import ModelCard, ModelTask
 from skulk.shared.types.common import CommandId, ModelId, NodeId
 from skulk.shared.types.events import ChunkGenerated, Event, TaskStatusUpdated
-from skulk.shared.types.tasks import TaskStatus, TextGeneration
+from skulk.shared.types.memory import Memory
+from skulk.shared.types.tasks import LoadModel, TaskStatus, TextGeneration
 from skulk.shared.types.text_generation import InputMessage, TextGenerationTaskParams
 from skulk.shared.types.worker.instances import InstanceId
 from skulk.shared.types.worker.runners import RunnerId, RunnerReady
@@ -63,12 +68,21 @@ class _CancelReceiver:
 
 def _make_runner(cancel: _CancelReceiver) -> tuple[Runner, _CaptureSender]:
     sender = _CaptureSender()
+    card = ModelCard(
+        model_id=ModelId("some/gguf-model"),
+        storage_size=Memory.from_bytes(1),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        gguf_file="model.gguf",
+    )
     bound = SimpleNamespace(
         instance=SimpleNamespace(),
         bound_runner_id=RunnerId("r1"),
         bound_shard=SimpleNamespace(
             world_size=1,
-            model_card=SimpleNamespace(model_id=ModelId("some/gguf-model")),
+            model_card=card,
             device_rank=0,
         ),
         bound_node_id=NodeId("n1"),
@@ -80,6 +94,36 @@ def _make_runner(cancel: _CancelReceiver) -> tuple[Runner, _CaptureSender]:
         cancel_receiver=cast("object", cancel),  # pyright: ignore[reportArgumentType]
     )
     return runner, sender
+
+
+def test_load_model_explicitly_disables_full_swa_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Dependency defaults must not expand SWA beyond admission's estimate."""
+    from skulk.download import download_utils
+    from skulk.shared.models.memory_estimate import LLAMA_CPP_FULL_SWA_CACHE
+
+    captured: dict[str, object] = {}
+
+    class _FakeLlama:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    fake_module = ModuleType("llama_cpp")
+    monkeypatch.setattr(fake_module, "Llama", _FakeLlama, raising=False)
+    monkeypatch.setitem(sys.modules, "llama_cpp", fake_module)
+
+    def _model_path(*_args: object) -> Path:
+        return tmp_path
+
+    monkeypatch.setattr(download_utils, "build_model_path", _model_path)
+    (tmp_path / "model.gguf").touch()
+
+    runner, _sender = _make_runner(_CancelReceiver())
+    runner._load_model(LoadModel(instance_id=InstanceId("i1")))
+
+    assert LLAMA_CPP_FULL_SWA_CACHE is False
+    assert captured["swa_full"] is LLAMA_CPP_FULL_SWA_CACHE
 
 
 def _tool_task() -> TextGeneration:

--- a/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_runner_cancel.py
+++ b/src/skulk/worker/runner/llama_cpp/tests/test_llama_cpp_runner_cancel.py
@@ -106,7 +106,8 @@ def test_load_model_explicitly_disables_full_swa_cache(
     captured: dict[str, object] = {}
 
     class _FakeLlama:
-        def __init__(self, **kwargs: object) -> None:
+        def __init__(self, *, swa_full: bool, **kwargs: object) -> None:
+            captured["swa_full"] = swa_full
             captured.update(kwargs)
 
     fake_module = ModuleType("llama_cpp")
@@ -124,6 +125,24 @@ def test_load_model_explicitly_disables_full_swa_cache(
 
     assert LLAMA_CPP_FULL_SWA_CACHE is False
     assert captured["swa_full"] is LLAMA_CPP_FULL_SWA_CACHE
+
+
+def test_load_model_rejects_binding_that_silently_ignores_swa_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An older ``**kwargs``-only binding must fail before allocating memory."""
+
+    class _LegacyLlama:
+        def __init__(self, **_kwargs: object) -> None:
+            pytest.fail("legacy binding must not be constructed")
+
+    fake_module = ModuleType("llama_cpp")
+    monkeypatch.setattr(fake_module, "Llama", _LegacyLlama, raising=False)
+    monkeypatch.setitem(sys.modules, "llama_cpp", fake_module)
+
+    runner, _sender = _make_runner(_CancelReceiver())
+    with pytest.raises(RuntimeError, match="does not explicitly support swa_full"):
+        runner._load_model(LoadModel(instance_id=InstanceId("i1")))
 
 
 def _tool_task() -> TextGeneration:


### PR DESCRIPTION
## Summary

- make bounded sliding-window attention an explicit llama.cpp runtime invariant
- pass the shared invariant to the in-process runner and surface it in runner diagnostics
- harden the provider-overflow regression setup so its upstream transport cannot mask the downstream overflow under test

## Root cause

The in-process llama.cpp runner inherited the dependency default `swa_full=true`. Placement admitted long-context GGUF workloads using bounded sliding-window cache assumptions, while runtime expanded every sliding layer to full context. That contract mismatch could overcommit unified memory during model load.

## Impact

Long-context GGUF models now load with the same bounded SWA behavior assumed by admission. This prevents the pathological full-context KV allocation while keeping the model-card context limit unchanged.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`
- `uv run pytest` — 2714 passed, 1 skipped, 222 deselected
- focused llama.cpp/admission tests — 38 passed
- provider-overflow regression repeated 5 times