### PR TITLE
Fix Qwen3-VL text generation through native VLM wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- Routed text-only requests on native MLX-VLM models through their language
+  model instead of the multimodal outer model. This prevents Qwen3-VL text
+  chats from producing long corrupted repetition while preserving the native
+  image-generation path.
+
 - Prevented a fresh node's startup download-progress scan from exhausting
   Hugging Face API limits by fetching metadata for every shipped model card.
   The scan now validates only models that have local files to resume or

--- a/src/skulk/worker/engines/mlx/utils_mlx.py
+++ b/src/skulk/worker/engines/mlx/utils_mlx.py
@@ -654,7 +654,15 @@ class _VlmModelWrapper(nn.Module):
             # inject image features into a decode token with no image markers.
             object.__setattr__(self, "_pixel_values", None)
             object.__setattr__(self, "_image_grid_thw", None)
-        result = cast(object, self._inner(*args, **kwargs))
+        inner = cast(object, self._inner)
+        language_model = getattr(inner, "language_model", None)
+        call_target = (
+            inner
+            if pixel_values is not None or language_model is None
+            else language_model
+        )
+        call = cast(Callable[..., object], call_target)
+        result = call(*args, **kwargs)
         if hasattr(result, "logits"):
             return cast(_HasLogits, result).logits
         return cast(mx.array, result)

--- a/src/skulk/worker/tests/unittests/test_mlx/test_vlm_wrapper.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_vlm_wrapper.py
@@ -25,10 +25,20 @@ class _FakeInner:
 
     def __init__(self) -> None:
         self.last_kwargs: dict[str, object] = {}
+        self.call_count = 0
 
     def __call__(self, *_args: object, **kwargs: object) -> _FakeOutput:
+        self.call_count += 1
         self.last_kwargs = dict(kwargs)
         return _FakeOutput(mx.array([1.0]))
+
+
+class _FakeVlmWithLanguageModel(_FakeInner):
+    """Multimodal model stub with a dedicated text-generation trunk."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.language_model = _FakeInner()
 
 
 def test_vlm_wrapper_tolerates_missing_pixel_values_attr() -> None:
@@ -45,6 +55,19 @@ def test_vlm_wrapper_tolerates_missing_pixel_values_attr() -> None:
     assert result.tolist() == [1.0]
 
 
+def test_vlm_wrapper_routes_text_only_calls_to_language_model() -> None:
+    """Text requests must bypass the multimodal outer model's position logic."""
+
+    inner = _FakeVlmWithLanguageModel()
+    wrapper = _vlm_model_wrapper(inner)
+
+    result = cast(Callable[[mx.array], mx.array], wrapper)(mx.array([1]))
+
+    assert inner.call_count == 0
+    assert result.tolist() == [1.0]
+    assert inner.language_model.call_count == 1
+
+
 def test_vlm_wrapper_injects_pixel_values_when_present() -> None:
     """Native vision pixel values should be forwarded exactly once per call."""
     inner = _FakeInner()
@@ -58,3 +81,22 @@ def test_vlm_wrapper_injects_pixel_values_when_present() -> None:
     _ = cast(Callable[[mx.array], mx.array], wrapper)(mx.array([1]))
 
     assert inner.last_kwargs["pixel_values"] is pixel_values
+
+
+def test_vlm_wrapper_keeps_vision_calls_on_multimodal_model() -> None:
+    """Image prefill uses the outer model; later decode uses its text trunk."""
+
+    inner = _FakeVlmWithLanguageModel()
+    wrapper = _vlm_model_wrapper(inner)
+    pixel_values = mx.array([2.0])
+    cast(
+        Callable[[mx.array | list[mx.array] | None], None],
+        object.__getattribute__(wrapper, "set_pixel_values"),
+    )(pixel_values)
+
+    _ = cast(Callable[[mx.array], mx.array], wrapper)(mx.array([1]))
+    _ = cast(Callable[[mx.array], mx.array], wrapper)(mx.array([2]))
+
+    assert inner.call_count == 1
+    assert inner.last_kwargs["pixel_values"] is pixel_values
+    assert inner.language_model.call_count == 1


### PR DESCRIPTION
## Summary

- route text-only native MLX-VLM calls through the model language trunk
- keep image prefill on the multimodal outer model and subsequent decode on the language trunk
- add focused regression coverage for both request paths

## Why

Fresh-install qualification found that image understanding worked correctly while a mandatory text chat on the same Qwen3-VL model produced corrupted repetition. The wrapper was sending generic text-generation calls through the multimodal outer model instead of its language model.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` — 2,914 passed, 1 skipped, 228 deselected
- focused native VLM wrapper/loading/generation tests — 33 passed