### PR TITLE
Prevent remote dashboard auto-open

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,9 @@ uv run skulk
 ```
 
 This starts the dashboard and API at `http://localhost:52415`.
+On the first run from a local interactive terminal, Skulk opens that URL in
+your default browser. SSH, redirected, and service launches print the URL
+without opening a browser.
 
 ### 3. Open the Dashboard
 

--- a/src/skulk/utils/banner.py
+++ b/src/skulk/utils/banner.py
@@ -8,6 +8,7 @@ from skulk.shared.constants import SKULK_CONFIG_HOME
 logger = logging.getLogger(__name__)
 
 _FIRST_RUN_MARKER = SKULK_CONFIG_HOME / ".dashboard_opened"
+_SSH_ENVIRONMENT_VARIABLES = ("SSH_CLIENT", "SSH_CONNECTION", "SSH_TTY")
 
 
 def _is_first_run() -> bool:
@@ -19,7 +20,34 @@ def _mark_first_run_done() -> None:
     _FIRST_RUN_MARKER.touch()
 
 
+def _should_open_dashboard() -> bool:
+    """Return whether this process should open the dashboard in a GUI browser.
+
+    Browser auto-open is reserved for a local interactive terminal. Remote SSH
+    commands and non-interactive service or qualification launches can still
+    have access to a logged-in macOS GUI session, where ``webbrowser.open``
+    would otherwise accumulate tabs in the user's desktop browser.
+    """
+
+    return (
+        not os.environ.get("SKULK_RUNTIME_DIR")
+        and not any(os.environ.get(name) for name in _SSH_ENVIRONMENT_VARIABLES)
+        and sys.stderr.isatty()
+    )
+
+
 def print_startup_banner(port: int) -> None:
