### PR TITLE
Fix single-image Gemma 4 vision batching

### DIFF
--- a/src/skulk/worker/engines/mlx/utils_mlx.py
+++ b/src/skulk/worker/engines/mlx/utils_mlx.py
@@ -551,12 +551,18 @@ class _Gemma4DynamicVisionTower(nn.Module):
                 encoded = self._encode_one(batched)
                 features.append(encoded[0] if encoded.ndim == 3 else encoded)
             return mx.concatenate(features, axis=0)[None]
-        return self._encode_one(pixel_values)
+        return self._encode_one(_batch_gemma4_pixel_values(pixel_values))
 
     def __getattr__(self, name: str) -> object:
         if name == "_inner":
             return cast(object, object.__getattribute__(self, name))
         return cast(object, getattr(self._inner, name))
+
+
+def _batch_gemma4_pixel_values(pixel_values: mx.array) -> mx.array:
+    """Add the image batch dimension omitted by single-image processors."""
+
+    return pixel_values[None] if pixel_values.ndim == 3 else pixel_values
 
 
 def _patch_gemma4_native_vision(model: nn.Module) -> nn.Module:

--- a/src/skulk/worker/engines/mlx/vision.py
+++ b/src/skulk/worker/engines/mlx/vision.py
@@ -1287,7 +1287,13 @@ class VisionEncoder:
                     mx.array(cast(MxArrayInput, v)) for v in cast(list[object], pv_raw)
                 ]
                 return pixel_values_list, None, soft_tokens
-            return mx.array(cast(MxArrayInput, pv_raw)), None, soft_tokens
+            pixel_values = mx.array(cast(MxArrayInput, pv_raw))
+            # Gemma 4's single-image processor may omit the batch dimension.
+            # Normalize it here so prefix-cache and pipeline-prefill slicing
+            # count images rather than treating the RGB channels as images.
+            if pixel_values.ndim == 3:
+                pixel_values = pixel_values[None]
+            return pixel_values, None, soft_tokens
 
         # Standard HuggingFace processor (Qwen, SiglipImageProcessor, etc.)
         raw_dict = _object_dict(raw)

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
@@ -179,6 +179,20 @@ def test_vlm_wrapper_uses_native_language_model_cache_factory() -> None:
     assert make_cache() == ["native-ssm-cache", "native-kv-cache"]
 
 
+def test_gemma4_native_vision_batches_single_image_pixels() -> None:
+    """A single CHW image must reach Gemma 4 as a BCHW tensor."""
+
+    batch_pixel_values = cast(
+        Callable[[mx.array], mx.array],
+        vars(utils_mlx)["_batch_gemma4_pixel_values"],
+    )
+    single_image = mx.zeros((3, 768, 768))
+    already_batched = mx.zeros((1, 3, 768, 768))
+
+    assert batch_pixel_values(single_image).shape == (1, 3, 768, 768)
+    assert batch_pixel_values(already_batched) is already_batched
+
+
 def test_vlm_loader_restores_qwen_sanitizer_after_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/skulk/worker/tests/unittests/test_mlx/test_vision_processor_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_vision_processor_loading.py
@@ -56,6 +56,62 @@ def test_processor_output_accepts_mapping_implementations() -> None:
     assert object_dict(processor_output)["pixel_values"] is pixel_values
 
 
+def test_gemma4_processor_batches_single_image_before_generation_slicing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Gemma 4 CHW output must be normalized before pipeline media slicing."""
+
+    class _FakeGemma4Processor:
+        max_soft_tokens: int | None = None
+
+        def preprocess(
+            self,
+            _messages: list[dict[str, object]],
+            *,
+            return_tensors: str,
+            **_kwargs: object,
+        ) -> dict[str, object]:
+            raise AssertionError("Gemma 4 should use the callable processor path")
+
+        def __call__(
+            self,
+            *,
+            images: list[Image.Image],
+            return_tensors: str,
+            **_kwargs: object,
+        ) -> tuple[dict[str, object], list[int]]:
+            assert len(images) == 1
+            assert return_tensors == "np"
+            return {
+                "pixel_values": np.zeros((3, 768, 768), dtype=np.float32)
+            }, [256]
+
+    def _model_path(*_args: object) -> Path:
+        return tmp_path
+
+    monkeypatch.setattr(vision_module, "build_model_path", _model_path)
+    encoder = VisionEncoder(
+        VisionCardConfig(
+            image_token_id=262144,
+            model_type="gemma4",
+            weights_repo="mlx-community/example",
+        ),
+        ModelId("mlx-community/example"),
+    )
+    vars(encoder)["_processor"] = _FakeGemma4Processor()
+    vars(encoder)["_processor_loaded"] = True
+
+    pixel_values, grid_thw, token_counts = encoder.preprocess_images(
+        [Image.new("RGB", (32, 24))]
+    )
+
+    assert not isinstance(pixel_values, list)
+    assert pixel_values.shape == (1, 3, 768, 768)
+    assert grid_thw is None
+    assert token_counts == [256]
+
+
 @pytest.mark.parametrize(
     ("model_type", "family_module_name"),
     [


### PR DESCRIPTION
## Summary

- add the missing batch dimension for a single Gemma 4 vision tensor
- preserve already-batched processor output
- cover both paths with a focused regression test

## Validation

- uv run basedpyright
- uv run ruff check
- nix fmt
- uv run pytest: 2,860 passed, 1 skipped