### PR TITLE
Fix thinking controls for native vision prompts

### DIFF
--- a/dashboard-react/e2e/vision-live.spec.ts
+++ b/dashboard-react/e2e/vision-live.spec.ts
@@ -133,8 +133,9 @@ test('the built-in dashboard sends and understands a real portrait', async ({ pa
   expect(Buffer.from(dataUrlMatch![1], 'base64').equals(readFileSync(exactImagePath))).toBe(true);
 
   const assistantMessage = page.locator('[data-message-role="assistant"]').last();
-  await expect(assistantMessage).toContainText(/\S/, { timeout: 2 * 60 * 1000 });
-  const answer = await assistantMessage.innerText();
+  const assistantResponse = assistantMessage.locator('[data-testid="assistant-response-content"]').last();
+  await expect(assistantResponse).toContainText(/\S/, { timeout: 2 * 60 * 1000 });
+  const answer = await assistantResponse.innerText();
 
   writeFileSync(
     testInfo.outputPath('vision-answer.json'),

--- a/dashboard-react/src/components/chat/ChatMessages.test.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.test.tsx
@@ -1,0 +1,71 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ThemeProvider } from 'styled-components';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { darkTheme } from '../../theme/theme';
+import type { ChatMessage } from '../../types/chat';
+import { ChatMessages } from './ChatMessages';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../i18n/tolgee', () => ({
+  useSkulkTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function renderChatMessages(messages: ChatMessage[]): Promise<void> {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <ThemeProvider theme={darkTheme}>
+        <ChatMessages
+          messages={messages}
+          onDelete={vi.fn()}
+          onRegenerate={vi.fn()}
+        />
+      </ThemeProvider>,
+    );
+  });
+}
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe('ChatMessages', () => {
+  it('exposes assistant response content without message chrome', async () => {
+    await renderChatMessages([
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'orange circle | GEM86Z',
+        timestamp: 0,
+        ttftMs: 1234,
+        tps: 56.7,
+      },
+    ]);
+
+    const fullMessageText = container
+      ?.querySelector('[aria-label="Assistant message"]')
+      ?.textContent;
+    const responseText = container
+      ?.querySelector('[data-testid="assistant-response-content"]')
+      ?.textContent;
+
+    expect(fullMessageText).toContain('TTFT');
+    expect(fullMessageText).toContain('Copy');
+    expect(fullMessageText).toContain('Regenerate');
+    expect(fullMessageText).toContain('Delete');
+    expect(responseText?.trim()).toBe('orange circle | GEM86Z');
+  });
+});

