### PR TITLE
fix: restore VLM MTP state on rejected drafts

### DIFF
--- a/src/skulk/worker/engines/mlx/cache.py
+++ b/src/skulk/worker/engines/mlx/cache.py
@@ -164,6 +164,11 @@ def is_non_kv_cache_entry(entry: object) -> bool:
     )
 
 
+def has_recurrent_state_caches(cache: KVCacheType) -> bool:
+    """Return whether a cache contains recurrent state requiring restoration."""
+    return any(isinstance(entry, (ArraysCache, VlmArraysCache)) for entry in cache)
+
+
 def snapshot_ssm_states(cache: KVCacheType) -> CacheSnapshot:
     states: list[
         ArraysCache

--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -59,6 +59,7 @@ from skulk.worker.engines.mlx.cache import (
     KVPrefixCache,
     encode_prompt,
     has_non_kv_caches,
+    has_recurrent_state_caches,
     is_non_kv_cache_entry,
     make_kv_cache,
     snapshot_ssm_states,
@@ -1555,12 +1556,15 @@ def _stream_generate_with_mtp(
     # be trimmed positionally — and trim_cache without a snapshot ZEROES it.
     # Skulk's trunk/head verify path returns hidden states directly, not the
     # family-specific GDN snapshots required by native Qwen3.5 rollback. Use
-    # Skulk's pre-verify snapshot for every stateful cache; native rollback is
-    # safe only for positionally trimmable caches whose method needs no GDN
-    # state (for example Gemma 4).
-    mtp_has_ssm = has_non_kv_caches(prompt_cache)
+    # Skulk's pre-verify snapshot only for recurrent caches. Rotating KV caches
+    # (Gemma 4) have a valid native positional rollback and must keep it to
+    # avoid copying their sliding-window buffers every speculative round.
+    mtp_has_recurrent_state = has_recurrent_state_caches(prompt_cache)
     native_rollback = (
-        None if mtp_has_ssm else native_rollback_candidate
+        None if mtp_has_recurrent_state else native_rollback_candidate
+    )
+    needs_pre_verify_snapshot = (
+        has_non_kv_caches(prompt_cache) and not callable(native_rollback)
     )
 
     # Deferred replay (snapshot path only): committed tokens whose cache
@@ -1827,7 +1831,11 @@ def _stream_generate_with_mtp(
         # ---- their rows are discarded (they were scored last round).   ----
         chain_len = len(draft_toks)
         replay_len = len(pending_replay)
-        pre_verify_snapshot = snapshot_ssm_states(prompt_cache) if mtp_has_ssm else None
+        pre_verify_snapshot = (
+            snapshot_ssm_states(prompt_cache)
+            if needs_pre_verify_snapshot
+            else None
+        )
         verify_input = mx.array([*pending_replay, bonus, *draft_toks])
         with mx.stream(generation_stream):
             full_h = trunk_fn(verify_input[None], cache=prompt_cache)  # (1,R+K+1,H)

--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -1547,15 +1547,21 @@ def _stream_generate_with_mtp(
 
     # Model-native speculative rollback (gemma4): no snapshots, no replay.
     _lm: object | None = getattr(model, "language_model", None)
-    native_rollback = cast(
+    native_rollback_candidate = cast(
         "Callable[..., None] | None",
         getattr(_lm, "rollback_speculative_cache", None) if _lm is not None else None,
     )
     # Hybrid models (e.g. Qwen3.5 GDN) carry recurrent SSM state that cannot
     # be trimmed positionally — and trim_cache without a snapshot ZEROES it.
-    # Rejects must restore a pre-verify snapshot instead (unless the model
-    # provides native rollback, which handles its own cache types).
-    mtp_has_ssm = has_non_kv_caches(prompt_cache) and not callable(native_rollback)
+    # Skulk's trunk/head verify path returns hidden states directly, not the
+    # family-specific GDN snapshots required by native Qwen3.5 rollback. Use
+    # Skulk's pre-verify snapshot for every stateful cache; native rollback is
+    # safe only for positionally trimmable caches whose method needs no GDN
+    # state (for example Gemma 4).
+    mtp_has_ssm = has_non_kv_caches(prompt_cache)
+    native_rollback = (
+        None if mtp_has_ssm else native_rollback_candidate
+    )
 
     # Deferred replay (snapshot path only): committed tokens whose cache
     # entries were lost to a reject-restore. Instead of paying a dedicated

--- a/src/skulk/worker/engines/mlx/tests/test_drafters.py
+++ b/src/skulk/worker/engines/mlx/tests/test_drafters.py
@@ -938,6 +938,57 @@ class TestStreamGenerateDepth(TestStreamGenerateWithMTP):
 
 
 class TestRejectPathSSMState:
+    def test_reject_keeps_native_rollback_for_rotating_cache(self) -> None:
+        """Gemma 4 rotating caches must retain their cheap native rollback."""
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        from skulk.worker.engines.mlx.generator.generate import (
+            _stream_generate_with_mtp,
+        )
+
+        model, tokenizer, drafter, trunk_fn, head_fn, _fake_cache = (
+            _build_fake_stream_env(
+                main_token_ids=[5, 3, 0],
+                draft_token_id=7,
+            )
+        )
+        native_rollback = MagicMock()
+        model.language_model = MagicMock(
+            rollback_speculative_cache=native_rollback
+        )
+
+        rotating_cache = RotatingKVCache(max_size=16)
+        _ = rotating_cache.update_and_fetch(  # pyright: ignore[reportUnknownMemberType]
+            mx.zeros((1, 1, 8, 4)), mx.zeros((1, 1, 8, 4))
+        )
+        kv_cache = KVCache()
+        _ = kv_cache.update_and_fetch(  # pyright: ignore[reportUnknownMemberType]
+            mx.zeros((1, 1, 8, 4)), mx.zeros((1, 1, 8, 4))
+        )
+        cache = [rotating_cache, kv_cache]
+
+        sampler = lambda lp: mx.argmax(lp, axis=-1)  # noqa: E731
+        outputs = list(
+            _stream_generate_with_mtp(
+                model=model,
+                tokenizer=tokenizer,
+                drafter=drafter,
+                trunk_fn=trunk_fn,
+                head_fn=head_fn,
+                prompt=mx.array([1, 2, 3]),
+                max_tokens=3,
+                sampler=sampler,
+                logits_processors=[],
+                prompt_cache=cache,
+                kv_group_size=None,
+                kv_bits=None,
+                depth=2,
+            )
+        )
+
+        assert outputs
+        native_rollback.assert_called()
+
     def test_reject_does_not_call_native_rollback_without_gdn_states(self) -> None:
         """Stateful Skulk verifies must use snapshots, not native GDN rollback.
 

--- a/src/skulk/worker/engines/mlx/tests/test_drafters.py
+++ b/src/skulk/worker/engines/mlx/tests/test_drafters.py
@@ -938,6 +938,66 @@ class TestStreamGenerateDepth(TestStreamGenerateWithMTP):
 
 
 class TestRejectPathSSMState:
+    def test_reject_does_not_call_native_rollback_without_gdn_states(self) -> None:
+        """Stateful Skulk verifies must use snapshots, not native GDN rollback.
+
+        The native mlx-vlm Qwen3.5 rollback iterates its ``gdn_states``
+        argument. Skulk's trunk/head MTP path does not produce that
+        family-specific payload, so passing ``None`` crashes on the first
+        rejected draft. The generic ArraysCache snapshot path already
+        preserves the same recurrent state without that unavailable payload.
+        """
+        from mlx_lm.models.cache import ArraysCache, KVCache
+
+        from skulk.worker.engines.mlx.generator.generate import (
+            _stream_generate_with_mtp,
+        )
+
+        model, tokenizer, drafter, trunk_fn, head_fn, _fake_cache = (
+            _build_fake_stream_env(
+                main_token_ids=[5, 3, 0],
+                draft_token_id=7,
+            )
+        )
+        native_rollback = MagicMock(
+            side_effect=TypeError("'NoneType' object is not iterable")
+        )
+        model.language_model = MagicMock(
+            rollback_speculative_cache=native_rollback
+        )
+
+        ssm_cache = ArraysCache(size=1)
+        sentinel = mx.ones((1, 4))
+        ssm_cache.state = [sentinel]
+        kv_cache = KVCache()
+        _ = kv_cache.update_and_fetch(  # pyright: ignore[reportUnknownMemberType]
+            mx.zeros((1, 1, 8, 4)), mx.zeros((1, 1, 8, 4))
+        )
+        cache = [ssm_cache, kv_cache]
+
+        sampler = lambda lp: mx.argmax(lp, axis=-1)  # noqa: E731
+        outputs = list(
+            _stream_generate_with_mtp(
+                model=model,
+                tokenizer=tokenizer,
+                drafter=drafter,
+                trunk_fn=trunk_fn,
+                head_fn=head_fn,
+                prompt=mx.array([1, 2, 3]),
+                max_tokens=3,
+                sampler=sampler,
+                logits_processors=[],
+                prompt_cache=cache,
+                kv_group_size=None,
+                kv_bits=None,
+            )
+        )
+
+        assert outputs
+        native_rollback.assert_not_called()
+        assert ssm_cache.state[0] is not None
+        assert mx.array_equal(ssm_cache.state[0], sentinel)
+
     def test_reject_restores_ssm_state(self) -> None:
         """A reject must restore SSM (ArraysCache) state, not zero it.
 


### PR DESCRIPTION
## Summary
- route stateful speculative-cache rejection through Skulk snapshot restoration
- avoid calling native Qwen3.5 rollback without the family-specific GDN state payload
- add a focused regression test matching the live crash contract

## Root cause
The trunk/head MTP verifier returns hidden states directly and does not expose mlx-vlm native GDN snapshots. A rejected Qwen3.5 VLM draft therefore passed a null GDN payload to native rollback, which raised TypeError and terminated the runner.

## Validation
- focused MTP rejection tests: 3 passed
- uv run basedpyright: clean
- uv run ruff check: clean
- nix fmt: no changes
- uv run pytest: 2,902 passed, 1 skipped, 228 deselected

## Documentation
No API, configuration, model-card, or architectural contract changed; no documentation update is required.