### PR TITLE
Fix Qwen3.5 2B default decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- Disabled the Qwen3.5 2B MLX card's MTP sidecar after clean-install text and
+  vision journeys showed repetitive generation until the output limit. The
+  same shipped model now uses vanilla decoding, which completes both journeys
+  normally while retaining its text, thinking-toggle, and vision capabilities.
+
 - Fresh multi-node installs now converge their per-node bootstrap model stores
   on the elected master's routable store endpoint. Followers retry
   authoritative config sync through the startup window, stop superseded local

--- a/resources/inference_model_cards/mlx-community--Qwen3.5-2B-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3.5-2B-4bit.toml
@@ -16,15 +16,12 @@ format = "token_delimited"
 default_effort = "medium"
 disabled_effort = "none"
 
-# MTP speculative decoding re-validated 2026-06-05 under the bonus-driven
-# cadence (deferred replay + quantize-on-load sidecar): 80% acceptance,
-# 91.3 tok/s vs 78.9 vanilla (1.16x — modest on a trunk this fast, where
-# per-round drafter overhead is a large fraction of a 13ms decode step)
-# (Skulk #192 / PR #193 / bonus-driven cadence rework).
+# MTP is deliberately disabled for this card. Although the sidecar previously
+# measured high token acceptance on a narrow greedy benchmark, fresh-install
+# text and vision journeys produced repetitive output until the token limit.
+# The same model completed both journeys normally without speculative decoding.
 [runtime]
-mtp_heads = true
-mtp_max_depth = 1
-mtp_sidecar_repo = "FoxlightAI/qwen3-5-2b-base-mtp"
+mtp_heads = false
 
 # Qwen3.5 is a natively multimodal (early-fusion) VLM: config.json ships a
 # vision_config and the repo is tagged image-text-to-text /

--- a/src/skulk/shared/tests/test_bundled_model_cards.py
+++ b/src/skulk/shared/tests/test_bundled_model_cards.py
@@ -91,6 +91,17 @@ def test_qwen3_vl_4b_card_pins_the_measured_artifact() -> None:
     assert card.storage_size.in_bytes == 3_109_732_071
 
 
+def test_qwen35_2b_card_keeps_unstable_mtp_disabled() -> None:
+    """Do not re-enable the sidecar that loops in clean user journeys."""
+    card = _load(
+        _CARD_DIRS["inference"] / "mlx-community--Qwen3.5-2B-4bit.toml"
+    )
+
+    assert card.runtime is not None
+    assert card.runtime.mtp_heads is False
+    assert card.runtime.mtp_sidecar_repo is None
+
+
 @pytest.mark.parametrize(("kind", "path"), _CARD_FILES, ids=_CARD_IDS)
 def test_bundled_card_invariants(kind: str, path: Path) -> None:
     card = _load(path)  # validation itself is the first gate


### PR DESCRIPTION
## Summary
- disable the Qwen3.5 2B MLX card's MTP sidecar after clean-install text and vision journeys looped to the output limit
- retain the model's text, thinking-toggle, and native vision capabilities under vanilla decoding
- add a bundled-card regression so the unstable sidecar is not silently re-enabled

## Live validation
On a clean single-node candidate environment, vanilla decoding completed the previously failing text prompt normally in 21 tokens and correctly identified a randomized image code, color, and shape before stopping normally. The MTP-enabled candidate exhausted the 4,096-token limit on both journeys.

## Repository validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt` (0 changed)
- `uv run pytest` (2,982 passed, 1 skipped, 228 deselected)