### PR TITLE
Fix per-request Qwen vision position state

### DIFF
--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -2311,16 +2311,58 @@ def _reset_native_vision_position_state(model: Model) -> None:
             object.__setattr__(language_model, attribute_name, None)
 
 
+def _seed_native_vision_position_state(
+    model: Model,
+    all_prompt_tokens: mx.array,
+    image_grid_thw: mx.array | None,
+) -> None:
+    """Seed the current image prompt's multimodal position state.
+
+    MLX-VLM computes ``position_ids`` and ``rope_deltas`` while preparing
+    native Qwen embeddings, then passes them only to the prefill forward. Its
+    decode loop clears those keyword arguments after prefill and expects the
+    language model's retained state to carry the same coordinates forward.
+    Starting from ``None`` makes Qwen recompute them from the first one-token
+    decode suffix, which produces repeated or corrupted output. Compute the
+    current request's coordinates before generation so decode never depends
+    on warmup or a previous image request.
+    """
+
+    language_model = getattr(model, "language_model", model)
+    get_rope_index = getattr(language_model, "get_rope_index", None)
+    if not callable(get_rope_index) or image_grid_thw is None:
+        return
+
+    position_ids, rope_deltas = cast(
+        tuple[mx.array, mx.array],
+        get_rope_index(
+            all_prompt_tokens[None],
+            image_grid_thw,
+            None,
+            None,
+        ),
+    )
+    if hasattr(language_model, "_position_ids"):
+        object.__setattr__(language_model, "_position_ids", position_ids)
+    if hasattr(language_model, "_rope_deltas"):
+        object.__setattr__(language_model, "_rope_deltas", rope_deltas)
+
+
 @contextlib.contextmanager
-def _isolated_native_vision_position_state(model: Model) -> Generator[None]:
+def _isolated_native_vision_position_state(
+    model: Model,
+    all_prompt_tokens: mx.array,
+    image_grid_thw: mx.array | None,
+) -> Generator[None]:
     """Isolate request-local multimodal RoPE state from later text requests.
 
     Qwen VLM text generation relies on its retained zero RoPE delta when a
     later request resumes from Skulk's text-only prefix cache. Native vision
-    must temporarily clear that state to calculate multimodal coordinates, but
-    leaving it cleared makes the next cached text suffix restart positions at
-    zero. Preserve the prior text state across the complete vision generator,
-    including cancellation and failure.
+    must temporarily replace that state with coordinates for the current image
+    prompt, but leaving the image state behind corrupts the next cached text
+    suffix. Preserve the prior text state across the complete vision generator,
+    including cancellation and failure, while seeding each image request from
+    its own prompt rather than whichever request happened to run before it.
     """
 
     language_model = getattr(model, "language_model", model)
@@ -2330,6 +2372,11 @@ def _isolated_native_vision_position_state(model: Model) -> Generator[None]:
         if hasattr(language_model, attribute_name)
     }
     _reset_native_vision_position_state(model)
+    _seed_native_vision_position_state(
+        model,
+        all_prompt_tokens,
+        image_grid_thw,
+    )
     try:
         yield
     finally:
@@ -2620,7 +2667,11 @@ def _mlx_generate_native_vision(
 ) -> Generator[GenerationResponse]:
     """Generate native vision without leaking multimodal position state."""
 