+    """Print the startup banner and open the dashboard on local first runs.
+
+    Args:
+        port: Local HTTP port serving the Skulk dashboard.
+
+    Side effects:
+        Writes the banner to stderr, may open the dashboard in the default
+        browser for an interactive local first run, and records that first-run
+        handling has completed.
+    """
+
     dashboard_url = f"http://localhost:{port}"
     first_run = _is_first_run()
     banner = f"""
@@ -51,13 +79,11 @@ def print_startup_banner(port: int) -> None:
 
     print(banner, file=sys.stderr)
 
+    if first_run and _should_open_dashboard():
+        try:
+            webbrowser.open(dashboard_url)
+            logger.info("First run detected — opening dashboard in browser")
+        except Exception:
+            logger.debug("Could not auto-open browser", exc_info=True)
     if first_run:
-        # Skip browser open when running inside the native macOS app —
-        # FirstLaunchPopout.swift handles the auto-open with a countdown.
-        if not os.environ.get("SKULK_RUNTIME_DIR"):
-            try:
-                webbrowser.open(dashboard_url)
-                logger.info("First run detected — opening dashboard in browser")
-            except Exception:
-                logger.debug("Could not auto-open browser", exc_info=True)
         _mark_first_run_done()

--- a/src/skulk/utils/tests/test_banner.py
+++ b/src/skulk/utils/tests/test_banner.py
@@ -1,0 +1,135 @@
+"""Tests for first-run dashboard browser behavior."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from skulk.utils import banner
+
+_SSH_ENVIRONMENT_VARIABLES = ("SSH_CLIENT", "SSH_CONNECTION", "SSH_TTY")
+
+
+class _TerminalStream(io.StringIO):
+    """In-memory stderr stream with configurable terminal behavior."""
+
+    def __init__(self, *, is_terminal: bool) -> None:
+        super().__init__()
+        self._is_terminal = is_terminal
+
+    def isatty(self) -> bool:
+        """Return the configured terminal state."""
+
+        return self._is_terminal
+
+
+def _prepare_first_run(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    is_terminal: bool,
+) -> tuple[Path, list[str]]:
+    """Prepare an isolated first run and capture browser-open attempts."""
+
+    marker = tmp_path / ".dashboard_opened"
+    opened_urls: list[str] = []
+    monkeypatch.setattr(banner, "_FIRST_RUN_MARKER", marker)
+    monkeypatch.setattr(banner.webbrowser, "open", opened_urls.append)
+    monkeypatch.setattr(
+        banner.sys,
+        "stderr",
+        _TerminalStream(is_terminal=is_terminal),
+    )
+    monkeypatch.delenv("SKULK_RUNTIME_DIR", raising=False)
+    for variable in _SSH_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(variable, raising=False)
+    return marker, opened_urls
+
+
+@pytest.mark.parametrize("ssh_variable", ["SSH_CLIENT", "SSH_CONNECTION", "SSH_TTY"])
+def test_should_not_open_dashboard_over_ssh(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    ssh_variable: str,
+) -> None:
+    marker, opened_urls = _prepare_first_run(
+        monkeypatch,
+        tmp_path,
+        is_terminal=True,
+    )
+    monkeypatch.setenv(ssh_variable, "present")
+
+    banner.print_startup_banner(52415)
+
+    assert marker.exists()
+    assert opened_urls == []
+
+
+def test_should_not_open_dashboard_without_interactive_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    marker, opened_urls = _prepare_first_run(
+        monkeypatch,
+        tmp_path,
+        is_terminal=False,
+    )
+
+    banner.print_startup_banner(52415)
+
+    assert marker.exists()
+    assert opened_urls == []
+
+
+def test_should_not_open_dashboard_inside_native_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    marker, opened_urls = _prepare_first_run(
+        monkeypatch,
+        tmp_path,
+        is_terminal=True,
+    )
+    monkeypatch.setenv("SKULK_RUNTIME_DIR", "/tmp/skulk-runtime")
+
+    banner.print_startup_banner(52415)
+
+    assert marker.exists()
+    assert opened_urls == []
+
+
+def test_should_open_dashboard_for_local_interactive_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    marker, opened_urls = _prepare_first_run(
+        monkeypatch,
+        tmp_path,
+        is_terminal=True,
+    )
+
+    banner.print_startup_banner(52415)
+
+    assert marker.exists()
+    assert opened_urls == ["http://localhost:52415"]
+
+
+def test_subsequent_run_never_opens_dashboard(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / ".dashboard_opened"
+    marker.touch()
+    opened_urls: list[str] = []
+    monkeypatch.setattr(banner, "_FIRST_RUN_MARKER", marker)
+    monkeypatch.setattr(banner.webbrowser, "open", opened_urls.append)
+    monkeypatch.setattr(banner.sys, "stderr", _TerminalStream(is_terminal=True))
+    monkeypatch.delenv("SKULK_RUNTIME_DIR", raising=False)
+    for variable in _SSH_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(variable, raising=False)
+
+    banner.print_startup_banner(52415)
+
+    assert opened_urls == []

--- a/website/docs/build-and-runtime.md
+++ b/website/docs/build-and-runtime.md
@@ -101,6 +101,9 @@ uv run skulk
 
 On macOS, this path uses the official `mlx` and `mlx-metal` wheel stack that
 the project pins in [pyproject.toml](https://github.com/Foxlight-Foundation/Skulk/blob/main/pyproject.toml).
+On the first run from a local interactive terminal, Skulk opens the dashboard
+in the default browser. SSH, redirected, and service launches still print the
+dashboard URL but do not open a GUI browser.
 
 That means the runtime path is the one most users and nodes should follow.
 


### PR DESCRIPTION
## Summary

- restrict first-run dashboard auto-open to a local interactive terminal
- suppress GUI browser launches from SSH, redirected, service, and native-app runtimes while still printing the dashboard URL
- retain the first-run marker even when auto-open is intentionally skipped
- document the startup behavior and add focused coverage for every launch context

## Root cause

Fresh-install qualification creates a new empty home on each run. Skulk treated
each run as a first launch and called `webbrowser.open`, which macOS routed into
the logged-in desktop Chrome session on the remote target. Repeated
qualification retries therefore accumulated live dashboard tabs and renderer
processes.

## User impact

Local users starting Skulk interactively still get the convenient first-run
browser open. Remote nodes, services, redirected commands, and automated
qualification runs no longer modify a logged-in user's GUI browser.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` (`2966 passed, 1 skipped, 228 deselected`)
