### PR TITLE
Fix Qwen3-VL post-vision text corruption

### DIFF
--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -2311,7 +2311,33 @@ def _reset_native_vision_position_state(model: Model) -> None:
             object.__setattr__(language_model, attribute_name, None)
 
 
-def _mlx_generate_native_vision(
+@contextlib.contextmanager
+def _isolated_native_vision_position_state(model: Model) -> Generator[None]:
+    """Isolate request-local multimodal RoPE state from later text requests.
+
+    Qwen VLM text generation relies on its retained zero RoPE delta when a
+    later request resumes from Skulk's text-only prefix cache. Native vision
+    must temporarily clear that state to calculate multimodal coordinates, but
+    leaving it cleared makes the next cached text suffix restart positions at
+    zero. Preserve the prior text state across the complete vision generator,
+    including cancellation and failure.
+    """
+
+    language_model = getattr(model, "language_model", model)
+    position_state = {
+        attribute_name: cast(object | None, getattr(language_model, attribute_name))
+        for attribute_name in ("_position_ids", "_rope_deltas")
+        if hasattr(language_model, attribute_name)
+    }
+    _reset_native_vision_position_state(model)
+    try:
+        yield
+    finally:
+        for attribute_name, attribute_value in position_state.items():
+            object.__setattr__(language_model, attribute_name, attribute_value)
+
+
+def _mlx_generate_native_vision_unisolated(
     model: Model,
     tokenizer: TokenizerWrapper,
     task: TextGenerationTaskParams,
@@ -2381,7 +2407,6 @@ def _mlx_generate_native_vision(
 
     logger.info(f"Native decode context: {decode_context}")
     logger.info("Starting native mlx-vlm multimodal decode")
-    _reset_native_vision_position_state(model)
     with (
         runner_phase(
             "decode_barrier",
@@ -2577,6 +2602,39 @@ def _mlx_generate_native_vision(
         _hang_debug_watch(f"native decode final barrier ({decode_context})"),
     ):
         mx_barrier(group)
+
+
+def _mlx_generate_native_vision(
+    model: Model,
+    tokenizer: TokenizerWrapper,
+    task: TextGenerationTaskParams,
+    all_prompt_tokens: mx.array,
+    vision: VisionResult,
+    max_tokens: int,
+    sampler: Callable[[mx.array], mx.array],
+    logits_processors: list[Callable[[mx.array, mx.array], mx.array]],
+    on_prefill_progress: Callable[[int, int], None] | None,
+    on_generation_token: Callable[[], None] | None,
+    group: mx.distributed.Group | None,
+    trace_task_id: str | None = None,
+) -> Generator[GenerationResponse]:
+    """Generate native vision without leaking multimodal position state."""
+
+    with _isolated_native_vision_position_state(model):
+        yield from _mlx_generate_native_vision_unisolated(
+            model=model,
+            tokenizer=tokenizer,
+            task=task,
+            all_prompt_tokens=all_prompt_tokens,
+            vision=vision,
+            max_tokens=max_tokens,
+            sampler=sampler,
+            logits_processors=logits_processors,
+            on_prefill_progress=on_prefill_progress,
+            on_generation_token=on_generation_token,
+            group=group,
+            trace_task_id=trace_task_id,
+        )
 
 
 def mlx_generate(

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -138,8 +138,8 @@ class _FakePositionState:
     """Mutable upstream position state used to simulate a completed warmup."""
 
     def __init__(self) -> None:
-        self._position_ids: object | None = object()
-        self._rope_deltas: object | None = object()
+        self._position_ids: object | None = mx.arange(64)[None]
+        self._rope_deltas: object | None = mx.zeros((1, 1))
 
     @property
     def position_state(self) -> object | None:
@@ -148,6 +148,13 @@ class _FakePositionState:
     @property
     def rope_state(self) -> object | None:
         return self._rope_deltas
+
+    def cached_suffix_start(self, cache_offset: int) -> int:
+        """Return the next position that Qwen assigns to a cached text suffix."""
+        if self._rope_deltas is None:
+            return 0
+        rope_deltas = cast(mx.array, self._rope_deltas)
+        return cache_offset + int(rope_deltas.item())
 
 
 def _fake_group(*, size: int = 3) -> mx.distributed.Group:
@@ -262,16 +269,19 @@ def test_native_vision_generation_uses_mlx_vlm_generate_step(
     assert responses[-1].usage.completion_tokens == 2
 
 
-def test_native_vision_clears_position_state_left_by_text_warmup(
+def test_text_vision_text_restores_cached_suffix_position_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A text warmup must not contaminate the first multimodal request."""
+    """Vision must not reset the cached suffix position of the next text request."""
 
     class _StatefulVisionModel:
         def __init__(self) -> None:
             self.language_model = _FakePositionState()
 
     model = _StatefulVisionModel()
+    original_position_state = model.language_model.position_state
+    original_rope_state = model.language_model.rope_state
+    assert model.language_model.cached_suffix_start(19) == 19
 
     def _fake_generate_step(**_kwargs: object):
         assert model.language_model.position_state is None
@@ -316,6 +326,70 @@ def test_native_vision_clears_position_state_left_by_text_warmup(
     )
 
     assert responses[-1].finish_reason == "stop"
+    assert model.language_model.position_state is original_position_state
+    assert model.language_model.rope_state is original_rope_state
+    assert model.language_model.cached_suffix_start(19) == 19
+
+
+def test_native_vision_restores_text_position_state_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed image request must not corrupt the next cached text request."""
+
+    class _StatefulVisionModel:
+        def __init__(self) -> None:
+            self.language_model = _FakePositionState()
+
+    model = _StatefulVisionModel()
+    original_position_state = model.language_model.position_state
+    original_rope_state = model.language_model.rope_state
+
+    def _failing_generate_step(**_kwargs: object):
+        assert model.language_model.position_state is None
+        assert model.language_model.rope_state is None
+        raise RuntimeError("native vision decode failed")
+        yield mx.array(999), mx.zeros((8,))
+
+    monkeypatch.setattr(
+        import_module("mlx_vlm.generate"),
+        "generate_step",
+        _failing_generate_step,
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/Qwen3-VL-4B-Instruct-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[],
+        pixel_values=mx.array([1.0]),
+        image_grid_thw=mx.array([[1, 2, 3]]),
+    )
+
+    with pytest.raises(RuntimeError, match="native vision decode failed"):
+        list(
+            _mlx_generate_native_vision_fn()(
+                model=cast(Model, cast(object, model)),
+                tokenizer=_fake_tokenizer(),
+                task=task,
+                all_prompt_tokens=vision.prompt_tokens,
+                vision=vision,
+                sampler=_identity_sampler,
+                logits_processors=[],
+                on_prefill_progress=None,
+                on_generation_token=None,
+                group=None,
+                max_tokens=8,
+            )
+        )
+
+    assert model.language_model.position_state is original_position_state
+    assert model.language_model.rope_state is original_rope_state
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- preserve Qwen VLM text position state across native vision generation
- restore the saved state on completion, cancellation, or failure
- add a regression covering text prefix-cache state across `text -> vision -> text`

## Root cause

Qwen3-VL retains `_position_ids` and `_rope_deltas` on its reusable language
model. Skulk correctly cleared those fields before native multimodal generation,
but left them cleared afterward. When the next independent text request resumed
from Skulk's text-only prefix cache, the missing RoPE delta made the uncached
suffix restart at position zero instead of the cache offset. The resulting
generation degraded into deterministic repetition.

The fix makes native vision position state request-scoped: save the prior text
state, clear it for multimodal coordinate calculation, and restore it in a
`finally` boundary.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` — 2,973 passed, 1 skipped
- focused native-vision suite — 34 passed

No public API or architectural contract changed, so no documentation update is
required.
