### PR TITLE
Fix fresh-install model download request exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- Prevented a fresh node's startup download-progress scan from exhausting
+  Hugging Face API limits by fetching metadata for every shipped model card.
+  The scan now validates only models that have local files to resume or
+  recover, so a user's first selected model receives the available request
+  budget.
+
 - Realtime STT admission no longer reports a ready runner as overloaded while
   cache-miss download lifecycle state is still converging across API nodes.
 

--- a/src/skulk/download/impl_shard_downloader.py
+++ b/src/skulk/download/impl_shard_downloader.py
@@ -14,6 +14,7 @@ from skulk.download.download_utils import (
     download_shard,
 )
 from skulk.download.shard_downloader import ShardDownloader
+from skulk.shared.constants import SKULK_MODELS_DIR
 from skulk.shared.models.model_cards import (
     ModelCard,
     ModelId,
@@ -57,6 +58,29 @@ def _remaining_direct_download_bytes(
             expected_size - target_bytes - partial_bytes,
         )
     return remaining_bytes
+
+
+def _has_local_download_state(model_card: ModelCard) -> bool:
+    """Return whether the canonical cache contains model download data.
+
+    The startup progress scan exists to recover downloads interrupted in an
+    earlier process. Catalog entries with no local files have nothing to
+    recover and must not consume Hugging Face metadata requests merely because
+    they are present in the shipped model-card registry.
+
+    Args:
+        model_card: Catalog card whose canonical direct-download directory
+            should be inspected.
+
+    Returns:
+        ``True`` when at least one file exists below the model's canonical
+        cache directory, including resumable ``.partial`` files.
+    """
+
+    model_directory = SKULK_MODELS_DIR / model_card.model_id.normalize()
+    if not model_directory.is_dir():
+        return False
+    return any(path.is_file() for path in model_directory.rglob("*"))
 
 
 def skulk_shard_downloader(
@@ -279,9 +303,17 @@ class ResumableShardDownloader(ShardDownloader):
             async with semaphore:
                 return await _status_for_model(model_card.model_id)
 
+        model_cards = await get_model_cards()
+        local_model_cards = await asyncio.to_thread(
+            lambda: [
+                model_card
+                for model_card in model_cards
+                if _has_local_download_state(model_card)
+            ]
+        )
         tasks = [
             create_task(download_with_semaphore(model_card))
-            for model_card in await get_model_cards()
+            for model_card in local_model_cards
         ]
 
         for task in asyncio.as_completed(tasks):

--- a/src/skulk/download/tests/test_existing_download_scan.py
+++ b/src/skulk/download/tests/test_existing_download_scan.py
@@ -1,0 +1,155 @@
+"""Tests for startup discovery of resumable direct downloads."""
+
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from skulk.download import impl_shard_downloader
+from skulk.download.download_utils import RepoDownloadProgress
+from skulk.download.impl_shard_downloader import ResumableShardDownloader
+from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from skulk.shared.types.memory import Memory
+from skulk.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
+
+
+def _model_card(model_id: str) -> ModelCard:
+    """Build the minimum text model card needed by the status scanner."""
+
+    return ModelCard(
+        model_id=ModelId(model_id),
+        storage_size=Memory.from_bytes(7),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        gguf_file="model.gguf",
+    )
+
+
+def _shard(model_card: ModelCard) -> PipelineShardMetadata:
+    """Build a complete single-rank shard for one test model."""
+
+    return PipelineShardMetadata(
+        model_card=model_card,
+        device_rank=0,
+        world_size=1,
+        start_layer=0,
+        end_layer=1,
+        n_layers=1,
+    )
+
+
+def _progress(shard: ShardMetadata) -> RepoDownloadProgress:
+    """Build a terminal progress snapshot returned by the fake downloader."""
+
+    return RepoDownloadProgress(
+        repo_id=str(shard.model_card.model_id),
+        repo_revision="main",
+        shard=shard,
+        completed_files=1,
+        total_files=1,
+        downloaded=Memory.from_bytes(7),
+        downloaded_this_session=Memory.from_bytes(0),
+        total=Memory.from_bytes(7),
+        overall_speed=0,
+        overall_eta=timedelta(0),
+        status="complete",
+        file_progress={},
+    )
+
+
+async def _collect_status(
+    downloader: ResumableShardDownloader,
+) -> list[tuple[Path, RepoDownloadProgress]]:
+    """Collect the async status iterator into a list."""
+
+    return [item async for item in downloader.get_shard_download_status()]
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_does_not_query_untouched_catalog_models(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A fresh cache must cause zero remote-backed download status probes."""
+
+    model_cards = [_model_card("org/one"), _model_card("org/two")]
+    probed_models: list[ModelId] = []
+
+    async def get_model_cards() -> list[ModelCard]:
+        return model_cards
+
+    async def build_full_shard(model_id: ModelId) -> PipelineShardMetadata:
+        probed_models.append(model_id)
+        return _shard(next(card for card in model_cards if card.model_id == model_id))
+
+    async def download_shard(
+        shard: ShardMetadata,
+        on_progress: Callable[
+            [ShardMetadata, RepoDownloadProgress], Awaitable[None]
+        ],
+        **_kwargs: object,
+    ) -> tuple[Path, RepoDownloadProgress]:
+        del on_progress
+        return tmp_path / shard.model_card.model_id.normalize(), _progress(shard)
+
+    monkeypatch.setattr(impl_shard_downloader, "SKULK_MODELS_DIR", tmp_path)
+    monkeypatch.setattr(impl_shard_downloader, "get_model_cards", get_model_cards)
+    monkeypatch.setattr(
+        impl_shard_downloader, "build_full_shard", build_full_shard
+    )
+    monkeypatch.setattr(impl_shard_downloader, "download_shard", download_shard)
+
+    results = await _collect_status(ResumableShardDownloader())
+
+    assert results == []
+    assert probed_models == []
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_queries_only_models_with_local_download_data(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An interrupted local model remains discoverable without probing peers."""
+
+    interrupted_card = _model_card("org/interrupted")
+    untouched_card = _model_card("org/untouched")
+    model_cards = [interrupted_card, untouched_card]
+    interrupted_directory = tmp_path / interrupted_card.model_id.normalize()
+    interrupted_directory.mkdir()
+    (interrupted_directory / "model.gguf.partial").write_bytes(b"partial")
+    (tmp_path / untouched_card.model_id.normalize()).mkdir()
+    probed_models: list[ModelId] = []
+
+    async def get_model_cards() -> list[ModelCard]:
+        return model_cards
+
+    async def build_full_shard(model_id: ModelId) -> PipelineShardMetadata:
+        probed_models.append(model_id)
+        return _shard(next(card for card in model_cards if card.model_id == model_id))
+
+    async def download_shard(
+        shard: ShardMetadata,
+        on_progress: Callable[
+            [ShardMetadata, RepoDownloadProgress], Awaitable[None]
+        ],
+        **_kwargs: object,
+    ) -> tuple[Path, RepoDownloadProgress]:
+        del on_progress
+        return interrupted_directory, _progress(shard)
+
+    monkeypatch.setattr(impl_shard_downloader, "SKULK_MODELS_DIR", tmp_path)
+    monkeypatch.setattr(impl_shard_downloader, "get_model_cards", get_model_cards)
+    monkeypatch.setattr(
+        impl_shard_downloader, "build_full_shard", build_full_shard
+    )
+    monkeypatch.setattr(impl_shard_downloader, "download_shard", download_shard)
+
+    results = await _collect_status(ResumableShardDownloader())
+
+    assert len(results) == 1
+    assert results[0][0] == interrupted_directory
+    assert probed_models == [interrupted_card.model_id]


### PR DESCRIPTION
## Summary
- restrict the one-time startup progress scan to catalog models with actual local cache files
- preserve interrupted partial-download discovery
- add regression coverage proving a fresh cache triggers zero remote-backed status probes

## Why
A brand-new node queried Hugging Face metadata for every shipped model card during startup. That consumed the anonymous API request budget before a user-selected model could download.

## Validation
- uv run basedpyright
- uv run ruff check
- nix fmt (0 files changed)
- uv run pytest (2912 passed, 1 skipped, 228 deselected)
- focused download/offline/revision suite (19 passed)