### PR TITLE
fix: redact serving payloads from logs

### DIFF
--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -29,6 +29,7 @@ from skulk.master.placement_utils import (
 )
 from skulk.shared.apply import apply
 from skulk.shared.constants import SKULK_EVENT_LOG_DIR, SKULK_TRACING_ENABLED
+from skulk.shared.log_summaries import summarize_command_for_log
 from skulk.shared.models.memory_estimate import (
     estimate_shard_footprint,
     shard_fraction_of_model,
@@ -856,7 +857,10 @@ class Master:
         with self.command_receiver as commands:
             async for forwarder_command in commands:
                 try:
-                    logger.info(f"Executing command: {forwarder_command.command}")
+                    logger.info(
+                        "Executing command: "
+                        f"{summarize_command_for_log(forwarder_command.command)}"
+                    )
 
                     generated_events: list[Event] = []
                     command = forwarder_command.command

--- a/src/skulk/shared/log_summaries.py
+++ b/src/skulk/shared/log_summaries.py
@@ -85,7 +85,10 @@ def summarize_command_for_log(command: command_types.Command) -> str:
             f"model={params.model!r}, "
             f"input_sample_rate={params.input_sample_rate})"
         )
-    return repr(command)
+    return (
+        f"{command.__class__.__name__}("
+        f"command_id={command.command_id!r})"
+    )
 
 
 def summarize_task_for_log(task: task_types.Task) -> str:
@@ -221,4 +224,9 @@ def summarize_task_for_log(task: task_types.Task) -> str:
             f"model={params.model!r}, "
             f"input_sample_rate={params.input_sample_rate})"
         )
-    return repr(task)
+    return (
+        f"{task.__class__.__name__}("
+        f"task_id={task.task_id!r}, "
+        f"instance_id={task.instance_id!r}, "
+        f"task_status={task.task_status!r})"
+    )

