### PR TITLE
fix: preserve Gemma 4 MLX vision processor

### DIFF
--- a/src/skulk/worker/engines/mlx/vision.py
+++ b/src/skulk/worker/engines/mlx/vision.py
@@ -329,22 +329,56 @@ def _gemma4_native_processor_kwargs(
 
 
 _video_processor_patched = False
+_video_processor_mapping_entry: object | None = None
 
 
 def _patch_video_processor() -> None:
     """Patch so we don't crash horribly when torch vision isn't installed"""
     # TODO: Update if we add torch vision.
-    global _video_processor_patched
+    global _video_processor_mapping_entry, _video_processor_patched
     if _video_processor_patched:
         return
     try:
         from transformers.processing_utils import MODALITY_TO_AUTOPROCESSOR_MAPPING
 
-        mapping = MODALITY_TO_AUTOPROCESSOR_MAPPING._MAPPING_NAMES  # type: ignore
+        mapping = cast(
+            dict[str, object],
+            MODALITY_TO_AUTOPROCESSOR_MAPPING._MAPPING_NAMES,  # type: ignore
+        )
+        _video_processor_mapping_entry = mapping.get("video_processor")
         mapping.pop("video_processor", None)
     except (ImportError, AttributeError):
         pass
     _video_processor_patched = True
+
+
+def _restore_video_processor() -> None:
+    """Restore the Transformers video slot removed by the compatibility patch."""
+    global _video_processor_patched
+    if not _video_processor_patched:
+        return
+    try:
+        from transformers.processing_utils import MODALITY_TO_AUTOPROCESSOR_MAPPING
+
+        mapping = cast(
+            dict[str, object],
+            MODALITY_TO_AUTOPROCESSOR_MAPPING._MAPPING_NAMES,  # type: ignore
+        )
+        if _video_processor_mapping_entry is not None:
+            mapping["video_processor"] = _video_processor_mapping_entry
+    except (ImportError, AttributeError):
+        pass
+    _video_processor_patched = False
+
+
+def _configure_video_processor_compatibility(model_type: str) -> None:
+    """Select the reversible no-torchvision mapping state for one model family."""
+    if model_type == "gemma4":
+        # Gemma 4's MLX-VLM processor ships a NumPy-only video processor and
+        # requires this constructor slot even when callers only process images.
+        _restore_video_processor()
+    else:
+        _patch_video_processor()
 
 
 def decode_base64_image(b64_data: str) -> Image.Image:
@@ -902,7 +936,7 @@ class VisionEncoder:
         self._processor_loaded = True
 
     def _load_weights(self) -> None:
-        _patch_video_processor()
+        _configure_video_processor_compatibility(self._config.model_type)
         logger.info(f"Loading vision weights from {self._model_path}")
         config = self._load_config_json()
         if not config:
@@ -995,15 +1029,7 @@ class VisionEncoder:
         vision_cfg: JsonDict | None = None,
     ) -> None:
         """Load the image processor without forcing vision-weight initialization."""
-        if self._config.model_type != "gemma4":
-            _patch_video_processor()
-        # Gemma 4's MLX-VLM processor ships its own NumPy-only video processor,
-        # so it does not need torchvision. Removing Transformers'
-        # ``video_processor`` slot prevents Gemma4Processor.from_pretrained from
-        # constructing that processor and incorrectly falls through to the
-        # Hugging Face image processor, whose pre-patchified [B, patches,
-        # patch_dim] output is incompatible with MLX-VLM's raw BCHW vision
-        # tower.
+        _configure_video_processor_compatibility(self._config.model_type)
         config = config or self._load_config_json()
         if not config:
             raise FileNotFoundError(f"config.json not found in {self._model_path}")

--- a/src/skulk/worker/engines/mlx/vision.py
+++ b/src/skulk/worker/engines/mlx/vision.py
@@ -995,7 +995,15 @@ class VisionEncoder:
         vision_cfg: JsonDict | None = None,
     ) -> None:
         """Load the image processor without forcing vision-weight initialization."""
-        _patch_video_processor()
+        if self._config.model_type != "gemma4":
+            _patch_video_processor()
+        # Gemma 4's MLX-VLM processor ships its own NumPy-only video processor,
+        # so it does not need torchvision. Removing Transformers'
+        # ``video_processor`` slot prevents Gemma4Processor.from_pretrained from
+        # constructing that processor and incorrectly falls through to the
+        # Hugging Face image processor, whose pre-patchified [B, patches,
+        # patch_dim] output is incompatible with MLX-VLM's raw BCHW vision
+        # tower.
         config = config or self._load_config_json()
         if not config:
             raise FileNotFoundError(f"config.json not found in {self._model_path}")

