### PR TITLE
Fix distributed Qwen3-VL vision prefill

### DIFF
--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -284,6 +284,20 @@ def _should_use_native_vision_reference_path() -> bool:
     )
 
 
+def _native_vision_model_requires_reference_path(model: Model) -> bool:
+    """Return whether a model needs family-aware native-vision prefill.
+
+    Qwen3-VL's distributed generic ``mlx_lm`` prefill produces different
+    logits from MLX-VLM's reference embedding path even on the fixed upstream
+    stack. Keep this family on the reference path for correctness while other
+    native VLMs retain Skulk's optimized distributed pipeline.
+    """
+
+    config = getattr(model, "config", None)
+    model_type = cast(str | None, getattr(config, "model_type", None))
+    return model_type == "qwen3_vl"
+
+
 def _native_pixel_values_debug_state(
     pixel_values: mx.array | list[mx.array] | None,
 ) -> str:
@@ -2849,6 +2863,7 @@ def mlx_generate(
             group is None
             or group.size() <= 1
             or _should_use_native_vision_reference_path()
+            or _native_vision_model_requires_reference_path(model)
         ):
             if kv_prefix_cache is not None:
                 logger.info(

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -47,6 +47,14 @@ def _should_use_native_vision_reference_path_fn() -> Callable[[], bool]:
     )
 
 
+def _native_vision_model_requires_reference_path_fn() -> Callable[[Model], bool]:
+    module_dict = cast(dict[str, object], generate_module.__dict__)
+    return cast(
+        Callable[[Model], bool],
+        module_dict["_native_vision_model_requires_reference_path"],
+    )
+
+
 def _slice_native_pixel_values_fn() -> Callable[
     [mx.array | list[mx.array], list[MediaRegion], int],
     mx.array | list[mx.array] | None,
@@ -942,6 +950,33 @@ def test_native_vision_reference_path_keeps_prereleases_on_safe_path(
     )
 
     assert _should_use_native_vision_reference_path_fn()() is True
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected"),
+    [
+        ("qwen3_vl", True),
+        ("gemma4", False),
+        (None, False),
+    ],
+)
+def test_qwen3_vl_requires_family_aware_reference_path(
+    model_type: str | None,
+    expected: bool,
+) -> None:
+    """Only Qwen3-VL bypasses generic distributed native-vision prefill."""
+
+    class _Config:
+        def __init__(self, configured_model_type: str | None) -> None:
+            self.model_type = configured_model_type
+
+    class _Model:
+        def __init__(self, configured_model_type: str | None) -> None:
+            self.config = _Config(configured_model_type)
+
+    model = cast(Model, cast(object, _Model(model_type)))
+
+    assert _native_vision_model_requires_reference_path_fn()(model) is expected
 
 
 def test_slice_native_pixel_values_for_uncached_suffix_drops_cached_images() -> None:


### PR DESCRIPTION
## Summary

- route Qwen3-VL native-vision requests through MLX-VLM's family-aware reference prefill on distributed placements
- retain the optimized generic distributed path for other native VLM families
- add focused model-family routing coverage

## Why

The generic distributed native-vision prefill diverges from MLX-VLM before normal decode begins for Qwen3-VL, producing incorrect logits even though image transport, placement, and preprocessing succeed. The family-aware reference path preserves the correct multimodal embeddings and positions.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt` (0 changed)
- `uv run pytest` (2953 passed, 1 skipped, 228 deselected)
- live two-rank Pipeline qualification through both colocated and remote API-owner routes: 1/1 passed, 0 issues; both responses identified the exact hidden code, color, and shape
