### PR TITLE
Steward as the virtual model skulk/steward on chat-completions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,9 +266,12 @@ exclusions). `TextGeneration.target_instance_id` pins generation to one
 instance (mirrors SpeechSynthesis). Harness = `src/skulk/api/steward.py`:
 bounded read-only tools (state/resources/telemetry/data-plane/versions/
 envelopes/doctor/catalog), 8 steps per turn, observe/advise only, rides the
-normal chat dispatch path. Endpoints `GET /v1/steward` + `POST
-/v1/steward/chat`; ordinary deletion of the steward is refused while the
-mode is on; the dashboard hides `systemRole` instances.
+normal chat dispatch path. Client surface = reserved virtual
+model `skulk/steward` on chat-completions (client tools 400; trace as
+reasoning_content; streaming via the ordinary adapters over
+`run_turn_chunks`); `GET /v1/steward` = presence; flagged entry in
+/v1/models (`system_role`). Ordinary deletion of the steward is refused
+while the mode is on; the dashboard hides `systemRole` instances.
 
 ### Message Flow
 Components communicate via typed pub/sub topics (src/skulk/routing/topics.py):

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -4017,6 +4017,16 @@ class API:
                     "Vision media timed out waiting for worker verification",
                 )
 
+    async def send_task_cancellation(self, command_id: CommandId) -> None:
+        """Public cancellation seam for internal callers (the steward harness).
+
+        Sends the same TaskCancelled command the HTTP cancel endpoint sends,
+        suppressing the final TaskFinished so the worker can observe the
+        cancelled task and stop the runner promptly.
+        """
+        await self._send(TaskCancelled(cancelled_command_id=command_id))
+        self._cancelled_command_ids.add(command_id)
+
     async def dispatch_text_generation(
         self,
         task_params: TextGenerationTaskParams,

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -116,8 +116,9 @@ from skulk.api.realtime import (
     RealtimeTranscriptionBridge,
 )
 from skulk.api.steward import (
-    StewardChatRequest,
-    StewardChatResponse,
+    STEWARD_VIRTUAL_MODEL_ID,
+    StewardChatMessage,
+    StewardHarness,
     StewardStatusResponse,
 )
 from skulk.api.types import (
@@ -140,6 +141,7 @@ from skulk.api.types import (
     CancelCommandResponse,
     ChatCompletionChoice,
     ChatCompletionMessage,
+    ChatCompletionMessageText,
     ChatCompletionRequest,
     ChatCompletionResponse,
     CreateInstanceParams,
@@ -2231,21 +2233,6 @@ class API:
             ),
         )(self.get_steward_status)
         self.app.post(
-            "/v1/steward/chat",
-            tags=["Steward"],
-            summary="Ask the cluster's resident steward",
-            description=(
-                "Send a conversation to the intelligent-fabric steward: a small "
-                "resident model the fabric keeps placed while the mode is "
-                "enabled. The steward investigates the cluster through a "
-                "bounded read-only tool surface (state, diagnostics, doctor, "
-                "catalog) and answers with its reasoning trace. Observe/advise "
-                "only: the steward cannot change the cluster. Returns 409 when "
-                "intelligent-fabric mode is disabled or the steward placement "
-                "is not currently available."
-            ),
-        )(self.steward_chat)
-        self.app.post(
             "/v1/diagnostics/node/runners/{runner_id}/cancel",
             tags=["Diagnostics"],
             summary="Request direct local runner cancellation",
@@ -2893,6 +2880,80 @@ class API:
             raise HTTPException(status_code=404, detail="Instance not found")
         return self.state.instances[instance_id]
 
+    async def _steward_chat_completions(
+        self, payload: ChatCompletionRequest
+    ) -> StreamingResponse:
+        """Serve the steward through the standard chat-completions surface.
+
+        The steward's tool surface belongs to the server, so client tool
+        definitions are rejected rather than silently ignored, and client
+        system messages are dropped in favor of the steward's own prompt
+        (documented in the API guide). History is the caller's user and
+        assistant turns; multimodal content parts are flattened to their
+        text. Both streaming and non-streaming ride the ordinary adapters
+        over the harness's chunk stream.
+        """
+        if payload.tools:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "The steward's tool surface is server-side; client tool "
+                    "definitions are not accepted for this model"
+                ),
+            )
+        if not self._intelligent_fabric_enabled():
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    "Model not available: intelligent-fabric mode is "
+                    "disabled. Enable intelligent_fabric in Settings to "
+                    "use the steward."
+                ),
+            )
+        history: list[StewardChatMessage] = []
+        for message in payload.messages:
+            if message.role not in ("user", "assistant"):
+                continue
+            content = message.content
+            if isinstance(content, list):
+                text = " ".join(
+                    part.text
+                    for part in content
+                    if isinstance(part, ChatCompletionMessageText) and part.text
+                )
+            elif isinstance(content, str):
+                text = content
+            else:
+                text = ""
+            if text:
+                history.append(
+                    StewardChatMessage(role=message.role, content=text)
+                )
+        if not history:
+            raise HTTPException(
+                status_code=400,
+                detail="At least one user message is required",
+            )
+        harness = StewardHarness(self)
+        command_id = CommandId()
+        chunk_stream = harness.run_turn_chunks(history)
+        if payload.stream:
+            return StreamingResponse(
+                with_sse_keepalive(
+                    generate_chat_stream(command_id, chunk_stream),
+                ),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "close",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+        return StreamingResponse(
+            collect_chat_response(command_id, chunk_stream),
+            media_type="application/json",
+        )
+
     async def get_steward_status(self) -> "StewardStatusResponse":
         """Report intelligent-fabric mode and the current steward placement."""
         from skulk.api.steward import StewardHarness, StewardStatusResponse
@@ -2904,39 +2965,6 @@ class API:
             steward_model=located[1] if located is not None else None,
             instance_id=str(located[0]) if located is not None else None,
         )
