### PR TITLE
fix(mlx): align Qwen3-VL deepstack across pipeline ranks

### DIFF
--- a/src/skulk/worker/engines/mlx/auto_parallel.py
+++ b/src/skulk/worker/engines/mlx/auto_parallel.py
@@ -822,6 +822,49 @@ def _slice_gemma3n_pipeline_state(
     )
 
 
+def _slice_qwen3_vl_deepstack_inputs(
+    inner_model_instance: nn.Module,
+    start_layer: int,
+    end_layer: int,
+) -> None:
+    """Align Qwen3-VL deep-stack image features with rank-local layer indices.
+
+    MLX-VLM enumerates the trunk's current ``layers`` list from zero and adds
+    ``deepstack_visual_embeds[layer_idx]`` to each matching layer. Pipeline
+    slicing also renumbers every rank's local layer list from zero, so without
+    this adapter every later rank injects the image features again into the
+    wrong global layers. The adapter slices the per-layer feature list by the
+    rank's original global range before the upstream trunk consumes it.
+    """
+    if not _is_qwen3_vl_pipeline_trunk(inner_model_instance):
+        return
+
+    inner_model_instance._skulk_deepstack_start_layer = start_layer
+    inner_model_instance._skulk_deepstack_end_layer = end_layer
+    cls = inner_model_instance.__class__
+    if getattr(cls, "_skulk_deepstack_pipeline_patched", False):
+        return
+
+    original_call = cls.__call__
+    call_signature = signature(original_call)
+
+    def patched_call(
+        self: object,
+        *args: object,
+        **kwargs: object,
+    ) -> mx.array:
+        bound = call_signature.bind_partial(self, *args, **kwargs)
+        deepstack = bound.arguments.get("deepstack_visual_embeds")
+        if deepstack is not None:
+            start = cast(int, self._skulk_deepstack_start_layer)  # type: ignore[attr-defined]
+            end = cast(int, self._skulk_deepstack_end_layer)  # type: ignore[attr-defined]
+            bound.arguments["deepstack_visual_embeds"] = deepstack[start:end]
+        return original_call(*bound.args, **bound.kwargs)  # type: ignore[misc]
+
+    cls.__call__ = patched_call
+    cls._skulk_deepstack_pipeline_patched = True  # type: ignore[attr-defined]
+
+
 def pipeline_auto_parallel(
     model: nn.Module,
     group: mx.distributed.Group,
@@ -913,6 +956,11 @@ def pipeline_auto_parallel(
             )
 
     _slice_gemma3n_pipeline_state(
+        inner_model_instance,
+        start_layer,
+        end_layer,
+    )
+    _slice_qwen3_vl_deepstack_inputs(
         inner_model_instance,
         start_layer,
         end_layer,
@@ -1263,6 +1311,14 @@ def _is_native_qwen_vlm_language_model(model: nn.Module) -> bool:
     }:
         return True
     return type(model).__name__ in {"Qwen3_5Model", "Qwen3_5MoeModel"}
+
+
+def _is_qwen3_vl_pipeline_trunk(model: nn.Module) -> bool:
+    """Return whether ``model`` owns Qwen3-VL's deep-stack language layers."""
+    return (
+        type(model).__module__.startswith("mlx_vlm.models.qwen3_vl.language")
+        and type(model).__name__ == "Qwen3VLModel"
+    )
 
 
 class TensorParallelShardingStrategy(ABC):

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vlm_model_loading.py
@@ -96,6 +96,45 @@ class _VlmWithPipelineLanguage(nn.Module):
         self.language_model = _NativeQwenPipelineLanguageModel(layer_types)
 
 
+class _Qwen3VlPipelineTrunk(nn.Module):
+    """Qwen3-VL-shaped trunk that records rank-local deep-stack inputs."""
+
+    __module__ = "mlx_vlm.models.qwen3_vl.language"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = [SimpleNamespace() for _ in range(8)]
+        self.received_deepstack: object | None = None
+
+    def __call__(
+        self,
+        _inputs: object,
+        *,
+        deepstack_visual_embeds: object | None = None,
+    ) -> mx.array:
+        self.received_deepstack = deepstack_visual_embeds
+        return mx.zeros((1, 1, 4))
+
+
+_Qwen3VlPipelineTrunk.__name__ = "Qwen3VLModel"
+
+
+class _Qwen3VlPipelineLanguageModel(nn.Module):
+    """Language wrapper owning a Qwen3-VL deep-stack trunk."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = _Qwen3VlPipelineTrunk()
+
+
+class _VlmWithQwen3VlPipelineLanguage(nn.Module):
+    """Native Qwen3-VL wrapper used to verify deep-stack layer alignment."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.language_model = _Qwen3VlPipelineLanguageModel()
+
+
 class _Gemma3nPipelineTrunk(nn.Module):
     """Gemma 3n-shaped trunk with shared caches and layer-specific inputs."""
 
@@ -515,6 +554,54 @@ def test_pipeline_reindexes_native_qwen_hybrid_cache(
     assert len(inner.layers) == 3
     assert inner.ssm_idx == 0
     assert inner.fa_idx == 1
+
+
+def test_pipeline_slices_qwen3_vl_deepstack_inputs_by_global_layer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Later Qwen3-VL ranks must not reinject early-layer image features."""
+    model = _VlmWithQwen3VlPipelineLanguage()
+    shard = SimpleNamespace(
+        start_layer=4,
+        end_layer=8,
+        device_rank=1,
+        world_size=2,
+    )
+
+    def _ignore_eval(*_args: object) -> None:
+        return None
+
+    def _identity_layer(
+        layer: object, *_args: object, **_kwargs: object
+    ) -> object:
+        return layer
+
+    def _identity_pipeline(
+        patched_model: nn.Module, _group: object
+    ) -> nn.Module:
+        return patched_model
+
+    monkeypatch.setattr(auto_parallel.mx, "eval", _ignore_eval)
+    monkeypatch.setattr(auto_parallel, "PipelineFirstLayer", _identity_layer)
+    monkeypatch.setattr(auto_parallel, "PipelineLastLayer", _identity_layer)
+    monkeypatch.setattr(
+        auto_parallel,
+        "patch_pipeline_model",
+        _identity_pipeline,
+    )
+
+    auto_parallel.pipeline_auto_parallel(
+        model,
+        cast(mx.distributed.Group, cast(object, SimpleNamespace())),
+        cast(PipelineShardMetadata, cast(object, shard)),
+        on_layer_loaded=None,
+    )
+
+    deepstack = ["layer-0", "layer-1", "layer-2", "layer-3", "layer-4"]
+    inner = model.language_model.model
+    inner(object(), deepstack_visual_embeds=deepstack)
+
+    assert inner.received_deepstack == ["layer-4"]
 
 
 @pytest.mark.parametrize("quantized", [False, True])


### PR DESCRIPTION
## Summary
- slice Qwen3-VL deep-stack visual embeddings by each pipeline rank’s original global layer range
- prevent later ranks from reinjecting early-layer image features after local layer renumbering
- add focused regression coverage for a later pipeline rank

## Evidence
A configured-fleet comparison showed the same Qwen3-VL model produced a semantically relevant image answer on one rank but newline-only output on a two-rank pipeline. Inspection of the upstream trunk showed deep-stack features are indexed against the locally sliced layer list, causing duplicate injection on later ranks.

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt` (0 changed)
- `uv run pytest` (2949 passed, 1 skipped, 228 deselected)