### PR TITLE
Filter nonportable IPv6 probes and quiet candidate failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project records release notes here and mirrors public-facing notes in
 - Realtime STT admission no longer reports a ready runner as overloaded while
   cache-miss download lifecycle state is still converging across API nodes.
 
+- Stopped unreachable per-interface IPv6 link-local probe candidates from
+  flooding normal logs with misleading peer-down warnings.
+
 - Fixed fresh Apple installs returning HTTP 500 for MP3, FLAC, OGG, and Opus
   speech output because `mlx-audio` expected an external `ffmpeg` executable.
   Skulk now ships a platform encoder dependency and exposes its bundled binary

--- a/src/skulk/utils/info_gatherer/net_profile.py
+++ b/src/skulk/utils/info_gatherer/net_profile.py
@@ -33,7 +33,11 @@ def _should_probe_remote_ip(target_ip: str) -> bool:
 
     Remote-node probing should ignore loopback and unspecified addresses such as
     ``127.0.0.1`` or ``::1`` because they resolve back to the local node on the
-    probing machine and create misleading identity-mismatch logs.
+    probing machine and create misleading identity-mismatch logs. IPv6
+    link-local addresses are also excluded: their scope identifiers name an
+    interface on the advertising node and are not portable to a different
+    machine. IPv4 link-local addresses remain eligible because Skulk uses them
+    for directly connected Thunderbolt paths.
     """
 
     candidate = target_ip.strip()
@@ -49,7 +53,11 @@ def _should_probe_remote_ip(target_ip: str) -> bool:
     except ValueError:
         return candidate not in {"localhost"}
 
-    return not (parsed.is_loopback or parsed.is_unspecified)
+    return not (
+        parsed.is_loopback
+        or parsed.is_unspecified
+        or (parsed.version == 6 and parsed.is_link_local)
+    )
 
 
 async def check_reachability(
@@ -115,9 +123,14 @@ async def check_reachability(
 
     if remote_node_id is None:
         if last_error is not None:
-            logger.warning(
-                f"peer probe failed with {type(last_error).__name__} from "
-                f"{target_ip} after {attempts} attempts; treating as down"
+            # One peer advertises many address candidates. Failure of a single
+            # candidate says nothing about peer liveness, and the worker
+            # already backs repeatedly failing candidates off. Keep this
+            # diagnostic available at debug level without flooding ordinary
+            # operator logs with one warning per VPN/interface address.
+            logger.debug(
+                f"address probe failed with {type(last_error).__name__} for "
+                f"{target_ip} after {attempts} attempts"
             )
         return
 

--- a/src/skulk/utils/info_gatherer/tests/test_net_profile.py
+++ b/src/skulk/utils/info_gatherer/tests/test_net_profile.py
@@ -28,7 +28,7 @@ async def _collect_reachable_targets(
 
 
 @pytest.mark.anyio
-async def test_check_reachable_skips_loopback_and_unspecified_addresses(
+async def test_check_reachable_skips_nonportable_remote_addresses(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     self_node_id = NodeId("self")
@@ -45,6 +45,7 @@ async def test_check_reachable_skips_loopback_and_unspecified_addresses(
                 NetworkInterfaceInfo(name="lo0", ip_address="::"),
                 NetworkInterfaceInfo(name="lo0", ip_address="localhost"),
                 NetworkInterfaceInfo(name="en0", ip_address="192.168.0.117"),
+                NetworkInterfaceInfo(name="en5", ip_address="169.254.12.34"),
                 NetworkInterfaceInfo(
                     name="en7", ip_address="fe80::20:315a:c2e5:286b%en0"
                 ),
@@ -72,10 +73,10 @@ async def test_check_reachable_skips_loopback_and_unspecified_addresses(
         node_network=node_network,
     )
 
-    assert probed_targets == ["192.168.0.117", "fe80::20:315a:c2e5:286b%en0"]
+    assert probed_targets == ["192.168.0.117", "169.254.12.34"]
     assert reachable_targets == [
         ("192.168.0.117", remote_node_id),
-        ("fe80::20:315a:c2e5:286b%en0", remote_node_id),
+        ("169.254.12.34", remote_node_id),
     ]
 
 
@@ -334,6 +335,56 @@ async def test_check_reachability_no_warning_on_eventual_success(
     assert calls == 2
     assert out == {NodeId("remote"): {"203.0.113.9"}}
     assert warnings == []
+
+
+@pytest.mark.anyio
+async def test_check_reachability_logs_candidate_failure_at_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One failed address is a debug diagnostic, not a peer-down warning."""
+
+    debug_messages: list[str] = []
+    warnings: list[str] = []
+
+    def _record_debug(
+        message: object, *_args: object, **_kwargs: object
+    ) -> None:
+        debug_messages.append(str(message))
+
+    def _record_warning(
+        message: object, *_args: object, **_kwargs: object
+    ) -> None:
+        warnings.append(str(message))
+
+    monkeypatch.setattr(
+        net_profile.logger,
+        "debug",
+        _record_debug,
+    )
+    monkeypatch.setattr(
+        net_profile.logger,
+        "warning",
+        _record_warning,
+    )
+
+    class _DeadClient:
+        async def get(self, url: str) -> object:
+            raise httpx.ConnectError(f"dead: {url}")
+
+    out: dict[NodeId, set[str]] = {}
+    await net_profile.check_reachability(
+        "203.0.113.9",
+        NodeId("remote"),
+        out,
+        _DeadClient(),  # pyright: ignore[reportArgumentType]
+        attempts=1,
+    )
+
+    assert warnings == []
+    assert debug_messages == [
+        "address probe failed with ConnectError for "
+        "203.0.113.9 after 1 attempts"
+    ]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- skip remote IPv6 link-local addresses whose interface scope identifiers are not portable to the probing node
- preserve IPv4 link-local candidates used by directly connected Thunderbolt paths
- log an individual failed address candidate at debug instead of claiming the peer is down
- add focused address-filtering and log-level regressions

A peer advertises several interface candidates, so one failed VPN or interface address is not evidence that the peer itself is down. The change was reconstructed onto current `dev` from the orphaned rolling branch without its unrelated commits.

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt` (0 files changed)
- `uv run pytest` — 2,908 passed, 1 skipped, 228 deselected
- post-rebase network profile tests — 20 passed