-
-    async def steward_chat(
-        self, payload: "StewardChatRequest"
-    ) -> "StewardChatResponse":
-        """Run one steward turn: investigate through read-only tools, reply."""
-        from skulk.api.steward import StewardHarness
-
-        if not self._intelligent_fabric_enabled():
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    "Intelligent-fabric mode is disabled. Enable it in "
-                    "Settings (intelligent_fabric.enabled) to talk to the "
-                    "steward."
-                ),
-            )
-        harness = StewardHarness(self)
-        try:
-            return await harness.run_turn(payload.messages)
-        except LookupError as error:
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    "The steward placement is not available yet. The fabric "
-                    "establishes it automatically; check /state for placement "
-                    "progress or node capacity."
-                ),
-            ) from error
-        except RuntimeError as error:
-            raise HTTPException(
-                status_code=502,
-                detail=f"Steward generation failed: {error}",
-            ) from error
 
     def _intelligent_fabric_enabled(self) -> bool:
         """Whether intelligent-fabric mode is currently enabled.
@@ -4128,6 +4156,12 @@ class API:
         self, payload: ChatCompletionRequest
     ) -> ChatCompletionResponse | StreamingResponse:
         """OpenAI Chat Completions API - adapter."""
+        if str(payload.model) == STEWARD_VIRTUAL_MODEL_ID:
+            # The reserved steward id selects model-plus-harness: the
+            # server-side investigation loop answers, with its tool trace
+            # streamed as reasoning content. Checked before card resolution
+            # so no repository of the same name can shadow it.
+            return await self._steward_chat_completions(payload)
         resolved_model = await self._resolve_and_validate_text_model(payload.model)
         model_card = await self._get_running_model_card(resolved_model)
         task_params = await chat_request_to_text_generation(
@@ -7268,7 +7302,26 @@ class API:
                         downloaded_model_ids.add(dl.shard_metadata.model_card.model_id)
             cards = [c for c in cards if c.model_id in downloaded_model_ids]
 
-        return ModelList(data=[self._model_list_entry(card) for card in cards])
+        entries = [self._model_list_entry(card) for card in cards]
+        if self._intelligent_fabric_enabled():
+            # The steward's virtual id is addressable like any chat model but
+            # is fabric-managed: flagged so pickers can badge or separate it.
+            entries.append(
+                ModelListModel(
+                    id=STEWARD_VIRTUAL_MODEL_ID,
+                    name="Steward",
+                    description=(
+                        "The cluster's resident assistant. Ask it about "
+                        "cluster health, models, and diagnostics; it "
+                        "investigates through read-only tools before "
+                        "answering and cannot change the cluster."
+                    ),
+                    tags=["system", "steward"],
+                    tasks=["TextGeneration"],
+                    system_role="steward",
+                )
+            )
+        return ModelList(data=entries)
 
     async def add_custom_model(self, payload: AddCustomModelParams) -> ModelListModel:
         """Fetch a Hugging Face model card, optionally pinning one GGUF file."""

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -2921,6 +2921,8 @@ class API:
                     for part in content
                     if isinstance(part, ChatCompletionMessageText) and part.text
                 )
+            elif isinstance(content, ChatCompletionMessageText):
+                text = content.text
             elif isinstance(content, str):
                 text = content
             else:
@@ -2929,10 +2931,15 @@ class API:
                 history.append(
                     StewardChatMessage(role=message.role, content=text)
                 )
-        if not history:
+        if not history or history[-1].role != "user":
+            # A steward turn answers an operator; assistant-only history or
+            # a trailing assistant message has no question to investigate.
             raise HTTPException(
                 status_code=400,
-                detail="At least one user message is required",
+                detail=(
+                    "The conversation must end with a user message for the "
+                    "steward to answer"
+                ),
             )
         harness = StewardHarness(self)
         command_id = CommandId()
@@ -2959,9 +2966,24 @@ class API:
         from skulk.api.steward import StewardHarness, StewardStatusResponse
 
         located = StewardHarness(self).steward_instance()
+        ready = False
+        if located is not None:
+            instance = self.state.instances.get(located[0])
+            if instance is not None:
+                runner_ids = instance.shard_assignments.node_to_runner.values()
+                # Running counts as ready: a steward mid-generation is
+                # serving, not still loading.
+                ready = bool(runner_ids) and all(
+                    isinstance(
+                        self.state.runners.get(runner_id),
+                        (RunnerReady, RunnerRunning),
+                    )
+                    for runner_id in runner_ids
+                )
         return StewardStatusResponse(
             enabled=self._intelligent_fabric_enabled(),
             present=located is not None,
+            ready=ready,
             steward_model=located[1] if located is not None else None,
             instance_id=str(located[0]) if located is not None else None,
         )

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -36,6 +36,7 @@ from skulk.shared.types.chunks import (
     TokenChunk,
     ToolCallChunk,
 )
+from skulk.shared.types.common import CommandId
 from skulk.shared.types.worker.instances import InstanceId
 
 if TYPE_CHECKING:
@@ -358,6 +359,10 @@ class StewardHarness:
 
     def __init__(self, api: "API") -> None:
         self._api = api
+        # The inner TextGeneration currently in flight for this turn, so an
+        # abandoned stream (client disconnect, cancel button) can stop the
+        # runner instead of leaving it generating for nobody.
+        self._active_command_id: CommandId | None = None
 
     def steward_instance(self) -> tuple[InstanceId, str] | None:
         """The current steward placement, as (instance_id, model_id)."""
@@ -504,6 +509,32 @@ class StewardHarness:
                 ChatCompletionMessage(role=message.role, content=message.content)
             )
 
+        completed = False
+        try:
+            yield_target = self._run_investigation(messages, model_id, instance_id)
+            async for chunk in yield_target:
+                yield chunk
+            completed = True
+        finally:
+            if not completed and self._active_command_id is not None:
+                # The stream was abandoned (client disconnect or cancel)
+                # mid-generation: stop the inner task so the steward runner
+                # is not left generating for nobody.
+                abandoned = self._active_command_id
+                self._active_command_id = None
+                try:
+                    await self._api.send_task_cancellation(abandoned)
+                except Exception:  # cancellation is best-effort on teardown
+                    pass
+
+    async def _run_investigation(
+        self,
+        messages: list[ChatCompletionMessage],
+        model_id: str,
+        instance_id: InstanceId,
+    ) -> "AsyncGenerator[TokenChunk | ErrorChunk | ToolCallChunk | PrefillProgressChunk, None]":
+        """The turn's investigation loop; separated so the public stream can
+        wrap it with abandonment cleanup."""
         reply = ""
         for step_index in range(MAX_STEPS_PER_TURN):
             if step_index == MAX_STEPS_PER_TURN - 1:
@@ -614,6 +645,7 @@ class StewardHarness:
         command = await api.dispatch_text_generation(
             task_params, target_instance_id=instance_id
         )
+        self._active_command_id = command.command_id
         chunk_stream = api.text_generation_chunk_stream(command, task_params)
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
@@ -633,4 +665,5 @@ class StewardHarness:
                     )
                 case _:
                     continue
+        self._active_command_id = None
         return "".join(text_parts), tool_calls, error_message

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -178,6 +178,14 @@ class StewardStatusResponse(BaseModel):
     present: bool = Field(
         description="Whether a steward placement currently exists in state."
     )
+    ready: bool = Field(
+        default=False,
+        description=(
+            "Whether every runner of the steward placement reports Ready: "
+            "present-but-not-ready means the model is still downloading or "
+            "loading, and chat requests will queue or fail until ready."
+        ),
+    )
     steward_model: str | None = Field(
         default=None,
         description="Model id of the steward brain, when present.",
@@ -537,7 +545,7 @@ class StewardHarness:
             yield TokenChunk(
                 model=ModelId(STEWARD_VIRTUAL_MODEL_ID),
                 text=trace_line + "\n",
-                token_id=0,
+                token_id=-1,
                 usage=None,
                 is_thinking=True,
             )
@@ -564,7 +572,7 @@ class StewardHarness:
         yield TokenChunk(
             model=ModelId(STEWARD_VIRTUAL_MODEL_ID),
             text=reply,
-            token_id=0,
+            token_id=-1,
             usage=None,
             finish_reason="stop",
         )

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -16,6 +16,7 @@ results transfer to production behavior.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
 from collections.abc import AsyncGenerator
@@ -522,10 +523,9 @@ class StewardHarness:
                 # is not left generating for nobody.
                 abandoned = self._active_command_id
                 self._active_command_id = None
-                try:
+                # Cancellation is best-effort on teardown.
+                with contextlib.suppress(Exception):
                     await self._api.send_task_cancellation(abandoned)
-                except Exception:  # cancellation is best-effort on teardown
-                    pass
 
     async def _run_investigation(
         self,

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -22,13 +22,17 @@ import re
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+import anyio
 from pydantic import BaseModel, ConfigDict, Field
 
 from skulk.api.types.api import (
     ChatCompletionMessage,
     ChatCompletionRequest,
+    CompletionTokensDetails,
+    PromptTokensDetails,
     ToolCall,
     ToolCallItem,
+    Usage,
 )
 from skulk.shared.models.model_cards import ModelId
 from skulk.shared.types.chunks import (
@@ -364,6 +368,26 @@ class StewardHarness:
         # abandoned stream (client disconnect, cancel button) can stop the
         # runner instead of leaving it generating for nobody.
         self._active_command_id: CommandId | None = None
+        # Aggregated across the turn's inner generations so the terminal
+        # chunk reports real usage instead of null, and the model's actual
+        # terminal reason (e.g. length) is preserved.
+        self._turn_usage: Usage | None = None
+        self._last_finish_reason: Literal["stop", "length", "content_filter"] = "stop"
+
+    def _accumulate_usage(self, usage: "Usage") -> None:
+        """Sum an inner generation's usage into the turn total."""
+        if self._turn_usage is None:
+            self._turn_usage = usage
+            return
+        self._turn_usage = Usage(
+            prompt_tokens=self._turn_usage.prompt_tokens + usage.prompt_tokens,
+            completion_tokens=(
+                self._turn_usage.completion_tokens + usage.completion_tokens
+            ),
+            total_tokens=self._turn_usage.total_tokens + usage.total_tokens,
+            prompt_tokens_details=PromptTokensDetails(),
+            completion_tokens_details=CompletionTokensDetails(),
+        )
 
     def steward_instance(self) -> tuple[InstanceId, str] | None:
         """The current steward placement, as (instance_id, model_id)."""
