### PR TITLE
Fix #728: generic-format MLX tokenizers parse XML tool calls

### DIFF
--- a/src/skulk/worker/engines/mlx/utils_mlx.py
+++ b/src/skulk/worker/engines/mlx/utils_mlx.py
@@ -1337,6 +1337,23 @@ def load_tokenizer_for_model_id(
         object.__setattr__(tokenizer, "_tool_call_end", "<tool_call|>")
         object.__setattr__(tokenizer, "_tool_parser", _parse_gemma4_tool_calls)
 
+    if (
+        capability_profile.tool_call_format == ToolCallFormat.Generic
+        and not getattr(tokenizer, "tool_parser", None)
+        and "<tool_call>" in (getattr(tokenizer, "chat_template", None) or "")
+    ):
+        # #728: tokenizers that reach this path without mlx-lm's inferred
+        # tool parser (notably the mlx-vlm native-vision loaders, which is
+        # every natively-multimodal family) silently pass tool-call markup
+        # through as text. When the chat template speaks the <tool_call>
+        # dialect, wire the repo's shared text parser (Qwen3 XML plus
+        # Hermes JSON, the same one the llama_cpp engine uses) through the
+        # standard marker mechanism. Template truth decides, so models
+        # whose templates use other dialects are untouched.
+        object.__setattr__(tokenizer, "_tool_call_start", "<tool_call>")
+        object.__setattr__(tokenizer, "_tool_call_end", "</tool_call>")
+        object.__setattr__(tokenizer, "_tool_parser", _parse_generic_text_tool_calls)
+
     return tokenizer
 
 
@@ -1730,6 +1747,25 @@ def mx_barrier(group: Group | None):
             "mx_barrier", {"group_size": group.size()}, is_prefill=False
         ),
     )
+
+
+def _parse_generic_text_tool_calls(text: str) -> list[dict[str, Any]]:
+    """Parse generic-format tool calls (Qwen3 XML or Hermes JSON) from text.
+
+    Receives the inner text between the ``<tool_call>`` markers (the runner's
+    marker mechanism strips them) and delegates to the shared text parser so
+    the MLX lane recognizes exactly the formats the llama_cpp engine does.
+    Argument values arrive as JSON strings, the shape ``ToolCallItem``
+    validation expects.
+    """
+    from skulk.worker.runner.llm_inference.tool_text_parser import (
+        parse_tool_calls_from_text,
+    )
+
+    items = parse_tool_calls_from_text(f"<tool_call>{text}</tool_call>")
+    if not items:
+        return []
+    return [{"name": item.name, "arguments": item.arguments} for item in items]
 
 
 def _parse_gemma4_tool_calls(text: str) -> list[dict[str, Any]]:

--- a/src/skulk/worker/engines/mlx/utils_mlx.py
+++ b/src/skulk/worker/engines/mlx/utils_mlx.py
@@ -1764,7 +1764,10 @@ def _parse_generic_text_tool_calls(text: str) -> list[dict[str, Any]]:
 
     items = parse_tool_calls_from_text(f"<tool_call>{text}</tool_call>")
     if not items:
-        return []
+        # Raising routes the runner to its malformed-tool-call fallback
+        # (raw text with finish_reason="error"), matching the behavior of
+        # every other parser instead of fabricating an empty success.
+        raise ValueError("no recognized tool calls in block")
     return [{"name": item.name, "arguments": item.arguments} for item in items]
 
 

