### PR TITLE
Steward docs grounding: search_docs over the checkout's documentation

### DIFF
--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -523,18 +523,26 @@ class StewardHarness:
                 return json.dumps(
                     {"results": [], "note": "no documentation section matched"}
                 )
-            return _bounded(
-                {
-                    "results": [
-                        {
-                            "source": section.source,
-                            "heading": section.heading,
-                            "text": section.text[:MAX_RESULT_TEXT_CHARS],
-                        }
-                        for section in sections
-                    ]
-                }
-            )
+            # Serialized size governs, not raw text length: escaping and
+            # metadata overhead can push a payload past the tool cap even
+            # with sliced text, and a truncated-mid-JSON result is worse
+            # than fewer results.
+            doc_results: list[dict[str, str]] = []
+            for section in sections:
+                candidate = doc_results + [
+                    {
+                        "source": section.source,
+                        "heading": section.heading,
+                        "text": section.text[:MAX_RESULT_TEXT_CHARS],
+                    }
+                ]
+                if (
+                    len(json.dumps({"results": candidate}, indent=1))
+                    > MAX_TOOL_RESULT_CHARS
+                ):
+                    break
+                doc_results = candidate
+            return json.dumps({"results": doc_results}, indent=1)
         if name == "get_model_catalog":
             models = await api.get_models(status=None)
             return _bounded(

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -499,7 +499,10 @@ class StewardHarness:
                 {"results": [result.model_dump(mode="json") for result in results]}
             )
         if name == "search_docs":
-            from skulk.api.steward_docs import search_docs
+            from skulk.api.steward_docs import (
+                MAX_RESULT_TEXT_CHARS,
+                search_docs,
+            )
 
             query = arguments.get("query")
             if not isinstance(query, str) or not query.strip():
@@ -526,7 +529,7 @@ class StewardHarness:
                         {
                             "source": section.source,
                             "heading": section.heading,
-                            "text": section.text,
+                            "text": section.text[:MAX_RESULT_TEXT_CHARS],
                         }
                         for section in sections
                     ]

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -69,7 +69,8 @@ cluster through your tools, then reporting clearly.
 
 Rules:
 - Investigate before concluding. Start from get_cluster_state unless the
-  question clearly points elsewhere.
+  question clearly points elsewhere; for what-is and how-to questions,
+  search_docs is the primary source.
 - Call ONE tool at a time and read its result before deciding the next step.
 - Evidence means concrete observed values from tool results, not guesses.
 - If everything is healthy, say so; do not invent problems.
@@ -139,6 +140,24 @@ def steward_tool_definitions() -> list[dict[str, Any]]:
             "return check results. Use for environment problems: missing "
             "engines, GPU detection, storage.",
             no_args,
