### PR TITLE
Intelligent fabric Phase 1: the resident steward (observe/advise)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,22 @@ A model card's `placement.compatible_backends` selects which engine serves it
   `AcceleratorMetrics.compute_capability` (+ `native_fp4`/`native_fp8`, via NVML)
   is the capability signal for keying placement on GPU generation, not vendor.
 
+### Intelligent fabric (steward)
+Optional resident operator assistant, config-gated (`intelligent_fabric` in
+skulk.yaml, default off). Identity = `BaseInstance.system_role` flagged
+placement (additive schema field); the master's `_maintain_steward_placement`
+planning-tick invariant keeps exactly one steward placed from the
+`steward_models` preference list (Qwen3.5-4B MLX/GGUF cards), tears down
+duplicates, and inherits failover from election since the invariant re-runs
+on every tick. Repair builders re-stamp `system_role` (same pattern as #658
+exclusions). `TextGeneration.target_instance_id` pins generation to one
+instance (mirrors SpeechSynthesis). Harness = `src/skulk/api/steward.py`:
+bounded read-only tools (state/resources/telemetry/data-plane/versions/
+envelopes/doctor/catalog), 8 steps per turn, observe/advise only, rides the
+normal chat dispatch path. Endpoints `GET /v1/steward` + `POST
+/v1/steward/chat`; ordinary deletion of the steward is refused while the
+mode is on; the dashboard hides `systemRole` instances.
+
 ### Message Flow
 Components communicate via typed pub/sub topics (src/skulk/routing/topics.py):
 - `GLOBAL_EVENTS`: Master broadcasts indexed events to all workers

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -449,6 +449,15 @@ export function App() {
   const instanceCards = useMemo<InstanceCardData[]>(() => {
     const cards: InstanceCardData[] = [];
     for (const [iid, inst] of Object.entries(instances)) {
+      // Fabric-maintained system placements (the intelligent-fabric steward)
+      // are not user instances: they are hidden here, which covers the
+      // Active Instances panel, the chat model picker, and instance counts
+      // in one place. The steward is reachable through its own chat surface.
+      const innerAny =
+        inst.MlxRingInstance ?? inst.MlxJacclInstance ?? inst.LlamaRpcInstance;
+      if (innerAny?.systemRole) {
+        continue;
+      }
       // Instance is a tagged union: MlxRing / MlxJaccl (in-process) and
       // LlamaRpc (pooled multi-node GGUF, #328). Handling only the first two
       // silently dropped every pooled instance from the Active Instances panel.

--- a/dashboard-react/src/App.tsx
+++ b/dashboard-react/src/App.tsx
@@ -13,7 +13,7 @@ const HeaderAnchor = styled.div`
 `;
 import { ThemeProvider } from 'styled-components';
 import { darkTheme, lightTheme, GlobalStyle } from './theme';
-import { useClusterState } from './hooks/useClusterState';
+import { useClusterState, type RawInstances } from './hooks/useClusterState';
 import { HeaderNav } from './components/layout/HeaderNav';
 import { MobileMenuSheet } from './components/layout/MobileMenuSheet';
 import { useIsMobile, MOBILE_BREAKPOINT_PX } from './hooks/useMediaQuery';
@@ -446,18 +446,26 @@ export function App() {
   }, [storeDownloads]);
 
   // Derive instance card data for the right panel
-  const instanceCards = useMemo<InstanceCardData[]>(() => {
-    const cards: InstanceCardData[] = [];
+  // Fabric-maintained system placements (the intelligent-fabric steward)
+  // are not user instances: filtering at the source hides them from every
+  // consumer at once (instance cards, chat picker, model-store page,
+  // placement views). The steward is reachable through its own chat surface.
+  const visibleInstances = useMemo<RawInstances>(() => {
+    const filtered: RawInstances = {};
     for (const [iid, inst] of Object.entries(instances)) {
-      // Fabric-maintained system placements (the intelligent-fabric steward)
-      // are not user instances: they are hidden here, which covers the
-      // Active Instances panel, the chat model picker, and instance counts
-      // in one place. The steward is reachable through its own chat surface.
-      const innerAny =
+      const inner =
         inst.MlxRingInstance ?? inst.MlxJacclInstance ?? inst.LlamaRpcInstance;
-      if (innerAny?.systemRole) {
+      if (inner?.systemRole) {
         continue;
       }
+      filtered[iid] = inst;
+    }
+    return filtered;
+  }, [instances]);
+
+  const instanceCards = useMemo<InstanceCardData[]>(() => {
+    const cards: InstanceCardData[] = [];
+    for (const [iid, inst] of Object.entries(visibleInstances)) {
       // Instance is a tagged union: MlxRing / MlxJaccl (in-process) and
       // LlamaRpc (pooled multi-node GGUF, #328). Handling only the first two
       // silently dropped every pooled instance from the Active Instances panel.
@@ -583,7 +591,7 @@ export function App() {
       });
     }
     return cards;
-  }, [instances, runners, topology, t]);
+  }, [visibleInstances, runners, topology, t]);
 
   const hasInstances = instanceCards.length > 0;
 
@@ -680,7 +688,7 @@ export function App() {
                 topology={topology}
                 downloads={downloads}
                 nodeDisk={nodeDisk}
-                instances={instances}
+                instances={visibleInstances}
                 runners={runners}
                 onChat={(modelId) => { dispatch(chatActions.selectModel(modelId)); setActiveRoute('chat'); }}
               />

--- a/dashboard-react/src/components/pages/OperatorPage.tsx
+++ b/dashboard-react/src/components/pages/OperatorPage.tsx
@@ -459,7 +459,16 @@ export function OperatorPage() {
   }
 
   // Cluster-level summary stats
-  const instanceCount = data?.instances ? Object.keys(data.instances).length : 0;
+  // Fabric-maintained system placements (systemRole set, e.g. the
+  // intelligent-fabric steward) are hidden from operator instance counts,
+  // matching every other instance surface.
+  const instanceCount = data?.instances
+    ? Object.values(data.instances).filter((inst) => {
+        const inner =
+          inst.MlxRingInstance ?? inst.MlxJacclInstance ?? inst.LlamaRpcInstance;
+        return !inner?.systemRole;
+      }).length
+    : 0;
   const runnerCount = data?.runners ? Object.keys(data.runners).length : 0;
   const nodeCount = nodes.length;
 

--- a/dashboard-react/src/hooks/useClusterState.ts
+++ b/dashboard-react/src/hooks/useClusterState.ts
@@ -301,6 +301,12 @@ export interface RawShardAssignments {
 export interface RawInstanceInner {
   instanceId?: string;
   shardAssignments?: RawShardAssignments;
+  /**
+   * Fabric-maintained system placement marker ("steward" = the
+   * intelligent-fabric resident). System placements are hidden from
+   * ordinary instance surfaces; the steward has its own chat surface.
+   */
+  systemRole?: string | null;
 }
 
 export type RawInstances = Record<

--- a/resources/inference_model_cards/mlx-community--Qwen3.5-4B-MLX-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3.5-4B-MLX-4bit.toml
@@ -1,0 +1,39 @@
+# Qwen3.5-4B (dense) MLX 4-bit, quantized from the instruct model. The
+# intelligent-fabric steward's full-brain artifact on Apple nodes, and a
+# general small chat/agent model. Architecture from config.json text_config
+# (arch qwen3_5: 32 layers, hidden 2560, 4 KV heads, 262144 ctx; hybrid
+# linear attention keeps the KV cache small at long context). Natively
+# multimodal (early-fusion VLM): the MLX vision path splices image
+# embeddings at image_token_id, so the [vision] block is load-bearing.
+# No [runtime] MTP block: no FoxlightAI 4B MTP sidecar exists yet.
+model_id = "mlx-community/Qwen3.5-4B-MLX-4bit"
+n_layers = 32
+hidden_size = 2560
+num_key_value_heads = 4
+supports_tensor = true
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "4bit"
+base_model = "Qwen3.5 4B"
+capabilities = ["text", "thinking", "thinking_toggle", "vision"]
+context_length = 262144
+
+[reasoning]
+supports_toggle = true
+format = "token_delimited"
+default_effort = "medium"
+disabled_effort = "none"
+
+[tooling]
+supports_tool_calling = true
+tool_call_format = "generic"
+
+[modalities]
+supports_native_multimodal = true
+
+[vision]
+image_token_id = 248056
+model_type = "qwen3_5"
+
+[storage_size]
+in_bytes = 3061170176

--- a/resources/inference_model_cards/unsloth--Qwen3.5-4B-GGUF.toml
+++ b/resources/inference_model_cards/unsloth--Qwen3.5-4B-GGUF.toml
@@ -1,0 +1,39 @@
+# Qwen3.5-4B (dense) GGUF Q4_K_M, quantized from the instruct model. The
+# intelligent-fabric steward's full-brain artifact on GPU/Linux nodes, and a
+# general small chat/agent model for GGUF lanes. Architecture matches the
+# MLX card (arch qwen3_5: 32 layers, hidden 2560, 4 KV heads, 262144 ctx).
+# Text-only through Skulk: the base model is natively multimodal, but the
+# served llama_server runner does not load the mmproj projector, and this
+# card deliberately omits vision so placement can route it to served lanes
+# (vision cards are gated to in-process engines by platform truth).
+# supports_tensor = false: single-node on either GGUF engine.
+model_id = "unsloth/Qwen3.5-4B-GGUF"
+n_layers = 32
+hidden_size = 2560
+num_key_value_heads = 4
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "Q4_K_M"
+base_model = "Qwen3.5 4B"
+capabilities = ["text", "thinking", "thinking_toggle"]
+context_length = 262144
+gguf_file = "Qwen3.5-4B-Q4_K_M.gguf"
+trust_remote_code = false
+
+[reasoning]
+supports_toggle = true
+format = "token_delimited"
+default_effort = "medium"
+disabled_effort = "none"
+
+[tooling]
+supports_tool_calling = true
+tool_call_format = "generic"
+
+[placement]
+compatible_backends = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_server-cpu", "llama_cpp-vulkan", "llama_cpp-cpu"]
+backend_preference = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_cpp-vulkan", "llama_server-cpu", "llama_cpp-cpu"]
+
+[storage_size]
+in_bytes = 2740937888

--- a/skulk.yaml.example
+++ b/skulk.yaml.example
@@ -86,3 +86,15 @@ logging:
 # Optional Hugging Face token.
 # The dashboard Settings UI can manage this too.
 # hf_token: hf_xxxxxxxxxxxxxxxxxxxx
+
+# Intelligent fabric: the resident steward (small always-on operator
+# assistant the fabric places and repairs automatically). Off by default.
+# When enabled, the master keeps exactly one hidden steward placement using
+# the first servable model from steward_models, and the dashboard/API expose
+# the steward chat surface. The steward is read-only in this release: it
+# observes and advises, it cannot change the cluster.
+#intelligent_fabric:
+#  enabled: false
+#  steward_models:
+#    - mlx-community/Qwen3.5-4B-MLX-4bit
+#    - unsloth/Qwen3.5-4B-GGUF

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -1349,6 +1349,14 @@ class API:
         self.last_completed_election: int = 0
         self.port = port
         self._skulk_config = skulk_config
+        # Terminal failures that arrived before their command's stream queue
+        # was registered (#223 follow-up): the low-level chunk stream
+        # registers its queue lazily on first iteration, so a fast TaskFailed
+        # (e.g. a pinned steward request whose instance vanished, on a
+        # single-node cluster where the master round-trip is local) can beat
+        # registration and _terminate_command_stream would silently no-op,
+        # hanging the caller. Bounded FIFO; consumed at stream registration.
+        self._pending_stream_failures: dict[CommandId, ErrorChunk] = {}
         self._store_client = store_client
         self._config_path = resolve_config_path()
         # Field telemetry (opt-in, consent-gated in skulk.yaml). The config
@@ -2554,6 +2562,18 @@ class API:
         self, payload: CreateInstanceParams
     ) -> CreateInstanceResponse:
         instance = payload.instance
+        if instance.system_role is not None:
+            # System placements (the intelligent-fabric steward) are minted
+            # and maintained by the fabric's own invariant; accepting one
+            # from a caller would let an arbitrary instance impersonate the
+            # steward and suppress the configured placement.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "system_role placements are fabric-managed and cannot "
+                    "be created through this endpoint"
+                ),
+            )
         model_card = await ModelCard.load(instance.shard_assignments.model_id)
         required_memory = model_card.storage_size
         available_memory = self._calculate_total_available_memory()
@@ -3075,6 +3095,15 @@ class API:
 
             if pending_error := self._take_vision_media_failure(command_id):
                 yield pending_error
+                return
+
+            if pending_failure := self._pending_stream_failures.pop(
+                command_id, None
+            ):
+                # The task already failed before this stream registered
+                # (fast local TaskFailed, e.g. a pinned instance that
+                # vanished); deliver the buffered terminal chunk.
+                yield pending_failure
                 return
 
             with recv as token_chunks:
@@ -8180,6 +8209,7 @@ class API:
                 except (BrokenResourceError, ClosedResourceError):
                     self._audio_transcription_queues.pop(task.command_id, None)
             return
+        delivered = False
         for queue_map in (
             self._text_generation_queues,
             self._image_generation_queues,
@@ -8188,10 +8218,19 @@ class API:
             self._audio_transcription_queues,
         ):
             if queue := queue_map.get(task.command_id):
+                delivered = True
                 try:
                     await queue.send(error_chunk)
                 except (BrokenResourceError, ClosedResourceError):
                     queue_map.pop(task.command_id, None)
+        if not delivered:
+            # No stream queue exists yet: buffer the terminal chunk for the
+            # lazily-registered stream to consume at startup, instead of
+            # dropping it and hanging the request.
+            while len(self._pending_stream_failures) >= 256:
+                oldest = next(iter(self._pending_stream_failures))
+                del self._pending_stream_failures[oldest]
+            self._pending_stream_failures[task.command_id] = error_chunk
 
     def _save_trace(
         self, task_id: task_types.TaskId, trace_data: Sequence[TraceEventData]

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -115,6 +115,11 @@ from skulk.api.realtime import (
     RealtimeResponseConfig,
     RealtimeTranscriptionBridge,
 )
+from skulk.api.steward import (
+    StewardChatRequest,
+    StewardChatResponse,
+    StewardStatusResponse,
+)
 from skulk.api.types import (
     AddCustomModelParams,
     AdvancedImageParams,
@@ -2206,6 +2211,32 @@ class API:
                 "explicit failures rather than vanishing."
             ),
         )(self.get_cluster_performance_envelopes)
+        self.app.get(
+            "/v1/steward",
+            tags=["Steward"],
+            summary="Get intelligent-fabric steward status",
+            description=(
+                "Report whether intelligent-fabric mode is enabled and whether "
+                "a steward placement currently exists, with its model and "
+                "instance id when present. The steward is the fabric-maintained "
+                "resident assistant; see the steward chat endpoint."
+            ),
+        )(self.get_steward_status)
+        self.app.post(
+            "/v1/steward/chat",
+            tags=["Steward"],
+            summary="Ask the cluster's resident steward",
+            description=(
+                "Send a conversation to the intelligent-fabric steward: a small "
+                "resident model the fabric keeps placed while the mode is "
+                "enabled. The steward investigates the cluster through a "
+                "bounded read-only tool surface (state, diagnostics, doctor, "
+                "catalog) and answers with its reasoning trace. Observe/advise "
+                "only: the steward cannot change the cluster. Returns 409 when "
+                "intelligent-fabric mode is disabled or the steward placement "
+                "is not currently available."
+            ),
+        )(self.steward_chat)
         self.app.post(
             "/v1/diagnostics/node/runners/{runner_id}/cancel",
             tags=["Diagnostics"],
@@ -2842,9 +2873,85 @@ class API:
             raise HTTPException(status_code=404, detail="Instance not found")
         return self.state.instances[instance_id]
 
+    async def get_steward_status(self) -> "StewardStatusResponse":
+        """Report intelligent-fabric mode and the current steward placement."""
+        from skulk.api.steward import StewardHarness, StewardStatusResponse
+
+        located = StewardHarness(self).steward_instance()
+        return StewardStatusResponse(
+            enabled=self._intelligent_fabric_enabled(),
+            present=located is not None,
+            steward_model=located[1] if located is not None else None,
+            instance_id=str(located[0]) if located is not None else None,
+        )
+
+    async def steward_chat(
+        self, payload: "StewardChatRequest"
+    ) -> "StewardChatResponse":
+        """Run one steward turn: investigate through read-only tools, reply."""
+        from skulk.api.steward import StewardHarness
+
+        if not self._intelligent_fabric_enabled():
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Intelligent-fabric mode is disabled. Enable it in "
+                    "Settings (intelligent_fabric.enabled) to talk to the "
+                    "steward."
+                ),
+            )
+        harness = StewardHarness(self)
+        try:
+            return await harness.run_turn(payload.messages)
+        except LookupError as error:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "The steward placement is not available yet. The fabric "
+                    "establishes it automatically; check /state for placement "
+                    "progress or node capacity."
+                ),
+            ) from error
+        except RuntimeError as error:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Steward generation failed: {error}",
+            ) from error
+
+    def _intelligent_fabric_enabled(self) -> bool:
+        """Whether intelligent-fabric mode is currently enabled.
+
+        Reads the on-disk cluster config (kept current on every node by
+        SyncConfig) so the answer tracks fleet-wide Settings changes made
+        from any node, falling back to the startup-parsed config when the
+        file is momentarily unreadable.
+        """
+        try:
+            config = load_skulk_config()
+        except Exception:
+            config = self._skulk_config
+        fabric = config.intelligent_fabric if config is not None else None
+        return fabric is not None and fabric.enabled
+
     async def delete_instance(self, instance_id: InstanceId) -> DeleteInstanceResponse:
         if instance_id not in self.state.instances:
             raise HTTPException(status_code=404, detail="Instance not found")