@@ -510,6 +534,8 @@ class StewardHarness:
                 ChatCompletionMessage(role=message.role, content=message.content)
             )
 
+        self._turn_usage = None
+        self._last_finish_reason = "stop"
         completed = False
         try:
             yield_target = self._run_investigation(messages, model_id, instance_id)
@@ -523,9 +549,13 @@ class StewardHarness:
                 # is not left generating for nobody.
                 abandoned = self._active_command_id
                 self._active_command_id = None
-                # Cancellation is best-effort on teardown.
+                # Teardown usually runs inside an already-cancelled scope
+                # (client disconnect cancels the response task), where an
+                # unshielded await re-raises before the cancel can send.
+                # Shield it, bounded so teardown can never hang.
                 with contextlib.suppress(Exception):
-                    await self._api.send_task_cancellation(abandoned)
+                    with anyio.move_on_after(2, shield=True):
+                        await self._api.send_task_cancellation(abandoned)
 
     async def _run_investigation(
         self,
@@ -604,8 +634,8 @@ class StewardHarness:
             model=ModelId(STEWARD_VIRTUAL_MODEL_ID),
             text=reply,
             token_id=-1,
-            usage=None,
-            finish_reason="stop",
+            usage=self._turn_usage,
+            finish_reason=self._last_finish_reason,
         )
 
     async def _generate(
@@ -622,6 +652,7 @@ class StewardHarness:
         """
         from skulk.api.adapters.chat_completions import (
             chat_request_to_text_generation,
+            usage_from_stats,
         )
         from skulk.shared.types.chunks import (
             ErrorChunk,
@@ -658,7 +689,13 @@ class StewardHarness:
                 case TokenChunk():
                     if not chunk.is_thinking:
                         text_parts.append(chunk.text)
+                    if chunk.finish_reason is not None:
+                        self._last_finish_reason = chunk.finish_reason
+                    if step_usage := chunk.usage or usage_from_stats(chunk.stats):
+                        self._accumulate_usage(step_usage)
                 case ToolCallChunk():
+                    if step_usage := chunk.usage or usage_from_stats(chunk.stats):
+                        self._accumulate_usage(step_usage)
                     tool_calls.extend(
                         ToolCall(id=item.id, index=i, function=item)
                         for i, item in enumerate(chunk.tool_calls)

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 import json
 import re
-from typing import TYPE_CHECKING, Any, Literal, cast, final
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -28,10 +29,25 @@ from skulk.api.types.api import (
     ToolCall,
     ToolCallItem,
 )
+from skulk.shared.models.model_cards import ModelId
+from skulk.shared.types.chunks import (
+    ErrorChunk,
+    PrefillProgressChunk,
+    TokenChunk,
+    ToolCallChunk,
+)
 from skulk.shared.types.worker.instances import InstanceId
 
 if TYPE_CHECKING:
     from skulk.api.main import API
+
+STEWARD_VIRTUAL_MODEL_ID = "skulk/steward"
+"""Reserved chat-completions model id selecting model-plus-harness.
+
+Checked before card resolution, so a Hugging Face repository of the same
+name can never shadow it. Requests to this id run the steward's server-side
+investigation loop; requests to the underlying card id reach the bare model.
+"""
 
 MAX_TOOL_RESULT_CHARS = 6000
 """Hard cap on one tool result rendered into the steward's context."""
@@ -151,32 +167,6 @@ class StewardChatMessage(BaseModel):
     content: str = Field(description="The message text.")
 
 
-class StewardChatRequest(BaseModel):
-    """Request body for the steward chat surface."""
-
-    model_config = ConfigDict(frozen=True, strict=True)
-
-    messages: list[StewardChatMessage] = Field(
-        min_length=1,
-        description=(
-            "Conversation history, oldest first, ending with the operator's "
-            "latest message. The steward system prompt and tool plumbing "
-            "are added server-side."
-        ),
-    )
-
-
-class StewardToolStep(BaseModel):
-    """One tool call the steward made while investigating."""
-
-    model_config = ConfigDict(frozen=True, strict=True)
-
-    tool: str = Field(description="Tool name invoked.")
-    arguments: dict[str, object] = Field(
-        default_factory=dict, description="Arguments the steward passed."
-    )
-
-
 class StewardStatusResponse(BaseModel):
     """Whether the steward exists and what serves it right now."""
 
@@ -195,24 +185,6 @@ class StewardStatusResponse(BaseModel):
     instance_id: str | None = Field(
         default=None,
         description="The steward instance id, when present.",
-    )
-
-
-class StewardChatResponse(BaseModel):
-    """The steward's reply plus its investigation trace."""
-
-    model_config = ConfigDict(frozen=True, strict=True)
-
-    reply: str = Field(description="The steward's answer to the operator.")
-    steps: list[StewardToolStep] = Field(
-        default_factory=list,
-        description="Tools consulted this turn, in order.",
-    )
-    steward_model: str = Field(
-        description="Model id of the steward brain that produced the reply."
-    )
-    instance_id: str = Field(
-        description="The hidden steward instance that served the turn."
     )
 
 
@@ -367,7 +339,6 @@ def strip_tool_markup(text: str) -> str:
     return text.strip()
 
 
-@final
 class StewardHarness:
     """Drives the steward brain through its tools for one API node.
 
@@ -491,17 +462,30 @@ class StewardHarness:
             {"error": f"unknown tool '{name}'", "available": STEWARD_TOOL_NAMES}
         )
 
-    async def run_turn(
+    async def run_turn_chunks(
         self, history: list[StewardChatMessage]
-    ) -> StewardChatResponse:
-        """Run one operator turn: investigate via tools, return the reply.
+    ) -> "AsyncGenerator[TokenChunk | ErrorChunk | ToolCallChunk | PrefillProgressChunk, None]":
+        """Run one steward turn as a chat-completions chunk stream.
 
-        Raises ``LookupError`` when no steward instance exists (callers map
-        this to an HTTP 409 with remediation).
+        Tool steps stream live as thinking chunks (mapped to
+        ``reasoning_content`` by the adapters) while the investigation runs,
+        and the final answer follows as a content chunk with
+        ``finish_reason="stop"``. Emitting the adapters' native chunk
+        vocabulary is what lets the steward ride ``/v1/chat/completions``
+        (streaming and non-streaming) with no adapter changes: clients see
+        a normal model whose reasoning happens to be its tool trace.
         """