+        ),
+        (
+            "search_docs",
+            "Search Skulk's own documentation (architecture, API guide, "
+            "doctor checks) for concepts, features, and how-to guidance. "
+            "Use for questions about what something IS or HOW to do "
+            "something, before or instead of guessing from general "
+            "knowledge.",
+            {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search terms, e.g. 'zenoh transport' or 'model store staging'.",
+                    }
+                },
+                "required": ["query"],
+            },
         ),
         (
             "get_model_catalog",
@@ -478,6 +497,40 @@ class StewardHarness:
             results = run_checks(current_node_facts())
             return _bounded(
                 {"results": [result.model_dump(mode="json") for result in results]}
+            )
+        if name == "search_docs":
+            from skulk.api.steward_docs import search_docs
+
+            query = arguments.get("query")
+            if not isinstance(query, str) or not query.strip():
+                return json.dumps({"error": "search_docs requires a query string"})
+            sections = search_docs(query)
+            if sections is None:
+                return json.dumps(
+                    {
+                        "error": (
+                            "documentation is not available on this "
+                            "installation (no docs directory); answer from "
+                            "tool evidence only and say docs were "
+                            "unavailable"
+                        )
+                    }
+                )
+            if not sections:
+                return json.dumps(
+                    {"results": [], "note": "no documentation section matched"}
+                )
+            return _bounded(
+                {
+                    "results": [
+                        {
+                            "source": section.source,
+                            "heading": section.heading,
+                            "text": section.text,
+                        }
+                        for section in sections
+                    ]
+                }
             )
         if name == "get_model_catalog":
             models = await api.get_models(status=None)

--- a/src/skulk/api/steward_docs.py
+++ b/src/skulk/api/steward_docs.py
@@ -31,9 +31,7 @@ MAX_RESULTS = 4
 _WORD_RE = re.compile(r"[a-z0-9_./-]+")
 
 _QUERY_STOPWORDS = frozenset(
-    """a an and are can d do does doing for from how i in is it its of on or
-    s t that the this to was we what when where which who why will with you
-    your""".split()
+    ["a", "an", "and", "are", "can", "d", "do", "does", "doing", "for", "from", "how", "i", "in", "is", "it", "its", "of", "on", "or", "s", "t", "that", "the", "this", "to", "was", "we", "what", "when", "where", "which", "who", "why", "will", "with", "you", "your"]
 )
 """Filler terms dropped from queries so 'what does zenoh do' ranks on
 'zenoh' rather than on sections dense in common words. Applied to queries

--- a/src/skulk/api/steward_docs.py
+++ b/src/skulk/api/steward_docs.py
@@ -207,5 +207,19 @@ _INDEX = DocsIndex()
 
 
 def search_docs(query: str) -> list[DocSection] | None:
-    """Module-level search over the process-cached index."""
+    """Search the documentation corpus for sections relevant to a query.
+
+    Args:
+        query: Free-text search terms; common filler words are ignored.
+
+    Returns:
+        Up to ``MAX_RESULTS`` sections ranked by relevance. An empty list
+        means the corpus exists but nothing matched; ``None`` means this
+        installation has no documentation directory at all, which callers
+        must report honestly rather than treating as a silent no-match.
+
+    Side effects:
+        The first call builds a process-cached index from the checkout's
+        documentation files; later calls reuse it.
+    """
     return _INDEX.search(query)

--- a/src/skulk/api/steward_docs.py
+++ b/src/skulk/api/steward_docs.py
@@ -135,8 +135,12 @@ def split_sections(source: str, text: str) -> list[DocSection]:
             first = False
             offset = end + (1 if end < len(body) else 0)
 
+    in_fence = False
     for line in text.splitlines():
-        if line.startswith("#"):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            current_lines.append(line)
+        elif line.startswith("#") and not in_fence:
             flush()
             current_heading = line.lstrip("# ").strip() or source
             current_lines = []
@@ -203,7 +207,20 @@ class DocsIndex:
                 )
 
     def search(self, query: str) -> list[DocSection] | None:
-        """Top sections for the query, or None when no corpus exists."""
+        """Rank documentation sections against a query.
+
+        Args:
+            query: Free-text search terms; common filler words are ignored.
+
+        Returns:
+            Up to ``MAX_RESULTS`` sections by descending relevance. An
+            empty list means the corpus exists but nothing matched;
+            ``None`` means this installation ships no documentation
+            directory at all.
+
+        Side effects:
+            The first call builds the process-cached index.
+        """
         with self._lock:
             if not self._built:
                 self._build()

--- a/src/skulk/api/steward_docs.py
+++ b/src/skulk/api/steward_docs.py
@@ -1,0 +1,172 @@
+"""Docs grounding for the steward: a dependency-free section index.
+
+Splits the repository's own documentation into heading-delimited sections
+and scores them against a query with a hand-rolled tf-idf, so the steward
+can answer Explain/Guide questions from the running checkout's docs rather
+than from base-model priors. Version-correct by construction: the index
+reads whatever documentation ships with the running code, so it can never
+describe a different release. No embedding model or external dependency is
+involved, deliberately: grounding must work on a cluster with nothing else
+mounted.
+
+The index degrades honestly: installations without the documentation files
+(a wheel install outside a repository checkout) report that absence as the
+tool result instead of pretending an empty corpus is knowledge.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+MAX_SECTION_CHARS = 2400
+"""Sections are truncated to stay digestible in a small model's context."""
+
+MAX_RESULTS = 4
+"""Result budget per query."""
+
+_WORD_RE = re.compile(r"[a-z0-9_./-]+")
+
+_DOC_SOURCES: tuple[str, ...] = (
+    "website/docs/architecture-reference.md",
+    "website/docs/api-guide.md",
+    "website/docs/architecture.md",
+    "website/docs/node-doctor.md",
+    "README.md",
+)
+"""Repo-relative documentation files indexed, most fact-dense first.
+
+architecture-reference.md exists specifically as the LLM-readable fact
+sheet, which makes it the corpus anchor.
+"""
+
+
+@dataclass(frozen=True)
+class DocSection:
+    """One heading-delimited slice of a documentation file."""
+
+    source: str
+    heading: str
+    text: str
+
+
+def _tokenize(text: str) -> list[str]:
+    return _WORD_RE.findall(text.lower())
+
+
+def split_sections(source: str, text: str) -> list[DocSection]:
+    """Split a markdown document on headings into bounded sections."""
+    sections: list[DocSection] = []
+    current_heading = source
+    current_lines: list[str] = []
+
+    def flush() -> None:
+        body = "\n".join(current_lines).strip()
+        if body:
+            sections.append(
+                DocSection(
+                    source=source,
+                    heading=current_heading,
+                    text=body[:MAX_SECTION_CHARS],
+                )
+            )
+
+    for line in text.splitlines():
+        if line.startswith("#"):
+            flush()
+            current_heading = line.lstrip("# ").strip() or source
+            current_lines = []
+        else:
+            current_lines.append(line)
+    flush()
+    return sections
+
+
+def _repo_root() -> Path | None:
+    """The repository root containing the docs, if this install has one.
+
+    Walks up from this module: a checkout places it under
+    ``<root>/src/skulk/api``, so the docs live three levels up. A wheel
+    install has no ``website/`` and returns None.
+    """
+    candidate = Path(__file__).resolve().parent.parent.parent.parent
+    if (candidate / "website" / "docs").is_dir():
+        return candidate
+    return None
+
+
+class DocsIndex:
+    """Lazily built, process-cached tf-idf index over the doc sections."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._built = False
+        self._sections: list[DocSection] = []
+        self._term_frequencies: list[dict[str, float]] = []
+        self._document_frequency: dict[str, int] = {}
+
+    def _build(self) -> None:
+        root = _repo_root()
+        if root is None:
+            return
+        for relative in _DOC_SOURCES:
+            path = root / relative
+            if not path.is_file():
+                continue
+            try:
+                text = path.read_text(errors="replace")
+            except OSError:
+                continue
+            self._sections.extend(_split_sections(relative, text))
+        for section in self._sections:
+            tokens = _tokenize(section.heading + " " + section.text)
+            frequencies: dict[str, float] = {}
+            for token in tokens:
+                frequencies[token] = frequencies.get(token, 0.0) + 1.0
+            length = max(1.0, float(len(tokens)))
+            self._term_frequencies.append(
+                {term: count / length for term, count in frequencies.items()}
+            )
+            for term in frequencies:
+                self._document_frequency[term] = (
+                    self._document_frequency.get(term, 0) + 1
+                )
+
+    def search(self, query: str) -> list[DocSection] | None:
+        """Top sections for the query, or None when no corpus exists."""
+        with self._lock:
+            if not self._built:
+                self._build()
+                self._built = True
+        if not self._sections:
+            return None
+        query_terms = _tokenize(query)
+        if not query_terms:
+            return []
+        total = len(self._sections)
+        scored: list[tuple[float, int]] = []
+        for index, frequencies in enumerate(self._term_frequencies):
+            score = 0.0
+            for term in query_terms:
+                term_frequency = frequencies.get(term)
+                if term_frequency is None:
+                    continue
+                document_frequency = self._document_frequency.get(term, total)
+                score += term_frequency * math.log(
+                    1.0 + total / document_frequency
+                )
+            if score > 0.0:
+                scored.append((score, index))
+        scored.sort(reverse=True)
+        return [self._sections[index] for _score, index in scored[:MAX_RESULTS]]
+
+
+_INDEX = DocsIndex()
+
+
+def search_docs(query: str) -> list[DocSection] | None:
+    """Module-level search over the process-cached index."""
+    return _INDEX.search(query)

--- a/src/skulk/api/steward_docs.py
+++ b/src/skulk/api/steward_docs.py
@@ -43,23 +43,43 @@ _QUERY_STOPWORDS = frozenset(
 'zenoh' rather than on sections dense in common words. Applied to queries
 only; section indexing keeps every term."""
 
-_DOC_SOURCES: tuple[str, ...] = (
+_ANCHOR_SOURCES: tuple[str, ...] = (
     "website/docs/architecture-reference.md",
     "website/docs/api-guide.md",
-    "website/docs/architecture.md",
-    "website/docs/node-doctor.md",
-    "README.md",
 )
-"""Repo-relative documentation files indexed, most fact-dense first.
+"""Indexed first: architecture-reference.md exists specifically as the
+LLM-readable fact sheet, making it the corpus anchor."""
 
-architecture-reference.md exists specifically as the LLM-readable fact
-sheet, which makes it the corpus anchor.
-"""
+
+def _doc_sources(root: Path) -> list[str]:
+    """Every top-level docs page plus the README, anchors first.
+
+    Globbing instead of an allowlist keeps dedicated how-to guides (service
+    setup, logging, and future pages) searchable without maintenance;
+    generated content lives in gitignored subdirectories and is untouched
+    by the top-level glob.
+    """
+    sources = [s for s in _ANCHOR_SOURCES if (root / s).is_file()]
+    docs_dir = root / "website" / "docs"
+    for path in sorted(docs_dir.glob("*.md")):
+        relative = str(path.relative_to(root))
+        if relative not in sources:
+            sources.append(relative)
+    if (root / "README.md").is_file():
+        sources.append("README.md")
+    return sources
 
 
 @dataclass(frozen=True)
 class DocSection:
-    """One heading-delimited slice of a documentation file."""
+    """One heading-delimited slice of a documentation file.
+
+    Attributes:
+        source: Repo-relative path of the document the slice came from.
+        heading: The section's heading text; continuation chunks of an
+            oversized section carry a ``"(cont.)"`` suffix.
+        text: The section body, bounded to ``MAX_SECTION_CHARS``.
+    """
 
     source: str
     heading: str
@@ -94,16 +114,26 @@ def split_sections(source: str, text: str) -> list[DocSection]:
         # Long sections are chunked, not truncated: truncating before the
         # index is built would make every fact after the cutoff
         # unsearchable rather than merely bounding returned context.
-        for offset in range(0, len(body), MAX_SECTION_CHARS):
-            chunk = body[offset : offset + MAX_SECTION_CHARS]
-            heading = (
-                current_heading
-                if offset == 0
-                else f"{current_heading} (cont.)"
-            )
-            sections.append(
-                DocSection(source=source, heading=heading, text=chunk)
-            )
+        offset = 0
+        first = True
+        while offset < len(body):
+            end = min(offset + MAX_SECTION_CHARS, len(body))
+            if end < len(body):
+                # Cut at the last whitespace inside the window so a term
+                # spanning the boundary never becomes unsearchable.
+                boundary = body.rfind(" ", offset, end)
+                newline_boundary = body.rfind("\n", offset, end)
+                boundary = max(boundary, newline_boundary)
+                if boundary > offset:
+                    end = boundary
+            chunk = body[offset:end].strip()
+            if chunk:
+                heading = current_heading if first else f"{current_heading} (cont.)"
+                sections.append(
+                    DocSection(source=source, heading=heading, text=chunk)
+                )
+            first = False
+            offset = end + (1 if end < len(body) else 0)
 
     for line in text.splitlines():
         if line.startswith("#"):
@@ -143,7 +173,7 @@ class DocsIndex:
         root = _repo_root()
         if root is None:
             return
-        for relative in _DOC_SOURCES:
+        for relative in _doc_sources(root):
             path = root / relative
             if not path.is_file():
                 continue

--- a/src/skulk/api/steward_docs.py
+++ b/src/skulk/api/steward_docs.py
@@ -30,6 +30,15 @@ MAX_RESULTS = 4
 
 _WORD_RE = re.compile(r"[a-z0-9_./-]+")
 
+_QUERY_STOPWORDS = frozenset(
+    """a an and are can d do does doing for from how i in is it its of on or
+    s t that the this to was we what when where which who why will with you
+    your""".split()
+)
+"""Filler terms dropped from queries so 'what does zenoh do' ranks on
+'zenoh' rather than on sections dense in common words. Applied to queries
+only; section indexing keeps every term."""
+
 _DOC_SOURCES: tuple[str, ...] = (
     "website/docs/architecture-reference.md",
     "website/docs/api-guide.md",
@@ -65,13 +74,20 @@ def split_sections(source: str, text: str) -> list[DocSection]:
 
     def flush() -> None:
         body = "\n".join(current_lines).strip()
-        if body:
+        if not body:
+            return
+        # Long sections are chunked, not truncated: truncating before the
+        # index is built would make every fact after the cutoff
+        # unsearchable rather than merely bounding returned context.
+        for offset in range(0, len(body), MAX_SECTION_CHARS):
+            chunk = body[offset : offset + MAX_SECTION_CHARS]
+            heading = (
+                current_heading
+                if offset == 0
+                else f"{current_heading} (cont.)"
+            )
             sections.append(
-                DocSection(
-                    source=source,
-                    heading=current_heading,
-                    text=body[:MAX_SECTION_CHARS],
-                )
+                DocSection(source=source, heading=heading, text=chunk)
             )
 
     for line in text.splitlines():
@@ -88,9 +104,9 @@ def split_sections(source: str, text: str) -> list[DocSection]:
 def _repo_root() -> Path | None:
     """The repository root containing the docs, if this install has one.
 
-    Walks up from this module: a checkout places it under
-    ``<root>/src/skulk/api``, so the docs live three levels up. A wheel
-    install has no ``website/`` and returns None.
+    Walks up from this module: a checkout places it at
+    ``<root>/src/skulk/api/steward_docs.py``, so the root is four parents
+    up. A wheel install has no ``website/`` and returns None.
     """
     candidate = Path(__file__).resolve().parent.parent.parent.parent
     if (candidate / "website" / "docs").is_dir():
@@ -143,7 +159,9 @@ class DocsIndex:
                 self._built = True
         if not self._sections:
             return None
-        query_terms = _tokenize(query)
+        query_terms = [
+            term for term in _tokenize(query) if term not in _QUERY_STOPWORDS
+        ]
         if not query_terms:
             return []
         total = len(self._sections)

--- a/src/skulk/api/steward_docs.py
+++ b/src/skulk/api/steward_docs.py
@@ -120,7 +120,7 @@ class DocsIndex:
                 text = path.read_text(errors="replace")
             except OSError:
                 continue
-            self._sections.extend(_split_sections(relative, text))
+            self._sections.extend(split_sections(relative, text))
         for section in self._sections:
             tokens = _tokenize(section.heading + " " + section.text)
             frequencies: dict[str, float] = {}

--- a/src/skulk/api/steward_docs.py
+++ b/src/skulk/api/steward_docs.py
@@ -28,6 +28,12 @@ MAX_SECTION_CHARS = 2400
 MAX_RESULTS = 4
 """Result budget per query."""
 
+MAX_RESULT_TEXT_CHARS = 1200
+"""Per-result text budget in tool output: four results plus JSON overhead
+must fit the harness's 6000-char tool-result cap without mid-JSON
+truncation. Indexing keeps the full section; only returned context is
+sliced."""
+
 _WORD_RE = re.compile(r"[a-z0-9_./-]+")
 
 _QUERY_STOPWORDS = frozenset(
@@ -65,7 +71,18 @@ def _tokenize(text: str) -> list[str]:
 
 
 def split_sections(source: str, text: str) -> list[DocSection]:
-    """Split a markdown document on headings into bounded sections."""
+    """Split a markdown document on headings into bounded sections.
+
+    Args:
+        source: Repo-relative path of the document, recorded on every
+            resulting section and used as the fallback heading.
+        text: The document's full markdown text.
+
+    Returns:
+        Sections in document order. A heading whose body exceeds
+        ``MAX_SECTION_CHARS`` yields multiple sections, the continuations
+        titled ``"<heading> (cont.)"``, so nothing becomes unsearchable.
+    """
     sections: list[DocSection] = []
     current_heading = source
     current_lines: list[str] = []
@@ -136,7 +153,13 @@ class DocsIndex:
                 continue
             self._sections.extend(split_sections(relative, text))
         for section in self._sections:
-            tokens = _tokenize(section.heading + " " + section.text)
+            # Continuation chunks skip their (repeated) heading terms so a
+            # heading-matching query cannot make tiny tail chunks outrank
+            # the substantive first chunk via length normalization.
+            if section.heading.endswith("(cont.)"):
+                tokens = _tokenize(section.text)
+            else:
+                tokens = _tokenize(section.heading + " " + section.text)
             frequencies: dict[str, float] = {}
             for token in tokens:
                 frequencies[token] = frequencies.get(token, 0.0) + 1.0

--- a/src/skulk/api/tests/test_steward_docs.py
+++ b/src/skulk/api/tests/test_steward_docs.py
@@ -36,3 +36,18 @@ async def test_steward_tool_returns_bounded_results() -> None:
     )
     if parsed:
         assert "results" in parsed or "error" in parsed
+
+
+def test_long_sections_chunk_instead_of_truncating() -> None:
+    text = "# Big\n" + ("alpha " * 300) + "UNIQUEMARKER-TAIL " + ("beta " * 300)
+    sections = split_sections("doc.md", text)
+    assert len(sections) >= 2
+    assert any("UNIQUEMARKER-TAIL".lower() in s.text.lower() or "UNIQUEMARKER-TAIL" in s.text for s in sections)
+    assert all(len(s.text) <= 2400 for s in sections)
+
+
+def test_filler_terms_do_not_dominate_ranking() -> None:
+    results = search_docs("what does zenoh do")
+    assert results is not None and results
+    joined = " ".join((s.heading + " " + s.text).lower() for s in results)
+    assert "zenoh" in joined

--- a/src/skulk/api/tests/test_steward_docs.py
+++ b/src/skulk/api/tests/test_steward_docs.py
@@ -1,0 +1,39 @@
+"""Docs grounding: section index and steward tool behavior."""
+
+import json
+
+from typing import cast
+
+from skulk.api.steward_docs import search_docs, split_sections
+
+
+def test_sections_split_on_headings_and_bound_length() -> None:
+    text = "# Alpha\nbody one\n## Beta\n" + ("x" * 5000)
+    sections = split_sections("doc.md", text)
+    assert [s.heading for s in sections] == ["Alpha", "Beta"]
+    assert len(sections[1].text) <= 2400
+
+
+def test_search_finds_relevant_repo_docs() -> None:
+    # The repo checkout ships the corpus; the fact-sheet is the anchor.
+    results = search_docs("zenoh data transport")
+    assert results is not None and results
+    joined = " ".join(s.text.lower() + s.heading.lower() for s in results)
+    assert "zenoh" in joined
+
+
+def test_empty_query_returns_no_results() -> None:
+    assert search_docs("   ") == []
+
+
+async def test_steward_tool_returns_bounded_results() -> None:
+    from skulk.api.steward import StewardHarness
+
+    harness = StewardHarness(cast("object", None))  # type: ignore[arg-type]
+    payload = await harness.execute_tool("search_docs", {"query": "steward"})
+    parsed = cast(
+        "dict[str, object]",
+        json.loads(payload if not payload.endswith("...[truncated]") else "{}"),
+    )
+    if parsed:
+        assert "results" in parsed or "error" in parsed

--- a/src/skulk/api/tests/test_steward_docs.py
+++ b/src/skulk/api/tests/test_steward_docs.py
@@ -72,3 +72,14 @@ def test_how_to_guides_are_indexed() -> None:
     assert results is not None and results
     sources = {s.source for s in results}
     assert any("docs/" in src for src in sources)
+
+
+def test_shell_comments_in_fences_are_not_headings() -> None:
+    text = (
+        "# Guide\nIntro line.\n```bash\n# install it\nmake install\n```\n"
+        "Outro line.\n## Next\nmore"
+    )
+    sections = split_sections("doc.md", text)
+    assert [s.heading for s in sections] == ["Guide", "Next"]
+    assert "# install it" in sections[0].text
+    assert "Outro line." in sections[0].text

--- a/src/skulk/api/tests/test_steward_docs.py
+++ b/src/skulk/api/tests/test_steward_docs.py
@@ -57,3 +57,18 @@ def test_filler_terms_do_not_dominate_ranking() -> None:
     assert results is not None and results
     joined = " ".join((s.heading + " " + s.text).lower() for s in results)
     assert "zenoh" in joined
+
+
+def test_chunk_boundaries_never_split_terms() -> None:
+    body = ("word " * 700).strip()  # far past one chunk
+    sections = split_sections("doc.md", "# Big\n" + body)
+    for section in sections:
+        # every chunk is whole words: reassembling with spaces loses nothing
+        assert all(token == "word" for token in section.text.split())
+
+
+def test_how_to_guides_are_indexed() -> None:
+    results = search_docs("run skulk as a service")
+    assert results is not None and results
+    sources = {s.source for s in results}
+    assert any("docs/" in src for src in sources)

--- a/src/skulk/api/tests/test_steward_docs.py
+++ b/src/skulk/api/tests/test_steward_docs.py
@@ -9,8 +9,14 @@ from skulk.api.steward_docs import search_docs, split_sections
 def test_sections_split_on_headings_and_bound_length() -> None:
     text = "# Alpha\nbody one\n## Beta\n" + ("x" * 5000)
     sections = split_sections("doc.md", text)
-    assert [s.heading for s in sections] == ["Alpha", "Beta"]
-    assert len(sections[1].text) <= 2400
+    # The oversized Beta section chunks into bounded continuations.
+    assert [s.heading for s in sections] == [
+        "Alpha",
+        "Beta",
+        "Beta (cont.)",
+        "Beta (cont.)",
+    ]
+    assert all(len(s.text) <= 2400 for s in sections)
 
 
 def test_search_finds_relevant_repo_docs() -> None:

--- a/src/skulk/api/tests/test_steward_docs.py
+++ b/src/skulk/api/tests/test_steward_docs.py
@@ -1,7 +1,6 @@
 """Docs grounding: section index and steward tool behavior."""
 
 import json
-
 from typing import cast
 
 from skulk.api.steward_docs import search_docs, split_sections

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -1205,7 +1205,8 @@ Semantics of the reserved id:
 - The server runs the steward's investigation loop (up to 8 read-only tool
   calls per turn: cluster state, node resources, telemetry and data-plane
   diagnostics, version status, performance envelopes, the local doctor
-  registry, and the model catalog) and answers from the evidence.
+  registry, the model catalog, and a search over Skulk's own bundled
+  documentation) and answers from the evidence.
 - The tool trace is returned as reasoning content: in streaming responses,
   each tool step arrives as a `reasoning_content` delta while the
   investigation runs, followed by the answer as `content`; non-streaming

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -98,7 +98,11 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 - Harness: `src/skulk/api/steward.py`. Read-only tools: cluster state
   summary, node resources, telemetry diagnostics, data-plane diagnostics,
   cluster versions, performance envelopes, local doctor registry, model
-  catalog. 6000-char tool-result bound, 8 steps/turn, observe/advise only.
+  catalog, and `search_docs` (steward_docs.py: dependency-free tf-idf
+  section index over the checkout's own docs, anchored on
+  architecture-reference.md; honest absence report on doc-less installs;
+  version-correct by construction, per the no-knowledge-in-weights
+  doctrine). 6000-char tool-result bound, 8 steps/turn, observe/advise only.
 - Client surface: reserved virtual model id `skulk/steward` on
   `POST /v1/chat/completions` (checked before card resolution; client
   `tools` rejected 400; client system messages ignored; trace streams as

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -645,8 +645,10 @@ steward-specific integration. The reserved id selects the model plus the
 server-side harness: a bounded, strictly read-only tool surface (cluster
 state with health reasons, per-node resources and capability conflicts,
 telemetry and data-plane diagnostics, per-node version status, performance
-envelopes, the local doctor check registry, and the model catalog) and an
-investigation loop of up to eight tool calls per turn. Tool steps stream to
+envelopes, the local doctor check registry, the model catalog, and a
+search over Skulk's own bundled documentation so what-is and how-to
+questions are answered from the shipped docs rather than model priors)
+and an investigation loop of up to eight tool calls per turn. Tool steps stream to
 the client as reasoning content while the investigation runs, followed by
 the answer; client-supplied tool definitions are rejected, and client system
 prompts are ignored in favor of the steward's own. Generation itself rides


### PR DESCRIPTION
## What

Item 3 of the current epic queue: the steward gains a `search_docs` tool so Explain/Guide questions ("what does zenoh do?", "how do I add a model?") are answered from Skulk's own documentation instead of base-model priors.

## Design

- **Dependency-free retrieval**: heading-delimited sections from the checkout's docs (anchored on architecture-reference.md, the LLM-readable fact sheet, plus the api-guide, architecture narrative, doctor docs, and README), scored with a hand-rolled tf-idf. No embedding model required: grounding works on a cluster with nothing else mounted.
- **Version-correct by construction**: the index reads whatever documentation ships with the running code, so it can never describe a different release. This is the deliberate alternative to baking release-specific knowledge into fine-tuned weights (per the initiative's fine-tune doctrine).
- **Honest degradation**: wheel-style installs without a docs directory get an explicit absence result telling the steward to answer from tool evidence and say docs were unavailable, never an empty index masquerading as knowledge.
- Bounded: four results, 2400 chars per section, inside the existing per-tool result cap. Process-cached, built lazily on first use.
- The system prompt now points what-is/how-to questions at the tool.

## Validation

basedpyright 0, ruff clean, nix fmt no changes, full suite green. Tests cover section splitting and bounding, live retrieval against the repo corpus (zenoh query), empty-query behavior, and the tool surface path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01262jKrQwepcSQtv1vk2chH