### PR TITLE
Fix fresh-install model-store port collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+- Fixed fresh-install model-store startup failures caused by the old `58080`
+  listener racing normal outbound connections in operating-system dynamic
+  client-port ranges. The runtime, installer-generated config, dashboard, and
+  docs now use the explicit `12415` default; existing configurations that set
+  `store_port` remain unchanged.
+
 - Fixed Fish Audio S2 synthesis returning speech unrelated to the input by
   pinning a minimal `mlx-audio 0.4.3.post1` maintenance carry of the upstream
   hidden-state generation fix.

--- a/dashboard-react/src/components/layout/SettingsPanel.tsx
+++ b/dashboard-react/src/components/layout/SettingsPanel.tsx
@@ -16,11 +16,13 @@ export interface SettingsPanelProps {
   onClose: () => void;
 }
 
+const DEFAULT_MODEL_STORE_PORT = 12415;
+
 const defaultStoreConfig = (): StoreConfig => ({
   enabled: false,
   store_host: '',
   store_http_host: '',
-  store_port: 58080,
+  store_port: DEFAULT_MODEL_STORE_PORT,
   store_path: '',
   download: {
     allow_hf_fallback: true,
@@ -444,7 +446,7 @@ export function SettingsPanel({ open, onClose }: SettingsPanelProps) {
                       size="sm"
                       type="number"
                       value={String(modelStoreDraft.store_port)}
-                      onChange={(e) => update({ store_port: parseInt((e.target as HTMLInputElement).value) || 58080 })}
+                      onChange={(e) => update({ store_port: parseInt((e.target as HTMLInputElement).value) || DEFAULT_MODEL_STORE_PORT })}
                       style={{ maxWidth: 80 }}
                     />
                   </Row>

--- a/docs/model-store.md
+++ b/docs/model-store.md
@@ -47,7 +47,9 @@ Make sure:
 - that machine has enough storage for the models you want to share
 - the chosen `store_path` is mounted and writable
 
-The store server uses port `58080` by default.
+The store server uses port `12415` by default. This listener is deliberately
+outside the dynamic client-port ranges used by supported operating systems, so
+an unrelated outbound connection cannot claim it before Skulk starts.
 
 ## Recommended Setup: Dashboard First
 
@@ -87,7 +89,7 @@ For most users:
 model_store:
   enabled: true
   store_host: mac-studio-1
-  store_port: 58080
+  store_port: 12415
   store_path: /Volumes/ModelStore/models
 
   download:
@@ -132,7 +134,7 @@ For most users, hostname is the easiest and most reliable choice.
 
 HTTP port used for store transfers.
 
-Default: `58080`
+Default: `12415`
 
 ### `model_store.store_path`
 
@@ -213,12 +215,12 @@ Check:
 
 - that the store host is running
 - that `store_host` matches the real hostname
-- that port `58080` is reachable on your LAN
+- that port `12415` is reachable on your LAN
 
 Useful check:
 
 ```bash
-curl http://STORE_HOST:58080/health
+curl http://STORE_HOST:12415/health
 ```
 
 ### The model is on disk but does not appear in the store registry

--- a/install.sh
+++ b/install.sh
@@ -320,6 +320,9 @@ if [[ ! -f skulk.yaml ]]; then
 # the docs).
 model_store:
   store_host: "$(hostname -s)"
+  # Kept outside operating-system dynamic client-port ranges so an unrelated
+  # outbound connection cannot claim the listener before Skulk starts.
+  store_port: 12415
   # Loopback keeps the single-node client working even when the short
   # hostname is not locally resolvable; on the store host, skulk replaces a
   # loopback literal with its best routable IPv4 before broadcasting to

--- a/skulk.yaml.example
+++ b/skulk.yaml.example
@@ -26,7 +26,7 @@ model_store:
   # store_http_host: 192.168.1.10
 
   # HTTP port used by the model store server.
-  store_port: 58080
+  store_port: 12415
 
   # Absolute path to the directory that holds store-managed models.
   store_path: /Volumes/ModelStore/models

--- a/src/skulk/store/config.py
+++ b/src/skulk/store/config.py
@@ -47,7 +47,7 @@ Example ``skulk.yaml``::
     model_store:
       enabled: true
       store_host: mac-studio-1    # hostname of the node with attached storage
-      store_port: 58080
+      store_port: 12415
       store_path: /Volumes/ModelStore/models
 
       download:
@@ -70,12 +70,18 @@ from __future__ import annotations
 
 import socket
 from pathlib import Path
-from typing import Literal, final
+from typing import Final, Literal, final
 
 import yaml
 from pydantic import Field
 
 from skulk.utils.pydantic_ext import FrozenModel
+
+# Keep the shipped listener outside the IANA dynamic/private range and the
+# lower ephemeral ranges commonly used by Linux. A fresh macOS install failed
+# to restart when mDNSResponder legitimately acquired the old 58080 default as
+# an outbound source port before Skulk could bind it.
+DEFAULT_MODEL_STORE_PORT: Final = 12415
 
 
 def _normalize_hostname(hostname: str) -> str:
@@ -245,7 +251,7 @@ class ModelStoreConfig(FrozenModel):
     enabled: bool = True
     store_host: str
     store_http_host: str | None = None
-    store_port: int = 58080
+    store_port: int = DEFAULT_MODEL_STORE_PORT
     store_path: str
     download: DownloadStoreConfig = DownloadStoreConfig()
     staging: StagingNodeConfig = StagingNodeConfig()

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -89,7 +89,7 @@ from skulk.download.shard_downloader import ShardDownloader
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.worker.downloads import RepoDownloadProgress
 from skulk.shared.types.worker.shards import ShardMetadata
-from skulk.store.config import StagingNodeConfig
+from skulk.store.config import DEFAULT_MODEL_STORE_PORT, StagingNodeConfig
 from skulk.store.staging_eviction import touch_last_used
 
 if TYPE_CHECKING:
@@ -461,7 +461,7 @@ class ModelStoreClient:
     def __init__(
         self,
         store_host: str,
-        store_port: int = 58080,
+        store_port: int = DEFAULT_MODEL_STORE_PORT,
         local_store_path: Path | None = None,
     ) -> None:
         self._store_host = store_host

--- a/src/skulk/store/model_store_server.py
+++ b/src/skulk/store/model_store_server.py
@@ -23,7 +23,7 @@ Design decisions
 * **Path traversal protection**: all requested file paths are resolved and
   checked to be within the model directory before any I/O is performed.
 * The server does **not** require authentication — it is intended for
-  trusted LAN use only.  Do not expose port 58080 to untrusted networks.
+  trusted LAN use only.  Do not expose port 12415 to untrusted networks.
 
 HTTP API
 --------
@@ -54,11 +54,11 @@ All endpoints return JSON unless noted.
 
 Example requests::
 
-    curl http://mac-studio-1:58080/health
-    curl http://mac-studio-1:58080/models
-    curl http://mac-studio-1:58080/models/mlx-community%2FQwen3-30B-A3B-4bit/files
+    curl http://mac-studio-1:12415/health
+    curl http://mac-studio-1:12415/models
+    curl http://mac-studio-1:12415/models/mlx-community%2FQwen3-30B-A3B-4bit/files
     curl -H "Range: bytes=0-8388607" \\
-         http://mac-studio-1:58080/models/mlx-community%2FQwen3-30B-A3B-4bit/config.json
+         http://mac-studio-1:12415/models/mlx-community%2FQwen3-30B-A3B-4bit/config.json
 """
 
 from __future__ import annotations
@@ -72,6 +72,7 @@ import aiofiles.os as aios
 import aiohttp.web as web
 from loguru import logger
 
+from skulk.store.config import DEFAULT_MODEL_STORE_PORT
 from skulk.store.model_store import ModelStore
 
 _CHUNK_SIZE = 8 * 1024 * 1024  # 8 MB per streaming chunk
@@ -119,7 +120,7 @@ class ModelStoreServer:
 
     Lifecycle::
 
-        server = ModelStoreServer(store, port=58080)
+        server = ModelStoreServer(store, port=DEFAULT_MODEL_STORE_PORT)
         await server.start()   # called once on startup
         # ... runs until shutdown ...
         await server.stop()    # called on graceful shutdown
@@ -133,7 +134,7 @@ class ModelStoreServer:
         self,
         store: ModelStore,
         host: str = "0.0.0.0",
-        port: int = 58080,
+        port: int = DEFAULT_MODEL_STORE_PORT,
     ) -> None:
         """
         Args:

--- a/src/skulk/store/tests/test_config.py
+++ b/src/skulk/store/tests/test_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from skulk.store.config import (
+    DEFAULT_MODEL_STORE_PORT,
     ExperimentsConfig,
     ModelStoreConfig,
     NodeOverrideConfig,
@@ -13,6 +14,15 @@ from skulk.store.config import (
     node_matches_store_host,
     resolve_node_staging,
 )
+
+
+def test_model_store_default_port_avoids_dynamic_client_range() -> None:
+    """Fresh listeners must not race ordinary outbound client connections."""
+
+    config = ModelStoreConfig(store_host="store.local", store_path="/models")
+
+    assert DEFAULT_MODEL_STORE_PORT == 12415
+    assert config.store_port == DEFAULT_MODEL_STORE_PORT
 
 
 def test_hostname_aliases_include_short_and_local_variants() -> None:

--- a/src/skulk/tests/test_install_script.py
+++ b/src/skulk/tests/test_install_script.py
@@ -3,6 +3,8 @@
 
 from pathlib import Path
 
+from skulk.store.config import DEFAULT_MODEL_STORE_PORT
+
 
 def _installer() -> str:
     return (Path(__file__).parents[3] / "install.sh").read_text()
@@ -35,3 +37,9 @@ def test_full_commit_ref_fetches_exact_object_and_detaches() -> None:
     assert 'git -C "$INSTALL_DIR" checkout --detach FETCH_HEAD' in installer
     assert 'RESOLVED_COMMIT="$(git rev-parse HEAD)"' in installer
     assert 'log "resolved ref $INSTALL_REF to commit $RESOLVED_COMMIT"' in installer
+
+
+def test_generated_config_pins_safe_model_store_port() -> None:
+    """The installer must materialize the same safe port as runtime defaults."""
+
+    assert f"store_port: {DEFAULT_MODEL_STORE_PORT}" in _installer()

--- a/website/docs/model-store.md
+++ b/website/docs/model-store.md
@@ -89,7 +89,9 @@ Make sure:
 - that machine has enough storage for the models you want to share
 - the chosen `store_path` is mounted and writable
 
-The store server uses port `58080` by default.
+The store server uses port `12415` by default. This listener is deliberately
+outside the dynamic client-port ranges used by supported operating systems, so
+an unrelated outbound connection cannot claim it before Skulk starts.
 
 :::note Fresh installs
 `install.sh` writes a `skulk.yaml` with single-node store defaults (this
@@ -137,7 +139,7 @@ For most users:
 model_store:
   enabled: true
   store_host: mac-studio-1
-  store_port: 58080
+  store_port: 12415
   store_path: /Volumes/ModelStore/models
 
   download:
@@ -272,7 +274,7 @@ For most users, hostname is the easiest and most reliable choice.
 
 HTTP port used for store transfers.
 
-Default: `58080`
+Default: `12415`
 
 ### `model_store.store_path`
 
@@ -378,12 +380,12 @@ Check:
 
 - that the store host is running
 - that `store_host` matches the real hostname
-- that port `58080` is reachable on your LAN
+- that port `12415` is reachable on your LAN
 
 Useful check:
 
 ```bash
-curl http://STORE_HOST:58080/health
+curl http://STORE_HOST:12415/health
 ```
 
 ### The model is on disk but does not appear in the store registry


### PR DESCRIPTION
## Summary

- move the model-store default from the IANA dynamic/private range to port 12415
- materialize the safe port in installer-generated config and align dashboard/example defaults
- update the model-store documentation and add regression coverage

A fresh-install restoration exposed the real failure mode: an operating-system service had legitimately acquired the old port for an outbound connection before Skulk restarted, leaving the model-store listener unable to bind. Existing configs with an explicit store port are unchanged.

## Validation

- uv run basedpyright (0 errors)
- uv run ruff check
- nix fmt (0 changes)
- uv run pytest (2,853 passed, 1 skipped, 228 deselected)
- dashboard unit tests (62 passed)
- dashboard production build
- complete docs build
