### PR TITLE
fix(cards): pin Qwen3 VL artifact size

### DIFF
--- a/resources/inference_model_cards/mlx-community--Qwen3-VL-4B-Instruct-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3-VL-4B-Instruct-4bit.toml
@@ -9,6 +9,7 @@ quantization = "4bit"
 base_model = "Qwen3-VL 4B Instruct"
 capabilities = ["text", "thinking", "thinking_toggle", "vision"]
 context_length = 262144
+source_revision = "2fd8dacbdb8f1e54b8c005f081ec5bf79c56376b"
 
 [vision]
 image_token_id = 151655
@@ -16,4 +17,4 @@ model_type = "qwen3_vl"
 weights_repo = "mlx-community/Qwen3-VL-4B-Instruct-4bit"
 
 [storage_size]
-in_bytes = 8875631616
+in_bytes = 3109732071

--- a/src/skulk/shared/tests/test_bundled_model_cards.py
+++ b/src/skulk/shared/tests/test_bundled_model_cards.py
@@ -80,6 +80,17 @@ def test_gemma4_12b_card_does_not_advertise_missing_vision_tower() -> None:
     assert card.modalities is None
 
 
+def test_qwen3_vl_4b_card_pins_the_measured_artifact() -> None:
+    """Keep disk admission aligned with the complete pinned upstream artifact."""
+    card = _load(
+        _CARD_DIRS["inference"]
+        / "mlx-community--Qwen3-VL-4B-Instruct-4bit.toml"
+    )
+
+    assert card.source_revision == "2fd8dacbdb8f1e54b8c005f081ec5bf79c56376b"
+    assert card.storage_size.in_bytes == 3_109_732_071
+
+
 @pytest.mark.parametrize(("kind", "path"), _CARD_FILES, ids=_CARD_IDS)
 def test_bundled_card_invariants(kind: str, path: Path) -> None:
     card = _load(path)  # validation itself is the first gate


### PR DESCRIPTION
## Summary
- pin the bundled Qwen3-VL 4B card to the qualified upstream revision
- correct disk-admission metadata to the complete 16-file artifact size
- add a regression invariant for revision and byte size

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (2979 passed, 1 skipped, 228 deselected)