### PR TITLE
Fix Vector default path expansion

### DIFF
--- a/deployment/install/vector-startup.sh
+++ b/deployment/install/vector-startup.sh
@@ -24,6 +24,14 @@ if [[ -f "$ENV_FILE" ]]; then
     set +a
 fi
 
+# Vector does not recursively expand environment-variable defaults. Leaving
+# these unset makes `${VAR:-${HOME}/...}` resolve to a literal `${HOME}` path,
+# and launchd's repository working directory then becomes a dirty checkout.
+# Resolve the user-relative defaults in the shell before Vector reads YAML.
+SKULK_VECTOR_DATA_DIR="${SKULK_VECTOR_DATA_DIR:-$HOME/.skulk/vector}"
+SKULK_LOG_FILE="${SKULK_LOG_FILE:-$HOME/.skulk/logs/skulk.stdout.log}"
+export SKULK_VECTOR_DATA_DIR SKULK_LOG_FILE
+
 if ! command -v vector >/dev/null 2>&1; then
     echo "error: 'vector' not found on PATH. Install Vector (https://vector.dev/docs/setup/installation/) and re-run." >&2
     exit 1

--- a/src/skulk/tests/test_service_install_scripts.py
+++ b/src/skulk/tests/test_service_install_scripts.py
@@ -1,6 +1,8 @@
 # Copyright 2026 Foxlight Foundation
 """Regression contracts for the documented supervised-service installers."""
 
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -33,3 +35,42 @@ def test_systemd_runner_oom_does_not_stop_skulk_node() -> None:
     unit = (_REPO_ROOT / "deployment/systemd/skulk.service").read_text()
 
     assert "OOMPolicy=continue" in unit
+
+
+def test_vector_startup_expands_home_defaults_before_vector(
+    tmp_path: Path,
+) -> None:
+    """Vector must receive absolute user paths instead of literal shell syntax."""
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_vector = fake_bin / "vector"
+    fake_vector.write_text(
+        "#!/bin/sh\n"
+        'printf "data=%s\\nlog=%s\\n" '
+        '"$SKULK_VECTOR_DATA_DIR" "$SKULK_LOG_FILE"\n'
+    )
+    fake_vector.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+            "SKULK_ENV_FILE": str(tmp_path / "missing.env"),
+        }
+    )
+
+    result = subprocess.run(
+        [_REPO_ROOT / "deployment/install/vector-startup.sh"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.stdout.splitlines() == [
+        f"data={home}/.skulk/vector",
+        f"log={home}/.skulk/logs/skulk.stdout.log",
+    ]

--- a/website/docs/external-logging.md
+++ b/website/docs/external-logging.md
@@ -206,6 +206,12 @@ All knobs live in `~/.skulk/skulk.env` and are picked up by both the Skulk and V
 | `SKULK_VECTOR_DATA_DIR` | Where Vector keeps its disk buffer and file checkpoints | `~/.skulk/vector` |
 | `SKULK_LOG_FILE` | Override the source file Vector tails | `~/.skulk/logs/skulk.stdout.log` |
 
+The supervised-service wrapper resolves the default data and log paths to
+absolute paths before starting Vector. This matters because Vector does not
+recursively expand nested environment-variable defaults; leaving `${HOME}` for
+Vector to resolve can otherwise create a literal `${HOME}` directory under the
+service working directory.
+
 After editing, restart the relevant agents (the table in the [service guide](./run-skulk-as-a-service.md#day-to-day-operations) has the commands).
 
 ## Things that go wrong


### PR DESCRIPTION
## Summary
- resolve supervised Vector data and log defaults to absolute user paths before startup
- prevent literal shell-expression directories from being created in the repository working tree
- add an executable service-wrapper regression test and document the behavior

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt` (no changes)
- `uv run pytest` (2916 passed, 1 skipped, 228 deselected)
- `uv run python scripts/build_docs.py`
- focused service-installer test (4 passed)