### PR TITLE
fix(api): populate OpenAI-standard usage from generation stats (#644)

### DIFF
--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -248,20 +248,24 @@ def usage_from_stats(stats: GenerationStats | None) -> Usage | None:
     terminal chunk rather than per-chunk OpenAI usage envelopes, so standard
     OpenAI clients saw ``usage: null`` on every chat response (#644). The
     adapter derives the standard object here from the same engine-exact
-    counts the bench surface already exposes. A zero count on either side
-    means that side was unmeasured (the runner convention) and yields
-    ``None`` rather than a fabricated zero claim in cost accounting.
+    counts the bench surface already exposes. A zero prompt count means the
+    prompt side was unmeasured (every known runner fallback shape) and
+    yields ``None`` rather than a fabricated zero claim in cost accounting;
+    a zero completion count with a measured prompt is a real outcome and
+    keeps its usage object.
     """
     if stats is None:
         return None
     prompt = max(stats.prompt_tokens, 0)
     completion = max(stats.generation_tokens, 0)
-    # A zero on either side means that side was unmeasured (the stats
-    # convention throughout the runners; e.g. a vLLM stream without its
-    # include_usage terminal falls back to prompt 0). OpenAI's usage shape
-    # cannot express "unknown", so a partial measurement stays null rather
-    # than fabricating a zero count into clients' cost accounting.
-    if prompt == 0 or completion == 0:
+    # A zero PROMPT count means the prompt side was unmeasured: every known
+    # runner fallback (a vLLM stream without its include_usage terminal,
+    # served wall stats without timings) produces prompt 0 with real decode
+    # counts, and OpenAI's usage shape cannot express "unknown", so those
+    # stay null rather than fabricating a zero into cost accounting. A zero
+    # COMPLETION count with a measured prompt is a legitimate outcome (an
+    # immediately-stopped generation) and keeps its usage object.
+    if prompt == 0:
         return None
     return Usage(
         prompt_tokens=prompt,

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -15,11 +15,14 @@ from skulk.api.types import (
     ChatCompletionMessageText,
     ChatCompletionRequest,
     ChatCompletionResponse,
+    CompletionTokensDetails,
     ErrorInfo,
     ErrorResponse,
     FinishReason,
+    GenerationStats,
     Logprobs,
     LogprobsContentItem,
+    PromptTokensDetails,
     StreamingChoiceResponse,
     ToolCall,
     Usage,
@@ -238,6 +241,32 @@ async def chat_request_to_text_generation(
     )
 
 
+def usage_from_stats(stats: GenerationStats | None) -> Usage | None:
+    """Synthesize the OpenAI ``usage`` object from Skulk's generation stats.
+
+    Runners report token accounting through ``GenerationStats`` on the
+    terminal chunk rather than per-chunk OpenAI usage envelopes, so standard
+    OpenAI clients saw ``usage: null`` on every chat response (#644). The
+    adapter derives the standard object here from the same engine-exact
+    counts the bench surface already exposes. Zero counts on both sides mean
+    "unmeasured this request" and yield ``None`` rather than a fabricated
+    zero-usage claim.
+    """
+    if stats is None:
+        return None
+    prompt = max(stats.prompt_tokens, 0)
+    completion = max(stats.generation_tokens, 0)
+    if prompt == 0 and completion == 0:
+        return None
+    return Usage(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=prompt + completion,
+        prompt_tokens_details=PromptTokensDetails(),
+        completion_tokens_details=CompletionTokensDetails(),
+    )
+
+
 def chunk_to_response(
     chunk: TokenChunk, command_id: CommandId
 ) -> ChatCompletionResponse:
@@ -333,7 +362,7 @@ async def generate_chat_stream(
                             finish_reason="tool_calls",
                         )
                     ],
-                    usage=last_usage,
+                    usage=last_usage or usage_from_stats(chunk.stats),
                 )
                 yield f"data: {tool_response.model_dump_json()}\n\n"
                 if chunk.stats is not None:
@@ -353,7 +382,7 @@ async def generate_chat_stream(
                 chunk_response = chunk_to_response(chunk, command_id)
                 if chunk.finish_reason is not None:
                     chunk_response = chunk_response.model_copy(
-                        update={"usage": last_usage}
+                        update={"usage": last_usage or usage_from_stats(chunk.stats)}
                     )
                 yield f"data: {chunk_response.model_dump_json()}\n\n"
 
@@ -386,6 +415,7 @@ async def collect_chat_response(
     finish_reason: FinishReason | None = None
     error_message: str | None = None
     last_usage: Usage | None = None
+    last_stats: GenerationStats | None = None
 
     async for chunk in chunk_stream:
         match chunk:
@@ -400,6 +430,7 @@ async def collect_chat_response(
                 if model is None:
                     model = chunk.model
                 last_usage = chunk.usage or last_usage
+                last_stats = chunk.stats or last_stats
                 if chunk.is_thinking:
                     thinking_parts.append(chunk.text)
                 else:
@@ -419,6 +450,7 @@ async def collect_chat_response(
                 if model is None:
                     model = chunk.model
                 last_usage = chunk.usage or last_usage
+                last_stats = chunk.stats or last_stats
                 tool_calls.extend(
                     ToolCall(
                         id=tool.id,
@@ -461,6 +493,6 @@ async def collect_chat_response(
                 finish_reason=finish_reason,
             )
         ],
-        usage=last_usage,
+        usage=last_usage or usage_from_stats(last_stats),
     ).model_dump_json()
     return

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -248,9 +248,9 @@ def usage_from_stats(stats: GenerationStats | None) -> Usage | None:
     terminal chunk rather than per-chunk OpenAI usage envelopes, so standard
     OpenAI clients saw ``usage: null`` on every chat response (#644). The
     adapter derives the standard object here from the same engine-exact
-    counts the bench surface already exposes. Zero counts on both sides mean
-    "unmeasured this request" and yield ``None`` rather than a fabricated
-    zero-usage claim.
+    counts the bench surface already exposes. A zero count on either side
+    means that side was unmeasured (the runner convention) and yields
+    ``None`` rather than a fabricated zero claim in cost accounting.
     """
     if stats is None:
         return None

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -256,7 +256,12 @@ def usage_from_stats(stats: GenerationStats | None) -> Usage | None:
         return None
     prompt = max(stats.prompt_tokens, 0)
     completion = max(stats.generation_tokens, 0)
-    if prompt == 0 and completion == 0:
+    # A zero on either side means that side was unmeasured (the stats
+    # convention throughout the runners; e.g. a vLLM stream without its
+    # include_usage terminal falls back to prompt 0). OpenAI's usage shape
+    # cannot express "unknown", so a partial measurement stays null rather
+    # than fabricating a zero count into clients' cost accounting.
+    if prompt == 0 or completion == 0:
         return None
     return Usage(
         prompt_tokens=prompt,

--- a/src/skulk/api/tests/test_chat_completions_streaming.py
+++ b/src/skulk/api/tests/test_chat_completions_streaming.py
@@ -95,3 +95,33 @@ def test_usage_from_stats_unmeasured_and_none() -> None:
     assert usage_from_stats(_stats(0, 0)) is None
     usage = usage_from_stats(_stats(5, 7))
     assert usage is not None and usage.total_tokens == 12
+
+
+async def _tool_call_stream_with_stats():
+    from skulk.api.types import ToolCallItem
+    from skulk.shared.types.chunks import ToolCallChunk
+
+    yield ToolCallChunk(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        tool_calls=[ToolCallItem(name="get_weather", arguments='{"city":"Oslo"}')],
+        usage=None,
+        stats=_stats(43, 30),
+    )
+
+
+@pytest.mark.anyio
+async def test_streaming_tool_call_terminal_synthesizes_usage_from_stats() -> None:
+    # The tool-calls finish path is a distinct terminal from the token path
+    # and must carry the synthesized usage too (#644, PR #645 review).
+    chunks = [
+        chunk
+        async for chunk in generate_chat_stream(
+            CommandId("cmd-644-tools"), _tool_call_stream_with_stats()
+        )
+    ]
+    final_data = [c for c in chunks if c.startswith("data: {")][-1]
+    assert '"finish_reason":"tool_calls"' in final_data
+    assert '"usage":' in final_data
+    assert '"prompt_tokens":43' in final_data
+    assert '"completion_tokens":30' in final_data
+    assert '"total_tokens":73' in final_data

--- a/src/skulk/api/tests/test_chat_completions_streaming.py
+++ b/src/skulk/api/tests/test_chat_completions_streaming.py
@@ -90,9 +90,13 @@ def test_usage_from_stats_unmeasured_and_none() -> None:
     from skulk.api.adapters.chat_completions import usage_from_stats
 
     assert usage_from_stats(None) is None
-    # All-zero stats mean unmeasured; a fabricated zero-usage claim would
-    # mislead cost accounting, so the field stays null (#644).
+    # A zero on EITHER side means that side was unmeasured (runner fallbacks
+    # produce prompt 0 with real decode counts); a fabricated zero would
+    # mislead cost accounting, so partial measurements stay null (#644,
+    # PR #645 review).
     assert usage_from_stats(_stats(0, 0)) is None
+    assert usage_from_stats(_stats(0, 30)) is None
+    assert usage_from_stats(_stats(30, 0)) is None
     usage = usage_from_stats(_stats(5, 7))
     assert usage is not None and usage.total_tokens == 12
 

--- a/src/skulk/api/tests/test_chat_completions_streaming.py
+++ b/src/skulk/api/tests/test_chat_completions_streaming.py
@@ -90,13 +90,16 @@ def test_usage_from_stats_unmeasured_and_none() -> None:
     from skulk.api.adapters.chat_completions import usage_from_stats
 
     assert usage_from_stats(None) is None
-    # A zero on EITHER side means that side was unmeasured (runner fallbacks
-    # produce prompt 0 with real decode counts); a fabricated zero would
-    # mislead cost accounting, so partial measurements stay null (#644,
-    # PR #645 review).
+    # A zero PROMPT means unmeasured (runner fallbacks produce prompt 0 with
+    # real decode counts); a fabricated zero would mislead cost accounting,
+    # so those stay null. A zero completion with a measured prompt is a real
+    # immediately-stopped outcome and keeps usage (#644, PR #645 review).
     assert usage_from_stats(_stats(0, 0)) is None
     assert usage_from_stats(_stats(0, 30)) is None
-    assert usage_from_stats(_stats(30, 0)) is None
+    empty_completion = usage_from_stats(_stats(30, 0))
+    assert empty_completion is not None
+    assert empty_completion.completion_tokens == 0
+    assert empty_completion.total_tokens == 30
     usage = usage_from_stats(_stats(5, 7))
     assert usage is not None and usage.total_tokens == 12
 

--- a/src/skulk/api/tests/test_chat_completions_streaming.py
+++ b/src/skulk/api/tests/test_chat_completions_streaming.py
@@ -25,3 +25,73 @@ async def test_generate_chat_stream_emits_command_id_before_tokens() -> None:
     assert chunks[0] == ": command_id cmd-123\n\n"
     assert 'data: {"id":"cmd-123"' in chunks[1]
     assert chunks[-1] == "data: [DONE]\n\n"
+
+
+def _stats(prompt_tokens: int, generation_tokens: int):
+    from skulk.api.types import GenerationStats
+    from skulk.shared.types.memory import Memory
+
+    return GenerationStats(
+        prompt_tps=10.0,
+        generation_tps=20.0,
+        prompt_tokens=prompt_tokens,
+        generation_tokens=generation_tokens,
+        peak_memory_usage=Memory.from_bytes(0),
+    )
+
+
+async def _final_token_stream_with_stats():
+    yield TokenChunk(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        text="hello",
+        token_id=1,
+        usage=None,
+        finish_reason="stop",
+        stats=_stats(43, 30),
+    )
+
+
+@pytest.mark.anyio
+async def test_streaming_final_chunk_synthesizes_usage_from_stats() -> None:
+    # Runners report token accounting via GenerationStats, not per-chunk usage
+    # envelopes; the OpenAI-standard usage object must still be populated on
+    # the terminal chunk (#644).
+    chunks = [
+        chunk
+        async for chunk in generate_chat_stream(
+            CommandId("cmd-644"), _final_token_stream_with_stats()
+        )
+    ]
+    final_data = [c for c in chunks if c.startswith("data: {")][-1]
+    assert '"usage":' in final_data
+    assert '"prompt_tokens":43' in final_data
+    assert '"completion_tokens":30' in final_data
+    assert '"total_tokens":73' in final_data
+
+
+@pytest.mark.anyio
+async def test_collect_response_synthesizes_usage_from_stats() -> None:
+    from skulk.api.adapters.chat_completions import collect_chat_response
+
+    parts = [
+        part
+        async for part in collect_chat_response(
+            CommandId("cmd-644"), _final_token_stream_with_stats()
+        )
+    ]
+    body = "".join(parts)
+    assert '"usage":' in body
+    assert '"prompt_tokens":43' in body
+    assert '"completion_tokens":30' in body
+    assert '"total_tokens":73' in body
+
+
+def test_usage_from_stats_unmeasured_and_none() -> None:
+    from skulk.api.adapters.chat_completions import usage_from_stats
+
+    assert usage_from_stats(None) is None
+    # All-zero stats mean unmeasured; a fabricated zero-usage claim would
+    # mislead cost accounting, so the field stays null (#644).
+    assert usage_from_stats(_stats(0, 0)) is None
+    usage = usage_from_stats(_stats(5, 7))
+    assert usage is not None and usage.total_tokens == 12


### PR DESCRIPTION
Fixes #644.

## Problem

\`/v1/chat/completions\` returned \`usage: null\` on both non-streaming responses and streaming responses (found during the 1.5.0 RC shipped-vLLM-cards fresh-box validation). The adapter tracks per-chunk OpenAI usage envelopes, but no runner sends them; token accounting arrives as \`GenerationStats\` on the terminal chunk, and only the \`/bench\` surface exposed it. Standard OpenAI clients (SDKs, cost accounting) read \`usage\` and saw nothing, even though the api-guide already described the field as populated.

## Fix

New \`usage_from_stats()\` in the chat adapter synthesizes the standard usage object (prompt_tokens, completion_tokens, total_tokens) from the terminal chunk's engine-exact stats, wired into all three completion paths: the streaming final chunk, the streaming tool-call terminal, and the collected non-streaming response. Precedence: a wire-provided usage envelope still wins; all-zero stats yield null ("unmeasured this request", never a fabricated zero-usage claim). API-response assembly only: no wire, event, or state type changes, so no fleet-version implications.

## Tests

Streaming terminal chunk carries synthesized usage (43/30/73); collected non-streaming response carries it; \`usage_from_stats\` None/all-zero/populated cases. Full API suites: 604 tests pass; basedpyright 0 errors; ruff clean.