+
         located = self.steward_instance()
         if located is None:
-            raise LookupError("no steward placement exists")
+            yield ErrorChunk(
+                model=ModelId(STEWARD_VIRTUAL_MODEL_ID),
+                error_message=(
+                    "The steward placement is not available yet; the fabric "
+                    "establishes it automatically"
+                ),
+            )
+            return
         instance_id, model_id = located
 
         messages: list[ChatCompletionMessage] = [
@@ -512,7 +496,6 @@ class StewardHarness:
                 ChatCompletionMessage(role=message.role, content=message.content)
             )
 
-        steps: list[StewardToolStep] = []
         reply = ""
         for step_index in range(MAX_STEPS_PER_TURN):
             if step_index == MAX_STEPS_PER_TURN - 1:
@@ -529,10 +512,11 @@ class StewardHarness:
                 messages, model_id, instance_id
             )
             if error is not None:
-                raise RuntimeError(error)
+                yield ErrorChunk(
+                    model=ModelId(STEWARD_VIRTUAL_MODEL_ID), error_message=error
+                )
+                return
             if not tool_calls:
-                # Engine-independent fallback: the in-process MLX path can
-                # leave the family's tool-call markup in the text stream.
                 tool_calls = parse_text_tool_calls(text)
                 if tool_calls:
                     text = strip_tool_markup(text)
