### PR TITLE
Custom model cards override bundled cards (#652)

### DIFF
--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -65,7 +65,17 @@ def _detect_vision_from_config(model_id: ModelId) -> "VisionCardConfig | None":
 
 
 async def _load_cards_from_dir(directory: Path, *, is_custom: bool) -> None:
-    """Load all TOML model cards from a directory into the cache."""
+    """Load all TOML model cards from a directory into the cache.
+
+    Within a load pass the first card for a model id wins (duplicate ids in
+    the builtin dirs, or among custom files, keep their existing precedence),
+    but a CUSTOM card replaces a bundled card for the same id: the custom
+    directory exists for operator override, and the previous first-wins
+    behavior silently ignored the override because the builtin dirs load
+    first (#652). Both the override and a failed custom-card parse are
+    logged, since a silently dropped operator card reads as "my card is
+    live" while the bundled card actually serves.
+    """
     async for toml_file in directory.rglob("*.toml"):
         try:
             card = await ModelCard.load_from_path(toml_file)
@@ -75,10 +85,20 @@ async def _load_cards_from_dir(directory: Path, *, is_custom: bool) -> None:
                 vision = _detect_vision_from_config(card.model_id)
                 if vision is not None:
                     card = card.model_copy(update={"vision": vision})
-            if card.model_id not in _card_cache:
+            existing = _card_cache.get(card.model_id)
+            if existing is None:
                 _card_cache[card.model_id] = card
-        except (ValidationError, TOMLKitError):
-            pass
+            elif is_custom and not existing.is_custom:
+                logger.info(
+                    f"custom model card {toml_file} overrides the bundled "
+                    f"card for {card.model_id}"
+                )
+                _card_cache[card.model_id] = card
+        except (ValidationError, TOMLKitError) as error:
+            if is_custom:
+                logger.warning(
+                    f"ignoring invalid custom model card {toml_file}: {error}"
+                )
 
 
 async def _refresh_card_cache() -> None:

--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -1190,11 +1190,20 @@ def add_to_card_cache(card: "ModelCard") -> None:
 
 
 async def delete_custom_card(model_id: ModelId) -> bool:
-    """Delete a user-added custom model card. Returns True if deleted."""
+    """Delete a user-added custom model card. Returns True if deleted.
+
+    If the deleted card was overriding a bundled card (#652), the bundled
+    card is reloaded immediately: the cache only self-refreshes when empty,
+    so a bare pop would leave the bundled model missing from the catalog
+    until process restart. The builtin reload is first-wins, so it restores
+    only ids that are now absent and cannot displace other live overrides.
+    """
     card_path = _custom_cards_dir / (ModelId(model_id).normalize() + ".toml")
     if await card_path.exists():
         await card_path.unlink()
         _card_cache.pop(model_id, None)
+        for builtin_dir in _BUILTIN_CARD_DIRS:
+            await _load_cards_from_dir(builtin_dir, is_custom=False)
         return True
     return False
 

--- a/src/skulk/shared/tests/test_model_cards.py
+++ b/src/skulk/shared/tests/test_model_cards.py
@@ -41,7 +41,8 @@ async def test_custom_card_overrides_bundled(
     (builtin_dir / "override-model.toml").write_text(
         _MINIMAL_CARD.format(quantization="fp16")
     )
-    (custom_dir / "override-model.toml").write_text(
+    # Named with the normalized model id so delete_custom_card resolves it.
+    (custom_dir / "testorg--override-model.toml").write_text(
         _MINIMAL_CARD.format(quantization="int4")
     )
     # An invalid custom card must be skipped (with a warning), not abort the
@@ -68,6 +69,23 @@ async def test_custom_card_overrides_bundled(
     assert model_cards_module._card_cache[
         ModelId("testorg/override-model")
     ].is_custom
+
+    # Deleting the override restores the BUNDLED card immediately (PR #655
+    # review): the cache only self-refreshes when empty, so without the
+    # delete-path reload the bundled model would vanish from the catalog
+    # until process restart.
+    monkeypatch.setattr(
+        model_cards_module, "_custom_cards_dir", Path(str(custom_dir))
+    )
+    monkeypatch.setattr(
+        model_cards_module, "_BUILTIN_CARD_DIRS", [Path(str(builtin_dir))]
+    )
+    assert await model_cards_module.delete_custom_card(
+        ModelId("testorg/override-model")
+    )
+    restored = model_cards_module._card_cache[ModelId("testorg/override-model")]
+    assert not restored.is_custom, "bundled card must return after delete"
+    assert restored.quantization == "fp16"
 
 
 def test_vllm_spec_pairing_validator() -> None:

--- a/src/skulk/shared/tests/test_model_cards.py
+++ b/src/skulk/shared/tests/test_model_cards.py
@@ -1,10 +1,73 @@
+# pyright: reportPrivateUsage=false
 """Tests for model-card metadata used by the public API."""
+
+import pathlib
 
 import pytest
 from anyio import Path
 
 from skulk.shared.constants import RESOURCES_DIR
+from skulk.shared.models import model_cards as model_cards_module
 from skulk.shared.models.model_cards import ModelCard, RuntimeCapabilityCardConfig
+from skulk.shared.types.common import ModelId
+
+_MINIMAL_CARD = """\
+model_id = "testorg/override-model"
+n_layers = 4
+hidden_size = 64
+supports_tensor = false
+tasks = ["TextGeneration"]
+quantization = "{quantization}"
+
+[storage_size]
+in_bytes = 1024
+"""
+
+
+@pytest.mark.anyio
+async def test_custom_card_overrides_bundled(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A custom card with a bundled card's model id must win (#652).
+
+    The custom directory exists for operator override; before the fix the
+    first-wins cache silently kept the bundled card, so the operator's card
+    appeared installed while the bundled card actually served.
+    """
+    builtin_dir = tmp_path / "builtin"
+    custom_dir = tmp_path / "custom"
+    builtin_dir.mkdir()
+    custom_dir.mkdir()
+    (builtin_dir / "override-model.toml").write_text(
+        _MINIMAL_CARD.format(quantization="fp16")
+    )
+    (custom_dir / "override-model.toml").write_text(
+        _MINIMAL_CARD.format(quantization="int4")
+    )
+    # An invalid custom card must be skipped (with a warning), not abort the
+    # load of the valid ones.
+    (custom_dir / "broken.toml").write_text("model_id = [not, valid, toml")
+
+    monkeypatch.setattr(model_cards_module, "_card_cache", {})
+    await model_cards_module._load_cards_from_dir(
+        Path(str(builtin_dir)), is_custom=False
+    )
+    await model_cards_module._load_cards_from_dir(
+        Path(str(custom_dir)), is_custom=True
+    )
+
+    card = model_cards_module._card_cache[ModelId("testorg/override-model")]
+    assert card.is_custom, "the custom card must replace the bundled card"
+    assert card.quantization == "int4"
+
+    # Within the builtin pass, first-wins is preserved: reloading the builtin
+    # dir must NOT displace the custom card.
+    await model_cards_module._load_cards_from_dir(
+        Path(str(builtin_dir)), is_custom=False
+    )
+    assert model_cards_module._card_cache[
+        ModelId("testorg/override-model")
+    ].is_custom
 
 
 def test_vllm_spec_pairing_validator() -> None:


### PR DESCRIPTION
## What

Fixes #652: a card placed in the custom cards directory with the same `model_id` as a bundled card was silently ignored, because the card cache is first-wins and the builtin directories load before the custom directory. The operator's override appeared installed while the bundled card actually served. Proven live during the 2026-07-22 benchmark battery: with an override card installed (bundled card minus its `[runtime]` section) and the node restarted, the spawned vLLM server still carried `--speculative-config` from the bundled card.

## Change

- A custom card now replaces a bundled card for the same id, with an info log naming the overriding file and the model id.
- Precedence is otherwise unchanged: first-wins within the builtin directories, and first-wins among custom files.
- A custom card that fails to parse now logs a warning instead of vanishing silently (the same operator-facing silent-failure class); bundled-card parse failures stay quiet as before, since the bundled invariant suite gates those.

## Validation

- New test covers the override, the invalid-custom-card skip, and that reloading the builtin directory does not displace an installed override.
- `uv run basedpyright`: 0 errors. `uv run ruff check`: clean. `nix fmt`: no changes. `uv run pytest`: full suite green (2752 passed before annotation cleanup; shared-tests 473 passed after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)