### PR TITLE
Fix runner shutdown completion race

### DIFF
--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -491,8 +491,7 @@ def stale_lifecycle_task_failures(
                     error_type="executor_lost",
                     error_message=(
                         "Lifecycle task outlived its instance with no "
-                        "surviving executor (node died mid-task and "
-                        "returned with a new identity)"
+                        "surviving executor"
                     ),
                 )
             )

--- a/src/skulk/master/tests/test_orphaned_task_failures.py
+++ b/src/skulk/master/tests/test_orphaned_task_failures.py
@@ -310,6 +310,7 @@ def test_stale_lifecycle_task_fails_only_after_grace() -> None:
     events = stale_lifecycle_task_failures(state, tracking, now=161.0)
     assert [e.task_id for e in events] == [task_id]
     assert events[0].error_type == "executor_lost"
+    assert "node died" not in events[0].error_message
     assert task_id not in tracking
 
 

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -1967,8 +1967,13 @@ class Worker:
                     # be retried), keep the files so the next runner can find them.
                     instance_deleted = task.instance_id not in self.state.instances
                     try:
-                        with fail_after(3):
-                            await runner.start_task(task)
+                        # Acknowledgement only means the subprocess received the
+                        # shutdown task. Wait for its terminal status before
+                        # cancelling the supervisor; otherwise cancellation can
+                        # close the event pipe between ACK and Complete, leaving
+                        # a permanently running lifecycle task in cluster state.
+                        with fail_after(15):
+                            await runner.start_task(task, wait_for_terminal=True)
                     except TimeoutError:
                         await self.event_sender.send(
                             TaskStatusUpdated(

--- a/src/skulk/worker/runner/bootstrap.py
+++ b/src/skulk/worker/runner/bootstrap.py
@@ -597,7 +597,10 @@ def entrypoint(
                 runner.main()
 
     except ClosedResourceError:
-        logger.warning("Runner communication closed unexpectedly")
+        # The parent intentionally closes IPC during bounded teardown. Actual
+        # runner failures take the exception path below and retain warning-level
+        # diagnostics, while a closed parent channel is normal shutdown noise.
+        logger.info("Runner communication closed during shutdown")
     except Exception as e:
         record_runner_phase(
             "error",

--- a/src/skulk/worker/runner/runner_supervisor.py
+++ b/src/skulk/worker/runner/runner_supervisor.py
@@ -150,6 +150,9 @@ class RunnerSupervisor:
     _tg: TaskGroup = field(default_factory=TaskGroup, init=False)
     status: RunnerStatus = field(default_factory=RunnerIdle, init=False)
     pending: dict[TaskId, anyio.Event] = field(default_factory=dict, init=False)
+    _terminal_waiters: dict[TaskId, anyio.Event] = field(
+        default_factory=dict, init=False
+    )
     in_progress: dict[TaskId, Task] = field(default_factory=dict, init=False)
     completed: set[TaskId] = field(default_factory=set, init=False)
     cancelled: set[TaskId] = field(default_factory=set, init=False)
@@ -511,7 +514,18 @@ class RunnerSupervisor:
         self._record_milestone("shutdown_requested")
         self._tg.cancel_tasks()
 
-    async def start_task(self, task: Task):
+    async def start_task(
+        self, task: Task, *, wait_for_terminal: bool = False
+    ) -> None:
+        """Submit a task and wait for its acknowledgement or terminal status.
+
+        Args:
+            task: Runner task to submit over the process boundary.
+            wait_for_terminal: When true, do not return after acknowledgement;
+                wait until the runner's terminal task status has been forwarded.
+                Shutdown uses this to prevent supervisor cancellation from racing
+                and dropping its completion event.
+        """
         if task.task_id in self.pending:
             logger.warning(
                 "Skipping invalid task "
@@ -527,6 +541,9 @@ class RunnerSupervisor:
         logger.info(f"Starting task {_summarize_task(task)}")
         event = anyio.Event()
         self.pending[task.task_id] = event
+        terminal_event = anyio.Event() if wait_for_terminal else None
+        if terminal_event is not None:
+            self._terminal_waiters[task.task_id] = terminal_event
         self.in_progress[task.task_id] = task
         # Record the owning API node so _emit can address this command's output
         # chunks to it over the Zenoh data plane (#279 Phase 2). Set before the
@@ -586,7 +603,9 @@ class RunnerSupervisor:
         try:
             await self._task_sender.send_async(task)
         except ClosedResourceError:
+            self.pending.pop(task.task_id, None)
             self.in_progress.pop(task.task_id, None)
+            self._terminal_waiters.pop(task.task_id, None)
             logger.warning(
                 f"Task {_summarize_task(task)} dropped, runner closed communication."
             )
@@ -595,7 +614,12 @@ class RunnerSupervisor:
                 f"{task.__class__.__name__}:{task.task_id}",
             )
             return
-        await event.wait()
+        try:
+            await event.wait()
+            if terminal_event is not None:
+                await terminal_event.wait()
+        finally:
+            self._terminal_waiters.pop(task.task_id, None)
 
     async def send_realtime_audio(self, frame: RealtimeAudioInputFrame) -> None:
         """Forward one bounded PCM frame to this runner process."""
@@ -722,6 +746,9 @@ class RunnerSupervisor:
                             await self._event_sender.send(
                                 TaskDeleted(task_id=event.task_id)
                             )
+                        terminal_waiter = self._terminal_waiters.get(event.task_id)
+                        if terminal_waiter is not None:
+                            terminal_waiter.set()
                         continue
                     # Catch-all: runner-produced events, including the per-token
                     # ChunkGenerated output, which _emit diverts to the data

--- a/src/skulk/worker/tests/unittests/test_runner/test_runner_supervisor.py
+++ b/src/skulk/worker/tests/unittests/test_runner/test_runner_supervisor.py
@@ -35,6 +35,7 @@ from skulk.shared.types.tasks import (
     AudioTranscription,
     ImageGeneration,
     RealtimeAudioTranscription,
+    Shutdown,
     SpeechSynthesis,
     Task,
     TaskId,
@@ -51,6 +52,7 @@ from skulk.shared.types.worker.runners import (
     RunnerFailed,
     RunnerId,
     RunnerRunning,
+    RunnerShuttingDown,
     ShardAssignments,
 )
 from skulk.shared.types.worker.shards import RpcDonorShardMetadata
@@ -84,6 +86,81 @@ class _DeadProcess:
 
     def kill(self) -> None:
         return None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_waits_for_terminal_status_after_acknowledgement() -> None:
+    """Shutdown completion must be forwarded before the supervisor can be cancelled."""
+
+    event_sender, _ = channel[Event](10)
+    task_sender, task_receiver = mp_channel[Task]()
+    cancel_sender, _ = mp_channel[TaskId]()
+    ev_send, ev_recv = mp_channel[Event]()
+    _, diag_recv = mp_channel[RunnerDiagnosticUpdate]()
+    bound_instance = get_bound_mlx_ring_instance(
+        instance_id=InstanceId("shutdown-instance"),
+        model_id=ModelId("mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runner_id=RunnerId("shutdown-runner"),
+        node_id=NodeId("shutdown-node"),
+    )
+    supervisor = RunnerSupervisor(
+        shard_metadata=bound_instance.bound_shard,
+        bound_instance=bound_instance,
+        runner_process=cast("mp.Process", cast(object, _DeadProcess())),
+        initialize_timeout=400,
+        _ev_recv=ev_recv,
+        _diag_recv=diag_recv,
+        _task_sender=task_sender,
+        _event_sender=event_sender,
+        _cancel_sender=cancel_sender,
+    )
+    supervisor.status = RunnerRunning()
+    task = Shutdown(
+        task_id=TaskId("shutdown-task"),
+        instance_id=bound_instance.instance.instance_id,
+        runner_id=bound_instance.bound_runner_id,
+    )
+    returned = anyio.Event()
+
+    async def submit_shutdown() -> None:
+        await supervisor.start_task(task, wait_for_terminal=True)
+        returned.set()
+
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(
+                supervisor._forward_events  # pyright: ignore[reportPrivateUsage]
+            )
+            task_group.start_soon(submit_shutdown)
+            dispatched = await to_thread.run_sync(task_receiver.receive_timeout, 1)
+            assert dispatched == task
+
+            ev_send.send(
+                RunnerStatusUpdated(
+                    runner_id=bound_instance.bound_runner_id,
+                    runner_status=RunnerShuttingDown(),
+                )
+            )
+            ev_send.send(TaskAcknowledged(task_id=task.task_id))
+            with anyio.move_on_after(0.05) as acknowledgement_only:
+                await returned.wait()
+            assert acknowledgement_only.cancel_called
+
+            ev_send.send(
+                TaskStatusUpdated(
+                    task_id=task.task_id,
+                    task_status=TaskStatus.Complete,
+                )
+            )
+            await returned.wait()
+            assert (
+                task.task_id
+                not in supervisor._terminal_waiters  # pyright: ignore[reportPrivateUsage]
+            )
+            task_group.cancel_scope.cancel()
+
+    ev_send.close()
+    event_sender.close()
 
 
 def test_trace_expected_ranks_excludes_rpc_memory_donors() -> None:


### PR DESCRIPTION
## Summary

- wait for a runner shutdown task's terminal status before cancelling its supervisor
- keep the existing bounded teardown timeout and clean waiter state on channel closure
- downgrade intentional parent-side IPC closure to normal shutdown logging
- remove the misleading assertion that every orphaned lifecycle task means a node died

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` (2,972 passed, 1 skipped)
- configured-fleet served-model cycle: placement, four generation checks, instance deletion, terminal shutdown state, process reaping, and zero residual instances/runners