+        instance = self.state.instances[instance_id]
+        if instance.system_role == "steward" and self._intelligent_fabric_enabled():
+            # The steward is a fabric-maintained system placement: while the
+            # mode is on, the master would immediately re-place it anyway, so
+            # an ordinary delete is refused loudly instead of producing a
+            # confusing delete-then-reappear. Internal correctness paths
+            # (worker give-up on a crashed instance, repair teardown) send
+            # DeleteInstance directly on the command plane and are unaffected.
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "This is the intelligent-fabric steward placement, which "
+                    "the fabric maintains automatically. Disable intelligent "
+                    "fabric in Settings to remove it."
+                ),
+            )
 
         command = DeleteInstance(
             instance_id=instance_id,
@@ -3831,8 +3938,47 @@ class API:
                     "Vision media timed out waiting for worker verification",
                 )
 
+    async def dispatch_text_generation(
+        self,
+        task_params: TextGenerationTaskParams,
+        target_instance_id: InstanceId | None = None,
+    ) -> TextGeneration:
+        """Public dispatch seam for internal callers (the steward harness).
+
+        Sends a text-generation command through the same validated path as
+        the HTTP chat adapters, optionally pinned to one instance.
+        """
+        return await self._send_text_generation_with_images(
+            task_params, target_instance_id=target_instance_id
+        )
+
+    def text_generation_chunk_stream(
+        self,
+        command: TextGeneration,
+        task_params: TextGenerationTaskParams,
+    ) -> AsyncGenerator[
+        ErrorChunk | ToolCallChunk | TokenChunk | PrefillProgressChunk, None
+    ]:
+        """Public tapped chunk stream for one dispatched command.
+
+        Same observation taps as the HTTP adapters (envelopes, telemetry,
+        extensions), so internal consumers are indistinguishable from
+        external ones to the observability planes.
+        """
+        return self._tapped_text_stream(
+            command.command_id,
+            task_params.model,
+            task_params=task_params,
+        )
+
+    async def running_model_card(self, model_id: ModelId) -> ModelCard | None:
+        """Public card lookup preferring the card carried on a live instance."""
+        return await self._get_running_model_card(model_id)
+
     async def _send_text_generation_with_images(
-        self, task_params: TextGenerationTaskParams
+        self,
+        task_params: TextGenerationTaskParams,
+        target_instance_id: InstanceId | None = None,
     ) -> TextGeneration:
         # Single dispatch chokepoint for every text-generation wire format
         # (chat, claude, ollama, responses, bench) — reject un-renderable
@@ -3863,7 +4009,11 @@ class API:
             )
         images = task_params.images
         if not images:
-            command = TextGeneration(task_params=task_params, owner_node=self.node_id)
+            command = TextGeneration(
+            task_params=task_params,
+            owner_node=self.node_id,
+            target_instance_id=target_instance_id,
+        )
             await self._send(command)
             return command
 
@@ -3904,7 +4054,11 @@ class API:
             task_params = task_params.model_copy(
                 update={"images": [], "image_hashes": cached_hashes}
             )
-            command = TextGeneration(task_params=task_params, owner_node=self.node_id)
+            command = TextGeneration(
+            task_params=task_params,
+            owner_node=self.node_id,
+            target_instance_id=target_instance_id,
+        )
             await self._send(command)
             return command
 
@@ -3921,7 +4075,11 @@ class API:
                 "image_count": len(new_images),
             }
         )