--- a/dashboard-react/src/components/chat/ChatMessages.tsx
+++ b/dashboard-react/src/components/chat/ChatMessages.tsx
@@ -597,10 +597,10 @@ export function ChatMessages({
 
               {/* Content */}
               {msg.role === 'assistant' ? (
-                <>
+                <div data-testid="assistant-response-content">
                   {msg.content && <MarkdownContent content={msg.content} />}
                   {isLoading && isLastAssistant(i) && <Cursor />}
-                </>
+                </div>
               ) : (
                 <UserContent>{msg.content}</UserContent>
               )}
@@ -705,10 +705,10 @@ export function ChatMessages({
             </ThinkingBlock>
           )}
           {streamingContent ? (
-            <>
+            <div data-testid="streaming-assistant-response-content">
               <MarkdownContent content={streamingContent} />
               <Cursor />
-            </>
+            </div>
           ) : (
             <Cursor />
           )}

--- a/src/skulk/worker/engines/mlx/generator/batch_generate.py
+++ b/src/skulk/worker/engines/mlx/generator/batch_generate.py
@@ -106,6 +106,8 @@ def resolve_request_vision(
             tokenizer=tokenizer,
             model=model,
             task_id=task_id,
+            enable_thinking=task_params.enable_thinking,
+            reasoning_effort=task_params.reasoning_effort,
         )
     except VisionPreprocessingError:
         raise

--- a/src/skulk/worker/engines/mlx/generator/generate.py
+++ b/src/skulk/worker/engines/mlx/generator/generate.py
@@ -2781,6 +2781,8 @@ def mlx_generate(
                     tokenizer=tokenizer,
                     model=model,
                     task_id=trace_task_id,
+                    enable_thinking=task.enable_thinking,
+                    reasoning_effort=task.reasoning_effort,
                 )
         except VisionPreprocessingError:
             record_runner_phase(

--- a/src/skulk/worker/engines/mlx/vision.py
+++ b/src/skulk/worker/engines/mlx/vision.py
@@ -712,7 +712,26 @@ def build_vision_prompt(
     enable_thinking: bool | None = None,
     reasoning_effort: ReasoningEffort | None = None,
 ) -> str:
-    """Build a full prompt string with image placeholders expanded to features."""
+    """Build a full prompt string with image placeholders expanded to features.
+
+    Args:
+        tokenizer: Tokenizer whose chat template renders the textual turns.
+        chat_template_messages: OpenAI-style chat messages that may include
+            image parts.
+        n_tokens_per_image: Number of placeholder tokens each image expands to.
+        image_token: Placeholder token text used by the model's vision template.
+        model_type: Optional model family override for custom prompt renderers.
+        boi_token_id: Optional beginning-of-image token for framed templates.
+        eoi_token_id: Optional end-of-image token for framed templates.
+        enable_thinking: Explicit thinking toggle forwarded to templates that
+            support it.
+        reasoning_effort: Optional reasoning effort forwarded to templates that
+            support it.
+
+    Returns:
+        The rendered prompt with each image placeholder expanded to match the
+        encoded vision feature count.
+    """
     return _build_vision_prompt_with_debug(
         tokenizer,
         chat_template_messages,
@@ -1621,6 +1640,23 @@ class VisionProcessor:
         enable_thinking: bool | None = None,
         reasoning_effort: ReasoningEffort | None = None,
     ) -> VisionResult:
+        """Convert images and chat messages into model-ready vision inputs.
+
+        Args:
+            images: Base64-encoded image payloads from the request.
+            chat_template_messages: Chat messages containing the image parts.
+            tokenizer: Tokenizer used to render and encode the multimodal prompt.
+            model: Loaded MLX model receiving the resulting prompt inputs.
+            task_id: Optional task identifier for diagnostics.
+            enable_thinking: Explicit thinking toggle forwarded to the prompt
+                renderer.
+            reasoning_effort: Optional reasoning effort forwarded to the prompt
+                renderer.
+
+        Returns:
+            Vision preprocessing output containing prompt tokens, media regions,
+            and either fused embeddings or native image tensors.
+        """
         logger.info(f"Vision pipeline: {len(images)} image(s)")
         record_runner_phase(
             "vision_preprocess",
@@ -1993,6 +2029,27 @@ def prepare_vision(
     reasoning_effort: ReasoningEffort | None = None,
 ) -> VisionResult | None:
     """Encode images and build the vision-augmented prompt.
+
+    Args:
+        images: Base64-encoded image payloads, or ``None`` for text-only tasks.
+        chat_template_messages: Chat messages preserving the request's image
+            placement.
+        vision_processor: Processor configured for the selected vision model.
+        tokenizer: Tokenizer used by the model's chat template.
+        model: Loaded MLX model receiving the vision-preprocessed inputs.
+        task_id: Optional task identifier for diagnostics.
+        enable_thinking: Explicit thinking toggle forwarded to vision prompt
+            rendering.
+        reasoning_effort: Optional reasoning effort forwarded to vision prompt
+            rendering.
+
+    Returns:
+        ``None`` for requests without images, otherwise a ``VisionResult`` ready
+        for generation.
+
+    Raises:
+        VisionPreprocessingError: Raised when a request contains images but the
+            prompt cannot be built without dropping or hallucinating them.
 
     Returns ``None`` only when the request carried no images. A request that
     does carry images either gets them spliced into the prompt or raises

--- a/src/skulk/worker/engines/mlx/vision.py
+++ b/src/skulk/worker/engines/mlx/vision.py
@@ -65,6 +65,7 @@ from skulk.shared.tracing import TraceAttrValue
 from skulk.shared.types.common import ModelId
 from skulk.shared.types.mlx import Model
 from skulk.shared.types.tasks import TaskId
+from skulk.shared.types.text_generation import ReasoningEffort
 from skulk.worker.engines.mlx.cache import encode_prompt
 from skulk.worker.engines.mlx.gemma4_prompt import render_gemma4_prompt
 from skulk.worker.engines.mlx.utils_mlx import fix_unmatched_think_end_tokens
@@ -618,6 +619,8 @@ def _build_vision_prompt_with_debug(
     model_type: str | None = None,
     boi_token_id: int | None = None,
     eoi_token_id: int | None = None,
+    enable_thinking: bool | None = None,
+    reasoning_effort: ReasoningEffort | None = None,
 ) -> _VisionPromptBuild:
     """Build the expanded prompt and retain the raw placeholder layout.
 
@@ -633,12 +636,22 @@ def _build_vision_prompt_with_debug(
         prompt = render_gemma4_prompt(
             chat_template_messages,
             add_generation_prompt=True,
+            enable_thinking=enable_thinking,
         )
     else:
+        extra_kwargs: dict[str, Any] = {}
+        if enable_thinking is not None:
+            # Qwen3 and GLM use "enable_thinking"; DeepSeek uses "thinking".
+            # Unknown Jinja variables are ignored by templates that do not need them.
+            extra_kwargs["enable_thinking"] = enable_thinking
+            extra_kwargs["thinking"] = enable_thinking
+        if reasoning_effort is not None:
+            extra_kwargs["reasoning_effort"] = reasoning_effort
         prompt = tokenizer.apply_chat_template(
             chat_template_messages,
             tokenize=False,
             add_generation_prompt=True,
+            **extra_kwargs,
         )
     raw_prompt = prompt
     raw_placeholder_positions = _prompt_placeholder_positions(raw_prompt, image_token)
@@ -696,6 +709,8 @@ def build_vision_prompt(
     model_type: str | None = None,
     boi_token_id: int | None = None,
     eoi_token_id: int | None = None,
+    enable_thinking: bool | None = None,
+    reasoning_effort: ReasoningEffort | None = None,
 ) -> str:
     """Build a full prompt string with image placeholders expanded to features."""
     return _build_vision_prompt_with_debug(
@@ -706,6 +721,8 @@ def build_vision_prompt(
         model_type=model_type,
         boi_token_id=boi_token_id,
         eoi_token_id=eoi_token_id,
+        enable_thinking=enable_thinking,
+        reasoning_effort=reasoning_effort,
     ).prompt
 
 
@@ -1601,6 +1618,8 @@ class VisionProcessor:
         model: Model,
         *,
         task_id: TaskId | str | None = None,
+        enable_thinking: bool | None = None,
+        reasoning_effort: ReasoningEffort | None = None,
     ) -> VisionResult:
         logger.info(f"Vision pipeline: {len(images)} image(s)")
         record_runner_phase(
@@ -1619,6 +1638,8 @@ class VisionProcessor:
                 tokenizer,
                 model,
                 task_id=task_id,
+                enable_thinking=enable_thinking,
+                reasoning_effort=reasoning_effort,
             )
 
         cache_key = self._image_cache_key(images)
@@ -1652,6 +1673,8 @@ class VisionProcessor:
             model_type=self.vision_config.model_type,
             boi_token_id=self.vision_config.boi_token_id,
             eoi_token_id=self.vision_config.eoi_token_id,
+            enable_thinking=enable_thinking,
+            reasoning_effort=reasoning_effort,
         )
         prompt = prompt_build.prompt
         record_runner_phase(
@@ -1747,6 +1770,8 @@ class VisionProcessor:
         model: Model,
         *,
         task_id: TaskId | str | None = None,
+        enable_thinking: bool | None = None,
+        reasoning_effort: ReasoningEffort | None = None,
     ) -> VisionResult:
         """Process images for models with native vision support (e.g. Gemma 4).
 
@@ -1850,6 +1875,8 @@ class VisionProcessor:
             model_type=self.vision_config.model_type,
             boi_token_id=self.vision_config.boi_token_id,
             eoi_token_id=self.vision_config.eoi_token_id,
+            enable_thinking=enable_thinking,
+            reasoning_effort=reasoning_effort,
         )
         prompt = prompt_build.prompt
         record_runner_phase(
@@ -1962,6 +1989,8 @@ def prepare_vision(
     model: Model,
     *,
     task_id: TaskId | str | None = None,
+    enable_thinking: bool | None = None,
+    reasoning_effort: ReasoningEffort | None = None,
 ) -> VisionResult | None:
     """Encode images and build the vision-augmented prompt.
 
@@ -1984,4 +2013,6 @@ def prepare_vision(
         tokenizer=tokenizer,
         model=model,
         task_id=task_id,
+        enable_thinking=enable_thinking,
+        reasoning_effort=reasoning_effort,
     )

--- a/tests/test_gemma_vision.py
+++ b/tests/test_gemma_vision.py
@@ -355,6 +355,55 @@ class TestGemma4ReferencePromptRenderer:
             == "<bos><|turn>user\n<|image><|image|><|image|><|image|><image|>what do you see?<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
         )
 
+    def test_build_vision_prompt_passes_thinking_controls_to_generic_templates(self):
+        from skulk.worker.engines.mlx.vision import build_vision_prompt
+
+        class _Tokenizer:
+            captured_kwargs: dict[str, object] = {}
+
+            def apply_chat_template(self, messages, **kwargs):
+                self.captured_kwargs = dict(kwargs)
+                assert messages == [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image"},
+                            {"type": "text", "text": "read it"},
+                        ],
+                    }
+                ]
+                return "<image>read it"
+
+            def decode(self, token_ids):
+                raise AssertionError("generic prompt test should not decode tokens")
+
+        tokenizer = _Tokenizer()
+
+        prompt = build_vision_prompt(
+            tokenizer=tokenizer,  # type: ignore[arg-type]
+            chat_template_messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": "read it"},
+                    ],
+                }
+            ],
+            n_tokens_per_image=[2],
+            image_token="<image>",
+            model_type="qwen3_5",
+            enable_thinking=False,
+            reasoning_effort="none",
+        )
+
+        assert prompt == "<image><image>read it"
+        assert tokenizer.captured_kwargs["tokenize"] is False
+        assert tokenizer.captured_kwargs["add_generation_prompt"] is True
+        assert tokenizer.captured_kwargs["enable_thinking"] is False
+        assert tokenizer.captured_kwargs["thinking"] is False
+        assert tokenizer.captured_kwargs["reasoning_effort"] == "none"
+
     def test_process_native_forwards_gemma4_model_type_to_prompt_builder(
         self, monkeypatch, tmp_path
     ):