--- a/src/skulk/shared/log_summaries.py
+++ b/src/skulk/shared/log_summaries.py
@@ -1,0 +1,224 @@
+"""Payload-free summaries for serving commands and worker tasks."""
+
+from skulk.shared.types import commands as command_types
+from skulk.shared.types import tasks as task_types
+
+
+def summarize_command_for_log(command: command_types.Command) -> str:
+    """Return an operational serving-command summary without user payloads."""
+
+    if isinstance(command, command_types.TextGeneration):
+        params = command.task_params
+        return (
+            "TextGeneration("
+            f"command_id={command.command_id!r}, "
+            f"model={params.model!r}, "
+            f"input_messages={len(params.input)}, "
+            f"chat_template_messages={len(params.chat_template_messages or [])}, "
+            f"images={len(params.images)}, "
+            f"cached_image_indices={sorted(params.image_hashes.keys())}, "
+            f"total_input_chunks={params.total_input_chunks}, "
+            f"image_count={params.image_count}, "
+            f"stream={params.stream})"
+        )
+    if isinstance(command, command_types.ImageGeneration):
+        params = command.task_params
+        return (
+            "ImageGeneration("
+            f"command_id={command.command_id!r}, "
+            f"model={params.model!r}, "
+            f"prompt_chars={len(params.prompt)}, "
+            f"n={params.n!r}, "
+            f"size={params.size!r}, "
+            f"stream={params.stream!r})"
+        )
+    if isinstance(command, command_types.ImageEdits):
+        params = command.task_params
+        return (
+            "ImageEdits("
+            f"command_id={command.command_id!r}, "
+            f"model={params.model!r}, "
+            f"prompt_chars={len(params.prompt)}, "
+            f"total_input_chunks={params.total_input_chunks}, "
+            f"has_inline_image_data={bool(params.image_data)}, "
+            f"n={params.n!r}, "
+            f"size={params.size!r}, "
+            f"stream={params.stream!r})"
+        )
+    if isinstance(command, command_types.TextEmbedding):
+        params = command.task_params
+        return (
+            "TextEmbedding("
+            f"command_id={command.command_id!r}, "
+            f"model={params.model!r}, "
+            f"input_texts={len(params.input_texts)}, "
+            f"encoding_format={params.encoding_format!r})"
+        )
+    if isinstance(command, command_types.SpeechSynthesis):
+        params = command.task_params
+        return (
+            "SpeechSynthesis("
+            f"command_id={command.command_id!r}, "
+            f"model={params.model!r}, "
+            f"input_chars={len(params.input_text)}, "
+            f"response_format={params.response_format!r}, "
+            f"reference_audio_present={params.reference_audio_present}, "
+            f"reference_audio_bytes={len(params.reference_audio_data or b'')}, "
+            f"stream={params.stream})"
+        )
+    if isinstance(command, command_types.AudioTranscription):
+        params = command.task_params
+        return (
+            "AudioTranscription("
+            f"command_id={command.command_id!r}, "
+            f"model={params.model!r}, "
+            f"total_input_chunks={params.total_input_chunks}, "
+            f"audio_payload_chars={len(params.audio_data or '')}, "
+            f"translate_to_english={params.translate_to_english}, "
+            f"stream={params.stream})"
+        )
+    if isinstance(command, command_types.RealtimeAudioTranscription):
+        params = command.task_params
+        return (
+            "RealtimeAudioTranscription("
+            f"command_id={command.command_id!r}, "
+            f"model={params.model!r}, "
+            f"input_sample_rate={params.input_sample_rate})"
+        )
+    return repr(command)
+
+
+def summarize_task_for_log(task: task_types.Task) -> str:
+    """Return an operational worker-task summary without user payloads."""
+
+    if isinstance(task, task_types.CreateRunner):
+        shard = task.bound_instance.bound_shard
+        return (
+            "CreateRunner("
+            f"instance_id={task.instance_id!r}, "
+            f"runner_id={task.bound_instance.bound_runner_id!r}, "
+            f"node_id={task.bound_instance.bound_node_id!r}, "
+            f"device_rank={shard.device_rank}, "
+            f"world_size={shard.world_size}, "
+            f"layers={shard.start_layer}:{shard.end_layer})"
+        )
+    if isinstance(task, task_types.DownloadModel):
+        shard = task.shard_metadata
+        return (
+            "DownloadModel("
+            f"instance_id={task.instance_id!r}, "
+            f"model={shard.model_card.model_id!r}, "
+            f"device_rank={shard.device_rank}, "
+            f"world_size={shard.world_size}, "
+            f"layers={shard.start_layer}:{shard.end_layer})"
+        )
+    if isinstance(task, task_types.Shutdown):
+        return (
+            f"Shutdown(instance_id={task.instance_id!r}, runner_id={task.runner_id!r})"
+        )
+    if isinstance(task, task_types.LoadModel):
+        return f"LoadModel(instance_id={task.instance_id!r})"
+    if isinstance(task, task_types.StartWarmup):
+        return f"StartWarmup(instance_id={task.instance_id!r})"
+    if isinstance(task, task_types.CancelTask):
+        return (
+            "CancelTask("
+            f"instance_id={task.instance_id!r}, "
+            f"runner_id={task.runner_id!r}, "
+            f"cancelled_task_id={task.cancelled_task_id!r})"
+        )
+    if isinstance(task, task_types.TextGeneration):
+        params = task.task_params
+        return (
+            "TextGeneration("
+            f"task_id={task.task_id!r}, "
+            f"command_id={task.command_id!r}, "
+            f"instance_id={task.instance_id!r}, "
+            f"model={params.model!r}, "
+            f"input_messages={len(params.input)}, "
+            f"chat_template_messages={len(params.chat_template_messages or [])}, "
+            f"images={len(params.images)}, "
+            f"cached_image_indices={sorted(params.image_hashes.keys())}, "
+            f"total_input_chunks={params.total_input_chunks}, "
+            f"image_count={params.image_count}, "
+            f"stream={params.stream}, "
+            f"reasoning_effort={params.reasoning_effort!r}, "
+            f"enable_thinking={params.enable_thinking!r})"
+        )
+    if isinstance(task, task_types.ImageGeneration):
+        params = task.task_params
+        return (
+            "ImageGeneration("
+            f"task_id={task.task_id!r}, "
+            f"command_id={task.command_id!r}, "
+            f"instance_id={task.instance_id!r}, "
+            f"model={params.model!r}, "
+            f"prompt_chars={len(params.prompt)}, "
+            f"n={params.n!r}, "
+            f"size={params.size!r}, "
+            f"stream={params.stream!r})"
+        )
+    if isinstance(task, task_types.ImageEdits):
+        params = task.task_params
+        return (
+            "ImageEdits("
+            f"task_id={task.task_id!r}, "
+            f"command_id={task.command_id!r}, "
+            f"instance_id={task.instance_id!r}, "
+            f"model={params.model!r}, "
+            f"prompt_chars={len(params.prompt)}, "
+            f"total_input_chunks={params.total_input_chunks}, "
+            f"has_inline_image_data={bool(params.image_data)}, "
+            f"n={params.n!r}, "
+            f"size={params.size!r}, "
+            f"stream={params.stream!r})"
+        )
+    if isinstance(task, task_types.TextEmbedding):
+        params = task.task_params
+        return (
+            "TextEmbedding("
+            f"task_id={task.task_id!r}, "
+            f"command_id={task.command_id!r}, "
+            f"instance_id={task.instance_id!r}, "
+            f"model={params.model!r}, "
+            f"input_texts={len(params.input_texts)}, "
+            f"encoding_format={params.encoding_format!r})"
+        )
+    if isinstance(task, task_types.SpeechSynthesis):
+        params = task.task_params
+        return (
+            "SpeechSynthesis("
+            f"task_id={task.task_id!r}, "
+            f"command_id={task.command_id!r}, "
+            f"instance_id={task.instance_id!r}, "
+            f"model={params.model!r}, "
+            f"input_chars={len(params.input_text)}, "
+            f"response_format={params.response_format!r}, "
+            f"reference_audio_present={params.reference_audio_present}, "
+            f"reference_audio_bytes={len(params.reference_audio_data or b'')}, "
+            f"stream={params.stream})"
+        )
+    if isinstance(task, task_types.AudioTranscription):
+        params = task.task_params
+        return (
+            "AudioTranscription("
+            f"task_id={task.task_id!r}, "
+            f"command_id={task.command_id!r}, "
+            f"instance_id={task.instance_id!r}, "
+            f"model={params.model!r}, "
+            f"total_input_chunks={params.total_input_chunks}, "
+            f"audio_payload_chars={len(params.audio_data or '')}, "
+            f"translate_to_english={params.translate_to_english}, "
+            f"stream={params.stream})"
+        )
+    if isinstance(task, task_types.RealtimeAudioTranscription):
+        params = task.task_params
+        return (
+            "RealtimeAudioTranscription("
+            f"task_id={task.task_id!r}, "
+            f"command_id={task.command_id!r}, "
+            f"instance_id={task.instance_id!r}, "
+            f"model={params.model!r}, "
+            f"input_sample_rate={params.input_sample_rate})"
+        )
+    return repr(task)