-        command = TextGeneration(task_params=task_params, owner_node=self.node_id)
+        command = TextGeneration(
+            task_params=task_params,
+            owner_node=self.node_id,
+            target_instance_id=target_instance_id,
+        )
         self._stage_vision_media(
             command.command_id,
             task_params.model,

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -8223,10 +8223,13 @@ class API:
                     await queue.send(error_chunk)
                 except (BrokenResourceError, ClosedResourceError):
                     queue_map.pop(task.command_id, None)
-        if not delivered:
+        if not delivered and isinstance(task, task_types.TextGeneration):
             # No stream queue exists yet: buffer the terminal chunk for the
             # lazily-registered stream to consume at startup, instead of
-            # dropping it and hanging the request.
+            # dropping it and hanging the request. Scoped to text generation,
+            # the only stream that drains this buffer today; buffering for
+            # the other task families would accumulate entries no consumer
+            # takes (their adapters can adopt the same drain as follow-up).
             while len(self._pending_stream_failures) >= 256:
                 oldest = next(iter(self._pending_stream_failures))
                 del self._pending_stream_failures[oldest]

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -1,0 +1,527 @@
+"""The steward: the intelligent-fabric resident's read-only harness (Phase 1).
+
+The steward is a small model the fabric keeps placed as a hidden system
+instance (see ``IntelligentFabricConfig`` and the master's
+``_maintain_steward_placement``). This module is the harness around that
+brain: a bounded tool surface over the node's own read-only operator APIs,
+and the per-turn investigation loop that drives the model through the
+existing chat-completions generation path (pinned to the steward instance
+via ``TextGeneration.target_instance_id``).
+
+Phase 1 authority is observe/advise only: every tool here is a read, and no
+mutating tool exists in this module by construction. The tool vocabulary
+deliberately matches the steward bench (skulk-steward repo), so bench
+results transfer to production behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, cast, final
+
+from pydantic import BaseModel, Field
+
+from skulk.api.types.api import (
+    ChatCompletionMessage,
+    ChatCompletionRequest,
+    ToolCall,
+)
+from skulk.shared.types.worker.instances import InstanceId
+
+if TYPE_CHECKING:
+    from skulk.api.main import API
+
+MAX_TOOL_RESULT_CHARS = 6000
+"""Hard cap on one tool result rendered into the steward's context."""
+
+MAX_STEPS_PER_TURN = 8
+"""Investigation budget: tool calls per operator message."""
+
+STEWARD_SYSTEM_PROMPT = """\
+You are the steward: the resident operator intelligence of this Skulk
+cluster. Skulk is a distributed AI inference fabric that runs models across
+multiple machines. You answer operator questions by investigating the
+cluster through your tools, then reporting clearly.
+
+Rules:
+- Investigate before concluding. Start from get_cluster_state unless the
+  question clearly points elsewhere.
+- Call ONE tool at a time and read its result before deciding the next step.
+- Evidence means concrete observed values from tool results, not guesses.
+- If everything is healthy, say so; do not invent problems.
+- You can only observe and advise. You cannot change the cluster; when
+  action is needed, tell the operator exactly what to do.
+- Answer in plain language an operator can act on, citing the evidence.
+"""
+
+
+def steward_tool_definitions() -> list[dict[str, Any]]:
+    """The steward's read-only tool surface as OpenAI function definitions."""
+    no_args: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
+    tools: list[tuple[str, str, dict[str, Any]]] = [
+        (
+            "get_cluster_state",
+            "Fetch the cluster's authoritative state summary: nodes with "
+            "health reasons, model instances and their placement, and "
+            "download records. This is the first thing to look at.",
+            no_args,
+        ),
+        (
+            "get_node_resources",
+            "Fetch per-node resource and capability detail: advertised "
+            "backend engines, data transport, zenoh peer counts, and "
+            "capability conflicts.",
+            {
+                "type": "object",
+                "properties": {
+                    "node_id": {
+                        "type": "string",
+                        "description": "Node to inspect; omit for all nodes.",
+                    }
+                },
+                "required": [],
+            },
+        ),
+        (
+            "get_telemetry_diagnostics",
+            "Fetch the local telemetry pipeline diagnostics: publish "
+            "counters, drops, and no-peer publish counts. Use when a node "
+            "seems invisible to the cluster or membership flaps.",
+            no_args,
+        ),
+        (
+            "get_data_plane_diagnostics",
+            "Fetch generated-output data plane diagnostics: stream "
+            "lifecycle counts, ordering gaps, queue pressure, drops, and "
+            "publish failures. Use when generation output stalls or fails.",
+            no_args,
+        ),
+        (
+            "get_cluster_versions",
+            "Fetch per-node Skulk version status. Mixed versions across a "
+            "cluster are unsupported and explain many strange failures.",
+            no_args,
+        ),
+        (
+            "get_performance_envelopes",
+            "Fetch observed performance envelopes: per (hardware, model, "
+            "engine, quant) concurrency buckets with TTFT and decode "
+            "throughput percentiles. Use for speed and capacity questions.",
+            no_args,
+        ),
+        (
+            "run_doctor",
+            "Run this node's diagnostic check registry (skulk doctor) and "
+            "return check results. Use for environment problems: missing "
+            "engines, GPU detection, storage.",
+            no_args,
+        ),
+        (
+            "get_model_catalog",
+            "Fetch the model catalog with card metadata: context length, "
+            "family, quantization, and capability tags.",
+            no_args,
+        ),
+    ]
+    return [
+        {
+            "type": "function",
+            "function": {"name": name, "description": desc, "parameters": params},
+        }
+        for name, desc, params in tools
+    ]
+
+
+STEWARD_TOOL_NAMES: tuple[str, ...] = tuple(
+    spec["function"]["name"]  # pyright's view: constructed literally above
+    for spec in steward_tool_definitions()
+)
+
+
+class StewardChatMessage(BaseModel):
+    """One turn of steward conversation history."""
+
+    role: str = Field(description="'user' or 'assistant'.")
+    content: str = Field(description="The message text.")
+
+
+class StewardChatRequest(BaseModel):
+    """Request body for the steward chat surface."""
+
+    messages: list[StewardChatMessage] = Field(
+        min_length=1,
+        description=(
+            "Conversation history, oldest first, ending with the operator's "
+            "latest message. The steward system prompt and tool plumbing "
+            "are added server-side."
+        ),
+    )
+
+
+class StewardToolStep(BaseModel):
+    """One tool call the steward made while investigating."""
+
+    tool: str = Field(description="Tool name invoked.")
+    arguments: dict[str, object] = Field(
+        default_factory=dict, description="Arguments the steward passed."
+    )
+
+
+class StewardStatusResponse(BaseModel):
+    """Whether the steward exists and what serves it right now."""
+
+    enabled: bool = Field(
+        description="Whether intelligent-fabric mode is enabled in Settings."
+    )
+    present: bool = Field(
+        description="Whether a steward placement currently exists in state."
+    )
+    steward_model: str | None = Field(
+        default=None,
+        description="Model id of the steward brain, when present.",
+    )
+    instance_id: str | None = Field(
+        default=None,
+        description="The steward instance id, when present.",
+    )
+
+
+class StewardChatResponse(BaseModel):
+    """The steward's reply plus its investigation trace."""
+
+    reply: str = Field(description="The steward's answer to the operator.")
+    steps: list[StewardToolStep] = Field(
+        default_factory=list,
+        description="Tools consulted this turn, in order.",
+    )
+    steward_model: str = Field(
+        description="Model id of the steward brain that produced the reply."
+    )
+    instance_id: str = Field(
+        description="The hidden steward instance that served the turn."
+    )
+
+
+def _as_object_dict(value: object) -> dict[str, object]:
+    """Narrow an untyped JSON value to a string-keyed dict (else empty)."""
+    if isinstance(value, dict):
+        return cast("dict[str, object]", value)
+    return {}
+
+
+def _as_object_list(value: object) -> list[object]:
+    """Narrow an untyped JSON value to a list (else empty)."""
+    if isinstance(value, list):
+        return cast("list[object]", value)
+    return []
+
+
+def _bounded(payload: object) -> str:
+    rendered = json.dumps(payload, indent=1, default=str)
+    if len(rendered) > MAX_TOOL_RESULT_CHARS:
+        rendered = rendered[:MAX_TOOL_RESULT_CHARS] + "\n...[truncated]"
+    return rendered
+
+
+def _instances_summary(state_payload: dict[str, object]) -> list[dict[str, object]]:
+    """Compact instance listing for the steward's context window."""
+    summary: list[dict[str, object]] = []
+    for instance_id, envelope in _as_object_dict(
+        state_payload.get("instances")
+    ).items():
+        for kind, body_obj in _as_object_dict(envelope).items():
+            body = _as_object_dict(body_obj)
+            assignments = _as_object_dict(body.get("shardAssignments"))
+            summary.append(
+                {
+                    "instanceId": instance_id,
+                    "kind": kind,
+                    "modelId": assignments.get("modelId"),
+                    "nodes": sorted(_as_object_dict(assignments.get("nodeToRunner"))),
+                    "systemRole": body.get("systemRole"),
+                }
+            )
+    return summary
+
+
+def _downloads_summary(state_payload: dict[str, object]) -> dict[str, object]:
+    """Compact download listing keeping error and progress essentials."""
+    summary: dict[str, object] = {}
+    for node_id, entries in _as_object_dict(state_payload.get("downloads")).items():
+        rows: list[dict[str, object]] = []
+        for envelope in _as_object_list(entries):
+            for kind, body_obj in _as_object_dict(envelope).items():
+                body = _as_object_dict(body_obj)
+                row: dict[str, object] = {"kind": kind}
+                if body.get("errorMessage"):
+                    row["errorMessage"] = body["errorMessage"]
+                progress = _as_object_dict(body.get("downloadProgress"))
+                if progress:
+                    row["downloaded"] = progress.get("downloaded")
+                    row["total"] = progress.get("total")
+                    row["etaMs"] = progress.get("etaMs")
+                rows.append(row)
+        if rows:
+            summary[node_id] = rows
+    return summary
+
+
+@final
+class StewardHarness:
+    """Drives the steward brain through its tools for one API node.
+
+    Stateless between turns: the dashboard (or other caller) carries the
+    conversation history; each ``run_turn`` re-derives the steward instance
+    from replicated state so master failover and re-placement are invisible
+    to callers.
+    """
+
+    def __init__(self, api: "API") -> None:
+        self._api = api
+
+    def steward_instance(self) -> tuple[InstanceId, str] | None:
+        """The current steward placement, as (instance_id, model_id)."""
+        for instance_id, instance in sorted(
+            self._api.state.instances.items(), key=lambda kv: str(kv[0])
+        ):
+            if instance.system_role == "steward":
+                return instance_id, str(instance.shard_assignments.model_id)
+        return None
+
+    async def execute_tool(self, name: str, arguments: dict[str, object]) -> str:
+        """Execute one read-only tool; failures return as tool results.
+
+        The steward recovering from its own bad call is part of the design,
+        so unknown tools and errors are surfaced to the model, never raised.
+        """
+        try:
+            return await self._execute(name, arguments)
+        except Exception as error:  # surfaced to the model, never raised
+            return json.dumps({"error": f"tool failed: {error}"})
+
+    async def _execute(self, name: str, arguments: dict[str, object]) -> str:
+        api = self._api
+        if name == "get_cluster_state":
+            payload = await api.get_cluster_state()
+            return _bounded(
+                {
+                    "nodeHealth": payload.get("nodeHealth", {}),
+                    "instances": _instances_summary(payload),
+                    "downloads": _downloads_summary(payload),
+                    "nodeIdentities": payload.get("nodeIdentities", {}),
+                    "nodeDisk": payload.get("nodeDisk", {}),
+                    "topologyNodes": _as_object_dict(payload.get("topology")).get(
+                        "nodes", []
+                    ),
+                }
+            )
+        if name == "get_node_resources":
+            payload = await api.get_cluster_state()
+            nodes = _as_object_dict(payload.get("nodeResources"))
+            node_id = arguments.get("node_id")
+            if isinstance(node_id, str) and node_id:
+                if node_id not in nodes:
+                    return json.dumps(
+                        {
+                            "error": f"unknown node_id '{node_id}'",
+                            "known_nodes": sorted(nodes),
+                        }
+                    )
+                nodes = {node_id: nodes[node_id]}
+            return _bounded({"nodes": nodes})
+        if name == "get_telemetry_diagnostics":
+            report = await api.get_telemetry_plane_diagnostics()
+            return _bounded(report.model_dump(by_alias=True, mode="json"))
+        if name == "get_data_plane_diagnostics":
+            diagnostics = await api.get_node_diagnostics()
+            return _bounded(
+                diagnostics.data_plane.model_dump(by_alias=True, mode="json")
+            )
+        if name == "get_cluster_versions":
+            cluster = await api.get_cluster_diagnostics()
+            return _bounded(
+                {
+                    "versionStatus": cluster.version_status,
+                    "masterNodeId": str(cluster.master_node_id)
+                    if cluster.master_node_id is not None
+                    else None,
+                    "nodes": [
+                        {
+                            "nodeId": str(node.node_id),
+                            "ok": node.ok,
+                            "versionStatus": node.version_status,
+                            "error": node.error,
+                        }
+                        for node in cluster.nodes
+                    ],
+                }
+            )
+        if name == "get_performance_envelopes":
+            report = await api.get_performance_envelopes()
+            return _bounded(report.model_dump(by_alias=True, mode="json"))
+        if name == "run_doctor":
+            # The doctor registry runs against the process-cached facts
+            # snapshot, so this is a cheap local read, not a fresh probe.
+            from skulk.doctor.checks import run_checks
+            from skulk.facts import current_node_facts
+
+            results = run_checks(current_node_facts())
+            return _bounded(
+                {"results": [result.model_dump(mode="json") for result in results]}
+            )
+        if name == "get_model_catalog":
+            models = await api.get_models(status=None)
+            return _bounded(
+                {
+                    "data": [
+                        {
+                            "id": entry.id,
+                            "context_length": entry.context_length,
+                            "family": entry.family,
+                            "quantization": entry.quantization,
+                            "tags": entry.tags,
+                            "capabilities": entry.capabilities,
+                        }
+                        for entry in models.data[:40]
+                    ]
+                }
+            )
+        return json.dumps(
+            {"error": f"unknown tool '{name}'", "available": STEWARD_TOOL_NAMES}
+        )
+
+    async def run_turn(
+        self, history: list[StewardChatMessage]
+    ) -> StewardChatResponse:
+        """Run one operator turn: investigate via tools, return the reply.
+
+        Raises ``LookupError`` when no steward instance exists (callers map
+        this to an HTTP 409 with remediation).
+        """
+        located = self.steward_instance()
+        if located is None:
+            raise LookupError("no steward placement exists")
+        instance_id, model_id = located
+
+        messages: list[ChatCompletionMessage] = [
+            ChatCompletionMessage(role="system", content=STEWARD_SYSTEM_PROMPT)
+        ]
+        for message in history:
+            role = message.role if message.role in ("user", "assistant") else "user"
+            messages.append(
+                ChatCompletionMessage(role=role, content=message.content)
+            )
+
+        steps: list[StewardToolStep] = []
+        reply = ""
+        for step_index in range(MAX_STEPS_PER_TURN):
+            if step_index == MAX_STEPS_PER_TURN - 1:
+                messages.append(
+                    ChatCompletionMessage(
+                        role="user",
+                        content=(
+                            "This is your final step: answer the operator "
+                            "now from the evidence you have."
+                        ),
+                    )
+                )
+            text, tool_calls, error = await self._generate(
+                messages, model_id, instance_id
+            )
+            if error is not None:
+                raise RuntimeError(error)
+            if not tool_calls:
+                reply = text.strip()
+                break
+            call = tool_calls[0]
+            arguments: dict[str, object] = {}
+            try:
+                parsed = cast("object", json.loads(call.function.arguments or "{}"))
+            except json.JSONDecodeError:
+                parsed = {}
+            if isinstance(parsed, dict):
+                arguments = cast("dict[str, object]", parsed)
+            steps.append(StewardToolStep(tool=call.function.name, arguments=arguments))
+            result = await self.execute_tool(call.function.name, arguments)
+            messages.append(
+                ChatCompletionMessage(
+                    role="assistant",
+                    content=text or None,
+                    tool_calls=[call],
+                )
+            )
+            messages.append(
+                ChatCompletionMessage(
+                    role="tool", content=result, tool_call_id=call.id
+                )
+            )
+        else:
+            reply = (
+                "I ran out of investigation budget before reaching a "
+                "conclusion; the tools consulted so far are listed."
+            )
+
+        return StewardChatResponse(
+            reply=reply,
+            steps=steps,
+            steward_model=model_id,
+            instance_id=str(instance_id),
+        )
+
+    async def _generate(
+        self,
+        messages: list[ChatCompletionMessage],
+        model_id: str,
+        instance_id: InstanceId,
+    ) -> tuple[str, list[ToolCall], str | None]:
+        """One completion against the steward instance.
+
+        Returns (text, tool_calls, error_message). Rides the exact
+        chat-completions dispatch path so the capability spine handles the
+        family's prompt rendering and tool-call parsing.
+        """
+        from skulk.api.adapters.chat_completions import (
+            chat_request_to_text_generation,
+        )
+        from skulk.shared.types.chunks import (
+            ErrorChunk,
+            TokenChunk,
+            ToolCallChunk,
+        )
+
+        api = self._api
+        request = ChatCompletionRequest(
+            model=model_id,  # type: ignore[arg-type]
+            messages=messages,
+            tools=steward_tool_definitions(),
+            temperature=0.1,
+            max_tokens=1024,
+            stream=False,
+        )
+        model_card = await api.running_model_card(request.model)
+        task_params = await chat_request_to_text_generation(
+            request, model_card=model_card
+        )
+        command = await api.dispatch_text_generation(
+            task_params, target_instance_id=instance_id
+        )
+        chunk_stream = api.text_generation_chunk_stream(command, task_params)
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+        error_message: str | None = None
+        async for chunk in chunk_stream:
+            match chunk:
+                case ErrorChunk():
+                    error_message = chunk.error_message or "steward generation failed"
+                    break
+                case TokenChunk():
+                    if not chunk.is_thinking:
+                        text_parts.append(chunk.text)
+                case ToolCallChunk():
+                    tool_calls.extend(
+                        ToolCall(id=item.id, index=i, function=item)
+                        for i, item in enumerate(chunk.tool_calls)
+                    )
+                case _:
+                    continue
+        return "".join(text_parts), tool_calls, error_message

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -265,6 +265,16 @@ def _downloads_summary(state_payload: dict[str, object]) -> dict[str, object]:
             for kind, body_obj in _as_object_dict(envelope).items():
                 body = _as_object_dict(body_obj)
                 row: dict[str, object] = {"kind": kind}
+                # The model id lives on the shard's card; without it a node
+                # staging several models gives the steward ambiguous rows.
+                shard_envelope = _as_object_dict(body.get("shardMetadata"))
+                for shard_body in shard_envelope.values():
+                    card = _as_object_dict(
+                        _as_object_dict(shard_body).get("modelCard")
+                    )
+                    if card.get("modelId") is not None:
+                        row["modelId"] = card.get("modelId")
+                    break
                 if body.get("errorMessage"):
                     row["errorMessage"] = body["errorMessage"]
                 progress = _as_object_dict(body.get("downloadProgress"))

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -17,9 +17,9 @@ results transfer to production behavior.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, cast, final
+from typing import TYPE_CHECKING, Any, Literal, cast, final
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from skulk.api.types.api import (
     ChatCompletionMessage,
@@ -141,12 +141,18 @@ STEWARD_TOOL_NAMES: tuple[str, ...] = tuple(
 class StewardChatMessage(BaseModel):
     """One turn of steward conversation history."""
 
-    role: str = Field(description="'user' or 'assistant'.")
+    model_config = ConfigDict(frozen=True)
+
+    role: Literal["user", "assistant"] = Field(
+        description="Message author: the operator or the steward."
+    )
     content: str = Field(description="The message text.")
 
 
 class StewardChatRequest(BaseModel):
     """Request body for the steward chat surface."""
+
+    model_config = ConfigDict(frozen=True)
 
     messages: list[StewardChatMessage] = Field(
         min_length=1,
@@ -161,6 +167,8 @@ class StewardChatRequest(BaseModel):
 class StewardToolStep(BaseModel):
     """One tool call the steward made while investigating."""
 
+    model_config = ConfigDict(frozen=True)
+
     tool: str = Field(description="Tool name invoked.")
     arguments: dict[str, object] = Field(
         default_factory=dict, description="Arguments the steward passed."
@@ -169,6 +177,8 @@ class StewardToolStep(BaseModel):
 
 class StewardStatusResponse(BaseModel):
     """Whether the steward exists and what serves it right now."""
+
+    model_config = ConfigDict(frozen=True)
 
     enabled: bool = Field(
         description="Whether intelligent-fabric mode is enabled in Settings."
@@ -188,6 +198,8 @@ class StewardStatusResponse(BaseModel):
 
 class StewardChatResponse(BaseModel):
     """The steward's reply plus its investigation trace."""
+
+    model_config = ConfigDict(frozen=True)
 
     reply: str = Field(description="The steward's answer to the operator.")
     steps: list[StewardToolStep] = Field(
@@ -407,9 +419,8 @@ class StewardHarness:
             ChatCompletionMessage(role="system", content=STEWARD_SYSTEM_PROMPT)
         ]
         for message in history:
-            role = message.role if message.role in ("user", "assistant") else "user"
             messages.append(
-                ChatCompletionMessage(role=role, content=message.content)
+                ChatCompletionMessage(role=message.role, content=message.content)
             )
 
         steps: list[StewardToolStep] = []

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -17,6 +17,7 @@ results transfer to production behavior.
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING, Any, Literal, cast, final
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -25,6 +26,7 @@ from skulk.api.types.api import (
     ChatCompletionMessage,
     ChatCompletionRequest,
     ToolCall,
+    ToolCallItem,
 )
 from skulk.shared.types.worker.instances import InstanceId
 
@@ -288,6 +290,83 @@ def _downloads_summary(state_payload: dict[str, object]) -> dict[str, object]:
     return summary
 
 
+_FUNCTION_BLOCK = re.compile(r"<function=([\w.-]+)>(.*?)</function>", re.DOTALL)
+_PARAMETER_BLOCK = re.compile(r"<parameter=([\w.-]+)>\n?(.*?)\n?</parameter>", re.DOTALL)
+_TOOL_CALL_BLOCK = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
+
+
+def parse_text_tool_calls(text: str) -> list[ToolCall]:
+    """Fallback parser for tool calls left in raw assistant text.
+
+    Served engines parse tool calls server-side into structured chunks, but
+    the in-process MLX path can pass the family's markup through as plain
+    text (observed live with Qwen3.5's XML function format on the MLX lane).
+    This recognizes both that XML format and Hermes-style JSON blocks, so
+    steward turns behave identically on every engine. Ported from the
+    Phase 0 bench harness, where both formats are exercised.
+    """
+    calls: list[ToolCall] = []
+
+    def from_xml(block: str) -> ToolCall | None:
+        match = _FUNCTION_BLOCK.search(block)
+        if match is None:
+            return None
+        arguments: dict[str, object] = {}
+        for key, raw in cast(
+            "list[tuple[str, str]]", _PARAMETER_BLOCK.findall(match.group(2))
+        ):
+            try:
+                arguments[key] = cast("object", json.loads(raw))
+            except (json.JSONDecodeError, ValueError):
+                arguments[key] = raw
+        return ToolCall(
+            id=f"steward-text-{len(calls)}",
+            index=len(calls),
+            function=ToolCallItem(
+                name=match.group(1), arguments=json.dumps(arguments)
+            ),
+        )
+
+    spans: list[tuple[int, int]] = []
+    for match in _TOOL_CALL_BLOCK.finditer(text):
+        spans.append(match.span())
+        block = match.group(1).strip()
+        xml_call = from_xml(block)
+        if xml_call is not None:
+            calls.append(xml_call)
+            continue
+        try:
+            data = _as_object_dict(cast("object", json.loads(block)))
+            name = data.get("name")
+            arguments = data.get("arguments", {})
+            if isinstance(name, str) and isinstance(arguments, dict):
+                calls.append(
+                    ToolCall(
+                        id=f"steward-text-{len(calls)}",
+                        index=len(calls),
+                        function=ToolCallItem(
+                            name=name, arguments=json.dumps(arguments)
+                        ),
+                    )
+                )
+        except (json.JSONDecodeError, ValueError):
+            continue
+    for match in _FUNCTION_BLOCK.finditer(text):
+        if any(start <= match.start() < end for start, end in spans):
+            continue
+        bare = from_xml(match.group(0))
+        if bare is not None:
+            calls.append(bare)
+    return calls
+
+
+def strip_tool_markup(text: str) -> str:
+    """Remove tool-call markup from text kept as assistant content."""
+    text = _TOOL_CALL_BLOCK.sub("", text)
+    text = _FUNCTION_BLOCK.sub("", text)
+    return text.strip()
+
+
 @final
 class StewardHarness:
     """Drives the steward brain through its tools for one API node.
@@ -451,6 +530,12 @@ class StewardHarness:
             )
             if error is not None:
                 raise RuntimeError(error)
+            if not tool_calls:
+                # Engine-independent fallback: the in-process MLX path can
+                # leave the family's tool-call markup in the text stream.
+                tool_calls = parse_text_tool_calls(text)
+                if tool_calls:
+                    text = strip_tool_markup(text)
             if not tool_calls:
                 reply = text.strip()
                 break

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -141,7 +141,7 @@ STEWARD_TOOL_NAMES: tuple[str, ...] = tuple(
 class StewardChatMessage(BaseModel):
     """One turn of steward conversation history."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, strict=True)
 
     role: Literal["user", "assistant"] = Field(
         description="Message author: the operator or the steward."
@@ -152,7 +152,7 @@ class StewardChatMessage(BaseModel):
 class StewardChatRequest(BaseModel):
     """Request body for the steward chat surface."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, strict=True)
 
     messages: list[StewardChatMessage] = Field(
         min_length=1,
@@ -167,7 +167,7 @@ class StewardChatRequest(BaseModel):
 class StewardToolStep(BaseModel):
     """One tool call the steward made while investigating."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, strict=True)
 
     tool: str = Field(description="Tool name invoked.")
     arguments: dict[str, object] = Field(
@@ -178,7 +178,7 @@ class StewardToolStep(BaseModel):
 class StewardStatusResponse(BaseModel):
     """Whether the steward exists and what serves it right now."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, strict=True)
 
     enabled: bool = Field(
         description="Whether intelligent-fabric mode is enabled in Settings."
@@ -199,7 +199,7 @@ class StewardStatusResponse(BaseModel):
 class StewardChatResponse(BaseModel):
     """The steward's reply plus its investigation trace."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, strict=True)
 
     reply: str = Field(description="The steward's answer to the operator.")
     steps: list[StewardToolStep] = Field(

--- a/src/skulk/api/tests/test_steward_text_tool_calls.py
+++ b/src/skulk/api/tests/test_steward_text_tool_calls.py
@@ -1,0 +1,41 @@
+"""Fallback text tool-call parsing for the steward harness (MLX lane)."""
+
+import json
+
+from skulk.api.steward import parse_text_tool_calls, strip_tool_markup
+
+
+def test_parses_qwen_xml_function_format() -> None:
+    text = (
+        "<tool_call>\n<function=get_cluster_state>\n</function>\n</tool_call>"
+    )
+    calls = parse_text_tool_calls(text)
+    assert len(calls) == 1
+    assert calls[0].function.name == "get_cluster_state"
+    assert json.loads(calls[0].function.arguments) == {}
+
+
+def test_parses_xml_parameters_and_strips_markup() -> None:
+    text = (
+        "Investigating.\n<tool_call>\n<function=get_node_resources>\n"
+        "<parameter=node_id>\nmac-den\n</parameter>\n</function>\n</tool_call>"
+    )
+    calls = parse_text_tool_calls(text)
+    assert calls[0].function.name == "get_node_resources"
+    assert json.loads(calls[0].function.arguments) == {"node_id": "mac-den"}
+    assert strip_tool_markup(text) == "Investigating."
+
+
+def test_parses_hermes_json_format() -> None:
+    text = '<tool_call>{"name": "run_doctor", "arguments": {}}</tool_call>'
+    calls = parse_text_tool_calls(text)
+    assert calls[0].function.name == "run_doctor"
+
+
+def test_bare_function_block_without_wrapper() -> None:
+    calls = parse_text_tool_calls("<function=get_model_catalog>\n</function>")
+    assert calls[0].function.name == "get_model_catalog"
+
+
+def test_plain_text_yields_no_calls() -> None:
+    assert parse_text_tool_calls("The cluster is healthy.") == []

--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -887,7 +887,17 @@ class Master:
                                         task_count
                                     )
 
-                            if not instance_task_counts:
+                            # A pinned request (steward/canary) must fail its
+                            # task cleanly even when NO instance serves the
+                            # model anymore (the pinned instance vanished
+                            # between caller lookup and processing); raising
+                            # here would leave the caller hanging with no
+                            # terminal event. Mirrors the SpeechSynthesis
+                            # guard.
+                            if (
+                                not instance_task_counts
+                                and command.target_instance_id is None
+                            ):
                                 raise ValueError(
                                     f"No instance found for model {command.task_params.model}"
                                 )

--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -1,7 +1,7 @@
 import copy
 import time
 from collections import deque
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -1960,9 +1960,6 @@ class Master:
             # simply stays off until the config loads again.
             return
         fabric = config.intelligent_fabric if config is not None else None
-        if fabric is None or not fabric.enabled:
-            return
-
         stewards = sorted(
             (
                 instance_id
@@ -1971,23 +1968,28 @@ class Master:
             ),
             key=str,
         )
+        if fabric is None or not fabric.enabled:
+            # Disable is a lifecycle transition, not a shrug: a steward left
+            # behind would keep occupying memory while hidden from every
+            # ordinary instance surface. Symmetric with enable.
+            if stewards:
+                logger.info(
+                    "Intelligent fabric is disabled; removing the steward "
+                    f"placement(s) {[str(s) for s in stewards]}"
+                )
+                await self._teardown_steward_instances(stewards)
+            return
+
         if len(stewards) > 1:
             # Duplicate stewards can appear when two masters each placed one
             # around a failover window. Keep the lowest id (stable across
             # replicas), tear down the rest.
-            survivors = dict(self.state.instances)
-            for extra in stewards[1:]:
-                logger.warning(
-                    f"Removing duplicate steward placement {extra} "
-                    f"(keeping {stewards[0]})"
-                )
-                survivors = delete_instance(
-                    DeleteInstance(instance_id=extra), survivors
-                )
-            for event in get_transition_events(
-                self.state.instances, survivors, self.state.tasks
-            ):
-                await self.event_sender.send(event)
+            extras = stewards[1:]
+            logger.warning(
+                f"Removing duplicate steward placement(s) "
+                f"{[str(e) for e in extras]} (keeping {stewards[0]})"
+            )
+            await self._teardown_steward_instances(extras)
             return
         if stewards:
             return
@@ -2052,6 +2054,37 @@ class Master:
             "Intelligent fabric is enabled but no configured steward model "
             "can be placed on the current topology; will retry"
         )
+
+    async def _teardown_steward_instances(
+        self, instance_ids: Sequence[InstanceId]
+    ) -> None:
+        """Tear down steward placements with full lifecycle hygiene.
+
+        Fails any in-flight tasks first (the TaskFailed-before-removal
+        invariant), emits the deletion transition events, and forwards
+        download cancellations so an in-flight steward-model download does
+        not keep occupying disk and bandwidth after its instance is gone —
+        the same steps the ordinary DeleteInstance path performs.
+        """
+        for task_failed in orphaned_task_failure_events(
+            self.state, set(instance_ids)
+        ):
+            await self.event_sender.send(task_failed)
+        survivors = dict(self.state.instances)
+        for instance_id in instance_ids:
+            survivors = delete_instance(
+                DeleteInstance(instance_id=instance_id), survivors
+            )
+        for cmd in cancel_unnecessary_downloads(
+            survivors, self._effective_downloads()
+        ):
+            await self.download_command_sender.send(
+                ForwarderDownloadCommand(origin=self._system_id, command=cmd)
+            )
+        for event in get_transition_events(
+            self.state.instances, survivors, self.state.tasks
+        ):
+            await self.event_sender.send(event)
     async def _event_processor(self) -> None:
         with self.local_event_receiver as local_events:
             async for local_event in local_events:

--- a/src/skulk/master/main.py
+++ b/src/skulk/master/main.py
@@ -34,6 +34,7 @@ from skulk.shared.models.memory_estimate import (
     estimate_shard_footprint,
     shard_fraction_of_model,
 )
+from skulk.shared.models.model_cards import ModelId, get_card, get_model_cards
 from skulk.shared.types.commands import (
     AddCustomModelCard,
     AudioTranscription,
@@ -121,10 +122,10 @@ from skulk.shared.types.worker.downloads import (
     DownloadPending,
     DownloadProgress,
 )
-from skulk.shared.types.worker.instances import Instance, InstanceId
+from skulk.shared.types.worker.instances import Instance, InstanceId, InstanceMeta
 from skulk.shared.types.worker.runners import RunnerReady, RunnerRunning
-from skulk.shared.types.worker.shards import RpcDonorShardMetadata
-from skulk.store.config import resolve_config_path
+from skulk.shared.types.worker.shards import RpcDonorShardMetadata, Sharding
+from skulk.store.config import load_skulk_config, resolve_config_path
 from skulk.utils.channels import Receiver, Sender
 from skulk.utils.disk_event_log import DiskEventLog
 from skulk.utils.event_buffer import MultiSourceBuffer
@@ -658,6 +659,10 @@ class Master:
         # id makes recovery fire once per wedged instance. Grows only by wedged
         # ids (rare); never reused since InstanceIds are unique.
         self._download_failure_recovered: set[InstanceId] = set()
+        # Steward invariant pacing: at most one placement attempt per minute,
+        # so an unplaceable steward (no eligible node yet) logs and retries
+        # calmly instead of hammering the planner every 10s tick.
+        self._steward_last_attempt_monotonic: float = 0.0
         # Per-node memory (bytes) freed by a just-deleted instance. The grace
         # window is zero by default, so entries are normally pruned without being
         # applied; keeping the structure preserves one place to revisit this if
@@ -887,15 +892,27 @@ class Master:
                                     f"No instance found for model {command.task_params.model}"
                                 )
 
-                            available_instance_ids = sorted(
-                                instance_task_counts.keys(),
-                                key=lambda instance_id: instance_task_counts[
-                                    instance_id
-                                ],
-                            )
-
                             task_id = TaskId()
-                            selected_instance_id = available_instance_ids[0]
+                            target_unavailable = False
+                            if command.target_instance_id is not None:
+                                # Steward/canary path: pin to the requested
+                                # instance (mirrors SpeechSynthesis); a miss
+                                # fails the task instead of silently landing
+                                # on another placement.
+                                if (
+                                    command.target_instance_id
+                                    not in instance_task_counts
+                                ):
+                                    target_unavailable = True
+                                selected_instance_id = command.target_instance_id
+                            else:
+                                available_instance_ids = sorted(
+                                    instance_task_counts.keys(),
+                                    key=lambda instance_id: instance_task_counts[
+                                        instance_id
+                                    ],
+                                )
+                                selected_instance_id = available_instance_ids[0]
                             trace_enabled = self.state.tracing_enabled
                             generated_events.append(
                                 TaskCreated(
@@ -909,7 +926,11 @@ class Master:
                                         # Phase 2).
                                         owner_node=command.owner_node,
                                         instance_id=selected_instance_id,
-                                        task_status=TaskStatus.Pending,
+                                        task_status=(
+                                            TaskStatus.Failed
+                                            if target_unavailable
+                                            else TaskStatus.Pending
+                                        ),
                                         task_params=command.task_params,
                                         trace_enabled=trace_enabled,
                                     ),
@@ -917,6 +938,18 @@ class Master:
                             )
 
                             self.command_task_mapping[command.command_id] = task_id
+                            if target_unavailable:
+                                generated_events.append(
+                                    TaskFailed(
+                                        task_id=task_id,
+                                        error_type="instance_unavailable",
+                                        error_message=(
+                                            "Requested text-generation instance "
+                                            "is unavailable or does not serve "
+                                            "the requested model"
+                                        ),
+                                    )
+                                )
                         case ImageGeneration():
                             for instance in self.state.instances.values():
                                 if (
@@ -1767,6 +1800,15 @@ class Master:
             if topology_settled:
                 await self._recover_download_failed_instances()
 
+            # Intelligent fabric (steward) invariant: while the mode is
+            # enabled, exactly one steward system placement exists. Behind
+            # the settle grace so a freshly failed-over master does not act
+            # on a stale seeded view; because this runs on every planning
+            # tick, a new master re-establishes the steward after election
+            # without any dedicated failover machinery.
+            if topology_settled:
+                await self._maintain_steward_placement()
+
             await anyio.sleep(10)
 
     async def _recover_download_failed_instances(self) -> None:
@@ -1887,6 +1929,119 @@ class Master:
                     "recovery)"
                 )
 
+
+    async def _maintain_steward_placement(self) -> None:
+        """Re-establish the intelligent-fabric steward placement invariant.
+
+        While ``intelligent_fabric.enabled`` is set in the cluster config,
+        exactly one instance carrying ``system_role="steward"`` must exist.
+        This pass places the first card from the configured preference list
+        the cluster can serve, tears down accidental duplicates (possible
+        across master handoffs), and does nothing while a steward exists.
+        Node loss needs no special handling here: the dead steward's
+        instance is torn down by the liveness pass and this invariant
+        re-places it on the next tick. Attempts are paced to one per minute
+        so an unplaceable steward logs calmly instead of spamming.
+        """
+        try:
+            config = load_skulk_config()
+        except Exception:
+            # An unreadable config never breaks the planning loop; the mode
+            # simply stays off until the config loads again.
+            return
+        fabric = config.intelligent_fabric if config is not None else None
+        if fabric is None or not fabric.enabled:
+            return
+
+        stewards = sorted(
+            (
+                instance_id
+                for instance_id, instance in self.state.instances.items()
+                if instance.system_role == "steward"
+            ),
+            key=str,
+        )
+        if len(stewards) > 1:
+            # Duplicate stewards can appear when two masters each placed one
+            # around a failover window. Keep the lowest id (stable across
+            # replicas), tear down the rest.
+            survivors = dict(self.state.instances)
+            for extra in stewards[1:]:
+                logger.warning(
+                    f"Removing duplicate steward placement {extra} "
+                    f"(keeping {stewards[0]})"
+                )
+                survivors = delete_instance(
+                    DeleteInstance(instance_id=extra), survivors
+                )
+            for event in get_transition_events(
+                self.state.instances, survivors, self.state.tasks
+            ):
+                await self.event_sender.send(event)
+            return
+        if stewards:
+            return
+
+        now = time.monotonic()
+        if now - self._steward_last_attempt_monotonic < 60:
+            return
+        self._steward_last_attempt_monotonic = now
+
+        # The card cache is lazily filled; a fresh master process may not
+        # have loaded it yet.
+        await get_model_cards()
+        for model_ref in fabric.steward_models:
+            card = get_card(ModelId(model_ref))
+            if card is None:
+                logger.warning(
+                    f"Steward model {model_ref} has no model card; skipping"
+                )
+                continue
+            command = PlaceInstance(
+                model_card=card,
+                sharding=Sharding.Pipeline,
+                instance_meta=InstanceMeta.MlxRing,
+                min_nodes=1,
+                system_role="steward",
+            )
+            try:
+                final_placement = place_instance(
+                    command,
+                    self.state.topology,
+                    self.state.instances,
+                    self._telemetry_view.node_memory,
+                    self.state.node_network,
+                    download_status=self._effective_downloads(),
+                    node_resources=self._telemetry_view.node_resources,
+                    node_vram=usable_vram_by_node(
+                        self._telemetry_view.node_system,
+                        self._telemetry_view.node_resources,
+                        node_memory=self._telemetry_view.node_memory,
+                    ),
+                    unified_memory_gpu_nodes=unified_memory_gpu_node_ids(
+                        self._telemetry_view.node_system,
+                        self._telemetry_view.node_resources,
+                        node_memory=self._telemetry_view.node_memory,
+                    ),
+                )
+            except (PlacementError, PlacementInfoPendingError) as err:
+                logger.warning(
+                    f"Steward placement with {model_ref} not possible yet: {err}"
+                )
+                continue
+            logger.info(
+                f"Establishing steward placement with {model_ref} "
+                "(intelligent fabric)"
+            )
+            for event in get_transition_events(
+                self.state.instances, final_placement, self.state.tasks
+            ):
+                await self.event_sender.send(event)
+            return
+        logger.warning(
+            "Intelligent fabric is enabled but no configured steward model "
+            "can be placed on the current topology; will retry"
+        )
     async def _event_processor(self) -> None:
         with self.local_event_receiver as local_events:
             async for local_event in local_events:

--- a/src/skulk/master/placement.py
+++ b/src/skulk/master/placement.py
@@ -799,6 +799,7 @@ def place_instance(
             shard_assignments=shard_assignments,
             context_token_limit=context_token_limit,
             excluded_nodes=stamped_exclusions_list,
+            system_role=command.system_role,
             driver_node=driver_node,
             donor_endpoints=donor_endpoints,
         )
@@ -846,6 +847,7 @@ def place_instance(
                 shard_assignments=shard_assignments,
                 context_token_limit=context_token_limit,
                 excluded_nodes=stamped_exclusions_list,
+                system_role=command.system_role,
                 jaccl_devices=mlx_jaccl_devices,
                 jaccl_coordinators=mlx_jaccl_coordinators,
             )
@@ -864,6 +866,7 @@ def place_instance(
                 shard_assignments=shard_assignments,
                 context_token_limit=context_token_limit,
                 excluded_nodes=stamped_exclusions_list,
+                system_role=command.system_role,
                 hosts_by_node=hosts_by_node,
                 ephemeral_port=ephemeral_port,
             )
@@ -928,6 +931,9 @@ def fallback_command_for_refused_instance(
         # exclusions (#658): the anywhere-fallback still may not land on
         # nodes the caller excluded.
         excluded_nodes=sorted({*instance.excluded_nodes, refusing_node}),
+        # System-role marker (intelligent-fabric steward): repair
+        # re-placements re-stamp it so the flag survives node loss.
+        system_role=instance.system_role,
     )
 
 
@@ -960,6 +966,9 @@ def replacement_command_for_refused_instance(instance: Instance) -> PlaceInstanc
         # The instance's original per-placement exclusions (#658); the wider
         # re-placement keeps honoring the caller's intent.
         excluded_nodes=sorted(instance.excluded_nodes),
+        # System-role marker (intelligent-fabric steward): repair
+        # re-placements re-stamp it so the flag survives node loss.
+        system_role=instance.system_role,
     )
 
 
@@ -993,6 +1002,9 @@ def replacement_command_for_download_failed_instance(
         # (#658) and the newly failed node(s): repair must not land on
         # nodes the caller excluded, nor on the nodes that just failed.
         excluded_nodes=sorted({*instance.excluded_nodes, *excluded_nodes}),
+        # System-role marker (intelligent-fabric steward): repair
+        # re-placements re-stamp it so the flag survives node loss.
+        system_role=instance.system_role,
     )
 
 

--- a/src/skulk/master/tests/test_placement.py
+++ b/src/skulk/master/tests/test_placement.py
@@ -1229,7 +1229,7 @@ def test_missing_node_resources_is_treated_as_eligible() -> None:
     assert len(placements) == 1
 
 
-def _fully_connected_three_nodes(
+def fully_connected_three_nodes(
     available_memory: tuple[float, float, float],
 ) -> tuple[
     Topology,
@@ -1269,7 +1269,7 @@ def _fully_connected_three_nodes(
 
 def test_replacement_command_widens_refused_instance_by_one_node() -> None:
     """A refused instance re-places one node wider, preserving model + backend (#290)."""
-    topology, node_memory, node_network, _ = _fully_connected_three_nodes(
+    topology, node_memory, node_network, _ = fully_connected_three_nodes(
         (10.0, 10.0, 10.0)
     )
     card = ModelCard(
@@ -1302,7 +1302,7 @@ def test_refusal_fallback_excludes_refuser_at_any_width() -> None:
     anywhere but the refusing node at min_nodes=1 (#290 on a heterogeneous
     fleet: an MLX model refused at the full Mac width cannot go wider, but a
     remaining node can hold it alone)."""
-    topology, node_memory, node_network, node_ids = _fully_connected_three_nodes(
+    topology, node_memory, node_network, node_ids = fully_connected_three_nodes(
         (10.0, 10.0, 24.0)
     )
     card = ModelCard(
@@ -1355,7 +1355,7 @@ def test_refused_instance_replaces_onto_a_wider_split() -> None:
     Bumping ``min_nodes`` to 3 forces the wider floor, so the re-placement lands
     a 3-node split (smaller per-node share) instead of the doomed 2-node one.
     """
-    topology, node_memory, node_network, _ = _fully_connected_three_nodes(
+    topology, node_memory, node_network, _ = fully_connected_three_nodes(
         (10.0, 10.0, 10.0)
     )
     card = ModelCard(
@@ -1391,7 +1391,7 @@ def test_replacement_at_full_cluster_width_is_terminal() -> None:
     satisfied — place_instance raises, and the master treats that as the terminal
     "cannot fit anywhere" outcome that stops the refuse→re-place loop.
     """
-    topology, node_memory, node_network, _ = _fully_connected_three_nodes(
+    topology, node_memory, node_network, _ = fully_connected_three_nodes(
         (10.0, 10.0, 10.0)
     )
     card = ModelCard(
@@ -1554,7 +1554,7 @@ def test_repair_commands_preserve_original_exclusions() -> None:
     the caller excluded (observed live: a placement pinned off five nodes
     was repaired onto one of them).
     """
-    topology, node_memory, node_network, node_ids = _fully_connected_three_nodes(
+    topology, node_memory, node_network, node_ids = fully_connected_three_nodes(
         (10.0, 10.0, 10.0)
     )
     operator_excluded = node_ids[2]

--- a/src/skulk/master/tests/test_steward_placement.py
+++ b/src/skulk/master/tests/test_steward_placement.py
@@ -1,0 +1,101 @@
+"""System-role (steward) placement stamping and repair-survival tests."""
+
+from skulk.master.placement import (
+    fallback_command_for_refused_instance,
+    place_instance,
+    replacement_command_for_download_failed_instance,
+    replacement_command_for_refused_instance,
+)
+from skulk.master.tests.test_placement import fully_connected_three_nodes
+from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from skulk.shared.types.commands import PlaceInstance
+from skulk.shared.types.memory import Memory
+from skulk.shared.types.worker.instances import InstanceMeta, MlxRingInstance
+from skulk.shared.types.worker.shards import Sharding
+
+
+def _steward_card() -> ModelCard:
+    return ModelCard(
+        model_id=ModelId("steward-brain-model"),
+        storage_size=Memory.from_gb(3),
+        n_layers=12,
+        hidden_size=30,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+    )
+
+
+def _place_steward() -> MlxRingInstance:
+    topology, node_memory, node_network, _node_ids = fully_connected_three_nodes(
+        (10.0, 10.0, 10.0)
+    )
+    command = PlaceInstance(
+        model_card=_steward_card(),
+        sharding=Sharding.Pipeline,
+        instance_meta=InstanceMeta.MlxRing,
+        min_nodes=1,
+        system_role="steward",
+    )
+    placed = place_instance(command, topology, {}, node_memory, node_network)
+    instance = next(iter(placed.values()))
+    assert isinstance(instance, MlxRingInstance)
+    return instance
+
+
+def test_place_instance_stamps_system_role() -> None:
+    """The minted instance carries the command's system-role marker."""
+    instance = _place_steward()
+    assert instance.system_role == "steward"
+
+
+def test_default_placement_has_no_system_role() -> None:
+    """Ordinary placements stay unmarked (and old event logs replay as None)."""
+    topology, node_memory, node_network, _node_ids = fully_connected_three_nodes(
+        (10.0, 10.0, 10.0)
+    )
+    command = PlaceInstance(
+        model_card=_steward_card(),
+        sharding=Sharding.Pipeline,
+        instance_meta=InstanceMeta.MlxRing,
+        min_nodes=1,
+    )
+    placed = place_instance(command, topology, {}, node_memory, node_network)
+    instance = next(iter(placed.values()))
+    assert instance.system_role is None
+
+
+def test_repair_commands_preserve_system_role() -> None:
+    """Every repair builder re-stamps the steward flag (failover survival).
+
+    Repair reconstructs placement intent from the instance's shards, which
+    have no channel for the flag; without explicit re-stamping a repaired
+    steward would silently demote to an ordinary instance and the invariant
+    pass would then place a second steward.
+    """
+    instance = _place_steward()
+
+    wider = replacement_command_for_refused_instance(instance)
+    assert wider.system_role == "steward"
+
+    refusing = next(iter(instance.shard_assignments.node_to_runner))
+    fallback = fallback_command_for_refused_instance(instance, refusing)
+    assert fallback.system_role == "steward"
+
+    failed = replacement_command_for_download_failed_instance(instance, {refusing})
+    assert failed.system_role == "steward"
+
+
+def test_repair_commands_keep_none_for_ordinary_instances() -> None:
+    """Ordinary instances never acquire a system role through repair."""
+    topology, node_memory, node_network, _node_ids = fully_connected_three_nodes(
+        (10.0, 10.0, 10.0)
+    )
+    command = PlaceInstance(
+        model_card=_steward_card(),
+        sharding=Sharding.Pipeline,
+        instance_meta=InstanceMeta.MlxRing,
+        min_nodes=1,
+    )
+    placed = place_instance(command, topology, {}, node_memory, node_network)
+    instance = next(iter(placed.values()))
+    assert replacement_command_for_refused_instance(instance).system_role is None

--- a/src/skulk/shared/types/commands.py
+++ b/src/skulk/shared/types/commands.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field
 
 from skulk.api.types import (
@@ -35,6 +37,12 @@ class TestCommand(BaseCommand):
 class TextGeneration(BaseCommand):
     task_params: TextGenerationTaskParams
     owner_node: NodeId | None = None
+    # Pin this generation to one specific instance instead of least-loaded
+    # selection across all instances serving the model (mirrors
+    # SpeechSynthesis.target_instance_id). Used by the steward chat surface
+    # and the steward canary so their requests always land on the hidden
+    # system placement; None preserves normal selection.
+    target_instance_id: InstanceId | None = None
 
 
 class ImageGeneration(BaseCommand):
@@ -92,6 +100,10 @@ class PlaceInstance(BaseCommand):
     # instances on these nodes are not affected — exclusion is purely a hint
     # to the candidate-cycle search for *this* placement.
     excluded_nodes: list[NodeId] = Field(default_factory=list)
+    # System-placement marker stamped onto the minted instance (the
+    # intelligent-fabric steward). Only the master's invariant pass and
+    # repair builders set this; the operator placement API never does.
+    system_role: Literal["steward"] | None = None
 
 
 class CreateInstance(BaseCommand):

--- a/src/skulk/shared/types/worker/instances.py
+++ b/src/skulk/shared/types/worker/instances.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 from pydantic import Field, model_validator
 
@@ -47,6 +48,20 @@ class BaseInstance(TaggedModel):
             "honoring these instead of widening eligibility back to the "
             "full topology. Sorted for deterministic replicated events; "
             "empty for instances replayed from older event logs."
+        ),
+    )
+    system_role: Literal["steward"] | None = Field(
+        default=None,
+        description=(
+            "Marks a fabric-maintained system placement. ``\"steward\"`` is "
+            "the intelligent-fabric resident: the master re-establishes "
+            "exactly one such placement while intelligent-fabric mode is "
+            "enabled, the dashboard hides it from ordinary instance "
+            "surfaces, and the API refuses ordinary deletion while the mode "
+            "is on. ``None`` (the default, and the value on every instance "
+            "replayed from older event logs) means a normal user placement. "
+            "Repair re-placements re-stamp the role so it survives node "
+            "loss."
         ),
     )
 

--- a/src/skulk/store/config.py
+++ b/src/skulk/store/config.py
@@ -364,6 +364,8 @@ class SkulkConfig(FrozenModel):
             the node.
         telemetry: Field-telemetry consent and settings.  ``None`` means the
             operator has never been asked (nothing is queued or sent).
+        intelligent_fabric: Intelligent-fabric (resident steward) settings.
+            ``None`` means the mode is off.
         hf_token: HuggingFace API token.  Stripped from ``GET /config``
             responses for security.
     """
@@ -375,7 +377,36 @@ class SkulkConfig(FrozenModel):
     connectivity: ConnectivityConfig | None = None
     experiments: ExperimentsConfig | None = None
     telemetry: "TelemetryConfig | None" = None
+    intelligent_fabric: "IntelligentFabricConfig | None" = None
     hf_token: str | None = None
+
+
+@final
+class IntelligentFabricConfig(FrozenModel):
+    """Intelligent-fabric mode: the resident steward (cluster-synced).
+
+    When ``enabled`` is ``True``, the master maintains exactly one hidden
+    steward placement as a planner invariant: it places the steward model on
+    the best available nodes, re-places it after node loss or master
+    failover, and protects it from ordinary deletion. The steward answers
+    operator questions about the cluster through the steward chat surface.
+
+    Attributes:
+        enabled: Master switch for intelligent-fabric mode. Off by default
+            while the feature hardens; flipping it on makes the master
+            establish the steward placement within one planning cycle.
+        steward_models: Ordered model-card preference list for the steward
+            brain. The master places the first card the cluster can serve.
+            The defaults are the benched steward class (Qwen3.5-4B in MLX
+            and GGUF form); operators may override with any bundled or
+            custom text model that supports tool calling.
+    """
+
+    enabled: bool = False
+    steward_models: tuple[str, ...] = (
+        "mlx-community/Qwen3.5-4B-MLX-4bit",
+        "unsloth/Qwen3.5-4B-GGUF",
+    )
 
 
 @final

--- a/src/skulk/store/config.py
+++ b/src/skulk/store/config.py
@@ -403,9 +403,14 @@ class IntelligentFabricConfig(FrozenModel):
     """
 
     enabled: bool = False
-    steward_models: tuple[str, ...] = (
-        "mlx-community/Qwen3.5-4B-MLX-4bit",
-        "unsloth/Qwen3.5-4B-GGUF",
+    # list (not tuple): strict validation rejects YAML sequences for tuple
+    # fields, which would make the documented override unloadable; matches
+    # the convention of other config lists (e.g. bootstrap_peers).
+    steward_models: list[str] = Field(
+        default_factory=lambda: [
+            "mlx-community/Qwen3.5-4B-MLX-4bit",
+            "unsloth/Qwen3.5-4B-GGUF",
+        ]
     )
 
 

--- a/src/skulk/store/tests/test_config.py
+++ b/src/skulk/store/tests/test_config.py
@@ -156,3 +156,23 @@ def test_load_skulk_config_parses_speech_streaming_experiments(
     assert config.experiments.tts_streaming is True
     assert config.experiments.stt_realtime is True
     assert config.experiments.speech_translation is True
+
+
+def test_intelligent_fabric_config_defaults() -> None:
+    """The intelligent-fabric section parses, defaults off, and carries the
+    benched steward model preference order."""
+    from skulk.store.config import IntelligentFabricConfig, SkulkConfig
+
+    config = SkulkConfig.model_validate({})
+    assert config.intelligent_fabric is None
+
+    parsed = SkulkConfig.model_validate({"intelligent_fabric": {"enabled": True}})
+    assert parsed.intelligent_fabric is not None
+    assert parsed.intelligent_fabric.enabled
+    assert parsed.intelligent_fabric.steward_models == (
+        "mlx-community/Qwen3.5-4B-MLX-4bit",
+        "unsloth/Qwen3.5-4B-GGUF",
+    )
+
+    default_section = IntelligentFabricConfig()
+    assert not default_section.enabled

--- a/src/skulk/store/tests/test_config.py
+++ b/src/skulk/store/tests/test_config.py
@@ -169,10 +169,18 @@ def test_intelligent_fabric_config_defaults() -> None:
     parsed = SkulkConfig.model_validate({"intelligent_fabric": {"enabled": True}})
     assert parsed.intelligent_fabric is not None
     assert parsed.intelligent_fabric.enabled
-    assert parsed.intelligent_fabric.steward_models == (
+    assert parsed.intelligent_fabric.steward_models == [
         "mlx-community/Qwen3.5-4B-MLX-4bit",
         "unsloth/Qwen3.5-4B-GGUF",
+    ]
+
+    # The documented YAML-sequence override must load (list, not tuple:
+    # strict validation rejects coercion).
+    override = SkulkConfig.model_validate(
+        {"intelligent_fabric": {"enabled": True, "steward_models": ["a/b"]}}
     )
+    assert override.intelligent_fabric is not None
+    assert override.intelligent_fabric.steward_models == ["a/b"]
 
     default_section = IntelligentFabricConfig()
     assert not default_section.enabled

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -1185,6 +1185,60 @@ Use this when you already have an `instance` object and want exact control.
 
 **DELETE** `/instance/{instance_id}`
 
+## Intelligent Fabric (Steward)
+
+When intelligent-fabric mode is enabled in the cluster configuration
+(`intelligent_fabric.enabled`), the fabric keeps a small resident model (the
+steward) placed as a hidden system instance and exposes it through these
+endpoints. The steward investigates the cluster through a bounded read-only
+tool surface and answers operator questions; it cannot change the cluster.
+
+### GET /v1/steward
+
+Returns steward availability.
+
+Response fields:
+
+- `enabled`: whether intelligent-fabric mode is enabled in Settings.
+- `present`: whether a steward placement currently exists.
+- `steward_model`: model id of the steward brain when present, else null.
+- `instance_id`: the steward instance id when present, else null.
+
+### POST /v1/steward/chat
+
+Ask the steward. The caller carries conversation history; the steward system
+prompt, tool definitions, and investigation loop are server-side.
+
+Request body:
+
+- `messages` (required): list of `{role, content}` objects, oldest first,
+  ending with the operator's latest message. Roles are `user` and
+  `assistant`.
+
+Behavior: the steward runs up to 8 read-only tool calls per turn (cluster
+state, node resources, telemetry / data-plane diagnostics, version status,
+performance envelopes, the local doctor registry, and the model catalog),
+then replies. Generation is pinned to the hidden steward instance and rides
+the normal text-generation path.
+
+Response fields:
+
+- `reply`: the steward's answer.
+- `steps`: ordered list of `{tool, arguments}` consulted this turn.
+- `steward_model`: the model id that produced the reply.
+- `instance_id`: the steward instance that served the turn.
+
+Errors:
+
+- `409`: intelligent-fabric mode is disabled, or the steward placement is
+  not currently available (for example, immediately after enabling the mode
+  or during re-placement after node loss).
+- `502`: steward generation failed.
+
+Note: deleting the steward instance through `DELETE /instance/{instance_id}`
+is refused with `409` while intelligent-fabric mode is enabled; disable the
+mode in Settings to remove the placement.
+
 ## Download Management
 
 ### Start a node download

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -80,6 +80,33 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 - **Mounts:** dashboard at `/` (skipped when the built assets are absent, e.g. a headless/non-Mac worker node with no `dashboard-react/dist`; `DASHBOARD_DIR` is then `None` and the API serves without the UI, #333); OpenAPI at `/api/openapi.json`
 - **Background tasks:** `_apply_state` (consumes `GLOBAL_EVENTS` and persists merged traces), `_pause_on_new_election`, `_cleanup_expired_images` (image-store TTL), `_prune_old_traces` (hourly trace janitor backed by `prune_old_trace_files`; retention via `tracing.retention_days`)
 
+### Steward (intelligent fabric)
+
+- Config: `intelligent_fabric` in `skulk.yaml` (`enabled`, default false;
+  `steward_models` preference list, default Qwen3.5-4B MLX then GGUF).
+- Identity: `BaseInstance.system_role = "steward" | None` (additive field;
+  None on replayed old logs). Stamped from `PlaceInstance.system_role` at
+  mint; all three repair builders re-stamp it from the instance.
+- Invariant: `Master._maintain_steward_placement` runs each planning tick
+  behind the topology-settle grace: places first servable card from the
+  preference list (min_nodes=1, MlxRing meta), tears down duplicate
+  stewards keeping the lowest instance id, paces attempts to one per
+  minute. Master failover re-establishes the steward via the invariant; no
+  dedicated failover code.
+- Pinning: `TextGeneration.target_instance_id` (mirrors SpeechSynthesis);
+  miss emits TaskFailed `instance_unavailable`.
+- Harness: `src/skulk/api/steward.py`. Read-only tools: cluster state
+  summary, node resources, telemetry diagnostics, data-plane diagnostics,
+  cluster versions, performance envelopes, local doctor registry, model
+  catalog. 6000-char tool-result bound, 8 steps/turn, observe/advise only.
+- Endpoints: `GET /v1/steward` (status), `POST /v1/steward/chat`
+  (409 when disabled/absent). Ordinary `DELETE /instance/{id}` of the
+  steward is refused 409 while the mode is enabled.
+- Dashboard: instances with `systemRole` set are hidden from all instance
+  surfaces (filter in App.tsx instanceCards).
+- Cards: `mlx-community/Qwen3.5-4B-MLX-4bit` (vision, MLX) and
+  `unsloth/Qwen3.5-4B-GGUF` (text-only so served lanes stay eligible).
+
 ### Dashboard
 
 - **Role:** operator UI for the same Skulk runtime

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -620,7 +620,36 @@ input chunks into exact classifier windows, and emits typed
 minimum-speech, silence-hangover, preroll, and maximum-utterance state. Media
 is processed per call and never retained.
 
-### The dashboard voice loop
+### Intelligent fabric (the steward)
+
+Skulk can keep a small resident model, the steward, always available to
+answer operator questions about the cluster. The mode is configured by the
+`intelligent_fabric` section of the cluster configuration and is off by
+default.
+
+The steward is an ordinary model instance with one extra property: its
+placement record carries a system-role marker, and the master treats "exactly
+one steward placement exists" as an invariant of its planning loop. The
+master places the first servable model from the configured preference list,
+re-places the steward after node loss through the same repair machinery every
+instance gets, and, because the invariant is re-evaluated on every planning
+tick, a newly elected master re-establishes the steward automatically after
+failover. Duplicate stewards (possible across a failover window) are detected
+and reduced to one. The steward placement is hidden from user-facing instance
+surfaces and refuses ordinary deletion while the mode is enabled.
+
+Conversation happens through the steward chat endpoint. The server-side
+harness gives the model a bounded, strictly read-only tool surface: cluster
+state with health reasons, per-node resources and capability conflicts,
+telemetry and data-plane diagnostics, per-node version status, performance
+envelopes, the local doctor check registry, and the model catalog. Each
+operator turn runs a bounded investigation loop; generation itself rides the
+normal text-generation dispatch path, pinned to the steward instance. In this
+release the steward observes and advises only: no tool can change the
+cluster, and anything action-shaped is returned to the operator as a
+recommendation.
+
+## The dashboard voice loop
 
 The dashboard composes these surfaces in chat: mounted TTS models can speak
 draft text, replay assistant messages, or auto-speak final assistant responses


### PR DESCRIPTION
## What this is

Phase 1 of the intelligent-fabric initiative: the cluster gains a small resident model (the steward) that the fabric itself keeps placed, repaired, and answerable, plus the chat surface to talk to it. Off by default behind the new `intelligent_fabric` config section. Design and the Phase 0 model bench (which selected Qwen3.5-4B: 8/8 on the steward investigation bench at ~2 GB resident) are in the private initiative docs.

## Design

**Identity: a flagged placement.** `BaseInstance.system_role: "steward" | None` is an additive schema field; instances replayed from older event logs default to None. `PlaceInstance` carries the marker, placement stamps it at mint, and all three repair builders re-stamp it from the instance, so the flag survives arbitrary repair chains exactly the way per-placement exclusions do (#658). Without that re-stamping, a repaired steward would silently demote to an ordinary instance and the invariant would then mint a second one; a test locks this in.

**Invariant, not bespoke failover.** The master's planning loop maintains "exactly one steward placement" each tick (behind the topology-settle grace): it places the first servable model from `intelligent_fabric.steward_models`, tears down duplicates (possible across failover windows, keeping the lowest instance id), and paces placement attempts to one per minute. Node death is handled by the existing liveness teardown plus this invariant re-placing on the next tick; master failover is handled by the new master running the same loop. No dedicated steward-failover machinery exists, deliberately.

**Chat rides the normal path.** `TextGeneration.target_instance_id` (mirroring `SpeechSynthesis`) pins generation to the hidden instance; a miss fails the task with `instance_unavailable` instead of landing on another placement. The steward harness (`src/skulk/api/steward.py`) runs a bounded investigation loop (8 steps/turn, 6000-char tool results) over a strictly read-only tool surface: cluster state summary, per-node resources and capability conflicts, telemetry and data-plane diagnostics, per-node version status, performance envelopes, the local doctor check registry, and the model catalog. Observe/advise only: no mutating tool exists in the module by construction.

**Protection and visibility.** `DELETE /instance/{id}` on the steward returns 409 while the mode is enabled (internal repair/teardown paths are unaffected: they send commands directly). The dashboard hides system-role placements from instance cards, counts, and the chat model picker via one filter.

**Cards.** Bundled Qwen3.5-4B in both formats: MLX 4-bit (vision-capable) and GGUF Q4_K_M (text-only, deliberately, so the vision platform-gate does not exclude served lanes). Values taken from the model config and actual artifact sizes.

## New API surface

- `GET /v1/steward`: mode + placement status.
- `POST /v1/steward/chat`: one steward turn; returns reply plus the ordered tool trace; 409 when disabled or the placement is unavailable.

Both documented in api-guide.md and present in the OpenAPI spec; architecture.md, architecture-reference.md, CLAUDE.md, and skulk.yaml.example updated.

## Validation

- basedpyright: 0 errors. ruff: clean. nix fmt: no changes.
- Full suite: 2982 passed, 1 skipped.
- New tests: system-role stamping at mint, None default for ordinary placements, re-stamping across all three repair builders, no role acquisition through repair for ordinary instances, and the config section's defaults.
- Dashboard: 65 tests pass, production build clean.
- Live single-node validation of the invariant loop and chat surface is planned separately (needs a running fleet window; the fleet is currently reserved for 1.5 hardening).

## Out of scope (follow-ups by design)

- The deterministic canary probe for a degraded-but-alive steward (design settled in the initiative; needs the master-side response-consumption seam).
- Dashboard chat UI for the steward and the Settings toggle surface.
- The flashlight degraded tier (Phase 4) and any acting authority (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01262jKrQwepcSQtv1vk2chH