### PR TITLE
fix: bundle speech encoder on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+- Fixed fresh Apple installs returning HTTP 500 for MP3, FLAC, OGG, and Opus
+  speech output because `mlx-audio` expected an external `ffmpeg` executable.
+  Skulk now ships a platform encoder dependency and exposes its bundled binary
+  to speech runners when no system `ffmpeg` is installed.
+
 - Fixed store-backed model launches exhausting a worker's filesystem while
   recently used staging data was still inside the 40 GiB warm-cache budget.
   Store transfers now serialize exact capacity admission with the byte

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ dependencies = [
   # codebooks, producing fluent but unrelated speech. The Foxlight post-release
   # carries only upstream mlx-audio #693 on top of the 0.4.3 tag.
   "mlx-audio @ https://github.com/Foxlight-Foundation/mlx-audio/archive/7f87787fe8a48faffe2a6fb16c87d457b5fac289.tar.gz ; sys_platform == 'darwin'",
+  # HARD dependency of encoded MLX speech output. mlx-audio delegates MP3,
+  # FLAC, OGG, and Opus encoding to an ffmpeg executable; the packaged binary
+  # keeps those advertised formats working on a fresh install without requiring
+  # a separate Homebrew or system package.
+  "imageio-ffmpeg>=0.6.0; sys_platform == 'darwin'",
   "transformers>=5.5.0,<6.0.0",
   # HARD dependency of the MLX vision path, not an extra (#614's rule: nothing
   # optional may be load-bearing). transformers 5.x routes every

--- a/src/skulk/worker/runner/speech/runner.py
+++ b/src/skulk/worker/runner/speech/runner.py
@@ -315,6 +315,7 @@ def _ensure_ffmpeg_available() -> Path:
     bundled_executable = _bundled_ffmpeg_executable()
     shim_directory = SKULK_CACHE_HOME / "bin"
     shim_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    shim_directory.chmod(0o700)
     ffmpeg_shim = shim_directory / "ffmpeg"
     temporary_shim = shim_directory / f".ffmpeg-{os.getpid()}-{time.monotonic_ns()}"
     try:

--- a/src/skulk/worker/runner/speech/runner.py
+++ b/src/skulk/worker/runner/speech/runner.py
@@ -8,6 +8,7 @@ import hashlib
 import inspect
 import io
 import os
+import shutil
 import tempfile
 import time
 from collections.abc import Callable, Iterable
@@ -18,7 +19,7 @@ from typing import Any, cast
 import numpy as np
 from anyio import ClosedResourceError, EndOfStream, WouldBlock
 
-from skulk.shared.constants import SKULK_MAX_CHUNK_SIZE
+from skulk.shared.constants import SKULK_CACHE_HOME, SKULK_MAX_CHUNK_SIZE
 from skulk.shared.models.model_cards import AudioCardKind, AudioResponseFormat
 from skulk.shared.tracing import (
     begin_trace_session,
@@ -69,6 +70,14 @@ from skulk.worker.runner.bootstrap import logger
 _DEFAULT_STAGED_TTS_VOICE = "af_heart"
 _AUDIO_BINARY_CHUNK_SIZE = max(1, (SKULK_MAX_CHUNK_SIZE // 4) * 3)
 _CANARY_MASK_COMPAT_MARKER = "_skulk_mask_dtype_compat"
+_FFMPEG_AUDIO_RESPONSE_FORMATS = frozenset(
+    {
+        AudioResponseFormat.Mp3,
+        AudioResponseFormat.Flac,
+        AudioResponseFormat.Ogg,
+        AudioResponseFormat.Opus,
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -272,6 +281,64 @@ def _result_audio_and_sample_rate(result: Any) -> tuple[Any | None, int | None]:
     return audio, sample_rate if isinstance(sample_rate, int) else None
 
 
+def _bundled_ffmpeg_executable() -> Path:
+    """Return the executable supplied by Skulk's hard encoder dependency."""
+    try:
+        from imageio_ffmpeg import get_ffmpeg_exe
+    except ImportError as exc:
+        raise RuntimeError(
+            "Skulk's bundled FFmpeg encoder is unavailable; reinstall Skulk "
+            "to restore encoded speech output"
+        ) from exc
+
+    try:
+        executable = Path(get_ffmpeg_exe()).resolve()
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "Skulk's bundled FFmpeg encoder could not be resolved; reinstall "
+            "Skulk to restore encoded speech output"
+        ) from exc
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise RuntimeError(
+            "Skulk's bundled FFmpeg encoder is not executable; reinstall Skulk "
+            "to restore encoded speech output"
+        )
+    return executable
+
+
+def _ensure_ffmpeg_available() -> Path:
+    """Expose a bundled encoder to ``mlx_audio`` when none is on ``PATH``."""
+    system_executable = shutil.which("ffmpeg")
+    if system_executable is not None:
+        return Path(system_executable)
+
+    bundled_executable = _bundled_ffmpeg_executable()
+    shim_directory = SKULK_CACHE_HOME / "bin"
+    shim_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    ffmpeg_shim = shim_directory / "ffmpeg"
+    temporary_shim = shim_directory / f".ffmpeg-{os.getpid()}-{time.monotonic_ns()}"
+    try:
+        temporary_shim.symlink_to(bundled_executable)
+        os.replace(temporary_shim, ffmpeg_shim)
+    finally:
+        temporary_shim.unlink(missing_ok=True)
+
+    path_entries = os.environ.get("PATH", "").split(os.pathsep)
+    shim_directory_text = os.fspath(shim_directory)
+    if shim_directory_text not in path_entries:
+        os.environ["PATH"] = os.pathsep.join(
+            (shim_directory_text, *filter(None, path_entries))
+        )
+
+    resolved_executable = shutil.which("ffmpeg")
+    if resolved_executable is None:
+        raise RuntimeError(
+            "Skulk prepared its bundled FFmpeg encoder but mlx-audio cannot "
+            "discover it on PATH"
+        )
+    return Path(resolved_executable)
+
+
 def _encode_audio(
     audio: np.ndarray, sample_rate: int, response_format: AudioResponseFormat
 ) -> bytes:
@@ -284,6 +351,9 @@ def _encode_audio(
             )
         clipped = np.clip(normalized, -1.0, 1.0)
         return (clipped * 32767.0).astype("<i2").tobytes()
+
+    if response_format in _FFMPEG_AUDIO_RESPONSE_FORMATS:
+        _ensure_ffmpeg_available()
 
     from mlx_audio.audio_io import write as audio_write
 

--- a/src/skulk/worker/runner/speech/tests/test_speech_runner.py
+++ b/src/skulk/worker/runner/speech/tests/test_speech_runner.py
@@ -4,6 +4,7 @@
 import base64
 import hashlib
 import inspect
+import os
 import sys
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -47,6 +48,7 @@ from skulk.worker.runner.speech import runner as speech_runner
 from skulk.worker.runner.speech.runner import (
     Runner,
     _encode_audio,
+    _ensure_ffmpeg_available,
     _filter_kwargs,
     _install_attention_mask_dtype_compat,
     _install_canary_compatibility,
@@ -96,6 +98,66 @@ def test_encode_audio_rejects_multi_channel_pcm() -> None:
             24000,
             AudioResponseFormat.Pcm,
         )
+
+
+def test_ensure_ffmpeg_available_preserves_system_executable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A system encoder should remain authoritative without preparing a shim."""
+
+    def _unexpected_bundled_lookup() -> Path:
+        raise AssertionError("bundled encoder should not be resolved")
+
+    monkeypatch.setattr(
+        speech_runner, "_bundled_ffmpeg_executable", _unexpected_bundled_lookup
+    )
+    monkeypatch.setattr(
+        speech_runner.shutil, "which", lambda _executable: "/usr/bin/ffmpeg"
+    )
+
+    assert _ensure_ffmpeg_available() == Path("/usr/bin/ffmpeg")
+
+
+def test_ensure_ffmpeg_available_prepares_private_bundled_shim(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A fresh install should expose its packaged encoder through runner PATH."""
+
+    executable = tmp_path / "ffmpeg-packaged"
+    executable.write_text("#!/bin/sh\nexit 0\n")
+    executable.chmod(0o700)
+    cache_home = tmp_path / "cache"
+    monkeypatch.setattr(speech_runner, "SKULK_CACHE_HOME", cache_home)
+    monkeypatch.setattr(
+        speech_runner, "_bundled_ffmpeg_executable", lambda: executable
+    )
+    monkeypatch.setenv("PATH", "")
+
+    resolved = _ensure_ffmpeg_available()
+
+    assert resolved == cache_home / "bin" / "ffmpeg"
+    assert resolved.resolve() == executable
+    assert (cache_home / "bin").stat().st_mode & 0o777 == 0o700
+    assert os.environ["PATH"].split(os.pathsep)[0] == os.fspath(cache_home / "bin")
+
+
+def test_encode_audio_mp3_uses_bundled_encoder_on_fresh_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """MP3 encoding should work without a preinstalled system executable."""
+
+    pytest.importorskip("imageio_ffmpeg")
+    pytest.importorskip("mlx_audio.audio_io")
+    monkeypatch.setattr(speech_runner, "SKULK_CACHE_HOME", tmp_path / "cache")
+    monkeypatch.setenv("PATH", "")
+
+    encoded = _encode_audio(
+        np.sin(np.linspace(0.0, np.pi * 2.0, 2400, dtype=np.float32)),
+        24000,
+        AudioResponseFormat.Mp3,
+    )
+
+    assert encoded.startswith((b"ID3", b"\xff"))
 
 
 class _CaptureSender:

--- a/src/skulk/worker/runner/speech/tests/test_speech_runner.py
+++ b/src/skulk/worker/runner/speech/tests/test_speech_runner.py
@@ -127,6 +127,7 @@ def test_ensure_ffmpeg_available_prepares_private_bundled_shim(
     executable.write_text("#!/bin/sh\nexit 0\n")
     executable.chmod(0o700)
     cache_home = tmp_path / "cache"
+    (cache_home / "bin").mkdir(parents=True, mode=0o755)
     monkeypatch.setattr(speech_runner, "SKULK_CACHE_HOME", cache_home)
     monkeypatch.setattr(
         speech_runner, "_bundled_ffmpeg_executable", lambda: executable

--- a/uv.lock
+++ b/uv.lock
@@ -914,6 +914,16 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3027,6 +3037,7 @@ dependencies = [
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "huggingface-hub", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "hypercorn", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "imageio-ffmpeg", marker = "sys_platform == 'darwin'" },
     { name = "jsonschema", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "loguru", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mflux", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -3083,6 +3094,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "huggingface-hub", specifier = ">=1.8.0" },
     { name = "hypercorn", specifier = ">=0.18.0" },
+    { name = "imageio-ffmpeg", marker = "sys_platform == 'darwin'", specifier = ">=0.6.0" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "llama-cpp-python", marker = "extra == 'llama-cpp'", specifier = ">=0.3.3" },
     { name = "loguru", specifier = ">=0.7.3" },

--- a/website/docs/speech-fabric-realtime.md
+++ b/website/docs/speech-fabric-realtime.md
@@ -29,7 +29,10 @@ path is available when the mounted TTS card declares
 `audio.supports_streaming = true`, every routable instance is ready, and the
 request format resolves to MP3 or raw PCM. PCM responses declare sample rate,
 channel count, and sample format in HTTP headers. Other encoded formats remain
-batch-only.
+batch-only. On Apple Silicon, Skulk includes the encoder used for MP3, FLAC,
+OGG, and Opus output; a fresh install does not require a separate Homebrew or
+system `ffmpeg` package. When a system `ffmpeg` is already available, the
+speech runner uses it.
 
 `/v1/audio/transcriptions` accepts a bounded multipart upload. Its stable
 `stream=true` path is available when the mounted STT card declares


### PR DESCRIPTION
## Summary

- ship a hard macOS `imageio-ffmpeg` dependency for the encoded formats Skulk advertises
- preserve an existing system `ffmpeg`, otherwise expose the packaged executable to `mlx-audio` through a private runner cache shim
- document the fresh-install behavior and add a real MP3 regression with an empty `PATH`

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt` (0 changes)
- `uv run pytest` (2906 passed, 1 skipped, 228 deselected)
- focused speech runner suite (30 passed)