### PR TITLE
Fix distributed native vision loading

### DIFF
--- a/src/skulk/worker/engines/mlx/auto_parallel.py
+++ b/src/skulk/worker/engines/mlx/auto_parallel.py
@@ -682,7 +682,9 @@ def pipeline_auto_parallel(
         inner_model_instance._swa_idx = 0 if not sliding_layers else sliding_layers[0]
         inner_model_instance._full_idx = 0 if not full_layers else full_layers[0]
 
-    if isinstance(inner_model_instance, (Qwen3_5TextModelInner, Qwen3NextInnerModel)):
+    if isinstance(
+        inner_model_instance, (Qwen3_5TextModelInner, Qwen3NextInnerModel)
+    ) or _is_native_qwen_vlm_language_model(inner_model_instance):
         full_attn_layers = [
             i for i, layer in enumerate(layers) if not getattr(layer, "is_linear", True)
         ]
@@ -1026,17 +1028,25 @@ def tensor_auto_parallel(
 
 
 def _is_native_qwen_vlm_language_model(model: nn.Module) -> bool:
-    """Return whether ``model`` is a supported MLX-VLM Qwen language trunk."""
+    """Return whether ``model`` is a supported MLX-VLM Qwen language component.
+
+    Tensor placement receives MLX-VLM's outer ``LanguageModel`` while pipeline
+    placement slices its nested ``Qwen3_5Model`` or ``Qwen3_5MoeModel``. Both
+    own family-specific sharding state, but only the outer class exposes
+    ``model_type``.
+    """
     module_name = type(model).__module__
     if not module_name.startswith("mlx_vlm.models.qwen3_5"):
         return False
     model_type = getattr(model, "model_type", None)
-    return model_type in {
+    if model_type in {
         "qwen3_5",
         "qwen3_5_text",
         "qwen3_5_moe",
         "qwen3_5_moe_text",
-    }
+    }:
+        return True
+    return type(model).__name__ in {"Qwen3_5Model", "Qwen3_5MoeModel"}
 
 
 class TensorParallelShardingStrategy(ABC):

--- a/src/skulk/worker/engines/mlx/auto_parallel.py
+++ b/src/skulk/worker/engines/mlx/auto_parallel.py
@@ -44,7 +44,7 @@ from mlx_lm.models.nemotron_h import (
     NemotronHMoE,
 )
 from mlx_lm.models.nemotron_h import NemotronHModel as NemotronHInnerModel
-from mlx_lm.models.qwen3_5 import DecoderLayer as Qwen3_5DecoderLayer
+from mlx_lm.models.qwen3_5 import GatedDeltaNet as Qwen3_5GatedDeltaNet
 from mlx_lm.models.qwen3_5 import Model as Qwen3_5TextModel
 from mlx_lm.models.qwen3_5 import Qwen3_5TextModel as Qwen3_5TextModelInner
 from mlx_lm.models.qwen3_5 import SparseMoeBlock as Qwen3_5SparseMoeBlock
@@ -52,11 +52,7 @@ from mlx_lm.models.qwen3_5_moe import Model as Qwen3_5MoeModel
 from mlx_lm.models.qwen3_moe import Model as Qwen3MoeModel
 from mlx_lm.models.qwen3_moe import Qwen3MoeDecoderLayer, Qwen3MoeSparseMoeBlock
 from mlx_lm.models.qwen3_next import Model as Qwen3NextModel
-from mlx_lm.models.qwen3_next import (
-    Qwen3NextDecoderLayer,
-    Qwen3NextGatedDeltaNet,
-    Qwen3NextSparseMoeBlock,
-)
+from mlx_lm.models.qwen3_next import Qwen3NextGatedDeltaNet, Qwen3NextSparseMoeBlock
 from mlx_lm.models.qwen3_next import Qwen3NextModel as Qwen3NextInnerModel
 from mlx_lm.models.step3p5 import Model as Step35Model
 from mlx_lm.models.step3p5 import Step3p5MLP as Step35MLP
@@ -283,6 +279,20 @@ class _LayerCallable(Protocol):
     """
 
     def __call__(self, x: mx.array, *args: object, **kwargs: object) -> mx.array: ...
+
+
+class _CacheContainer(Protocol):
+    """Cache wrapper whose first item carries the tensor dependency."""
+
+    caches: object
+
+    def __getitem__(self, index: int) -> object: ...
+
+
+class _CacheWithKeys(Protocol):
+    """KV cache entry exposing the keys array used for synchronization."""
+
+    keys: mx.array
 
 
 class CustomMlxLayer(nn.Module):
@@ -840,16 +850,33 @@ def patch_tensor_model[T](model: T) -> T:
         **kwargs: object,
     ) -> mx.array:
         logits: mx.array = original_call(self, *args, **kwargs)  # pyright: ignore[reportAny]
-        cache = call_signature.bind_partial(self, *args, **kwargs).arguments.get(
-            "cache", None
+        bound_arguments = cast(
+            Mapping[str, object],
+            cast(
+                object,
+                call_signature.bind_partial(self, *args, **kwargs).arguments,
+            ),
         )
+        cache = bound_arguments.get("cache")
+        if cache is None:
+            cache = next(
+                (
+                    cast(Mapping[object, object], value).get("cache")
+                    for value in bound_arguments.values()
+                    if isinstance(value, Mapping) and "cache" in value
+                ),
+                None,
+            )
 
         # Add dependency to last cache entry to ensure distributed ops are evaluated
-        if cache is not None and len(cache) > 0:  # pyright: ignore[reportAny]
-            last = cache[-1]  # pyright: ignore[reportAny]
-            dep_cache = last[0] if hasattr(last, "caches") else last  # pyright: ignore[reportAny]
-            if hasattr(dep_cache, "keys"):  # type: ignore
-                dep_cache.keys = mx.depends(dep_cache.keys, logits)  # pyright: ignore[reportAny]
+        if isinstance(cache, (list, tuple)) and cache:
+            last = cast(object, cache[-1])
+            dep_cache = (
+                cast(_CacheContainer, last)[0] if hasattr(last, "caches") else last
+            )
+            if hasattr(dep_cache, "keys"):
+                cache_with_keys = cast(_CacheWithKeys, dep_cache)
+                cache_with_keys.keys = mx.depends(cache_with_keys.keys, logits)
 
         return logits
 
@@ -863,7 +890,17 @@ def tensor_auto_parallel(
     timeout_seconds: float,
     on_timeout: TimeoutCallback | None,
     on_layer_loaded: LayerLoadedCallback | None,
+    *,
+    generation_model: nn.Module | None = None,
 ) -> nn.Module:
+    """Shard a language trunk and patch its logits-returning generation model.
+
+    Native VLMs wrap their language trunk in a multimodal model whose call
+    returns a structured output. ``model`` is therefore the object whose
+    weights and layers are sharded, while ``generation_model`` is the optional
+    Skulk compatibility wrapper whose call participates in distributed
+    synchronization.
+    """
     all_to_sharded_linear = partial(
         shard_linear,
         sharding="all-to-sharded",
@@ -946,7 +983,7 @@ def tensor_auto_parallel(
         )
     elif isinstance(
         model, (Qwen3MoeModel, Qwen3NextModel, Qwen3_5TextModel, Qwen3_5MoeModel)
-    ):
+    ) or _is_native_qwen_vlm_language_model(model):
         tensor_parallel_sharding_strategy = QwenShardingStrategy(
             group,
             all_to_sharded_linear,
@@ -984,7 +1021,17 @@ def tensor_auto_parallel(
     model = tensor_parallel_sharding_strategy.shard_model(
         model, timeout_seconds, on_timeout, on_layer_loaded
     )
-    return patch_tensor_model(model)
+    patch_target = model if generation_model is None else generation_model
+    return patch_tensor_model(patch_target)
+
+
+def _is_native_qwen_vlm_language_model(model: nn.Module) -> bool:
+    """Return whether ``model`` is a supported MLX-VLM Qwen language trunk."""
+    module_name = type(model).__module__
+    if not module_name.startswith("mlx_vlm.models.qwen3_5"):
+        return False
+    model_type = getattr(model, "model_type", None)
+    return model_type in {"qwen3_5", "qwen3_5_moe"}
 
 
 class TensorParallelShardingStrategy(ABC):
@@ -1145,10 +1192,15 @@ class ShardedMoE(CustomMlxLayer):
         super().__init__(layer)
         self.sharding_group: mx.distributed.Group | None = None
 
-    def __call__(self, x: mx.array) -> mx.array:
+    def __call__(
+        self,
+        x: mx.array,
+        *args: object,
+        **kwargs: object,
+    ) -> mx.array:
         if self.sharding_group is not None:
             x = sum_gradients(self.sharding_group)(x)
-        y = self.original_layer.__call__(x)
+        y = self.original_layer.__call__(x, *args, **kwargs)
         if self.sharding_group is not None:
             y = mx.distributed.all_sum(y, group=self.sharding_group)
         return y
@@ -1350,7 +1402,8 @@ class QwenShardingStrategy(TensorParallelShardingStrategy):
         on_layer_loaded: LayerLoadedCallback | None,
     ) -> nn.Module:
         model = cast(
-            Qwen3MoeModel | Qwen3NextModel | Qwen3_5TextModel | Qwen3_5MoeModel, model
+            Qwen3MoeModel | Qwen3NextModel | Qwen3_5TextModel | Qwen3_5MoeModel,
+            model,
         )
         total = len(model.layers)
         for i, layer in enumerate(model.layers):
@@ -1372,49 +1425,56 @@ class QwenShardingStrategy(TensorParallelShardingStrategy):
                 layer.self_attn.n_heads //= self.N
                 layer.self_attn.n_kv_heads //= self.N
             else:
-                assert isinstance(layer, (Qwen3NextDecoderLayer, Qwen3_5DecoderLayer))
-                if hasattr(layer, "linear_attn"):
-                    linear_attn = layer.linear_attn
+                qwen_layer = layer
+                if hasattr(qwen_layer, "linear_attn"):
+                    linear_attn = qwen_layer.linear_attn
 
-                    if isinstance(linear_attn, Qwen3NextGatedDeltaNet):
+                    if hasattr(linear_attn, "in_proj_qkvz"):
+                        next_linear_attn = cast(Qwen3NextGatedDeltaNet, linear_attn)
                         # Qwen3-Next: combined projections
-                        linear_attn.in_proj_qkvz = self.all_to_sharded_linear(
-                            linear_attn.in_proj_qkvz
+                        next_linear_attn.in_proj_qkvz = self.all_to_sharded_linear(
+                            next_linear_attn.in_proj_qkvz
                         )
-                        linear_attn.in_proj_ba = self.all_to_sharded_linear(
-                            linear_attn.in_proj_ba
+                        next_linear_attn.in_proj_ba = self.all_to_sharded_linear(
+                            next_linear_attn.in_proj_ba
                         )
                     else:
+                        qwen35_linear_attn = cast(
+                            Qwen3_5GatedDeltaNet, linear_attn
+                        )
                         # Qwen3.5: separate projections
                         # in_proj_qkv has sections [q(key_dim), k(key_dim), v(value_dim)]
                         # that must be split section-aware, not as a contiguous block
-                        key_dim = linear_attn.key_dim
-                        value_dim = linear_attn.value_dim
-                        linear_attn.in_proj_qkv = shard_linear(
-                            linear_attn.in_proj_qkv,
+                        key_dim = qwen35_linear_attn.key_dim
+                        value_dim = qwen35_linear_attn.value_dim
+                        qwen35_linear_attn.in_proj_qkv = shard_linear(
+                            qwen35_linear_attn.in_proj_qkv,
                             "all-to-sharded",
                             segments=[key_dim, key_dim + key_dim],
                             group=self.group,
                         )
-                        linear_attn.in_proj_z = self.all_to_sharded_linear(
-                            linear_attn.in_proj_z
+                        qwen35_linear_attn.in_proj_z = self.all_to_sharded_linear(
+                            qwen35_linear_attn.in_proj_z
                         )
-                        linear_attn.in_proj_b = self.all_to_sharded_linear(
-                            linear_attn.in_proj_b
+                        qwen35_linear_attn.in_proj_b = self.all_to_sharded_linear(
+                            qwen35_linear_attn.in_proj_b
                         )
-                        linear_attn.in_proj_a = self.all_to_sharded_linear(
-                            linear_attn.in_proj_a
+                        qwen35_linear_attn.in_proj_a = self.all_to_sharded_linear(
+                            qwen35_linear_attn.in_proj_a
                         )
-                    linear_attn.out_proj = self.sharded_to_all_linear(
-                        linear_attn.out_proj
+                    qwen35_or_next_linear_attn = linear_attn
+                    qwen35_or_next_linear_attn.out_proj = (
+                        self.sharded_to_all_linear(
+                            qwen35_or_next_linear_attn.out_proj
+                        )
                     )
 
                     # Shard conv1d: depthwise conv with non-contiguous channel slicing.
                     # Channel layout is [q(key_dim), k(key_dim), v(value_dim)].
                     # Each rank takes its head-slice from each of the three sections.
                     rank = self.group.rank()
-                    key_dim = linear_attn.key_dim
-                    value_dim = linear_attn.value_dim
+                    key_dim = qwen35_or_next_linear_attn.key_dim
+                    value_dim = qwen35_or_next_linear_attn.value_dim
                     key_dim_shard = key_dim // self.N
                     value_dim_shard = value_dim // self.N
 
@@ -1428,42 +1488,51 @@ class QwenShardingStrategy(TensorParallelShardingStrategy):
                         2 * key_dim + (rank + 1) * value_dim_shard,
                     )
                     conv_indices = mx.concatenate([q_idx, k_idx, v_idx])
-                    linear_attn.conv1d.weight = linear_attn.conv1d.weight[conv_indices]
+                    qwen35_or_next_linear_attn.conv1d.weight = (
+                        qwen35_or_next_linear_attn.conv1d.weight[conv_indices]
+                    )
                     new_conv_dim = key_dim_shard * 2 + value_dim_shard
-                    linear_attn.conv1d.groups = new_conv_dim
+                    qwen35_or_next_linear_attn.conv1d.groups = new_conv_dim
 
-                    num_v_shard = linear_attn.num_v_heads // self.N
+                    num_v_shard = qwen35_or_next_linear_attn.num_v_heads // self.N
                     v_start = rank * num_v_shard
                     v_end = v_start + num_v_shard
-                    linear_attn.A_log = linear_attn.A_log[v_start:v_end]
-                    linear_attn.dt_bias = linear_attn.dt_bias[v_start:v_end]
+                    qwen35_or_next_linear_attn.A_log = (
+                        qwen35_or_next_linear_attn.A_log[v_start:v_end]
+                    )
+                    qwen35_or_next_linear_attn.dt_bias = (
+                        qwen35_or_next_linear_attn.dt_bias[v_start:v_end]
+                    )
 
-                    linear_attn.num_k_heads //= self.N
-                    linear_attn.num_v_heads //= self.N
-                    linear_attn.key_dim = (
-                        linear_attn.head_k_dim * linear_attn.num_k_heads
+                    qwen35_or_next_linear_attn.num_k_heads //= self.N
+                    qwen35_or_next_linear_attn.num_v_heads //= self.N
+                    qwen35_or_next_linear_attn.key_dim = (
+                        qwen35_or_next_linear_attn.head_k_dim
+                        * qwen35_or_next_linear_attn.num_k_heads
                     )
-                    linear_attn.value_dim = (
-                        linear_attn.head_v_dim * linear_attn.num_v_heads
+                    qwen35_or_next_linear_attn.value_dim = (
+                        qwen35_or_next_linear_attn.head_v_dim
+                        * qwen35_or_next_linear_attn.num_v_heads
                     )
-                    linear_attn.conv_dim = (
-                        linear_attn.key_dim * 2 + linear_attn.value_dim
+                    qwen35_or_next_linear_attn.conv_dim = (
+                        qwen35_or_next_linear_attn.key_dim * 2
+                        + qwen35_or_next_linear_attn.value_dim
                     )
                 else:
-                    layer.self_attn.q_proj = self.all_to_sharded_linear(
-                        layer.self_attn.q_proj
+                    qwen_layer.self_attn.q_proj = self.all_to_sharded_linear(
+                        qwen_layer.self_attn.q_proj
                     )
-                    layer.self_attn.k_proj = self.all_to_sharded_linear(
-                        layer.self_attn.k_proj
+                    qwen_layer.self_attn.k_proj = self.all_to_sharded_linear(
+                        qwen_layer.self_attn.k_proj
                     )
-                    layer.self_attn.v_proj = self.all_to_sharded_linear(
-                        layer.self_attn.v_proj
+                    qwen_layer.self_attn.v_proj = self.all_to_sharded_linear(
+                        qwen_layer.self_attn.v_proj
                     )
-                    layer.self_attn.o_proj = self.sharded_to_all_linear(
-                        layer.self_attn.o_proj
+                    qwen_layer.self_attn.o_proj = self.sharded_to_all_linear(
+                        qwen_layer.self_attn.o_proj
                     )
-                    layer.self_attn.num_attention_heads //= self.N
-                    layer.self_attn.num_key_value_heads //= self.N
+                    qwen_layer.self_attn.num_attention_heads //= self.N
+                    qwen_layer.self_attn.num_key_value_heads //= self.N
 
             # Shard the MoE.
             if isinstance(
@@ -1473,22 +1542,26 @@ class QwenShardingStrategy(TensorParallelShardingStrategy):
                     Qwen3NextSparseMoeBlock,
                     Qwen3_5SparseMoeBlock,
                 ),
-            ):
-                self.all_to_sharded_linear_in_place(layer.mlp.switch_mlp.gate_proj)
-                self.sharded_to_all_linear_in_place(layer.mlp.switch_mlp.down_proj)
-                self.all_to_sharded_linear_in_place(layer.mlp.switch_mlp.up_proj)
-                if isinstance(
-                    layer.mlp, (Qwen3NextSparseMoeBlock, Qwen3_5SparseMoeBlock)
-                ):
+            ) or hasattr(layer.mlp, "switch_mlp"):
+                sparse_mlp = cast(Qwen3NextSparseMoeBlock, layer.mlp)
+                self.all_to_sharded_linear_in_place(sparse_mlp.switch_mlp.gate_proj)
+                self.sharded_to_all_linear_in_place(sparse_mlp.switch_mlp.down_proj)
+                self.all_to_sharded_linear_in_place(sparse_mlp.switch_mlp.up_proj)
+                if not isinstance(sparse_mlp, Qwen3MoeSparseMoeBlock):
                     self.all_to_sharded_linear_in_place(
-                        layer.mlp.shared_expert.gate_proj
+                        sparse_mlp.shared_expert.gate_proj
                     )
                     self.sharded_to_all_linear_in_place(
-                        layer.mlp.shared_expert.down_proj
+                        sparse_mlp.shared_expert.down_proj
                     )
-                    self.all_to_sharded_linear_in_place(layer.mlp.shared_expert.up_proj)
-                layer.mlp = ShardedMoE(layer.mlp)  # pyright: ignore[reportAttributeAccessIssue, reportArgumentType]
-                layer.mlp.sharding_group = self.group
+                    self.all_to_sharded_linear_in_place(
+                        sparse_mlp.shared_expert.up_proj
+                    )
+                sharded_mlp = ShardedMoE(
+                    cast(_LayerCallable, cast(object, sparse_mlp))
+                )
+                sharded_mlp.sharding_group = self.group
+                layer.mlp = sharded_mlp  # pyright: ignore[reportAttributeAccessIssue]
 
             # Shard the MLP
             else:

--- a/src/skulk/worker/engines/mlx/auto_parallel.py
+++ b/src/skulk/worker/engines/mlx/auto_parallel.py
@@ -1031,7 +1031,12 @@ def _is_native_qwen_vlm_language_model(model: nn.Module) -> bool:
     if not module_name.startswith("mlx_vlm.models.qwen3_5"):
         return False
     model_type = getattr(model, "model_type", None)
-    return model_type in {"qwen3_5", "qwen3_5_moe"}
+    return model_type in {
+        "qwen3_5",
+        "qwen3_5_text",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
+    }
 
 
 class TensorParallelShardingStrategy(ABC):

--- a/src/skulk/worker/engines/mlx/utils_mlx.py
+++ b/src/skulk/worker/engines/mlx/utils_mlx.py
@@ -711,8 +711,8 @@ def load_model(
         model_path: Local model bundle.
         prefer_vlm: Load through MLX-VLM even when MLX-LM recognizes the model
             type. MLX-LM intentionally strips vision towers from Qwen VLM
-            checkpoints, so a single-node vision placement must opt into the
-            native model to preserve its image-grid-aware embeddings and RoPE.
+            checkpoints, so vision placements must opt into the native model to
+            preserve their image-grid-aware embeddings and RoPE.
         **kwargs: Loader options forwarded to the selected upstream loader.
 
     Returns:
@@ -738,6 +738,20 @@ def load_model(
             raise ValueError(
                 f"{exc}. Install mlx-vlm for vision model support: pip install -U mlx-vlm"
             ) from exc
+
+
+def _prefers_native_vlm(model_card: ModelCard) -> bool:
+    """Return whether a card's primary weights require the native VLM loader.
+
+    MLX-LM recognizes some multimodal checkpoints as text models and strips
+    their vision towers. When the card points vision at the same checkpoint as
+    its language weights, every placement shape must load through MLX-VLM so
+    family-specific image-grid positions and embeddings remain available.
+    """
+    vision_config = model_card.vision
+    return vision_config is not None and vision_config.weights_repo == str(
+        model_card.model_id
+    )
 
 
 def sidecar_load_eligible(
@@ -892,15 +906,11 @@ def load_mlx_items(
         card = bound_instance.bound_shard.model_card
         model_path = build_model_path(card.model_id, card.source_revision)
         start_time = time.perf_counter()
-        vision_config = card.vision
-        prefer_vlm = vision_config is not None and vision_config.weights_repo == str(
-            card.model_id
-        )
         model, _ = load_model(
             model_path,
             lazy=True,
             strict=False,
-            prefer_vlm=prefer_vlm,
+            prefer_vlm=_prefers_native_vlm(card),
         )
         # Eval layers one by one for progress reporting
         try:
@@ -1071,7 +1081,12 @@ def shard_and_load(
         shard_metadata.model_card.source_revision,
     )
 
-    model, _ = load_model(model_path, lazy=True, strict=False)
+    model, _ = load_model(
+        model_path,
+        lazy=True,
+        strict=False,
+        prefer_vlm=_prefers_native_vlm(shard_metadata.model_card),
+    )
     logger.debug(model)
     if hasattr(model, "model") and isinstance(model.model, DeepseekV3Model):  # type: ignore
         pass

--- a/src/skulk/worker/engines/mlx/utils_mlx.py
+++ b/src/skulk/worker/engines/mlx/utils_mlx.py
@@ -631,6 +631,24 @@ class _VlmModelWrapper(nn.Module):
         layers = cast(Model, inner).layers
         return [KVCache() for _ in layers]
 
+    def tensor_parallel_target(self) -> nn.Module:
+        """Return the nested language model whose weights tensor sharding owns.
+
+        The wrapper itself owns generation compatibility and the native VLM
+        owns the vision tower, but tensor parallelism shards only the language
+        trunk. Keeping those roles separate also ensures the distributed
+        generation synchronization patch continues to observe plain logits
+        rather than an upstream ``LanguageModelOutput``.
+        """
+        inner = cast(object, self._inner)
+        language_model = getattr(inner, "language_model", None)
+        if not isinstance(language_model, nn.Module):
+            raise ValueError(
+                "Native vision model does not expose a tensor-shardable "
+                "language model"
+            )
+        return language_model
+
     def __call__(self, *args: object, **kwargs: object) -> mx.array:
         pixel_values = cast(
             mx.array | list[mx.array] | None,
@@ -1123,8 +1141,19 @@ def shard_and_load(
     match shard_metadata:
         case TensorShardMetadata():
             logger.info(f"loading model from {model_path} with tensor parallelism")
+            generation_model = model
+            sharding_model = (
+                model.tensor_parallel_target()
+                if isinstance(model, _VlmModelWrapper)
+                else model
+            )
             model = tensor_auto_parallel(
-                model, group, timeout_seconds, on_timeout, on_layer_loaded
+                sharding_model,
+                group,
+                timeout_seconds,
+                on_timeout,
+                on_layer_loaded,
+                generation_model=generation_model,
             )
         case PipelineShardMetadata():
             logger.info(f"loading model from {model_path} with pipeline parallelism")

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
@@ -10,6 +10,14 @@ import mlx.core as mx
 import mlx.nn as nn
 import pytest
 
+from skulk.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    ModelTask,
+    VisionCardConfig,
+)
+from skulk.shared.types.memory import Memory
+from skulk.shared.types.worker.shards import PipelineShardMetadata
 from skulk.worker.engines.mlx import utils_mlx
 
 
@@ -84,6 +92,81 @@ def test_prefer_vlm_bypasses_text_only_mlx_lm_loader(
     assert seen == {
         "model_path": model_path,
         "kwargs": {"lazy": True, "strict": False},
+    }
+
+
+def test_pipeline_shards_use_native_loader_for_primary_vision_weights(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Distributed vision must preserve the same native model as one-rank loads."""
+    model_id = ModelId("mlx-community/Qwen3-VL-4B-Instruct-4bit")
+    shard_metadata = PipelineShardMetadata(
+        model_card=ModelCard(
+            model_id=model_id,
+            storage_size=Memory.from_bytes(1),
+            n_layers=2,
+            hidden_size=4,
+            supports_tensor=False,
+            tasks=[ModelTask.TextGeneration],
+            vision=VisionCardConfig(
+                image_token_id=151655,
+                model_type="qwen3_vl",
+                weights_repo=str(model_id),
+            ),
+        ),
+        device_rank=0,
+        world_size=2,
+        start_layer=0,
+        end_layer=1,
+        n_layers=2,
+    )
+    loaded_model = _FakeVlmModel()
+    seen: dict[str, object] = {}
+
+    def _record_load_model(model_path: Path, **kwargs: object) -> tuple[nn.Module, None]:
+        seen["model_path"] = model_path
+        seen["kwargs"] = kwargs
+        return loaded_model, None
+
+    def _model_path(*_args: object, **_kwargs: object) -> Path:
+        return Path("/model")
+
+    def _identity_pipeline(
+        model: nn.Module, *_args: object, **_kwargs: object
+    ) -> nn.Module:
+        return model
+
+    def _ignore(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    def _tokenizer(*_args: object, **_kwargs: object) -> str:
+        return "tokenizer"
+
+    monkeypatch.setattr(utils_mlx, "build_model_path", _model_path)
+    monkeypatch.setattr(utils_mlx, "load_model", _record_load_model)
+    monkeypatch.setattr(utils_mlx, "pipeline_auto_parallel", _identity_pipeline)
+    monkeypatch.setattr(utils_mlx, "eval_with_timeout", _ignore)
+    monkeypatch.setattr(utils_mlx, "mx_barrier", _ignore)
+    monkeypatch.setattr(utils_mlx.mx, "eval", _ignore)
+    monkeypatch.setattr(utils_mlx, "get_tokenizer", _tokenizer)
+    group = SimpleNamespace(size=lambda: 2, rank=lambda: 0)
+
+    model, tokenizer = utils_mlx.shard_and_load(
+        shard_metadata,
+        cast(utils_mlx.Group, cast(object, group)),
+        on_timeout=None,
+        on_layer_loaded=None,
+    )
+
+    assert model is loaded_model
+    assert tokenizer == "tokenizer"
+    assert seen == {
+        "model_path": Path("/model"),
+        "kwargs": {
+            "lazy": True,
+            "strict": False,
+            "prefer_vlm": True,
+        },
     }
 
 

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
@@ -60,7 +60,7 @@ class _NativeQwenLanguageModel(nn.Module):
     """Minimal model carrying MLX-VLM's runtime identity and model type."""
 
     __module__ = "mlx_vlm.models.qwen3_5.language"
-    model_type = "qwen3_5"
+    model_type = "qwen3_5_text"
 
 
 class _VlmWithTensorLanguage(nn.Module):

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
@@ -17,8 +17,11 @@ from skulk.shared.models.model_cards import (
     VisionCardConfig,
 )
 from skulk.shared.types.memory import Memory
-from skulk.shared.types.worker.shards import PipelineShardMetadata
-from skulk.worker.engines.mlx import utils_mlx
+from skulk.shared.types.worker.shards import (
+    PipelineShardMetadata,
+    TensorShardMetadata,
+)
+from skulk.worker.engines.mlx import auto_parallel, utils_mlx
 
 
 class _FakeVlmModel(nn.Module):
@@ -51,6 +54,28 @@ class _VlmWithNativeLanguageCache(nn.Module):
         super().__init__()
         self.language_model = _NativeLanguageModel()
         self.layers = [object(), object()]
+
+
+class _NativeQwenLanguageModel(nn.Module):
+    """Minimal model carrying MLX-VLM's runtime identity and model type."""
+
+    __module__ = "mlx_vlm.models.qwen3_5.language"
+    model_type = "qwen3_5"
+
+
+class _VlmWithTensorLanguage(nn.Module):
+    """Native VLM stub whose tensor-shardable trunk is nested."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.language_model = _NativeQwenLanguageModel()
+
+
+class _VariadicGenerationModel(nn.Module):
+    """Generation wrapper whose cache is carried through ``**kwargs``."""
+
+    def __call__(self, *_args: object, **_kwargs: object) -> mx.array:
+        return mx.zeros((1, 1, 4))
 
 
 def test_prefer_vlm_bypasses_text_only_mlx_lm_loader(
@@ -168,6 +193,169 @@ def test_pipeline_shards_use_native_loader_for_primary_vision_weights(
             "prefer_vlm": True,
         },
     }
+
+
+def test_tensor_shards_delegate_to_native_language_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tensor sharding must retain the native VLM wrapper and vision tower."""
+    model_id = ModelId("mlx-community/Qwen3.5-2B-4bit")
+    shard_metadata = TensorShardMetadata(
+        model_card=ModelCard(
+            model_id=model_id,
+            storage_size=Memory.from_bytes(1),
+            n_layers=2,
+            hidden_size=4,
+            num_key_value_heads=2,
+            supports_tensor=True,
+            tasks=[ModelTask.TextGeneration],
+            vision=VisionCardConfig(
+                image_token_id=248056,
+                model_type="qwen3_5",
+                weights_repo=str(model_id),
+            ),
+        ),
+        device_rank=0,
+        world_size=2,
+        start_layer=0,
+        end_layer=2,
+        n_layers=2,
+    )
+    inner_model = _VlmWithTensorLanguage()
+    wrapper_class = cast(
+        Callable[[nn.Module], nn.Module],
+        vars(utils_mlx)["_VlmModelWrapper"],
+    )
+    wrapper = wrapper_class(inner_model)
+    seen: dict[str, object] = {}
+
+    def _model_path(*_args: object, **_kwargs: object) -> Path:
+        return Path("/model")
+
+    def _load_model(*_args: object, **_kwargs: object) -> tuple[nn.Module, None]:
+        return wrapper, None
+
+    def _tensor_parallel(
+        model: nn.Module,
+        _group: object,
+        _timeout_seconds: float,
+        _on_timeout: object,
+        _on_layer_loaded: object,
+        *,
+        generation_model: nn.Module | None = None,
+    ) -> nn.Module:
+        seen["sharding_model"] = model
+        seen["generation_model"] = generation_model
+        assert generation_model is not None
+        return generation_model
+
+    def _ignore(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    def _tokenizer(*_args: object, **_kwargs: object) -> str:
+        return "tokenizer"
+
+    def _weight_size(_metadata: object) -> Memory:
+        return Memory.from_bytes(1)
+
+    monkeypatch.setattr(utils_mlx, "build_model_path", _model_path)
+    monkeypatch.setattr(utils_mlx, "load_model", _load_model)
+    monkeypatch.setattr(utils_mlx, "tensor_auto_parallel", _tensor_parallel)
+    monkeypatch.setattr(utils_mlx, "mx_barrier", _ignore)
+    monkeypatch.setattr(utils_mlx.mx, "eval", _ignore)
+    monkeypatch.setattr(utils_mlx, "get_tokenizer", _tokenizer)
+    monkeypatch.setattr(
+        utils_mlx,
+        "get_weights_size",
+        _weight_size,
+    )
+    group = SimpleNamespace(size=lambda: 2, rank=lambda: 0)
+
+    model, tokenizer = utils_mlx.shard_and_load(
+        shard_metadata,
+        cast(utils_mlx.Group, cast(object, group)),
+        on_timeout=None,
+        on_layer_loaded=None,
+    )
+
+    assert model is wrapper
+    assert tokenizer == "tokenizer"
+    assert seen == {
+        "sharding_model": inner_model.language_model,
+        "generation_model": wrapper,
+    }
+
+
+def test_tensor_parallel_selects_native_qwen_strategy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A nested MLX-VLM Qwen trunk must reach the Qwen sharding strategy."""
+    native_model = _NativeQwenLanguageModel()
+    generation_model = _FakeVlmModel()
+    seen: dict[str, object] = {}
+
+    class _RecordingStrategy:
+        def __init__(self, *_args: object) -> None:
+            return None
+
+        def shard_model(
+            self,
+            model: nn.Module,
+            _timeout_seconds: float,
+            _on_timeout: object,
+            _on_layer_loaded: object,
+        ) -> nn.Module:
+            seen["sharding_model"] = model
+            return model
+
+    def _record_patch(model: nn.Module) -> nn.Module:
+        seen["generation_model"] = model
+        return model
+
+    monkeypatch.setattr(auto_parallel, "QwenShardingStrategy", _RecordingStrategy)
+    monkeypatch.setattr(auto_parallel, "patch_tensor_model", _record_patch)
+    group = SimpleNamespace(size=lambda: 2, rank=lambda: 0)
+
+    result = auto_parallel.tensor_auto_parallel(
+        native_model,
+        cast(mx.distributed.Group, cast(object, group)),
+        timeout_seconds=1,
+        on_timeout=None,
+        on_layer_loaded=None,
+        generation_model=generation_model,
+    )
+
+    assert result is generation_model
+    assert seen == {
+        "sharding_model": native_model,
+        "generation_model": generation_model,
+    }
+
+
+def test_tensor_patch_finds_cache_in_variadic_generation_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wrapper patch must preserve the tensor collective dependency."""
+    cache_keys = mx.ones((1,))
+    seen: dict[str, object] = {}
+
+    class _CacheEntry:
+        def __init__(self) -> None:
+            self.keys = cache_keys
+
+    def _record_depends(keys: mx.array, logits: mx.array) -> mx.array:
+        seen["keys"] = keys
+        seen["logits"] = logits
+        return keys
+
+    monkeypatch.setattr(auto_parallel.mx, "depends", _record_depends)
+    model = _VariadicGenerationModel()
+    patched = auto_parallel.patch_tensor_model(model)
+
+    logits = patched(mx.array([[1]]), cache=[_CacheEntry()])
+
+    assert seen["keys"] is cache_keys
+    assert seen["logits"] is logits
 
 
 def test_converted_qwen_norm_guard_preserves_mlx_norm_weights() -> None:

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
@@ -63,6 +63,39 @@ class _NativeQwenLanguageModel(nn.Module):
     model_type = "qwen3_5_text"
 
 
+class _NativeQwenPipelineTrunk(nn.Module):
+    """Minimal native Qwen inner trunk used by pipeline placement."""
+
+    __module__ = "mlx_vlm.models.qwen3_5.language"
+
+    def __init__(self, layer_types: list[bool]) -> None:
+        super().__init__()
+        self.layers = [
+            SimpleNamespace(is_linear=is_linear) for is_linear in layer_types
+        ]
+        self.fa_idx = 3
+        self.ssm_idx = 0
+
+
+_NativeQwenPipelineTrunk.__name__ = "Qwen3_5Model"
+
+
+class _NativeQwenPipelineLanguageModel(nn.Module):
+    """Minimal native language model that owns the pipeline inner trunk."""
+
+    def __init__(self, layer_types: list[bool]) -> None:
+        super().__init__()
+        self.model = _NativeQwenPipelineTrunk(layer_types)
+
+
+class _VlmWithPipelineLanguage(nn.Module):
+    """Native VLM stub whose hybrid language trunk is pipeline-sharded."""
+
+    def __init__(self, layer_types: list[bool]) -> None:
+        super().__init__()
+        self.language_model = _NativeQwenPipelineLanguageModel(layer_types)
+
+
 class _VlmWithTensorLanguage(nn.Module):
     """Native VLM stub whose tensor-shardable trunk is nested."""
 
@@ -330,6 +363,64 @@ def test_tensor_parallel_selects_native_qwen_strategy(
         "sharding_model": native_model,
         "generation_model": generation_model,
     }
+
+
+def test_pipeline_reindexes_native_qwen_hybrid_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sliced native Qwen trunk must use cache indices local to its rank."""
+    model = _VlmWithPipelineLanguage(
+        [True, True, True, False, True, True, True, False]
+    )
+    shard = SimpleNamespace(
+        start_layer=2,
+        end_layer=5,
+        device_rank=1,
+        world_size=3,
+    )
+
+    def _ignore_eval(*_args: object) -> None:
+        return None
+
+    def _identity_layer(
+        layer: object, *_args: object, **_kwargs: object
+    ) -> object:
+        return layer
+
+    def _identity_pipeline(
+        patched_model: nn.Module, _group: object
+    ) -> nn.Module:
+        return patched_model
+
+    monkeypatch.setattr(auto_parallel.mx, "eval", _ignore_eval)
+    monkeypatch.setattr(
+        auto_parallel,
+        "PipelineFirstLayer",
+        _identity_layer,
+    )
+    monkeypatch.setattr(
+        auto_parallel,
+        "PipelineLastLayer",
+        _identity_layer,
+    )
+    monkeypatch.setattr(
+        auto_parallel,
+        "patch_pipeline_model",
+        _identity_pipeline,
+    )
+    group = SimpleNamespace()
+
+    auto_parallel.pipeline_auto_parallel(
+        model,
+        cast(mx.distributed.Group, cast(object, group)),
+        cast(PipelineShardMetadata, cast(object, shard)),
+        on_layer_loaded=None,
+    )
+
+    inner = model.language_model.model
+    assert len(inner.layers) == 3
+    assert inner.ssm_idx == 0
+    assert inner.fa_idx == 1
 
 
 def test_tensor_patch_finds_cache_in_variadic_generation_kwargs(


### PR DESCRIPTION
## Summary

- load distributed MLX vision shards through the native MLX-VLM loader when a model card's vision weights are the model's primary checkpoint
- share the loader-selection rule with the existing single-node path
- add a focused regression test proving pipeline shards retain the native VLM loader contract

## Root cause

MLX-LM recognizes some Qwen VLM checkpoints as text models and strips their vision towers. Single-node placements already bypassed that behavior, but distributed `shard_and_load` did not. Multi-rank requests therefore fell back to precomputed image embeddings without the model family's image-grid-aware positions and produced deterministic OCR corruption while still recognizing coarse color and shape attributes.

## User impact

Distributed Apple vision placements now preserve the same native multimodal model contract as single-node placements instead of producing plausible but incorrect image text.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` — 2932 passed, 1 skipped, 228 deselected
- live two-node Apple qualification using an image-only hidden code fixture — 2/2 exact code, color, and shape assertions passed
