### PR TITLE
Fix realtime STT admission after cache-miss downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- Realtime STT admission no longer reports a ready runner as overloaded while
+  cache-miss download lifecycle state is still converging across API nodes.
+
 - Fixed fresh Apple installs returning HTTP 500 for MP3, FLAC, OGG, and Opus
   speech output because `mlx-audio` expected an external `ffmpeg` executable.
   Skulk now ships a platform encoder dependency and exposes its bundled binary

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -4310,6 +4310,18 @@ class API:
                 )
                 or any(
                     task.instance_id == instance_id
+                    # RunnerReady is authoritative for lifecycle completion.
+                    # Download/load bookkeeping can remain non-terminal briefly
+                    # on another API node after the runner becomes ready, but it
+                    # does not occupy STT inference capacity. Only active STT
+                    # workloads must block cross-owner admission here.
+                    and isinstance(
+                        task,
+                        (
+                            task_types.AudioTranscription,
+                            task_types.RealtimeAudioTranscription,
+                        ),
+                    )
                     and task.task_status not in _TERMINAL_TASK_STATUSES
                     for task in self.state.tasks.values()
                 )

--- a/src/skulk/api/tests/test_realtime_stt_provider.py
+++ b/src/skulk/api/tests/test_realtime_stt_provider.py
@@ -49,9 +49,13 @@ from skulk.shared.types.events import (
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.state import State
 from skulk.shared.types.tasks import (
+    DownloadModel,
+    TaskId,
+    TaskStatus,
+)
+from skulk.shared.types.tasks import (
     RealtimeAudioTranscription as RealtimeAudioTranscriptionTask,
 )
-from skulk.shared.types.tasks import TaskId, TaskStatus
 from skulk.shared.types.telemetry import TelemetryView
 from skulk.shared.types.worker.instances import InstanceId, MlxRingInstance
 from skulk.shared.types.worker.runners import (
@@ -818,6 +822,32 @@ async def test_realtime_stt_admission_skips_busy_instance(
         await session.input.cancel("test complete")
         _ = [frame async for frame in session.frames]
         task_group.cancel_scope.cancel()
+
+
+def test_realtime_stt_admission_ignores_ready_instance_download_lifecycle() -> None:
+    """A stale download task must not make a ready STT runner look overloaded."""
+
+    api, _, _ = _build_api()
+    card = _realtime_card()
+    state = _local_state(card)
+    instance_id, instance = next(iter(state.instances.items()))
+    shard = next(iter(instance.shard_assignments.runner_to_shard.values()))
+    download = DownloadModel(
+        task_id=TaskId("stale-download-task"),
+        task_status=TaskStatus.Running,
+        instance_id=instance_id,
+        shard_metadata=shard,
+    )
+    api.state = state.model_copy(update={"tasks": {download.task_id: download}})
+
+    selected = api._realtime_stt_instance(
+        card.model_id,
+        call_id="new-realtime-call",
+        require_idle=True,
+    )
+
+    assert selected is not None
+    assert selected[0] == instance_id
 
 
 @pytest.mark.anyio

--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -1196,7 +1196,17 @@ class Master:
                             instance_busy = command.target_instance_id in (
                                 self._realtime_instance_by_command.values()
                             ) or any(
-                                task.instance_id == command.target_instance_id
+                                # Runner readiness can precede lifecycle-task
+                                # convergence. Only transcription inference
+                                # consumes mounted STT capacity once ready.
+                                isinstance(
+                                    task,
+                                    (
+                                        AudioTranscriptionTask,
+                                        RealtimeAudioTranscriptionTask,
+                                    ),
+                                )
+                                and task.instance_id == command.target_instance_id
                                 and task.task_status
                                 in (TaskStatus.Pending, TaskStatus.Running)
                                 for task in self.state.tasks.values()

--- a/src/skulk/master/tests/test_tracing_control.py
+++ b/src/skulk/master/tests/test_tracing_control.py
@@ -44,10 +44,14 @@ from skulk.shared.types.memory import Memory
 from skulk.shared.types.state_sync import StateSyncMessage
 from skulk.shared.types.tasks import AudioTranscription as AudioTranscriptionTask
 from skulk.shared.types.tasks import (
+    DownloadModel,
+    TaskId,
+    TaskStatus,
+)
+from skulk.shared.types.tasks import (
     RealtimeAudioTranscription as RealtimeAudioTranscriptionTask,
 )
 from skulk.shared.types.tasks import SpeechSynthesis as SpeechSynthesisTask
-from skulk.shared.types.tasks import TaskStatus
 from skulk.shared.types.tasks import TextGeneration as TextGenerationTask
 from skulk.shared.types.text_generation import InputMessage, TextGenerationTaskParams
 from skulk.shared.types.worker.instances import InstanceId, MlxRingInstance
@@ -481,6 +485,50 @@ async def test_realtime_stt_master_reserves_before_task_event_round_trip() -> No
     assert second_failed.error_type == "instance_busy"
     assert first.command_id in master.command_task_mapping
     assert second.command_id in master.command_task_mapping
+
+
+@pytest.mark.asyncio
+async def test_realtime_stt_master_ignores_running_lifecycle_task() -> None:
+    """Ready realtime runners remain usable while lifecycle state converges."""
+
+    master, node_id, command_sender, event_receiver = _build_master()
+    instance = _single_node_transcription_instance(node_id)
+    shard = next(iter(instance.shard_assignments.runner_to_shard.values()))
+    stale_download = DownloadModel(
+        task_id=TaskId("stale-download-task"),
+        instance_id=instance.instance_id,
+        task_status=TaskStatus.Running,
+        shard_metadata=shard,
+    )
+    master.state = master.state.model_copy(
+        update={
+            "instances": {instance.instance_id: instance},
+            "tasks": {stale_download.task_id: stale_download},
+        }
+    )
+    command = RealtimeAudioTranscription(
+        command_id=CommandId("realtime-after-ready"),
+        owner_node=NodeId("remote-api"),
+        target_instance_id=instance.instance_id,
+        task_params=RealtimeAudioTranscriptionTaskParams(
+            model=instance.shard_assignments.model_id,
+            input_sample_rate=16000,
+            transcription_delay_ms=480,
+        ),
+    )
+    event: Event | None = None
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(master._command_processor)  # pyright: ignore[reportPrivateUsage]
+        await command_sender.send(
+            ForwarderCommand(origin=SystemId("API"), command=command)
+        )
+        event = await event_receiver.receive()
+        task_group.cancel_scope.cancel()
+
+    assert isinstance(event, TaskCreated)
+    assert isinstance(event.task, RealtimeAudioTranscriptionTask)
+    assert event.task.task_status is TaskStatus.Pending
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- exclude download/load lifecycle bookkeeping from realtime STT inference occupancy once the runner is ready
- retain cross-owner protection for active batch/realtime STT work and provider reservations
- add the cache-miss lifecycle regression test and release note

## Evidence
A distributed cache-miss realtime qualification intermittently returned WebSocket 1013 with an overloaded provider before admitting any stream. The failed instance retained a cancelling download lifecycle task; an immediate cached rerun admitted cancellation, local-owner, and remote-owner sessions successfully.

## Validation
- `uv run basedpyright` (0 errors)
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt` (0 changes)
- `uv run pytest src/skulk/api/tests/test_realtime_stt_provider.py -q` (30 passed)
- `uv run pytest` (2907 passed, 1 skipped, 228 deselected)