### PR TITLE
Fix fresh service installer uv discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+- Fixed the documented launchd/systemd install step failing immediately after a
+  successful one-command install because `uv` lived under `~/.local/bin` but
+  the parent shell had not reloaded its PATH. Both service installers now
+  resolve the same user-space tool locations as the runtime wrapper.
+
 - Fixed fresh-install model-store startup failures caused by the old `58080`
   listener racing normal outbound connections in operating-system dynamic
   client-port ranges. The runtime, installer-generated config, dashboard, and

--- a/deployment/install/install-launchd.sh
+++ b/deployment/install/install-launchd.sh
@@ -56,6 +56,18 @@ if [[ "$OSTYPE" != darwin* ]]; then
     exit 1
 fi
 
+# The one-command installer places uv under ~/.local/bin without modifying its
+# parent shell. A user who follows the printed service command immediately
+# therefore has the binary installed but not yet visible on PATH. Resolve the
+# same user-space locations as the runtime wrapper before rejecting the setup.
+for candidate_dir in "$HOME/.local/bin" "$HOME/.cargo/bin"; do
+    if [[ -d "$candidate_dir" && ":$PATH:" != *":$candidate_dir:"* ]]; then
+        PATH="$candidate_dir:$PATH"
+    fi
+done
+export PATH
+unset candidate_dir
+
 uid="$(id -u)"
 
 bootout_if_loaded() {

--- a/deployment/install/install-systemd.sh
+++ b/deployment/install/install-systemd.sh
@@ -27,6 +27,18 @@ if [[ "$OSTYPE" != linux-gnu* ]]; then
     exit 1
 fi
 
+# The one-command installer places uv under ~/.local/bin without modifying its
+# parent shell. A user who follows the printed service command immediately
+# therefore has the binary installed but not yet visible on PATH. Resolve the
+# same user-space locations as the runtime wrapper before rejecting the setup.
+for candidate_dir in "$HOME/.local/bin" "$HOME/.cargo/bin"; do
+    if [[ -d "$candidate_dir" && ":$PATH:" != *":$candidate_dir:"* ]]; then
+        PATH="$candidate_dir:$PATH"
+    fi
+done
+export PATH
+unset candidate_dir
+
 if ! command -v uv >/dev/null 2>&1; then
     echo "error: 'uv' not found on PATH. Install uv first (https://docs.astral.sh/uv/) and re-run." >&2
     exit 1

--- a/src/skulk/tests/test_service_install_scripts.py
+++ b/src/skulk/tests/test_service_install_scripts.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Foxlight Foundation
+"""Regression contracts for the documented supervised-service installers."""
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).parents[3]
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "deployment/install/install-launchd.sh",
+        "deployment/install/install-systemd.sh",
+    ],
+)
+def test_service_installer_resolves_fresh_uv_location(relative_path: str) -> None:
+    """A just-installed uv must be visible before the installer rejects PATH."""
+
+    script = (_REPO_ROOT / relative_path).read_text()
+    path_resolution = script.index('for candidate_dir in "$HOME/.local/bin"')
+    uv_guard = script.index("if ! command -v uv")
+
+    assert path_resolution < uv_guard
+    assert "PATH=\"$candidate_dir:$PATH\"" in script
+    assert "export PATH" in script[path_resolution:uv_guard]


### PR DESCRIPTION
## Summary

- add the standard user-space uv locations to PATH in both supervised-service installers
- preserve the existing explicit error when uv is genuinely unavailable
- add a regression contract covering both launchd and systemd paths

## Root cause

The one-command installer can install uv under `~/.local/bin`, but the already-running parent shell does not inherit that PATH update. Following the printed service-install command immediately could therefore fail despite a successful product installation.

## User impact

A first-time install can now proceed directly from the official installer to the documented launchd or systemd setup without opening a new shell or applying a private PATH workaround.

## Validation

- `bash -n deployment/install/install-launchd.sh`
- `bash -n deployment/install/install-systemd.sh`
- focused service-installer regression tests
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`
- `uv run pytest` (2,855 passed, 1 skipped, 228 deselected)