@@ -547,12 +531,22 @@ class StewardHarness:
                 parsed = {}
             if isinstance(parsed, dict):
                 arguments = cast("dict[str, object]", parsed)
-            steps.append(StewardToolStep(tool=call.function.name, arguments=arguments))
+            trace_line = call.function.name + (
+                f" {json.dumps(arguments)}" if arguments else ""
+            )
+            yield TokenChunk(
+                model=ModelId(STEWARD_VIRTUAL_MODEL_ID),
+                text=trace_line + "\n",
+                token_id=0,
+                usage=None,
+                is_thinking=True,
+            )
             result = await self.execute_tool(call.function.name, arguments)
+            content_text = strip_tool_markup(text)
             messages.append(
                 ChatCompletionMessage(
                     role="assistant",
-                    content=text or None,
+                    content=content_text or None,
                     tool_calls=[call],
                 )
             )
@@ -564,14 +558,15 @@ class StewardHarness:
         else:
             reply = (
                 "I ran out of investigation budget before reaching a "
-                "conclusion; the tools consulted so far are listed."
+                "conclusion this turn."
             )
 
-        return StewardChatResponse(
-            reply=reply,
-            steps=steps,
-            steward_model=model_id,
-            instance_id=str(instance_id),
+        yield TokenChunk(
+            model=ModelId(STEWARD_VIRTUAL_MODEL_ID),
+            text=reply,
+            token_id=0,
+            usage=None,
+            finish_reason="stop",
         )
 
     async def _generate(

--- a/src/skulk/api/tests/test_steward_chunk_stream.py
+++ b/src/skulk/api/tests/test_steward_chunk_stream.py
@@ -106,3 +106,24 @@ async def test_text_markup_tool_calls_are_recovered() -> None:
     assert isinstance(last, TokenChunk)
     assert last.text == "Doctor says fine."
     assert last.model == ModelId("skulk/steward")
+
+
+async def test_abandoned_stream_cancels_active_generation() -> None:
+    """Closing the stream mid-turn cancels the in-flight inner generation."""
+    cancelled: list[object] = []
+
+    class _Api:
+        async def send_task_cancellation(self, command_id: object) -> None:
+            cancelled.append(command_id)
+
+    harness = _ScriptedHarness(turns=[("", [_call("get_cluster_state")])])
+    harness._api = cast("API", cast(object, _Api()))  # pyright: ignore[reportPrivateUsage]
+    harness._active_command_id = cast(Any, "cmd-inner-1")  # pyright: ignore[reportPrivateUsage]
+
+    stream = harness.run_turn_chunks(
+        [StewardChatMessage(role="user", content="hi")]
+    )
+    first = await stream.__anext__()
+    assert isinstance(first, TokenChunk)
+    await stream.aclose()
+    assert cancelled == ["cmd-inner-1"]

--- a/src/skulk/api/tests/test_steward_chunk_stream.py
+++ b/src/skulk/api/tests/test_steward_chunk_stream.py
@@ -1,0 +1,108 @@
+"""The steward's chat-completions chunk stream (virtual-model turn).
+
+StewardHarness is deliberately not @final: overriding its generation and
+tool collaborators is the loop's unit-test seam.
+"""
+
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from skulk.api.main import API
+
+from skulk.api.steward import StewardChatMessage, StewardHarness
+from skulk.api.types.api import ToolCall, ToolCallItem
+from skulk.shared.models.model_cards import ModelId
+from skulk.shared.types.chunks import ErrorChunk, TokenChunk
+from skulk.shared.types.worker.instances import InstanceId
+
+
+class _ScriptedHarness(StewardHarness):
+    """Harness with generation and tools stubbed for loop testing."""
+
+    def __init__(self, turns: list[tuple[str, list[ToolCall]]]) -> None:
+        # The API handle is unused once the collaborators are overridden.
+        super().__init__(cast("API", cast(object, None)))
+        self._turns = turns
+        self._cursor = 0
+        self.executed: list[str] = []
+
+    def steward_instance(self) -> tuple[InstanceId, str] | None:
+        return InstanceId(), "org/steward-model"
+
+    async def execute_tool(self, name: str, arguments: dict[str, object]) -> str:
+        self.executed.append(name)
+        return '{"ok": true}'
+
+    async def _generate(
+        self,
+        messages: list[Any],
+        model_id: str,
+        instance_id: InstanceId,
+    ) -> tuple[str, list[ToolCall], str | None]:
+        text, calls = self._turns[min(self._cursor, len(self._turns) - 1)]
+        self._cursor += 1
+        return text, calls, None
+
+
+def _call(name: str) -> ToolCall:
+    return ToolCall(id=f"call-{name}", index=0, function=ToolCallItem(name=name, arguments="{}"))
+
+
+async def _collect(harness: StewardHarness, question: str) -> list[TokenChunk | ErrorChunk]:
+    chunks: list[TokenChunk | ErrorChunk] = []
+    async for chunk in harness.run_turn_chunks(
+        [StewardChatMessage(role="user", content=question)]
+    ):
+        assert isinstance(chunk, (TokenChunk, ErrorChunk))
+        chunks.append(chunk)
+    return chunks
+
+
+async def test_tool_steps_stream_as_thinking_then_reply_stops() -> None:
+    harness = _ScriptedHarness(
+        turns=[
+            ("", [_call("get_cluster_state")]),
+            ("All healthy.", []),
+        ]
+    )
+    chunks = await _collect(harness, "Is the cluster healthy?")
+    assert [type(c) for c in chunks] == [TokenChunk, TokenChunk]
+    first, last = cast(TokenChunk, chunks[0]), cast(TokenChunk, chunks[1])
+    assert first.is_thinking and "get_cluster_state" in first.text
+    assert not last.is_thinking
+    assert last.text == "All healthy."
+    assert last.finish_reason == "stop"
+    assert harness.executed == ["get_cluster_state"]
+
+
+async def test_missing_steward_yields_error_chunk() -> None:
+    harness = _ScriptedHarness(turns=[("irrelevant", [])])
+    harness.steward_instance = lambda: None
+    chunks = await _collect(harness, "hello")
+    assert len(chunks) == 1
+    assert isinstance(chunks[0], ErrorChunk)
+
+
+async def test_budget_exhaustion_still_emits_terminal_stop() -> None:
+    harness = _ScriptedHarness(turns=[("", [_call("get_cluster_state")])])
+    chunks = await _collect(harness, "loop forever")
+    last = chunks[-1]
+    assert isinstance(last, TokenChunk)
+    assert last.finish_reason == "stop"
+    thinking = [c for c in chunks if isinstance(c, TokenChunk) and c.is_thinking]
+    assert len(thinking) >= 7  # every budgeted step surfaced as trace
+
+
+async def test_text_markup_tool_calls_are_recovered() -> None:
+    harness = _ScriptedHarness(
+        turns=[
+            ("<tool_call>\n<function=run_doctor>\n</function>\n</tool_call>", []),
+            ("Doctor says fine.", []),
+        ]
+    )
+    chunks = await _collect(harness, "run a checkup")
+    assert harness.executed == ["run_doctor"]
+    last = chunks[-1]
+    assert isinstance(last, TokenChunk)
+    assert last.text == "Doctor says fine."
+    assert last.model == ModelId("skulk/steward")

--- a/src/skulk/api/types/api.py
+++ b/src/skulk/api/types/api.py
@@ -119,6 +119,15 @@ class ModelListModel(BaseModel):
     supports_tensor: bool = Field(default=False)
     tasks: list[str] = Field(default=[])
     is_custom: bool = Field(default=False)
+    system_role: str | None = Field(
+        default=None,
+        description=(
+            "Set for fabric-managed system entries (\"steward\" = the "
+            "intelligent-fabric resident, addressable as a chat model but "
+            "not user-placeable). Model pickers should badge or separate "
+            "these rather than listing them as ordinary models."
+        ),
+    )
     family: str = Field(default="")
     quantization: str = Field(default="")
     base_model: str = Field(default="")

--- a/src/skulk/api/types/api.py
+++ b/src/skulk/api/types/api.py
@@ -119,7 +119,7 @@ class ModelListModel(BaseModel):
     supports_tensor: bool = Field(default=False)
     tasks: list[str] = Field(default=[])
     is_custom: bool = Field(default=False)
-    system_role: str | None = Field(
+    system_role: Literal["steward"] | None = Field(
         default=None,
         description=(
             "Set for fabric-managed system entries (\"steward\" = the "

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -1189,55 +1189,60 @@ Use this when you already have an `instance` object and want exact control.
 
 When intelligent-fabric mode is enabled in the cluster configuration
 (`intelligent_fabric.enabled`), the fabric keeps a small resident model (the
-steward) placed as a hidden system instance and exposes it through these
-endpoints. The steward investigates the cluster through a bounded read-only
-tool surface and answers operator questions; it cannot change the cluster.
+steward) placed as a hidden system instance. The steward investigates the
+cluster through a bounded read-only tool surface and answers operator
+questions; it cannot change the cluster.
+
+### Talking to the steward: the virtual model
+
+Clients consume the steward through the standard OpenAI-compatible
+`POST /v1/chat/completions` endpoint using the reserved model id
+`skulk/steward`. Any OpenAI-compatible client works, streaming included; no
+steward-specific client code is required beyond the model id.
+
+Semantics of the reserved id:
+
+- The server runs the steward's investigation loop (up to 8 read-only tool
+  calls per turn: cluster state, node resources, telemetry and data-plane
+  diagnostics, version status, performance envelopes, the local doctor
+  registry, and the model catalog) and answers from the evidence.
+- The tool trace is returned as reasoning content: in streaming responses,
+  each tool step arrives as a `reasoning_content` delta while the
+  investigation runs, followed by the answer as `content`; non-streaming
+  responses carry the trace in the message's `reasoning_content` field.
+- Client-supplied `tools` are rejected with `400`: the steward's tool
+  surface belongs to the server.
+- Client `system` messages are ignored in favor of the steward's own system
+  prompt; `user` and `assistant` turns form the conversation history, which
+  the client owns and resends each turn (the server is stateless).
+- Requests to the id while intelligent-fabric mode is disabled return `404`
+  with an explanatory message. If the mode is enabled but the placement is
+  not currently available (first placement, repair in flight), the response
+  is an error chunk in the normal chat-completions error shape.
+- The underlying model card id (for example the bundled Qwen3.5-4B) remains
+  addressable as an ordinary model and answers WITHOUT tools or cluster
+  access: only the reserved id selects model-plus-harness.
+
+The steward appears in `GET /v1/models` as an entry flagged with
+`system_role: "steward"` while the mode is enabled, so model pickers can
+badge or separate it rather than listing it as an ordinary model.
 
 ### GET /v1/steward
 
-Returns steward availability.
+Returns steward availability. Clients use this to decide whether to show a
+steward surface at all.
 
 Response fields:
 
 - `enabled`: whether intelligent-fabric mode is enabled in Settings.
 - `present`: whether a steward placement currently exists.
-- `steward_model`: model id of the steward brain when present, else null.
+- `steward_model`: model card id of the steward brain when present, else null.
 - `instance_id`: the steward instance id when present, else null.
-
-### POST /v1/steward/chat
-
-Ask the steward. The caller carries conversation history; the steward system
-prompt, tool definitions, and investigation loop are server-side.
-
-Request body:
-
-- `messages` (required): list of `{role, content}` objects, oldest first,
-  ending with the operator's latest message. Roles are `user` and
-  `assistant`.
-
-Behavior: the steward runs up to 8 read-only tool calls per turn (cluster
-state, node resources, telemetry / data-plane diagnostics, version status,
-performance envelopes, the local doctor registry, and the model catalog),
-then replies. Generation is pinned to the hidden steward instance and rides
-the normal text-generation path.
-
-Response fields:
-
-- `reply`: the steward's answer.
-- `steps`: ordered list of `{tool, arguments}` consulted this turn.
-- `steward_model`: the model id that produced the reply.
-- `instance_id`: the steward instance that served the turn.
-
-Errors:
-
-- `409`: intelligent-fabric mode is disabled, or the steward placement is
-  not currently available (for example, immediately after enabling the mode
-  or during re-placement after node loss).
-- `502`: steward generation failed.
 
 Note: deleting the steward instance through `DELETE /instance/{instance_id}`
 is refused with `409` while intelligent-fabric mode is enabled; disable the
-mode in Settings to remove the placement.
+mode in Settings to remove the placement (the fabric then tears it down
+automatically).
 
 ## Download Management
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -1236,6 +1236,9 @@ Response fields:
 
 - `enabled`: whether intelligent-fabric mode is enabled in Settings.
 - `present`: whether a steward placement currently exists.
+- `ready`: whether every steward runner reports Ready or Running. Present
+  but not ready means the model is still downloading or loading; clients
+  should keep showing a preparing state and hold chat until ready.
 - `steward_model`: model card id of the steward brain when present, else null.
 - `instance_id`: the steward instance id when present, else null.
 

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -99,9 +99,17 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   summary, node resources, telemetry diagnostics, data-plane diagnostics,
   cluster versions, performance envelopes, local doctor registry, model
   catalog. 6000-char tool-result bound, 8 steps/turn, observe/advise only.
-- Endpoints: `GET /v1/steward` (status), `POST /v1/steward/chat`
-  (409 when disabled/absent). Ordinary `DELETE /instance/{id}` of the
-  steward is refused 409 while the mode is enabled.
+- Client surface: reserved virtual model id `skulk/steward` on
+  `POST /v1/chat/completions` (checked before card resolution; client
+  `tools` rejected 400; client system messages ignored; trace streams as
+  `reasoning_content` deltas then the answer as `content`; 404 when the
+  mode is disabled). Harness emits the adapters' native chunk vocabulary
+  (`run_turn_chunks`), so streaming and non-streaming ride the ordinary
+  adapters unchanged. `GET /v1/models` carries a flagged entry
+  (`system_role: "steward"`) while enabled. `GET /v1/steward` = presence.
+  The earlier bespoke `POST /v1/steward/chat` was removed before any
+  release. Ordinary `DELETE /instance/{id}` of the steward is refused 409
+  while the mode is enabled.
 - Dashboard: instances with `systemRole` set are hidden from all instance
   surfaces (filter in App.tsx instanceCards).
 - Cards: `mlx-community/Qwen3.5-4B-MLX-4bit` (vision, MLX) and

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -638,16 +638,24 @@ failover. Duplicate stewards (possible across a failover window) are detected
 and reduced to one. The steward placement is hidden from user-facing instance
 surfaces and refuses ordinary deletion while the mode is enabled.
 
-Conversation happens through the steward chat endpoint. The server-side
-harness gives the model a bounded, strictly read-only tool surface: cluster
+Conversation happens through the standard OpenAI-compatible chat-completions
+endpoint using the reserved virtual model id `skulk/steward`, streaming
+included, so any OpenAI-compatible client can talk to the cluster with no
+steward-specific integration. The reserved id selects the model plus the
+server-side harness: a bounded, strictly read-only tool surface (cluster
 state with health reasons, per-node resources and capability conflicts,
 telemetry and data-plane diagnostics, per-node version status, performance
-envelopes, the local doctor check registry, and the model catalog. Each
-operator turn runs a bounded investigation loop; generation itself rides the
-normal text-generation dispatch path, pinned to the steward instance. In this
-release the steward observes and advises only: no tool can change the
-cluster, and anything action-shaped is returned to the operator as a
-recommendation.
+envelopes, the local doctor check registry, and the model catalog) and an
+investigation loop of up to eight tool calls per turn. Tool steps stream to
+the client as reasoning content while the investigation runs, followed by
+the answer; client-supplied tool definitions are rejected, and client system
+prompts are ignored in favor of the steward's own. Generation itself rides
+the normal text-generation dispatch path, pinned to the steward instance,
+and the underlying model card id remains addressable as an ordinary model
+without tools or cluster access. A small status endpoint reports presence
+and readiness so clients know whether to offer the surface. In this release
+the steward observes and advises only: no tool can change the cluster, and
+anything action-shaped is returned to the operator as a recommendation.
 
 ## The dashboard voice loop
 


### PR DESCRIPTION
## What

Implements the decided client contract: the steward is consumed through the standard OpenAI-compatible `POST /v1/chat/completions` using the reserved model id `skulk/steward`, streaming included. Any OpenAI client gets the steward with zero integration beyond the model id; the app inherits it through the client it already has.

## Design

- **Routing**: the reserved id is checked before card resolution (so no same-named repository can shadow it) and selects model-plus-harness; the underlying card id remains addressable as bare model.
- **Streaming for free**: the harness gained `run_turn_chunks`, emitting the adapters' native chunk vocabulary: each tool step streams live as a thinking chunk (arriving as `reasoning_content` deltas) while the investigation runs, then the answer follows as content with `finish_reason: stop`. Both SSE and non-streaming JSON ride the existing adapters with zero adapter changes, which also means the trace renders in every client that already renders reasoning, dashboard included.
- **Semantics of the reserved id**: client `tools` rejected with 400 (the steward's tool surface belongs to the server), client system messages ignored in favor of the steward's prompt, user/assistant turns form the history (client-owned, server stateless), 404 with explanation while the mode is disabled, error chunk in the normal shape when the placement is momentarily absent.
- **Discovery**: `GET /v1/models` carries a flagged entry (`system_role: "steward"`, additive field) while the mode is enabled so pickers can badge it. `GET /v1/steward` remains the presence surface.
- **Removed**: the bespoke `POST /v1/steward/chat` and its request/response models, before ever shipping. One conversation surface, not two.

## Validation

- basedpyright 0 errors, ruff clean, nix fmt no changes, full suite 2991 passed.
- New unit tests cover the chunk stream: step-then-reply ordering with thinking flags, missing-placement error chunk, budget exhaustion still emitting a terminal stop, and text-markup tool-call recovery on the MLX lane.
- api-guide rewritten around the virtual model (semantics, streaming shape, error cases); OpenAPI reflects the removed endpoint; architecture-reference and CLAUDE.md updated.

## Follow-up in this epic

PR #729 (dashboard steward page) switches its data layer to this streaming virtual model once this merges, retiring its use of the removed endpoint before #729 itself merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01262jKrQwepcSQtv1vk2chH