### PR TITLE
fix: keep Gemma 3n pipeline state rank-local

### DIFF
--- a/src/skulk/worker/engines/mlx/auto_parallel.py
+++ b/src/skulk/worker/engines/mlx/auto_parallel.py
@@ -612,6 +612,216 @@ class _Gemma4ArgsLike(Protocol):
     num_kv_shared_layers: int
 
 
+class _Gemma3nConfigLike(Protocol):
+    """Configuration fields that must become rank-local after pipeline slicing."""
+
+    model_type: str
+    layer_types: list[str]
+    num_hidden_layers: int
+    num_kv_shared_layers: int
+    hidden_size_per_layer_input: int
+
+
+class _Gemma3nTrunkLike(Protocol):
+    """Gemma 3n trunk state coupled to full-model layer numbering."""
+
+    config: _Gemma3nConfigLike
+    layer_idx_to_cache_idx: list[int]
+    first_kv_shared_layer_idx: int
+    first_full_idx: int
+    first_sliding_idx: int
+    num_hidden_layers: int
+    embed_tokens_per_layer: nn.Module
+    per_layer_model_projection: nn.Module
+
+
+class _EmbeddingParameters(Protocol):
+    """Mutable feature-axis parameters shared by MLX embedding variants."""
+
+    weight: mx.array
+    dims: int
+
+
+class _QuantizedEmbeddingParameters(_EmbeddingParameters, Protocol):
+    """Mutable quantization metadata for an MLX quantized embedding."""
+
+    scales: mx.array
+    biases: mx.array | None
+
+
+class _LinearParameters(Protocol):
+    """Mutable output-axis parameters shared by MLX linear variants."""
+
+    weight: mx.array
+    bias: mx.array
+
+
+class _QuantizedLinearParameters(_LinearParameters, Protocol):
+    """Mutable quantization metadata for an MLX quantized linear layer."""
+
+    scales: mx.array
+    biases: mx.array | None
+
+
+def _slice_embedding_features(
+    module: nn.Module,
+    start_feature: int,
+    end_feature: int,
+    total_features: int,
+) -> None:
+    """Retain one contiguous output-feature range in an embedding module."""
+    if isinstance(module, nn.QuantizedEmbedding):
+        quantized = cast(_QuantizedEmbeddingParameters, cast(object, module))
+        packed_width = int(quantized.weight.shape[1])
+        scale_width = int(quantized.scales.shape[1])
+        packed_start = start_feature * packed_width // total_features
+        packed_end = end_feature * packed_width // total_features
+        scale_start = start_feature * scale_width // total_features
+        scale_end = end_feature * scale_width // total_features
+        quantized.weight = quantized.weight[:, packed_start:packed_end]
+        quantized.scales = quantized.scales[:, scale_start:scale_end]
+        if quantized.biases is not None:
+            quantized.biases = quantized.biases[:, scale_start:scale_end]
+        quantized.dims = end_feature - start_feature
+        return
+
+    if isinstance(module, nn.Embedding):
+        embedding = cast(_EmbeddingParameters, cast(object, module))
+        embedding.weight = embedding.weight[:, start_feature:end_feature]
+        embedding.dims = end_feature - start_feature
+        return
+
+    raise TypeError(
+        "Gemma 3n per-layer embedding must be an MLX Embedding or "
+        f"QuantizedEmbedding, got {type(module).__name__}"
+    )
+
+
+def _slice_linear_outputs(
+    module: nn.Module,
+    start_feature: int,
+    end_feature: int,
+) -> None:
+    """Retain one contiguous output-feature range in a linear module."""
+    if isinstance(module, nn.QuantizedLinear):
+        quantized = cast(_QuantizedLinearParameters, cast(object, module))
+        quantized.weight = quantized.weight[start_feature:end_feature]
+        quantized.scales = quantized.scales[start_feature:end_feature]
+        if quantized.biases is not None:
+            quantized.biases = quantized.biases[start_feature:end_feature]
+        if "bias" in module:
+            quantized.bias = quantized.bias[start_feature:end_feature]
+        return
+
+    if isinstance(module, nn.Linear):
+        linear = cast(_LinearParameters, cast(object, module))
+        linear.weight = linear.weight[start_feature:end_feature]
+        if "bias" in module:
+            linear.bias = linear.bias[start_feature:end_feature]
+        return
+
+    raise TypeError(
+        "Gemma 3n per-layer projection must be an MLX Linear or "
+        f"QuantizedLinear, got {type(module).__name__}"
+    )
+
+
+def _slice_gemma3n_pipeline_state(
+    inner_model_instance: nn.Module,
+    start_layer: int,
+    end_layer: int,
+) -> None:
+    """Convert Gemma 3n's full-model cache and per-layer inputs to rank-local state.
+
+    Gemma 3n's final layers reuse K/V produced by the last concrete sliding and
+    full-attention layers. Its two per-layer input projections also concatenate
+    one feature block per original layer. Pipeline ranks therefore cannot merely
+    replace ``layers``: every dependent index and projection must be sliced in
+    the same coordinate system or the first shared layer reads an empty cache.
+    """
+    config_source = getattr(inner_model_instance, "config", None)
+    if getattr(config_source, "model_type", None) != "gemma3n_text":
+        return
+    if not all(
+        hasattr(inner_model_instance, name)
+        for name in (
+            "layer_idx_to_cache_idx",
+            "first_kv_shared_layer_idx",
+            "embed_tokens_per_layer",
+            "per_layer_model_projection",
+        )
+    ):
+        raise ValueError(
+            "Gemma 3n pipeline trunk is missing cache or per-layer input metadata"
+        )
+
+    trunk = cast(_Gemma3nTrunkLike, cast(object, inner_model_instance))
+    config = trunk.config
+    full_layer_types = list(config.layer_types)
+    full_cache_indices = list(trunk.layer_idx_to_cache_idx)
+    if len(full_layer_types) != len(full_cache_indices):
+        raise ValueError(
+            "Gemma 3n layer type and cache dependency metadata have different lengths"
+        )
+
+    shard_cache_indices = full_cache_indices[start_layer:end_layer]
+    external_dependencies = sorted(
+        {
+            cache_index
+            for cache_index in shard_cache_indices
+            if cache_index < start_layer or cache_index >= end_layer
+        }
+    )
+    if external_dependencies:
+        raise ValueError(
+            "Gemma 3n pipeline slice crosses a shared-KV dependency: "
+            f"slice=[{start_layer}, {end_layer}), "
+            f"external_cache_layers={external_dependencies}"
+        )
+
+    local_layer_types = full_layer_types[start_layer:end_layer]
+    local_layer_count = end_layer - start_layer
+    local_concrete_count = max(
+        min(trunk.first_kv_shared_layer_idx, end_layer) - start_layer,
+        0,
+    )
+    feature_width = config.hidden_size_per_layer_input
+    feature_start = start_layer * feature_width
+    feature_end = end_layer * feature_width
+    total_features = len(full_layer_types) * feature_width
+
+    _slice_embedding_features(
+        trunk.embed_tokens_per_layer,
+        feature_start,
+        feature_end,
+        total_features,
+    )
+    _slice_linear_outputs(
+        trunk.per_layer_model_projection,
+        feature_start,
+        feature_end,
+    )
+
+    config.layer_types = local_layer_types
+    config.num_hidden_layers = local_layer_count
+    config.num_kv_shared_layers = local_layer_count - local_concrete_count
+    trunk.num_hidden_layers = local_layer_count
+    trunk.first_kv_shared_layer_idx = local_concrete_count
+    trunk.layer_idx_to_cache_idx = [
+        cache_index - start_layer for cache_index in shard_cache_indices
+    ]
+    trunk.first_full_idx = (
+        local_layer_types.index("full_attention")
+        if "full_attention" in local_layer_types
+        else 0
+    )
+    trunk.first_sliding_idx = (
+        local_layer_types.index("sliding_attention")
+        if "sliding_attention" in local_layer_types
+        else 0
+    )
+
+
 def pipeline_auto_parallel(
     model: nn.Module,
     group: mx.distributed.Group,
@@ -701,6 +911,12 @@ def pipeline_auto_parallel(
                 ssm_idx=inner_model_instance.ssm_idx,
                 has_linear=bool(linear_layers),
             )
+
+    _slice_gemma3n_pipeline_state(
+        inner_model_instance,
+        start_layer,
+        end_layer,
+    )
 
     if isinstance(inner_model_instance, NemotronHInnerModel):
         # NemotronH uses block_type: "M" (Mamba/SSM), "*" (Attention), "E" (MoE), "-" (MLP)

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
@@ -4,7 +4,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Callable, cast
+from typing import Callable, Protocol, cast
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -94,6 +94,100 @@ class _VlmWithPipelineLanguage(nn.Module):
     def __init__(self, layer_types: list[bool]) -> None:
         super().__init__()
         self.language_model = _NativeQwenPipelineLanguageModel(layer_types)
+
+
+class _Gemma3nPipelineTrunk(nn.Module):
+    """Gemma 3n-shaped trunk with shared caches and layer-specific inputs."""
+
+    def __init__(self, *, quantized: bool) -> None:
+        super().__init__()
+        feature_width = 32
+        layer_types = [
+            "full_attention" if layer_index % 5 == 4 else "sliding_attention"
+            for layer_index in range(30)
+        ]
+        self.config = _Gemma3nTestConfig(
+            layer_types=layer_types,
+            hidden_size_per_layer_input=feature_width,
+        )
+        self.layers = [SimpleNamespace() for _ in layer_types]
+        self.num_hidden_layers = 30
+        self.first_kv_shared_layer_idx = 20
+        self.first_full_idx = 4
+        self.first_sliding_idx = 0
+        self.layer_idx_to_cache_idx = list(range(20)) + [
+            18 if layer_type == "sliding_attention" else 19
+            for layer_type in layer_types[20:]
+        ]
+        embedding = nn.Embedding(8, 30 * feature_width)
+        projection = nn.Linear(32, 30 * feature_width, bias=False)
+        if quantized:
+            self.embed_tokens_per_layer = nn.QuantizedEmbedding.from_embedding(
+                embedding,
+                group_size=32,
+                bits=4,
+            )
+            self.per_layer_model_projection = nn.QuantizedLinear.from_linear(
+                projection,
+                group_size=32,
+                bits=4,
+            )
+        else:
+            self.embed_tokens_per_layer = embedding
+            self.per_layer_model_projection = projection
+
+
+class _Gemma3nTestConfig:
+    """Typed Gemma 3n configuration used by pipeline slicing tests."""
+
+    model_type = "gemma3n_text"
+
+    def __init__(
+        self,
+        *,
+        layer_types: list[str],
+        hidden_size_per_layer_input: int,
+    ) -> None:
+        self.layer_types = layer_types
+        self.num_hidden_layers = 30
+        self.num_kv_shared_layers = 10
+        self.hidden_size_per_layer_input = hidden_size_per_layer_input
+
+
+class _FeatureSizedModule(Protocol):
+    """Test-facing feature metadata exposed by an embedding module."""
+
+    dims: int
+
+
+class _WeightedModule(Protocol):
+    """Test-facing matrix exposed by a projection module."""
+
+    weight: mx.array
+
+
+class _Gemma3nPipelineLanguageModel(nn.Module):
+    """Language wrapper whose cache factory reads the rank-local config."""
+
+    def __init__(self, *, quantized: bool) -> None:
+        super().__init__()
+        self.model = _Gemma3nPipelineTrunk(quantized=quantized)
+        self.config = self.model.config
+
+    def make_cache(self) -> list[str]:
+        return list(
+            self.config.layer_types[
+                : self.model.first_kv_shared_layer_idx
+            ]
+        )
+
+
+class _VlmWithGemma3nPipelineLanguage(nn.Module):
+    """Native Gemma 3n wrapper used to exercise pipeline metadata slicing."""
+
+    def __init__(self, *, quantized: bool) -> None:
+        super().__init__()
+        self.language_model = _Gemma3nPipelineLanguageModel(quantized=quantized)
 
 
 class _VlmWithTensorLanguage(nn.Module):
@@ -421,6 +515,125 @@ def test_pipeline_reindexes_native_qwen_hybrid_cache(
     assert len(inner.layers) == 3
     assert inner.ssm_idx == 0
     assert inner.fa_idx == 1
+
+
+@pytest.mark.parametrize("quantized", [False, True])
+def test_pipeline_slices_gemma3n_shared_cache_and_per_layer_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    quantized: bool,
+) -> None:
+    """A Gemma 3n rank must use local cache indices and input feature blocks."""
+    model = _VlmWithGemma3nPipelineLanguage(quantized=quantized)
+    shard = SimpleNamespace(
+        start_layer=12,
+        end_layer=30,
+        device_rank=1,
+        world_size=2,
+    )
+
+    def _ignore_eval(*_args: object) -> None:
+        return None
+
+    def _identity_layer(
+        layer: object, *_args: object, **_kwargs: object
+    ) -> object:
+        return layer
+
+    def _identity_pipeline(
+        patched_model: nn.Module, _group: object
+    ) -> nn.Module:
+        return patched_model
+
+    monkeypatch.setattr(auto_parallel.mx, "eval", _ignore_eval)
+    monkeypatch.setattr(auto_parallel, "PipelineFirstLayer", _identity_layer)
+    monkeypatch.setattr(auto_parallel, "PipelineLastLayer", _identity_layer)
+    monkeypatch.setattr(auto_parallel, "patch_pipeline_model", _identity_pipeline)
+
+    auto_parallel.pipeline_auto_parallel(
+        model,
+        cast(mx.distributed.Group, cast(object, SimpleNamespace())),
+        cast(PipelineShardMetadata, cast(object, shard)),
+        on_layer_loaded=None,
+    )
+
+    inner = model.language_model.model
+    assert len(inner.layers) == 18
+    assert inner.config.num_hidden_layers == 18
+    assert inner.config.num_kv_shared_layers == 10
+    assert inner.first_kv_shared_layer_idx == 8
+    assert inner.layer_idx_to_cache_idx == list(range(8)) + [
+        6,
+        6,
+        6,
+        6,
+        7,
+        6,
+        6,
+        6,
+        6,
+        7,
+    ]
+    assert model.language_model.make_cache() == [
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+    ]
+    embedding = cast(
+        _FeatureSizedModule,
+        cast(object, inner.embed_tokens_per_layer),
+    )
+    projection = cast(
+        _WeightedModule,
+        cast(object, inner.per_layer_model_projection),
+    )
+    assert embedding.dims == 18 * 32
+    assert projection.weight.shape[0] == 18 * 32
+
+
+def test_pipeline_rejects_gemma3n_slice_without_shared_cache_producer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rank may not consume K/V owned by an earlier pipeline rank."""
+    model = _VlmWithGemma3nPipelineLanguage(quantized=False)
+    shard = SimpleNamespace(
+        start_layer=20,
+        end_layer=30,
+        device_rank=2,
+        world_size=3,
+    )
+
+    def _ignore_eval(*_args: object) -> None:
+        return None
+
+    def _identity_layer(
+        layer: object, *_args: object, **_kwargs: object
+    ) -> object:
+        return layer
+
+    monkeypatch.setattr(auto_parallel.mx, "eval", _ignore_eval)
+    monkeypatch.setattr(
+        auto_parallel,
+        "PipelineFirstLayer",
+        _identity_layer,
+    )
+    monkeypatch.setattr(
+        auto_parallel,
+        "PipelineLastLayer",
+        _identity_layer,
+    )
+
+    with pytest.raises(ValueError, match="crosses a shared-KV dependency"):
+        auto_parallel.pipeline_auto_parallel(
+            model,
+            cast(mx.distributed.Group, cast(object, SimpleNamespace())),
+            cast(PipelineShardMetadata, cast(object, shard)),
+            on_layer_loaded=None,
+        )
 
 
 def test_tensor_patch_finds_cache_in_variadic_generation_kwargs(


### PR DESCRIPTION
## Summary
- reindex Gemma 3n shared-KV cache dependencies after pipeline slicing
- slice rank-local per-layer input embeddings and projections for both quantized and unquantized MLX modules
- reject shard boundaries that would consume K/V owned by another rank instead of running incorrect attention

## Why
The configured-fleet release battery found a deterministic two-rank Gemma 3n warmup crash: a shared layer read an empty rotating cache because full-model indices survived pipeline slicing. The same drift also selected the wrong per-layer input blocks.

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (2948 passed, 1 skipped, 228 deselected)
- focused regression covers unquantized and 4-bit quantized layouts plus unsafe shard rejection