--- a/src/skulk/shared/tests/test_log_summaries.py
+++ b/src/skulk/shared/tests/test_log_summaries.py
@@ -9,6 +9,7 @@ from skulk.shared.types.audio import (
     AudioTranscriptionTaskParams,
     SpeechSynthesisTaskParams,
 )
+from skulk.shared.types.chunks import AudioInputChunk
 from skulk.shared.types.common import CommandId, ModelId
 from skulk.shared.types.embedding import TextEmbeddingTaskParams
 from skulk.shared.types.text_generation import InputMessage, TextGenerationTaskParams
@@ -75,6 +76,18 @@ def test_serving_log_summaries_exclude_user_payloads() -> None:
             command_id=CommandId("transcription-command"),
             task_params=transcription_params,
         ),
+        command_types.SendInputChunk(
+            command_id=CommandId("chunk-command"),
+            chunk=AudioInputChunk(
+                model=ModelId("stt-model"),
+                command_id=CommandId("transcription-command"),
+                data="FALLBACK_AUDIO_PAYLOAD_SENTINEL",
+                chunk_index=0,
+                total_chunks=1,
+                filename="FALLBACK_FILENAME_SENTINEL",
+                audio_sha256="c" * 64,
+            ),
+        ),
     ]
     tasks: list[task_types.Task] = [
         task_types.TextGeneration(
@@ -133,6 +146,8 @@ def test_serving_log_summaries_exclude_user_payloads() -> None:
         "TRANSCRIPTION_AUDIO_SENTINEL",
         "TRANSCRIPTION_PROMPT_SENTINEL",
         "TRANSCRIPTION_CONTEXT_SENTINEL",
+        "FALLBACK_AUDIO_PAYLOAD_SENTINEL",
+        "FALLBACK_FILENAME_SENTINEL",
     ):
         assert sentinel not in joined
 
@@ -141,3 +156,4 @@ def test_serving_log_summaries_exclude_user_payloads() -> None:
     assert "input_texts=1" in joined
     assert "reference_audio_bytes=24" in joined
     assert "audio_payload_chars=28" in joined
+    assert "SendInputChunk(command_id='chunk-command')" in joined

--- a/src/skulk/shared/tests/test_log_summaries.py
+++ b/src/skulk/shared/tests/test_log_summaries.py
@@ -1,0 +1,143 @@
+from skulk.api.types import ImageEditsTaskParams, ImageGenerationTaskParams
+from skulk.shared.log_summaries import (
+    summarize_command_for_log,
+    summarize_task_for_log,
+)
+from skulk.shared.types import commands as command_types
+from skulk.shared.types import tasks as task_types
+from skulk.shared.types.audio import (
+    AudioTranscriptionTaskParams,
+    SpeechSynthesisTaskParams,
+)
+from skulk.shared.types.common import CommandId, ModelId
+from skulk.shared.types.embedding import TextEmbeddingTaskParams
+from skulk.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+from skulk.shared.types.worker.instances import InstanceId
+
+
+def test_serving_log_summaries_exclude_user_payloads() -> None:
+    text_params = TextGenerationTaskParams(
+        model=ModelId("text-model"),
+        input=[InputMessage(role="user", content="TEXT_PAYLOAD_SENTINEL")],
+        stream=True,
+    )
+    image_generation_params = ImageGenerationTaskParams(
+        prompt="IMAGE_PROMPT_SENTINEL",
+        model="image-model",
+    )
+    image_edit_params = ImageEditsTaskParams(
+        image_data="IMAGE_BYTES_SENTINEL",
+        prompt="IMAGE_EDIT_PROMPT_SENTINEL",
+        model="image-edit-model",
+    )
+    embedding_params = TextEmbeddingTaskParams(
+        model=ModelId("embedding-model"),
+        input_texts=["EMBEDDING_PAYLOAD_SENTINEL"],
+    )
+    speech_params = SpeechSynthesisTaskParams(
+        model=ModelId("tts-model"),
+        input_text="SPEECH_TEXT_SENTINEL",
+        reference_text="REFERENCE_TEXT_SENTINEL",
+        reference_audio_present=True,
+        reference_audio_sha256="a" * 64,
+        reference_audio_data=b"REFERENCE_AUDIO_SENTINEL",
+    )
+    transcription_params = AudioTranscriptionTaskParams(
+        model=ModelId("stt-model"),
+        audio_sha256="b" * 64,
+        audio_data="TRANSCRIPTION_AUDIO_SENTINEL",
+        prompt="TRANSCRIPTION_PROMPT_SENTINEL",
+        context="TRANSCRIPTION_CONTEXT_SENTINEL",
+    )
+
+    commands: list[command_types.Command] = [
+        command_types.TextGeneration(
+            command_id=CommandId("text-command"),
+            task_params=text_params,
+        ),
+        command_types.ImageGeneration(
+            command_id=CommandId("image-command"),
+            task_params=image_generation_params,
+        ),
+        command_types.ImageEdits(
+            command_id=CommandId("edit-command"),
+            task_params=image_edit_params,
+        ),
+        command_types.TextEmbedding(
+            command_id=CommandId("embedding-command"),
+            task_params=embedding_params,
+        ),
+        command_types.SpeechSynthesis(
+            command_id=CommandId("speech-command"),
+            task_params=speech_params,
+        ),
+        command_types.AudioTranscription(
+            command_id=CommandId("transcription-command"),
+            task_params=transcription_params,
+        ),
+    ]
+    tasks: list[task_types.Task] = [
+        task_types.TextGeneration(
+            task_id=task_types.TaskId("text-task"),
+            command_id=CommandId("text-command"),
+            instance_id=InstanceId("text-instance"),
+            task_params=text_params,
+        ),
+        task_types.ImageGeneration(
+            task_id=task_types.TaskId("image-task"),
+            command_id=CommandId("image-command"),
+            instance_id=InstanceId("image-instance"),
+            task_params=image_generation_params,
+        ),
+        task_types.ImageEdits(
+            task_id=task_types.TaskId("edit-task"),
+            command_id=CommandId("edit-command"),
+            instance_id=InstanceId("edit-instance"),
+            task_params=image_edit_params,
+        ),
+        task_types.TextEmbedding(
+            task_id=task_types.TaskId("embedding-task"),
+            command_id=CommandId("embedding-command"),
+            instance_id=InstanceId("embedding-instance"),
+            task_params=embedding_params,
+        ),
+        task_types.SpeechSynthesis(
+            task_id=task_types.TaskId("speech-task"),
+            command_id=CommandId("speech-command"),
+            instance_id=InstanceId("speech-instance"),
+            task_params=speech_params,
+        ),
+        task_types.AudioTranscription(
+            task_id=task_types.TaskId("transcription-task"),
+            command_id=CommandId("transcription-command"),
+            instance_id=InstanceId("transcription-instance"),
+            task_params=transcription_params,
+        ),
+    ]
+
+    summaries = [
+        *(summarize_command_for_log(command) for command in commands),
+        *(summarize_task_for_log(task) for task in tasks),
+    ]
+    joined = "\n".join(summaries)
+
+    for sentinel in (
+        "TEXT_PAYLOAD_SENTINEL",
+        "IMAGE_PROMPT_SENTINEL",
+        "IMAGE_BYTES_SENTINEL",
+        "IMAGE_EDIT_PROMPT_SENTINEL",
+        "EMBEDDING_PAYLOAD_SENTINEL",
+        "SPEECH_TEXT_SENTINEL",
+        "REFERENCE_TEXT_SENTINEL",
+        "REFERENCE_AUDIO_SENTINEL",
+        "TRANSCRIPTION_AUDIO_SENTINEL",
+        "TRANSCRIPTION_PROMPT_SENTINEL",
+        "TRANSCRIPTION_CONTEXT_SENTINEL",
+    ):
+        assert sentinel not in joined
+
+    assert "input_messages=1" in joined
+    assert "prompt_chars=21" in joined
+    assert "input_texts=1" in joined
+    assert "reference_audio_bytes=24" in joined
+    assert "audio_payload_chars=28" in joined

--- a/src/skulk/worker/engines/mlx/utils_mlx.py
+++ b/src/skulk/worker/engines/mlx/utils_mlx.py
@@ -1412,6 +1412,18 @@ def _patch_lossy_chat_template(template: str) -> str | None:
     return patched if n > 0 else None
 
 
+def _log_rendered_prompt_shape(
+    renderer: PromptRendererType,
+    prompt: str,
+    message_count: int,
+) -> None:
+    """Log prompt construction metadata without retaining user content."""
+    logger.info(
+        "Rendered model prompt "
+        f"(renderer={renderer.value}, messages={message_count}, chars={len(prompt)})"
+    )
+
+
 def apply_chat_template(
     tokenizer: TokenizerWrapper,
     task_params: TextGenerationTaskParams,
@@ -1476,7 +1488,11 @@ def apply_chat_template(
         )
         if partial_assistant_content:
             prompt += partial_assistant_content
-        logger.info(prompt)
+        _log_rendered_prompt_shape(
+            capability_profile.prompt_renderer,
+            prompt,
+            len(formatted_messages),
+        )
         return prompt
 
     if capability_profile.prompt_renderer == PromptRendererType.Gemma4:
@@ -1488,7 +1504,11 @@ def apply_chat_template(
         )
         if partial_assistant_content:
             prompt += partial_assistant_content
-        logger.info(prompt)
+        _log_rendered_prompt_shape(
+            capability_profile.prompt_renderer,
+            prompt,
+            len(formatted_messages),
+        )
         return prompt
 
     for msg in formatted_messages:
@@ -1528,7 +1548,11 @@ def apply_chat_template(
     if partial_assistant_content:
         prompt += partial_assistant_content
 
-    logger.info(prompt)
+    _log_rendered_prompt_shape(
+        capability_profile.prompt_renderer,
+        prompt,
+        len(formatted_messages),
+    )
 
     return prompt
 
@@ -1756,12 +1780,17 @@ def _parse_gemma4_tool_calls(text: str) -> list[dict[str, Any]]:
         try:
             args_dict = cast(dict[str, object], json.loads(args_json))
         except json.JSONDecodeError:
-            logger.warning(f"Failed to parse Gemma 4 tool call args: {args_json}")
+            logger.warning(
+                "Failed to parse Gemma 4 tool call arguments "
+                f"(argument_chars={len(args_json)})"
+            )
             args_dict = {}
         results.append(dict(name=func_name, arguments=args_dict))
 
     if not results:
-        raise ValueError(f"No Gemma 4 tool calls found in: {text}")
+        raise ValueError(
+            f"No Gemma 4 tool calls found in generated text ({len(text)} chars)"
+        )
     return results
 
 

--- a/src/skulk/worker/engines/mlx/vision.py
+++ b/src/skulk/worker/engines/mlx/vision.py
@@ -624,14 +624,10 @@ def _build_vision_prompt_with_debug(
     For models that use BOI/EOI framing (Gemma 3n/4), each expanded image
     sequence is wrapped as ``BOI + (IMAGE × N) + EOI`` matching the format
     the model was trained on."""
-    prompt_debug_messages = [
-        {
-            key: (value[:50] if isinstance(value, str) else value)
-            for key, value in message.items()
-        }
-        for message in chat_template_messages
-    ]
-    logger.info(f"Vision prompt messages: {prompt_debug_messages}")
+    logger.info(
+        "Building vision prompt "
+        f"(messages={len(chat_template_messages)}, images={len(n_tokens_per_image)})"
+    )
     uses_gemma4_reference_prompt = model_type == "gemma4"
     if uses_gemma4_reference_prompt:
         prompt = render_gemma4_prompt(

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -28,6 +28,7 @@ from skulk.routing.vision_media import VisionMediaPacket
 from skulk.routing.zenoh_status import ZenohPeerSampler
 from skulk.shared.apply import apply
 from skulk.shared.constants import SKULK_IMAGE_TRANSPORT_DEBUG
+from skulk.shared.log_summaries import summarize_task_for_log
 from skulk.shared.models.memory_estimate import (
     GPU_VRAM_WORKING_SET_FRACTION,
     KV_CONTEXT_BUDGET_TOKENS,
@@ -88,7 +89,6 @@ from skulk.shared.types.tasks import (
     RealtimeAudioTranscription,
     Shutdown,
     SpeechSynthesis,
-    StartWarmup,
     Task,
     TaskId,
     TaskStatus,
@@ -389,75 +389,7 @@ def _local_usable_vram() -> Memory | None:
 
 def _summarize_worker_task(task: Task) -> str:
     """Return a compact task summary for worker lifecycle logs."""
-    if isinstance(task, CreateRunner):
-        shard = task.bound_instance.bound_shard
-        return (
-            "CreateRunner("
-            f"instance_id={task.instance_id!r}, "
-            f"runner_id={task.bound_instance.bound_runner_id!r}, "
-            f"node_id={task.bound_instance.bound_node_id!r}, "
-            f"device_rank={shard.device_rank}, "
-            f"world_size={shard.world_size}, "
-            f"layers={shard.start_layer}:{shard.end_layer})"
-        )
-    if isinstance(task, DownloadModel):
-        shard = task.shard_metadata
-        return (
-            "DownloadModel("
-            f"instance_id={task.instance_id!r}, "
-            f"model={shard.model_card.model_id!r}, "
-            f"device_rank={shard.device_rank}, "
-            f"world_size={shard.world_size}, "
-            f"layers={shard.start_layer}:{shard.end_layer})"
-        )
-    if isinstance(task, Shutdown):
-        return (
-            f"Shutdown(instance_id={task.instance_id!r}, runner_id={task.runner_id!r})"
-        )
-    if isinstance(task, LoadModel):
-        return f"LoadModel(instance_id={task.instance_id!r})"
-    if isinstance(task, StartWarmup):
-        return f"StartWarmup(instance_id={task.instance_id!r})"
-    if isinstance(task, CancelTask):
-        return (
-            "CancelTask("
-            f"instance_id={task.instance_id!r}, "
-            f"runner_id={task.runner_id!r}, "
-            f"cancelled_task_id={task.cancelled_task_id!r})"
-        )
-    if isinstance(task, TextGeneration):
-        params = task.task_params
-        return (
-            "TextGeneration("
-            f"task_id={task.task_id!r}, "
-            f"command_id={task.command_id!r}, "
-            f"instance_id={task.instance_id!r}, "
-            f"model={params.model!r}, "
-            f"input_messages={len(params.input)}, "
-            f"chat_template_messages={len(params.chat_template_messages or [])}, "
-            f"images={len(params.images)}, "
-            f"cached_image_indices={sorted(params.image_hashes.keys())}, "
-            f"total_input_chunks={params.total_input_chunks}, "
-            f"image_count={params.image_count}, "
-            f"stream={params.stream}, "
-            f"reasoning_effort={params.reasoning_effort!r}, "
-            f"enable_thinking={params.enable_thinking!r})"
-        )
-    if isinstance(task, ImageEdits):
-        params = task.task_params
-        return (
-            "ImageEdits("
-            f"task_id={task.task_id!r}, "
-            f"command_id={task.command_id!r}, "
-            f"instance_id={task.instance_id!r}, "
-            f"model={params.model!r}, "
-            f"total_input_chunks={params.total_input_chunks}, "
-            f"has_inline_image_data={bool(params.image_data)}, "
-            f"n={params.n!r}, "
-            f"size={params.size!r}, "
-            f"stream={params.stream!r})"
-        )
-    return task.__class__.__name__
+    return summarize_task_for_log(task)
 
 
 def _staging_model_ids(card: ModelCard) -> frozenset[str]:

--- a/src/skulk/worker/runner/image_models/runner.py
+++ b/src/skulk/worker/runner/image_models/runner.py
@@ -6,6 +6,7 @@ import mlx.core as mx
 
 from skulk.api.types import ImageGenerationStats
 from skulk.shared.constants import SKULK_MAX_CHUNK_SIZE
+from skulk.shared.log_summaries import summarize_task_for_log
 from skulk.shared.models.model_cards import ModelTask
 from skulk.shared.tracing import (
     begin_trace_session,
@@ -298,7 +299,10 @@ class Runner:
                 isinstance(self.current_status, RunnerReady)
             ):
                 assert self.image_model
-                logger.info(f"received image generation request: {str(task)[:500]}")
+                logger.info(
+                    "received image generation request: "
+                    f"{summarize_task_for_log(task)}"
+                )
                 logger.info("runner running")
                 self.update_status(RunnerRunning())
                 self.acknowledge_task(task)
@@ -392,7 +396,9 @@ class Runner:
                 isinstance(self.current_status, RunnerReady)
             ):
                 assert self.image_model
-                logger.info(f"received image edits request: {str(task)[:500]}")
+                logger.info(
+                    f"received image edits request: {summarize_task_for_log(task)}"
+                )
                 logger.info("runner running")
                 self.update_status(RunnerRunning())
                 self.acknowledge_task(task)

--- a/src/skulk/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/skulk/worker/runner/llm_inference/model_output_parsers.py
@@ -324,11 +324,13 @@ def parse_gpt_oss(
         ch = stream.current_channel
         recipient = stream.current_recipient
 
-        # Debug: log every token with state
+        # Keep parser-state diagnostics useful without retaining generated text.
         logger.debug(
-            f"parse_gpt_oss token={response.token} text={response.text!r} "
-            f"recipient={recipient!r} ch={ch!r} delta={delta!r} "
-            f"state={stream.state} current_tool={current_tool_name!r}"
+            f"parse_gpt_oss token={response.token} "
+            f"text_chars={len(response.text)} "
+            f"has_recipient={recipient is not None} channel={ch!r} "
+            f"delta_chars={len(delta or '')} state={stream.state} "
+            f"has_current_tool={current_tool_name is not None}"
         )
 
         if recipient != current_tool_name:
@@ -337,7 +339,8 @@ def parse_gpt_oss(
                 if current_tool_name.startswith(prefix):
                     current_tool_name = current_tool_name[len(prefix) :]
                 logger.info(
-                    f"parse_gpt_oss yielding tool call: name={current_tool_name!r}"
+                    "parse_gpt_oss yielding tool call "
+                    f"(name_chars={len(current_tool_name)})"
                 )
                 yield ToolCallResponse(
                     tool_calls=[
@@ -406,7 +409,9 @@ def parse_deepseek_v32(
             return ToolCallResponse(
                 tool_calls=parsed, usage=response.usage, stats=response.stats
             )
-        logger.warning(f"DSML tool call parsing failed for: {text}")
+        logger.warning(
+            f"DSML tool call parsing failed (generated_chars={len(text)})"
+        )
         return response.model_copy(update={"text": text})
 
     for response in responses:
@@ -702,12 +707,20 @@ def parse_tool_calls(
             # parse the actual tool calls from the tool call text
             combined = "".join(tool_call_text_parts)
             parsed = tool_parser.parse(combined.strip(), tools=tools)
-            logger.info(f"parsed {tool_call_text_parts=} into {parsed=}")
+            logger.info(
+                "Parsed generated tool-call block "
+                f"(chunks={len(tool_call_text_parts)}, "
+                f"generated_chars={len(combined)}, "
+                f"parsed_calls={len(parsed) if parsed is not None else 0})"
+            )
             in_tool_call = False
             tool_call_text_parts = []
 
             if parsed is None:
-                logger.warning(f"tool call parsing failed for text {combined}")
+                logger.warning(
+                    "Tool-call parsing failed "
+                    f"(generated_chars={len(combined)})"
+                )
                 if trace_task_id is not None:
                     record_trace_marker(
                         "tool_call_parse_error",

--- a/src/skulk/worker/runner/runner_supervisor.py
+++ b/src/skulk/worker/runner/runner_supervisor.py
@@ -16,6 +16,7 @@ from anyio import (
 from loguru import logger
 
 from skulk.routing.trace_data import TraceDataPacket
+from skulk.shared.log_summaries import summarize_task_for_log
 from skulk.shared.models.model_cards import ModelId
 from skulk.shared.types.audio import RealtimeAudioInputFrame
 from skulk.shared.types.chunks import (
@@ -125,21 +126,7 @@ def _now_utc_iso() -> str:
 
 def _summarize_task(task: Task) -> str:
     """Return a compact task summary for logs."""
-    if isinstance(task, TextGeneration):
-        params = task.task_params
-        return (
-            "TextGeneration("
-            f"task_id={task.task_id!r}, "
-            f"command_id={task.command_id!r}, "
-            f"model={params.model!r}, "
-            f"input_messages={len(params.input)}, "
-            f"chat_template_messages={len(params.chat_template_messages or [])}, "
-            f"images={len(params.images)}, "
-            f"cached_image_indices={sorted(params.image_hashes.keys())}, "
-            f"total_input_chunks={params.total_input_chunks}, "
-            f"image_count={params.image_count})"
-        )
-    return repr(task)
+    return summarize_task_for_log(task)
 
 
 @dataclass(eq=False)
@@ -523,12 +510,14 @@ class RunnerSupervisor:
     async def start_task(self, task: Task):
         if task.task_id in self.pending:
             logger.warning(
-                f"Skipping invalid task {task} as it has already been submitted"
+                "Skipping invalid task "
+                f"{_summarize_task(task)} as it has already been submitted"
             )
             return
         if task.task_id in self.completed:
             logger.warning(
-                f"Skipping invalid task {task} as it has already been completed"
+                "Skipping invalid task "
+                f"{_summarize_task(task)} as it has already been completed"
             )
             return
         logger.info(f"Starting task {_summarize_task(task)}")
@@ -594,7 +583,9 @@ class RunnerSupervisor:
             await self._task_sender.send_async(task)
         except ClosedResourceError:
             self.in_progress.pop(task.task_id, None)
-            logger.warning(f"Task {task} dropped, runner closed communication.")
+            logger.warning(
+                f"Task {_summarize_task(task)} dropped, runner closed communication."
+            )
             self._record_milestone(
                 "task_send_failed",
                 f"{task.__class__.__name__}:{task.task_id}",

--- a/src/skulk/worker/tests/unittests/test_payload_free_model_logs.py
+++ b/src/skulk/worker/tests/unittests/test_payload_free_model_logs.py
@@ -1,0 +1,202 @@
+"""Regression tests that serving logs retain shape, not user/model payloads."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Generator, Iterator
+from contextlib import contextmanager
+from typing import cast
+
+import pytest
+from loguru import logger
+from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+from skulk.shared.models.model_cards import (
+    ModelCard,
+    ModelTask,
+    PromptRendererType,
+    RuntimeCapabilityCardConfig,
+)
+from skulk.shared.types.common import ModelId
+from skulk.shared.types.memory import Memory
+from skulk.shared.types.text_generation import InputMessage, TextGenerationTaskParams
+from skulk.shared.types.worker.runner_response import GenerationResponse
+from skulk.worker.engines.mlx import utils_mlx as utils_mlx_module
+from skulk.worker.engines.mlx import vision as vision_module
+from skulk.worker.engines.mlx.dsml_encoding import (
+    TOOL_CALLS_END,
+    TOOL_CALLS_START,
+)
+from skulk.worker.engines.mlx.utils_mlx import apply_chat_template
+from skulk.worker.runner.llm_inference.model_output_parsers import (
+    parse_deepseek_v32,
+    parse_gpt_oss,
+    parse_tool_calls,
+)
+from skulk.worker.runner.llm_inference.tool_parsers import make_mlx_parser
+
+_PAYLOAD_SENTINEL = "PRIVATE-PAYLOAD-SENTINEL-8f41"
+
+
+@contextmanager
+def _captured_logs() -> Iterator[io.StringIO]:
+    """Capture Loguru messages emitted by the exercised serving path."""
+    stream = io.StringIO()
+    handler_id = logger.add(stream, format="{message}")
+    try:
+        yield stream
+    finally:
+        logger.remove(handler_id)
+
+
+class _PromptEchoTokenizer:
+    """Minimal tokenizer that makes prompt-content leakage observable."""
+
+    chat_template = "{{ messages }}"
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, object]],
+        *,
+        tokenize: bool,
+        add_generation_prompt: bool,
+        tools: list[dict[str, object]] | None = None,
+        **_kwargs: object,
+    ) -> str:
+        del tokenize, add_generation_prompt, tools
+        return repr(messages)
+
+
+def _text_card(renderer: PromptRendererType) -> ModelCard:
+    """Build a minimal card that selects one prompt renderer."""
+    return ModelCard(
+        model_id=ModelId(f"test/payload-free-{renderer.value}"),
+        storage_size=Memory.from_mb(100),
+        n_layers=2,
+        hidden_size=128,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        runtime=RuntimeCapabilityCardConfig(prompt_renderer=renderer),
+    )
+
+
+@pytest.mark.parametrize("renderer", list(PromptRendererType))
+def test_rendered_prompt_logs_only_shape(renderer: PromptRendererType) -> None:
+    """Every renderer must keep the prompt payload out of ordinary logs."""
+    task = TextGenerationTaskParams(
+        model=ModelId(f"test/payload-free-{renderer.value}"),
+        input=[InputMessage(role="user", content=_PAYLOAD_SENTINEL)],
+    )
+    tokenizer = cast(
+        TokenizerWrapper,
+        cast(object, _PromptEchoTokenizer()),
+    )
+
+    with _captured_logs() as captured:
+        prompt = apply_chat_template(
+            tokenizer,
+            task,
+            model_card=_text_card(renderer),
+        )
+
+    logs = captured.getvalue()
+    assert _PAYLOAD_SENTINEL in prompt
+    assert _PAYLOAD_SENTINEL not in logs
+    assert f"renderer={renderer.value}" in logs
+    assert "messages=1" in logs
+    assert "chars=" in logs
+
+
+def test_vision_prompt_logs_only_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vision prompt construction must not log even truncated user messages."""
+    monkeypatch.delenv("SKULK_TRACE_REQUEST_SHAPES", raising=False)
+    tokenizer = cast(
+        TokenizerWrapper,
+        cast(object, _PromptEchoTokenizer()),
+    )
+
+    with _captured_logs() as captured:
+        built = vision_module._build_vision_prompt_with_debug(  # pyright: ignore[reportPrivateUsage]
+            tokenizer,
+            [{"role": "user", "content": f"<image>{_PAYLOAD_SENTINEL}"}],
+            [2],
+            "<image>",
+        )
+
+    logs = captured.getvalue()
+    assert _PAYLOAD_SENTINEL in built.prompt
+    assert _PAYLOAD_SENTINEL not in logs
+    assert "messages=1" in logs
+    assert "images=1" in logs
+
+
+def _responses(text: str) -> Generator[GenerationResponse]:
+    """Yield one completed generation response."""
+    yield GenerationResponse(
+        text=text,
+        token=0,
+        finish_reason="stop",
+        usage=None,
+    )
+
+
+def test_generic_tool_parser_logs_only_shape() -> None:
+    """Generic tool parsing failures must not retain generated arguments."""
+
+    def _fail(_text: str) -> dict[str, object]:
+        raise ValueError("expected parser failure")
+
+    generated = f"<tool_call>{_PAYLOAD_SENTINEL}</tool_call>"
+    parser = make_mlx_parser("<tool_call>", "</tool_call>", _fail)
+
+    with _captured_logs() as captured:
+        results = list(parse_tool_calls(_responses(generated), parser, tools=None))
+
+    logs = captured.getvalue()
+    assert _PAYLOAD_SENTINEL in cast(GenerationResponse, results[0]).text
+    assert _PAYLOAD_SENTINEL not in logs
+    assert "generated_chars=" in logs
+
+
+def test_dsml_parser_logs_only_shape() -> None:
+    """DSML parsing failures must not retain generated content."""
+    generated = f"{TOOL_CALLS_START}{_PAYLOAD_SENTINEL}{TOOL_CALLS_END}"
+
+    with _captured_logs() as captured:
+        results = list(parse_deepseek_v32(_responses(generated)))
+
+    logs = captured.getvalue()
+    assert _PAYLOAD_SENTINEL in cast(GenerationResponse, results[0]).text
+    assert _PAYLOAD_SENTINEL not in logs
+    assert "generated_chars=" in logs
+
+
+def test_gpt_oss_parser_logs_only_shape() -> None:
+    """GPT-OSS token diagnostics must not retain generated content."""
+    generated = f"ordinary generated text {_PAYLOAD_SENTINEL}"
+
+    with _captured_logs() as captured:
+        list(parse_gpt_oss(_responses(generated)))
+
+    logs = captured.getvalue()
+    assert _PAYLOAD_SENTINEL not in logs
+    assert "text_chars=" in logs
+
+
+def test_gemma4_parser_logs_and_errors_only_shape() -> None:
+    """Gemma 4 parse diagnostics must not retain tool arguments or output."""
+    invalid_args = f"call:lookup{{query:{_PAYLOAD_SENTINEL}}}"
+    no_call = f"ordinary generated text {_PAYLOAD_SENTINEL}"
+
+    with _captured_logs() as captured:
+        parsed = utils_mlx_module._parse_gemma4_tool_calls(invalid_args)  # pyright: ignore[reportPrivateUsage]
+        with pytest.raises(ValueError) as error:
+            utils_mlx_module._parse_gemma4_tool_calls(no_call)  # pyright: ignore[reportPrivateUsage]
+
+    logs = captured.getvalue()
+    assert parsed[0]["arguments"] == {}
+    assert _PAYLOAD_SENTINEL not in logs
+    assert _PAYLOAD_SENTINEL not in str(error.value)
+    assert "argument_chars=" in logs


### PR DESCRIPTION
## Summary

- replace full serving-command and task representations with payload-free operational summaries
- cover master, worker, runner-supervisor retry/error paths, and image runners
- retain useful model, count, format, and lifecycle metadata without logging prompts, images, embeddings, or audio
- add regression coverage across text, image, embedding, TTS, and STT payloads

## Validation

- uv run basedpyright
- uv run ruff check
- nix fmt
- uv run pytest (2937 passed, 1 skipped, 228 deselected)
- focused log-summary and runner tests (23 passed)