--- a/src/skulk/worker/tests/unittests/test_mlx/test_vision_processor_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_vision_processor_loading.py
@@ -171,6 +171,68 @@ def test_processor_loader_uses_mlx_vlm_family_without_torchvision(
     assert _FakeFamilyProcessor.seen_trust_remote_code is True
 
 
+def test_gemma4_processor_keeps_numpy_video_slot_without_torchvision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Gemma 4 must not disable the slot required by its NumPy-only processor."""
+    (tmp_path / "config.json").write_text(
+        '{"vision_config": {"model_type": "gemma4"}}',
+        encoding="utf-8",
+    )
+    _FakeFamilyProcessor.seen_repo = None
+    _FakeFamilyProcessor.seen_trust_remote_code = None
+
+    def _model_path(*_args: object) -> Path:
+        return tmp_path
+
+    def _no_upstream_processor(_repo: str) -> None:
+        return None
+
+    def _must_not_patch_video_processor() -> None:
+        raise AssertionError(
+            "Gemma 4's NumPy video processor does not require torchvision"
+        )
+
+    def _fake_import_module(module_name: str) -> object:
+        if module_name == "mlx_vlm.models.gemma4":
+            return SimpleNamespace(Gemma4Processor=_FakeFamilyProcessor)
+        raise ModuleNotFoundError(name=module_name)
+
+    def _fail_transformers_loader(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError(
+            "Gemma 4 must not fall through to the pre-patchified HF processor"
+        )
+
+    monkeypatch.setattr(vision_module, "build_model_path", _model_path)
+    monkeypatch.setattr(vision_module, "load_image_processor", _no_upstream_processor)
+    monkeypatch.setattr(
+        vision_module,
+        "_patch_video_processor",
+        _must_not_patch_video_processor,
+    )
+    monkeypatch.setattr(vision_module.importlib, "import_module", _fake_import_module)
+    monkeypatch.setattr(
+        vision_module,
+        "AutoImageProcessor",
+        SimpleNamespace(from_pretrained=_fail_transformers_loader),
+    )
+
+    encoder = VisionEncoder(
+        VisionCardConfig(
+            image_token_id=1,
+            model_type="gemma4",
+            weights_repo="mlx-community/example",
+        ),
+        ModelId("mlx-community/example"),
+    )
+    encoder.ensure_processor_loaded()
+
+    assert isinstance(encoder.processor, _FakeImageProcessor)
+    assert _FakeFamilyProcessor.seen_repo == str(tmp_path)
+    assert _FakeFamilyProcessor.seen_trust_remote_code is True
+
+
 def test_processor_loader_reports_transformers_torchvision_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/src/skulk/worker/tests/unittests/test_mlx/test_vision_processor_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_vision_processor_loading.py
@@ -171,17 +171,45 @@ def test_processor_loader_uses_mlx_vlm_family_without_torchvision(
     assert _FakeFamilyProcessor.seen_trust_remote_code is True
 
 
-def test_gemma4_processor_keeps_numpy_video_slot_without_torchvision(
+def test_gemma4_processor_restores_numpy_video_slot_without_torchvision(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Gemma 4 must not disable the slot required by its NumPy-only processor."""
+    """Gemma 4 must restore the slot required by its NumPy-only processor."""
     (tmp_path / "config.json").write_text(
         '{"vision_config": {"model_type": "gemma4"}}',
         encoding="utf-8",
     )
-    _FakeFamilyProcessor.seen_repo = None
-    _FakeFamilyProcessor.seen_trust_remote_code = None
+    from transformers.processing_utils import MODALITY_TO_AUTOPROCESSOR_MAPPING
+
+    mapping = cast(
+        dict[str, object],
+        MODALITY_TO_AUTOPROCESSOR_MAPPING._MAPPING_NAMES,  # type: ignore
+    )
+    vision_module.__dict__["_restore_video_processor"]()
+    original_video_entry = mapping["video_processor"]
+    monkeypatch.setattr(vision_module, "_video_processor_patched", False)
+    monkeypatch.setattr(
+        vision_module,
+        "_video_processor_mapping_entry",
+        original_video_entry,
+    )
+    monkeypatch.setitem(mapping, "video_processor", original_video_entry)
+    vision_module.__dict__["_patch_video_processor"]()
+    assert "video_processor" not in mapping
+
+    class _FakeGemma4Processor:
+        seen_repo: str | None = None
+
+        @classmethod
+        def from_pretrained(
+            cls,
+            repo: str,
+            **_kwargs: object,
+        ) -> _FakeCombinedProcessor:
+            assert mapping.get("video_processor") == original_video_entry
+            cls.seen_repo = repo
+            return _FakeCombinedProcessor()
 
     def _model_path(*_args: object) -> Path:
         return tmp_path
@@ -189,14 +217,9 @@ def test_gemma4_processor_keeps_numpy_video_slot_without_torchvision(
     def _no_upstream_processor(_repo: str) -> None:
         return None
 
-    def _must_not_patch_video_processor() -> None:
-        raise AssertionError(
-            "Gemma 4's NumPy video processor does not require torchvision"
-        )
-
     def _fake_import_module(module_name: str) -> object:
         if module_name == "mlx_vlm.models.gemma4":
-            return SimpleNamespace(Gemma4Processor=_FakeFamilyProcessor)
+            return SimpleNamespace(Gemma4Processor=_FakeGemma4Processor)
         raise ModuleNotFoundError(name=module_name)
 
     def _fail_transformers_loader(*_args: object, **_kwargs: object) -> object:
@@ -206,11 +229,6 @@ def test_gemma4_processor_keeps_numpy_video_slot_without_torchvision(
 
     monkeypatch.setattr(vision_module, "build_model_path", _model_path)
     monkeypatch.setattr(vision_module, "load_image_processor", _no_upstream_processor)
-    monkeypatch.setattr(
-        vision_module,
-        "_patch_video_processor",
-        _must_not_patch_video_processor,
-    )
     monkeypatch.setattr(vision_module.importlib, "import_module", _fake_import_module)
     monkeypatch.setattr(
         vision_module,
@@ -229,8 +247,62 @@ def test_gemma4_processor_keeps_numpy_video_slot_without_torchvision(
     encoder.ensure_processor_loaded()
 
     assert isinstance(encoder.processor, _FakeImageProcessor)
-    assert _FakeFamilyProcessor.seen_repo == str(tmp_path)
-    assert _FakeFamilyProcessor.seen_trust_remote_code is True
+    assert _FakeGemma4Processor.seen_repo == str(tmp_path)
+    assert mapping.get("video_processor") == original_video_entry
+
+
+def test_gemma4_weight_loading_restores_video_slot_before_model_import(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Distributed Gemma 4 vision must restore the slot before loading weights."""
+    (tmp_path / "config.json").write_text(
+        '{"vision_config": {"model_type": "gemma4"}}',
+        encoding="utf-8",
+    )
+    from transformers.processing_utils import MODALITY_TO_AUTOPROCESSOR_MAPPING
+
+    mapping = cast(
+        dict[str, object],
+        MODALITY_TO_AUTOPROCESSOR_MAPPING._MAPPING_NAMES,  # type: ignore
+    )
+    vision_module.__dict__["_restore_video_processor"]()
+    original_video_entry = mapping["video_processor"]
+    monkeypatch.setattr(vision_module, "_video_processor_patched", False)
+    monkeypatch.setattr(
+        vision_module,
+        "_video_processor_mapping_entry",
+        original_video_entry,
+    )
+    monkeypatch.setitem(mapping, "video_processor", original_video_entry)
+    vision_module.__dict__["_patch_video_processor"]()
+    assert "video_processor" not in mapping
+
+    def _model_path(*_args: object) -> Path:
+        return tmp_path
+
+    class _StopAfterCompatibilityCheckError(Exception):
+        """Stop weight loading after the mapping state has been verified."""
+
+    def _verify_mapping_before_import(*_submodules: str) -> object:
+        assert mapping.get("video_processor") == original_video_entry
+        raise _StopAfterCompatibilityCheckError
+
+    monkeypatch.setattr(vision_module, "build_model_path", _model_path)
+    encoder = VisionEncoder(
+        VisionCardConfig(
+            image_token_id=1,
+            model_type="gemma4",
+            weights_repo="mlx-community/example",
+        ),
+        ModelId("mlx-community/example"),
+    )
+    monkeypatch.setattr(encoder, "_import_mlx_vlm", _verify_mapping_before_import)
+
+    with pytest.raises(_StopAfterCompatibilityCheckError):
+        encoder.ensure_loaded()
+
+    assert mapping.get("video_processor") == original_video_entry
 
 
 def test_processor_loader_reports_transformers_torchvision_failure(


### PR DESCRIPTION
## Summary

- keep Transformers' video processor registration intact for Gemma 4, whose MLX-VLM processor supplies a NumPy-only video implementation and does not require torchvision
- prevent fallback to Transformers' incompatible pre-patchified Gemma 4 image tensors
- add a regression test proving Gemma 4 selects the MLX-VLM combined processor without invoking the torchvision compatibility patch or Transformers fallback

## Root cause

The general no-torchvision compatibility patch removed the `video_processor` constructor slot before `Gemma4Processor.from_pretrained` ran. That loader then failed and Skulk fell through to Transformers' Gemma 4 image processor. Transformers returns pre-patchified `[batch, patches, patch_dim]` data, while MLX-VLM's vision tower expects raw BCHW pixels, causing the tower to reinterpret tensor dimensions as an image grid and fail pooling.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` (2,862 passed, 1 skipped, 228 deselected)
- focused processor/vision tests: 41 passed
- reproduced the failure on a clean configured Apple placement and confirmed the selected fallback tensor contract before applying the fix