@@ -393,8 +442,12 @@ class TestGemma4ReferencePromptRenderer:
             model_type=None,
             boi_token_id=None,
             eoi_token_id=None,
+            enable_thinking=None,
+            reasoning_effort=None,
         ):
             captured["model_type"] = model_type
+            captured["enable_thinking"] = enable_thinking
+            captured["reasoning_effort"] = reasoning_effort
             return vision_module._VisionPromptBuild(  # pyright: ignore[reportPrivateUsage]
                 prompt="<|image|>",
                 raw_prompt="<|image|>",
@@ -430,9 +483,13 @@ class TestGemma4ReferencePromptRenderer:
             chat_template_messages=[{"role": "user", "content": [{"type": "image"}]}],
             tokenizer=_Tokenizer(),  # type: ignore[arg-type]
             model=SimpleNamespace(),  # type: ignore[arg-type]
+            enable_thinking=False,
+            reasoning_effort="none",
         )
 
         assert captured["model_type"] == "gemma4"
+        assert captured["enable_thinking"] is False
+        assert captured["reasoning_effort"] == "none"
         assert result.prompt_tokens.shape == (1,)
 
 


### PR DESCRIPTION
## Summary
- forward thinking controls through native MLX vision prompt rendering so Qwen-style templates honor enable_thinking=false
- pass request reasoning fields from both batched and direct MLX generation paths into vision preprocessing
- add a stable dashboard selector for assistant response content so qualification reads model output without header/action chrome

## Validation
- uv run basedpyright
- uv run ruff check
- nix --extra-experimental-features 'nix-command flakes' fmt
- uv run pytest
- npm run test (dashboard-react)
- npm run build (dashboard-react)