### PR TITLE
fix(mlx): restore reliable single-rank vision defaults

### DIFF
--- a/src/skulk/worker/engines/mlx/generator/batch_generate.py
+++ b/src/skulk/worker/engines/mlx/generator/batch_generate.py
@@ -42,6 +42,7 @@ from skulk.worker.engines.mlx.generator.generate import (
     extract_top_logprobs,
     patch_embed_tokens,
     prefill,
+    resolve_mlx_temperature,
     set_native_vision_inputs,
     slice_native_pixel_values_for_uncached_suffix,
 )
@@ -278,9 +279,10 @@ class SkulkBatchGenerator:
         mx.random.seed(seed)
 
         sampler = make_sampler(
-            temp=task_params.temperature
-            if task_params.temperature is not None
-            else 0.7,
+            temp=resolve_mlx_temperature(
+                task_params,
+                has_vision=vision is not None,
+            ),
             top_p=task_params.top_p if task_params.top_p is not None else 1.0,
             min_p=task_params.min_p if task_params.min_p is not None else 0.05,
             top_k=task_params.top_k if task_params.top_k is not None else 0,

--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -2216,6 +2216,22 @@ def eos_ids_from_tokenizer(tokenizer: TokenizerWrapper) -> list[int]:
     return eos
 
 
+def resolve_mlx_temperature(
+    task: TextGenerationTaskParams, *, has_vision: bool
+) -> float:
+    """Resolve the request temperature against the appropriate engine default.
+
+    Explicit client values always win. Multimodal requests otherwise follow
+    mlx-vlm's greedy default because small native VLMs can sample the requested
+    output schema instead of the image content at the generic text default.
+    Text-only MLX requests retain Skulk's established 0.7 default.
+    """
+
+    if task.temperature is not None:
+        return task.temperature
+    return 0.0 if has_vision else 0.7
+
+
 def extract_top_logprobs(
     logprobs: mx.array,
     tokenizer: TokenizerWrapper,
@@ -2788,8 +2804,12 @@ def mlx_generate(
         eos_ids = eos_ids_from_tokenizer(tokenizer)
         logits_processors = [ban_token_ids(eos_ids)] + logits_processors
 
+    effective_temperature = resolve_mlx_temperature(
+        task,
+        has_vision=vision is not None,
+    )
     sampler = make_sampler(
-        temp=task.temperature if task.temperature is not None else 0.7,
+        temp=effective_temperature,
         top_p=task.top_p if task.top_p is not None else 1.0,
         min_p=task.min_p if task.min_p is not None else 0.05,
         top_k=task.top_k if task.top_k is not None else 0,
@@ -3097,7 +3117,7 @@ def mlx_generate(
     # arbitrary samplers, so the params below must stay in lockstep with
     # the make_sampler call above.
     _mtp_sampling = SamplingParams(
-        temperature=task.temperature if task.temperature is not None else 0.7,
+        temperature=effective_temperature,
         top_p=task.top_p if task.top_p is not None else 1.0,
         min_p=task.min_p if task.min_p is not None else 0.05,
         top_k=task.top_k if task.top_k is not None else 0,

--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -2804,7 +2804,15 @@ def mlx_generate(
     max_stop_len = max((len(s) for s in stop_sequences), default=0)
 
     if vision is not None and vision.pixel_values is not None:
-        if group is None or _should_use_native_vision_reference_path():
+        # A one-rank placement still receives an MLX distributed group, but it
+        # has no pipeline peers to serve. Keep it on mlx-vlm's family-aware
+        # reference path; the generic pipeline path can produce valid-looking
+        # yet incorrect tokens for native Qwen vision models.
+        if (
+            group is None
+            or group.size() <= 1
+            or _should_use_native_vision_reference_path()
+        ):
             if kv_prefix_cache is not None:
                 logger.info(
                     "Disabling KV prefix cache for native vision generation to follow "

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -26,6 +26,7 @@ from skulk.worker.engines.mlx.vision import (
 )
 
 mlx_generate = generate_module.mlx_generate
+resolve_mlx_temperature = generate_module.resolve_mlx_temperature
 
 
 def _mlx_generate_native_vision_fn() -> Callable[
@@ -143,6 +144,31 @@ def _always_false(**_kwargs: object) -> bool:
 
 def _version_map(package: str, *, mlx_version: str, mlx_vlm_version: str) -> str:
     return {"mlx": mlx_version, "mlx-vlm": mlx_vlm_version}[package]
+
+
+@pytest.mark.parametrize(
+    ("temperature", "has_vision", "expected"),
+    [
+        (None, True, 0.0),
+        (None, False, 0.7),
+        (0.35, True, 0.35),
+        (0.35, False, 0.35),
+    ],
+)
+def test_mlx_temperature_uses_upstream_vision_default(
+    temperature: float | None,
+    has_vision: bool,
+    expected: float,
+) -> None:
+    """Omitted VLM temperature must be greedy without changing text defaults."""
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/Qwen3-VL-4B-Instruct-4bit"),
+        input=[InputMessage(role="user", content="hello")],
+        temperature=temperature,
+    )
+
+    assert resolve_mlx_temperature(task, has_vision=has_vision) == expected
 
 
 def _raise_patch_embed_tokens_error(*_args: object, **_kwargs: object) -> None:

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -125,8 +125,8 @@ class _FakeGroup:
         return self._size
 
 
-def _fake_group() -> mx.distributed.Group:
-    return cast(mx.distributed.Group, cast(object, _FakeGroup()))
+def _fake_group(*, size: int = 3) -> mx.distributed.Group:
+    return cast(mx.distributed.Group, cast(object, _FakeGroup(size=size)))
 
 
 def _noop_barrier(_group: object) -> None:
@@ -212,10 +212,20 @@ def test_native_vision_generation_uses_mlx_vlm_generate_step(
     assert responses[-1].usage.completion_tokens == 2
 
 
-def test_mlx_generate_routes_native_vision_through_reference_path(
+@pytest.mark.parametrize(
+    ("group", "reference_path_enabled"),
+    [
+        (None, False),
+        (_fake_group(size=1), False),
+        (_fake_group(size=3), True),
+    ],
+)
+def test_mlx_generate_routes_eligible_native_vision_through_reference_path(
     monkeypatch: pytest.MonkeyPatch,
+    group: mx.distributed.Group | None,
+    reference_path_enabled: bool,
 ) -> None:
-    """``mlx_generate`` should bypass generic text generation for native vision."""
+    """Single-rank and compatibility-gated VLMs must use reference generation."""
 
     vision = VisionResult(
         prompt="ignored",
@@ -240,7 +250,7 @@ def test_mlx_generate_routes_native_vision_through_reference_path(
     )
     monkeypatch.setattr(
         "skulk.worker.engines.mlx.generator.generate._should_use_native_vision_reference_path",
-        cast(Callable[[], bool], lambda: True),
+        lambda: reference_path_enabled,
     )
     monkeypatch.setattr(
         "skulk.worker.engines.mlx.generator.generate._mlx_generate_native_vision",
@@ -279,7 +289,7 @@ def test_mlx_generate_routes_native_vision_through_reference_path(
             task=task,
             prompt="<bos>",
             kv_prefix_cache=None,
-            group=None,
+            group=group,
             vision_processor=_fake_vision_processor(),
         )
     )


### PR DESCRIPTION
## Summary

- route one-rank native VLM placements through mlx-vlm's family-aware reference generator
- retain the pipeline-aware path for genuine multi-rank placements
- use mlx-vlm's deterministic default when an image request omits temperature
- preserve explicit client temperatures and Skulk's established text-only default
- cover ungrouped, one-rank, and compatibility-gated multi-rank routing
- cover multimodal and text-only temperature resolution

## Why

A one-rank placement still has an MLX distributed group, so it was incorrectly taking the generic pipeline generation path. Some native Qwen vision requests produced plausible but incorrect repetitive tokens even though image transport and preprocessing were correct.

After correcting that route, fresh-install browser qualification exposed a second default mismatch: the dashboard omits temperature, mlx-vlm defaults multimodal generation to greedy decoding, but Skulk substituted its generic text temperature. The sampled default allowed a small VLM to copy the requested answer schema instead of reading the image.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` (2931 passed, 1 skipped)
- focused native-vision suite (29 passed)
- exact failed browser fixture reproduced through upstream mlx-vlm at its deterministic default
- full one-node Apple fresh-install qualification passed on this head
  - official installer and generated defaults
  - one-node Zenoh runtime contract
  - dashboard and direct API randomized vision journeys for both shipped Apple models
  - temporary-install teardown and selected-target restoration
