### PR TITLE
Fix VLM position state after startup warmup

### DIFF
--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -2895,6 +2895,7 @@ def mlx_generate(
             "Using pipeline-aware native vision generation path on fixed "
             "mlx/mlx-vlm stack"
         )
+        _reset_native_vision_position_state(model)
         record_runner_phase(
             "vision_preprocess",
             event="pipeline_native_vision_path_selected",

--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -2281,6 +2281,22 @@ def extract_top_logprobs(
     return selected_logprob, top_logprob_items
 
 
+def _reset_native_vision_position_state(model: Model) -> None:
+    """Clear request-local multimodal RoPE state retained by upstream models.
+
+    Qwen VLM language models cache position IDs and RoPE deltas on the model
+    object. Skulk's text-only startup warmup populates those fields before the
+    first user request, while MLX-VLM's direct generation path starts from a
+    fresh model. Clear the cache at each native multimodal request boundary so
+    image generation cannot inherit text or prior-image coordinates.
+    """
+
+    language_model = getattr(model, "language_model", model)
+    for attribute_name in ("_position_ids", "_rope_deltas"):
+        if hasattr(language_model, attribute_name):
+            object.__setattr__(language_model, attribute_name, None)
+
+
 def _mlx_generate_native_vision(
     model: Model,
     tokenizer: TokenizerWrapper,
@@ -2351,6 +2367,7 @@ def _mlx_generate_native_vision(
 
     logger.info(f"Native decode context: {decode_context}")
     logger.info("Starting native mlx-vlm multimodal decode")
+    _reset_native_vision_position_state(model)
     with (
         runner_phase(
             "decode_barrier",

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -238,6 +238,75 @@ def test_native_vision_generation_uses_mlx_vlm_generate_step(
     assert responses[-1].usage.completion_tokens == 2
 
 
+def test_native_vision_clears_position_state_left_by_text_warmup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A text warmup must not contaminate the first multimodal request."""
+
+    class _StatefulLanguageModel:
+        def __init__(self) -> None:
+            self._position_ids: object | None = object()
+            self._rope_deltas: object | None = object()
+
+        @property
+        def position_state(self) -> object | None:
+            return self._position_ids
+
+        @property
+        def rope_state(self) -> object | None:
+            return self._rope_deltas
+
+    class _StatefulVisionModel:
+        def __init__(self) -> None:
+            self.language_model = _StatefulLanguageModel()
+
+    model = _StatefulVisionModel()
+
+    def _fake_generate_step(**_kwargs: object):
+        assert model.language_model.position_state is None
+        assert model.language_model.rope_state is None
+        yield mx.array(999), mx.zeros((8,))
+
+    monkeypatch.setattr(
+        import_module("mlx_vlm.generate"),
+        "generate_step",
+        _fake_generate_step,
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/Qwen3-VL-4B-Instruct-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[],
+        pixel_values=mx.array([1.0]),
+        image_grid_thw=mx.array([[1, 2, 3]]),
+    )
+
+    responses = list(
+        _mlx_generate_native_vision_fn()(
+            model=cast(Model, cast(object, model)),
+            tokenizer=_fake_tokenizer(),
+            task=task,
+            all_prompt_tokens=vision.prompt_tokens,
+            vision=vision,
+            sampler=_identity_sampler,
+            logits_processors=[],
+            on_prefill_progress=None,
+            on_generation_token=None,
+            group=None,
+            max_tokens=8,
+        )
+    )
+
+    assert responses[-1].finish_reason == "stop"
+
+
 @pytest.mark.parametrize(
     ("group", "reference_path_enabled"),
     [

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -126,6 +126,22 @@ class _FakeGroup:
         return self._size
 
 
+class _FakePositionState:
+    """Mutable upstream position state used to simulate a completed warmup."""
+
+    def __init__(self) -> None:
+        self._position_ids: object | None = object()
+        self._rope_deltas: object | None = object()
+
+    @property
+    def position_state(self) -> object | None:
+        return self._position_ids
+
+    @property
+    def rope_state(self) -> object | None:
+        return self._rope_deltas
+
+
 def _fake_group(*, size: int = 3) -> mx.distributed.Group:
     return cast(mx.distributed.Group, cast(object, _FakeGroup(size=size)))
 
@@ -243,22 +259,9 @@ def test_native_vision_clears_position_state_left_by_text_warmup(
 ) -> None:
     """A text warmup must not contaminate the first multimodal request."""
 
-    class _StatefulLanguageModel:
-        def __init__(self) -> None:
-            self._position_ids: object | None = object()
-            self._rope_deltas: object | None = object()
-
-        @property
-        def position_state(self) -> object | None:
-            return self._position_ids
-
-        @property
-        def rope_state(self) -> object | None:
-            return self._rope_deltas
-
     class _StatefulVisionModel:
         def __init__(self) -> None:
-            self.language_model = _StatefulLanguageModel()
+            self.language_model = _FakePositionState()
 
     model = _StatefulVisionModel()
 
@@ -1430,6 +1433,7 @@ def test_mlx_generate_full_prefills_distributed_single_native_image(
 
     class _FakeModel:
         def __init__(self) -> None:
+            self.language_model = _FakePositionState()
             self.pixel_values: mx.array | None = None
             self.saw_non_none_pixel_values = False
 
@@ -1450,6 +1454,8 @@ def test_mlx_generate_full_prefills_distributed_single_native_image(
         *_args: object,
         **_kwargs: object,
     ) -> tuple[float, int, list[CacheSnapshot]]:
+        assert model.language_model.position_state is None
+        assert model.language_model.rope_state is None
         assert model.pixel_values is not None
         assert model.pixel_values.tolist() == [[10.0]]
         assert prompt_tokens.tolist() == [1, 2, 3, 4, 5, 6, 7]


### PR DESCRIPTION
## Summary
- clear request-local multimodal RoPE state before native image generation
- prevent the text-only startup warmup from contaminating the first Qwen VLM request
- add focused regression coverage for warmup-retained position state

## Root cause
Qwen VLM language models retain position IDs and RoPE deltas on the model object. Skulk's startup warmup populated those fields with a text prompt before the first user image request. The native MLX-VLM generation path then inherited stale coordinates and could return visually plausible but incorrect OCR.

## Validation
- focused native-vision tests: 30 passed
- strict type checking: clean
- lint: clean
- formatter: clean
- full test suite: 2,950 passed, 1 skipped
- live configured-fleet semantic vision qualification: exact hidden code, color, and shape all passed on a one-node Apple placement after normal startup warmup
