### PR TITLE
Default toggleable thinking off when controls are omitted

### DIFF
--- a/src/skulk/api/tests/test_chat_completions_adapter.py
+++ b/src/skulk/api/tests/test_chat_completions_adapter.py
@@ -13,6 +13,7 @@ from skulk.shared.models.model_cards import (
     ModelCard,
     ModelTask,
     ReasoningCardConfig,
+    ReasoningFormat,
 )
 from skulk.shared.types.common import ModelId
 from skulk.shared.types.memory import Memory
@@ -101,6 +102,36 @@ async def test_toggleable_model_explicit_false_normalizes_to_disabled_effort() -
 
     assert params.enable_thinking is False
     assert params.reasoning_effort == "minimal"
+
+
+@pytest.mark.anyio
+async def test_qwen35_toggleable_model_defaults_to_thinking_disabled() -> None:
+    model_id = ModelId("mlx-community/Qwen3.5-2B-4bit")
+    card = ModelCard(
+        model_id=model_id,
+        storage_size=Memory.from_mb(1700),
+        n_layers=24,
+        hidden_size=2048,
+        supports_tensor=True,
+        tasks=[ModelTask.TextGeneration],
+        family="qwen",
+        capabilities=["text", "thinking", "thinking_toggle", "vision"],
+        reasoning=ReasoningCardConfig(
+            supports_toggle=True,
+            format=ReasoningFormat.TokenDelimited,
+            default_effort="medium",
+            disabled_effort="none",
+        ),
+    )
+    request = ChatCompletionRequest(
+        model=model_id,
+        messages=[ChatCompletionMessage(role="user", content="Hello")],
+    )
+
+    params = await chat_request_to_text_generation(request, model_card=card)
+
+    assert params.enable_thinking is False
+    assert params.reasoning_effort == "none"
 
 
 @pytest.mark.anyio

--- a/src/skulk/shared/tests/test_model_capabilities.py
+++ b/src/skulk/shared/tests/test_model_capabilities.py
@@ -343,6 +343,7 @@ def test_resolve_reasoning_params_uses_profile_defaults() -> None:
 
     assert resolve_reasoning_params(None, True, profile) == ("high", True)
     assert resolve_reasoning_params(None, False, profile) == ("none", False)
+    assert resolve_reasoning_params(None, None, profile) == ("none", False)
 
 
 def test_resolve_reasoning_params_treats_none_as_disabled_even_for_custom_profiles() -> None:

--- a/src/skulk/shared/types/text_generation.py
+++ b/src/skulk/shared/types/text_generation.py
@@ -36,7 +36,10 @@ def resolve_reasoning_params(
       non-disabled effort or the profile default effort
     - when only ``reasoning_effort`` is provided, it determines thinking on/off
       relative to the profile's disabled effort
-    - when neither value is provided, the runtime uses the model's default behavior
+    - when neither value is provided for a toggleable model with a known
+      capability profile, use the profile's disabled effort so a missing UI/API
+      control does not let tokenizer defaults route the whole answer into hidden
+      reasoning
     """
     enabled_effort = (
         capability_profile.default_reasoning_effort
@@ -77,6 +80,9 @@ def resolve_reasoning_params(
 
     if reasoning_effort is not None:
         return reasoning_effort, reasoning_effort != disabled_effort
+
+    if capability_profile is not None:
+        return disabled_effort, False
 
     return None, None
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -409,6 +409,7 @@ Notes:
 - Treat `resolved_capabilities` as the default tool-free request path; request-specific options such as tools can change prompt rendering and related resolved values for mixed-mode model families.
 - Thinking-control semantics are model-aware:
   - if `supports_thinking_toggle` is `true`, send `enable_thinking=true` or `false` explicitly
+  - if both `enable_thinking` and `reasoning_effort` are omitted for a model with a known toggleable capability profile, Skulk disables thinking using the profile's disabled effort
   - `reasoning_effort="none"` disables thinking for toggleable models
   - if a model does not support toggleable thinking, Skulk ignores explicit toggle overrides but still preserves explicit non-disabled reasoning-effort hints when the model family supports them
 

--- a/website/docs/model-capabilities.md
+++ b/website/docs/model-capabilities.md
@@ -89,6 +89,7 @@ If `resolved_capabilities.supports_thinking_toggle` is `true`:
 
 - `enable_thinking=true` enables thinking using the model profile's default effort unless an explicit non-disabled effort is provided
 - `enable_thinking=false` disables thinking using the profile's disabled effort
+- omitting both `enable_thinking` and `reasoning_effort` disables thinking using the profile's disabled effort
 - `reasoning_effort="none"` also disables thinking
 
 ### Non-toggleable reasoning models


### PR DESCRIPTION
## Summary
- Resolve omitted thinking controls to the disabled effort for models with a known toggleable capability profile
- Prevent Qwen-style tokenizer defaults from routing an entire response into hidden reasoning when the caller omits `enable_thinking`
- Add regression coverage for the Qwen3.5 2B model-card shape used by fresh-install qualification

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`\n- `uv run pytest src/skulk/shared/tests/test_resolve_reasoning_params.py src/skulk/shared/tests/test_model_capabilities.py::test_resolve_reasoning_params_uses_profile_defaults src/skulk/api/tests/test_chat_completions_adapter.py -q`\n- `uv run pytest`