--- a/src/skulk/worker/tests/unittests/test_mlx/test_tokenizer_capability_resolution.py
+++ b/src/skulk/worker/tests/unittests/test_mlx/test_tokenizer_capability_resolution.py
@@ -196,3 +196,96 @@ def test_get_tokenizer_passes_shard_model_card_to_tokenizer_loader(
     assert captured["model_path"] == tmp_path
     assert captured["model_card"] == card
     assert captured["trust_remote_code"] == card.trust_remote_code
+
+
+class _QwenTemplateBackend(_TokenizerBackend):
+    """Backend whose chat template speaks the <tool_call> dialect but that
+    arrives without an inferred tool parser (the mlx-vlm vision-path shape,
+    #728)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.chat_template = (
+            "{% if tools %}<tool_call>\n<function=example>\n</function>\n"
+            "</tool_call>{% endif %}"
+        )
+
+
+def test_generic_format_wires_text_parser_when_template_speaks_tool_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """#728: a Generic-format card whose tokenizer lacks an inferred parser
+    but whose template uses <tool_call> gets the shared text parser wired, so
+    the MLX lane (including vision loaders) emits structured tool calls."""
+    card = ModelCard(
+        model_id=ModelId("mlx-community/Qwen3.5-4B-MLX-4bit"),
+        storage_size=Memory.from_mb(100),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text"],
+        family="qwen",
+        tooling=ToolingCardConfig(tool_call_format=ToolCallFormat.Generic),
+    )
+
+    def _fake_load_tokenizer(*_args: object, **_kwargs: object) -> TokenizerWrapper:
+        return TokenizerWrapper(_QwenTemplateBackend())
+
+    monkeypatch.setattr(
+        "skulk.worker.engines.mlx.utils_mlx.load_tokenizer",
+        _fake_load_tokenizer,
+    )
+
+    tokenizer = load_tokenizer_for_model_id(
+        card.model_id,
+        tmp_path,
+        model_card=card,
+    )
+    assert tokenizer.tool_call_start == "<tool_call>"
+    assert tokenizer.tool_call_end == "</tool_call>"
+    parser = cast(
+        Callable[[str], list[dict[str, object]]] | None,
+        tokenizer.tool_parser,
+    )
+    assert parser is not None
+    parsed = parser(
+        "\n<function=get_node_resources>\n<parameter=node_id>\nmac-den\n"
+        "</parameter>\n</function>\n"
+    )
+    assert parsed == [
+        {"name": "get_node_resources", "arguments": '{"node_id": "mac-den"}'}
+    ]
+
+
+def test_generic_format_leaves_other_template_dialects_alone(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    card = ModelCard(
+        model_id=ModelId("mlx-community/some-other-model"),
+        storage_size=Memory.from_mb(100),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        capabilities=["text"],
+        family="other",
+        tooling=ToolingCardConfig(tool_call_format=ToolCallFormat.Generic),
+    )
+
+    def _fake_load_tokenizer(*_args: object, **_kwargs: object) -> TokenizerWrapper:
+        return TokenizerWrapper(_TokenizerBackend())
+
+    monkeypatch.setattr(
+        "skulk.worker.engines.mlx.utils_mlx.load_tokenizer",
+        _fake_load_tokenizer,
+    )
+
+    tokenizer = load_tokenizer_for_model_id(
+        card.model_id,
+        tmp_path,
+        model_card=card,
+    )
+    assert cast(object, tokenizer.tool_parser) is None


### PR DESCRIPTION
## What

Closes #728. On the in-process MLX lane, tokenizers that arrive without mlx-lm's inferred tool parser passed Qwen3.5's XML tool-call markup through as plain text. Live investigation pinned the real trigger: the mlx-vlm native-vision loading path (used by every natively-multimodal family, the whole Qwen3.5 line included) produces tokenizers with no tool parser at all, so structured tool calls silently never happened regardless of the card's tooling declaration.

## Fix

In the capability-resolution step (the same place Gemma 4's markers are wired), a Generic-format card whose tokenizer lacks a parser but whose chat template speaks the `<tool_call>` dialect gets the repo's shared text parser wired through the standard marker mechanism: the exact parser the llama_cpp engine already uses, covering Qwen3 XML and Hermes JSON. Template truth decides, so models whose templates use other dialects are untouched, and tokenizers that already carry an inferred parser are left alone. Marker chunk-alignment holds because the family tokenizes both markers as single special tokens (verified against the real 4B tokenizer).

## Validation

- Two new capability-resolution tests: the Qwen-dialect template gets the parser wired end to end (asserting a parsed XML call), and other dialects remain untouched.
- basedpyright 0, ruff clean, nix fmt no changes, full suite 2994 passed.
- The steward harness's text fallback (from the epic) remains as defense in depth; with this fix the engine emits structured calls first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01262jKrQwepcSQtv1vk2chH