-    with _isolated_native_vision_position_state(model):
+    with _isolated_native_vision_position_state(
+        model,
+        all_prompt_tokens,
+        vision.image_grid_thw,
+    ):
         yield from _mlx_generate_native_vision_unisolated(
             model=model,
             tokenizer=tokenizer,

--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -2371,13 +2371,13 @@ def _isolated_native_vision_position_state(
         for attribute_name in ("_position_ids", "_rope_deltas")
         if hasattr(language_model, attribute_name)
     }
-    _reset_native_vision_position_state(model)
-    _seed_native_vision_position_state(
-        model,
-        all_prompt_tokens,
-        image_grid_thw,
-    )
     try:
+        _reset_native_vision_position_state(model)
+        _seed_native_vision_position_state(
+            model,
+            all_prompt_tokens,
+            image_grid_thw,
+        )
         yield
     finally:
         for attribute_name, attribute_value in position_state.items():

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -140,6 +140,7 @@ class _FakePositionState:
     def __init__(self) -> None:
         self._position_ids: object | None = mx.arange(64)[None]
         self._rope_deltas: object | None = mx.zeros((1, 1))
+        self.seeded_grids: list[int] = []
 
     @property
     def position_state(self) -> object | None:
@@ -155,6 +156,23 @@ class _FakePositionState:
             return 0
         rope_deltas = cast(mx.array, self._rope_deltas)
         return cache_offset + int(rope_deltas.item())
+
+    def get_rope_index(
+        self,
+        input_ids: mx.array,
+        image_grid_thw: mx.array,
+        _video_grid_thw: object,
+        _attention_mask: object,
+    ) -> tuple[mx.array, mx.array]:
+        """Return request-specific multimodal coordinates like native Qwen."""
+
+        grid_marker = int(image_grid_thw[0, 0].item())
+        self.seeded_grids.append(grid_marker)
+        position_ids = mx.broadcast_to(
+            mx.arange(input_ids.shape[-1])[None, None, :],
+            (3, input_ids.shape[0], input_ids.shape[-1]),
+        )
+        return position_ids, mx.array([[grid_marker]])
 
 
 def _fake_group(*, size: int = 3) -> mx.distributed.Group:
@@ -284,8 +302,8 @@ def test_text_vision_text_restores_cached_suffix_position_state(
     assert model.language_model.cached_suffix_start(19) == 19
 
     def _fake_generate_step(**_kwargs: object):
-        assert model.language_model.position_state is None
-        assert model.language_model.rope_state is None
+        assert cast(mx.array, model.language_model.position_state).shape == (3, 1, 3)
+        assert cast(mx.array, model.language_model.rope_state).item() == 1
         yield mx.array(999), mx.zeros((8,))
 
     monkeypatch.setattr(
@@ -329,6 +347,7 @@ def test_text_vision_text_restores_cached_suffix_position_state(
     assert model.language_model.position_state is original_position_state
     assert model.language_model.rope_state is original_rope_state
     assert model.language_model.cached_suffix_start(19) == 19
+    assert model.language_model.seeded_grids == [1]
 
 
 def test_native_vision_restores_text_position_state_after_failure(
@@ -345,8 +364,8 @@ def test_native_vision_restores_text_position_state_after_failure(
     original_rope_state = model.language_model.rope_state
 
     def _failing_generate_step(**_kwargs: object):
-        assert model.language_model.position_state is None
-        assert model.language_model.rope_state is None
+        assert cast(mx.array, model.language_model.position_state).shape == (3, 1, 3)
+        assert cast(mx.array, model.language_model.rope_state).item() == 1
         raise RuntimeError("native vision decode failed")
         yield mx.array(999), mx.zeros((8,))
 
@@ -390,6 +409,78 @@ def test_native_vision_restores_text_position_state_after_failure(
 
     assert model.language_model.position_state is original_position_state
     assert model.language_model.rope_state is original_rope_state
+
+
+def test_back_to_back_native_vision_requests_seed_their_own_position_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each image decode must use its own grid rather than prior request state."""
+
+    class _StatefulVisionModel:
+        def __init__(self) -> None:
+            self.language_model = _FakePositionState()
+
+    model = _StatefulVisionModel()
+    original_position_state = model.language_model.position_state
+    original_rope_state = model.language_model.rope_state
+    observed_rope_deltas: list[int] = []
+
+    def _fake_generate_step(**_kwargs: object):
+        current_delta = int(
+            cast(mx.array, model.language_model.rope_state).item()
+        )
+        observed_rope_deltas.append(current_delta)
+        # Upstream decode mutates retained request state. The next request
+        # must replace it rather than inheriting this terminal value.
+        object.__setattr__(
+            model.language_model,
+            "_rope_deltas",
+            mx.array([[999]]),
+        )
+        yield mx.array(999), mx.zeros((8,))
+
+    monkeypatch.setattr(
+        import_module("mlx_vlm.generate"),
+        "generate_step",
+        _fake_generate_step,
+    )
+
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/Qwen3-VL-4B-Instruct-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+    for grid_marker in (2, 7):
+        vision = VisionResult(
+            prompt="ignored",
+            prompt_tokens=mx.array([1, 2, 3]),
+            embeddings=mx.zeros((1, 0, 1)),
+            media_regions=[],
+            pixel_values=mx.array([1.0]),
+            image_grid_thw=mx.array([[grid_marker, 2, 3]]),
+        )
+        responses = list(
+            _mlx_generate_native_vision_fn()(
+                model=cast(Model, cast(object, model)),
+                tokenizer=_fake_tokenizer(),
+                task=task,
+                all_prompt_tokens=vision.prompt_tokens,
+                vision=vision,
+                sampler=_identity_sampler,
+                logits_processors=[],
+                on_prefill_progress=None,
+                on_generation_token=None,
+                group=None,
+                max_tokens=8,
+            )
+        )
+        assert responses[-1].finish_reason == "stop"
+        assert model.language_model.position_state is original_position_state
+        assert model.language_model.rope_state is original_rope_state
+
+    assert observed_rope_deltas == [2, 7]
+    assert model.language_model.seeded_grids == [2, 7]
 
 
 @pytest.mark.parametrize(

--- a/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_native_vision_generate.py
@@ -411,6 +411,63 @@ def test_native_vision_restores_text_position_state_after_failure(
     assert model.language_model.rope_state is original_rope_state
 
 
+def test_native_vision_restores_text_position_state_when_seeding_fails() -> None:
+    """A failed RoPE seed must not clear state retained for cached text."""
+
+    class _FailingPositionState(_FakePositionState):
+        def get_rope_index(
+            self,
+            input_ids: mx.array,
+            image_grid_thw: mx.array,
+            _video_grid_thw: object,
+            _attention_mask: object,
+        ) -> tuple[mx.array, mx.array]:
+            del input_ids, image_grid_thw
+            raise RuntimeError("native vision position seed failed")
+
+    class _StatefulVisionModel:
+        def __init__(self) -> None:
+            self.language_model = _FailingPositionState()
+
+    model = _StatefulVisionModel()
+    original_position_state = model.language_model.position_state
+    original_rope_state = model.language_model.rope_state
+    task = TextGenerationTaskParams(
+        model=ModelId("mlx-community/Qwen3-VL-4B-Instruct-4bit"),
+        input=[InputMessage(role="user", content="what is this?")],
+        max_output_tokens=8,
+        temperature=0.0,
+    )
+    vision = VisionResult(
+        prompt="ignored",
+        prompt_tokens=mx.array([1, 2, 3]),
+        embeddings=mx.zeros((1, 0, 1)),
+        media_regions=[],
+        pixel_values=mx.array([1.0]),
+        image_grid_thw=mx.array([[1, 2, 3]]),
+    )
+
+    with pytest.raises(RuntimeError, match="native vision position seed failed"):
+        list(
+            _mlx_generate_native_vision_fn()(
+                model=cast(Model, cast(object, model)),
+                tokenizer=_fake_tokenizer(),
+                task=task,
+                all_prompt_tokens=vision.prompt_tokens,
+                vision=vision,
+                sampler=_identity_sampler,
+                logits_processors=[],
+                on_prefill_progress=None,
+                on_generation_token=None,
+                group=None,
+                max_tokens=8,
+            )
+        )
+
+    assert model.language_model.position_state is original_position_state
+    assert model.language_model.rope_state is original_rope_state
+
+
 def test_back_to_back_native_vision_requests_seed_their_own_position_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What changed

- Seed native Qwen vision decode with the current image prompt's multimodal position IDs and RoPE delta.
- Preserve and restore the existing text-generation position state around each vision request.
- Add focused coverage for success, failure, text-state restoration, and two back-to-back image requests with different grids.

## Root cause

MLX-VLM computes request-specific multimodal coordinates during image prefill, but clears those keyword arguments before token-by-token decode. Skulk previously reset the model's retained position state to `None`, so decode recomputed coordinates from a one-token suffix. Depending on request history, this produced repeated or corrupted vision output. The current request's coordinates are now installed for the duration of vision generation, while the batched text path's state is restored afterward.

## User impact

Repeated dashboard and direct-API image requests no longer depend on warmup or prior request history. In a retained real-model reproduction, two different qualification fixtures now return their exact color, shape, and six-character code back-to-back.

## Validation

- `uv run basedpyright` — 0 errors
- `uv run ruff check` — clean
- `nix --extra-experimental-features 'nix-command flakes' fmt` — no changes
- `uv run pytest` — 2980 passed, 1 skipped, 228 deselected
- Focused native-vision tests — 35 passed
- Real pinned Qwen3-VL model — both retained qualification fixtures passed exactly in sequence
