### PR TITLE
fix: retry dashboard model store convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- The dashboard model-store page now retries transient registry and download
+  request failures until it has both a successful registry snapshot and no
+  active downloads. A brief API connection reset during a fresh-install model
+  download can no longer leave the page stuck at "0 models in store" after the
+  model was registered successfully.
+
 - Disabled the Qwen3.5 2B MLX card's MTP sidecar after clean-install text and
   vision journeys showed repetitive generation until the output limit. The
   same shipped model now uses vanilla decoding, which completes both journeys

--- a/dashboard-react/src/components/pages/DownloadsPage.test.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.test.tsx
@@ -163,4 +163,36 @@ describe('ModelStorePage registry convergence', () => {
     expect(container?.textContent).toContain('org/new-model');
     expect(registryRequests).toBe(3);
   });
+
+  it('does not restart polling when an in-flight refresh finishes after unmount', async () => {
+    vi.useFakeTimers();
+    let registryRequests = 0;
+    let resolveRegistry: ((response: Response) => void) | undefined;
+    const pendingRegistry = new Promise<Response>((resolve) => {
+      resolveRegistry = resolve;
+    });
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path === '/models') return jsonResponse({ data: [] });
+      if (path === '/store/downloads') return jsonResponse({ downloads: [] });
+      if (path === '/store/registry') {
+        registryRequests += 1;
+        return pendingRegistry;
+      }
+      throw new Error(`unexpected fetch: ${path}`);
+    }));
+
+    await renderModelStore();
+    expect(registryRequests).toBe(1);
+
+    await act(async () => root?.unmount());
+    root = null;
+    resolveRegistry?.(new Response(null, { status: 503 }));
+    await flushEffects();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(registryRequests).toBe(1);
+  });
 });

--- a/dashboard-react/src/components/pages/DownloadsPage.test.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.test.tsx
@@ -1,0 +1,166 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ThemeProvider } from 'styled-components';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { darkTheme } from '../../theme/theme';
+import { ModelStorePage } from './DownloadsPage';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../i18n/tolgee', () => ({
+  useSkulkTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+vi.mock('../../hooks/useToast', () => ({
+  addToast: vi.fn(),
+}));
+
+vi.mock('../layout/StoreRegistryTable', () => ({
+  StoreRegistryTable: ({ entries }: { entries: Array<{ model_id: string }> }) => (
+    <div data-testid="store-registry">
+      {entries.map((entry) => entry.model_id).join(',')}
+    </div>
+  ),
+}));
+
+vi.mock('./ModelSearchModal', () => ({
+  ModelSearchModal: () => null,
+}));
+
+vi.mock('../cluster/PlacementManager', () => ({
+  PlacementManager: () => null,
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function jsonResponse(payload: object): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function renderModelStore(): Promise<void> {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <ThemeProvider theme={darkTheme}>
+        <ModelStorePage
+          topology={null}
+          downloads={{}}
+          nodeDisk={{}}
+          instances={{}}
+          runners={{}}
+        />
+      </ThemeProvider>,
+    );
+  });
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('ModelStorePage registry convergence', () => {
+  it('retries an initial registry failure and renders the recovered model', async () => {
+    vi.useFakeTimers();
+    let registryRequests = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path === '/models') return jsonResponse({ data: [] });
+      if (path === '/store/downloads') return jsonResponse({ downloads: [] });
+      if (path === '/store/registry') {
+        registryRequests += 1;
+        if (registryRequests === 1) throw new TypeError('connection reset');
+        return jsonResponse({
+          entries: [{
+            model_id: 'org/recovered-model',
+            total_bytes: 1024,
+            files: ['model.gguf'],
+            downloaded_at: '2026-07-31T00:00:00Z',
+          }],
+        });
+      }
+      throw new Error(`unexpected fetch: ${path}`);
+    }));
+
+    await renderModelStore();
+    await flushEffects();
+    expect(container?.textContent).not.toContain('org/recovered-model');
+    expect(registryRequests).toBe(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await flushEffects();
+
+    expect(container?.textContent).toContain('org/recovered-model');
+    expect(registryRequests).toBe(2);
+  });
+
+  it('keeps polling when the final download check succeeds but registry refresh fails', async () => {
+    vi.useFakeTimers();
+    let registryRequests = 0;
+    let downloadRequests = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path === '/models') return jsonResponse({ data: [] });
+      if (path === '/store/downloads') {
+        downloadRequests += 1;
+        return jsonResponse({
+          downloads: downloadRequests === 1 ? [{ model_id: 'org/new-model' }] : [],
+        });
+      }
+      if (path === '/store/registry') {
+        registryRequests += 1;
+        if (registryRequests === 2) throw new TypeError('empty response');
+        return jsonResponse({
+          entries: registryRequests >= 3 ? [{
+            model_id: 'org/new-model',
+            total_bytes: 2048,
+            files: ['model.gguf'],
+            downloaded_at: '2026-07-31T00:00:00Z',
+          }] : [],
+        });
+      }
+      throw new Error(`unexpected fetch: ${path}`);
+    }));
+
+    await renderModelStore();
+    await flushEffects();
+    expect(registryRequests).toBe(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await flushEffects();
+    expect(registryRequests).toBe(2);
+    expect(container?.textContent).not.toContain('org/new-model');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await flushEffects();
+
+    expect(container?.textContent).toContain('org/new-model');
+    expect(registryRequests).toBe(3);
+  });
+});

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -154,7 +154,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
   // model_id. Derived from each parent card's runtime references so the store
   // can mark them as non-placeable instead of offering launch/placement/optiq.
   const [companionRoles, setCompanionRoles] = useState<Record<string, CompanionInfo>>({});
-  const pollRef = useRef<ReturnType<typeof setInterval>>(undefined);
+  const pollRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const optimizePollRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
   // Fetch authoritative model card info from /models API
@@ -269,50 +269,64 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
     return cards;
   }, [downloads, apiModelCards]);
 
-  const fetchDownloads = useCallback(async () => {
+  const fetchDownloads = useCallback(async (): Promise<StoreDownloadProgress[] | null> => {
     try {
       const res = await fetch('/store/downloads');
-      if (!res.ok) return [];
+      if (!res.ok) return null;
       const data = await res.json();
       return (data.downloads ?? []) as StoreDownloadProgress[];
-    } catch { return []; }
+    } catch { return null; }
   }, []);
+
+  const fetchRegistry = useCallback(async (): Promise<StoreRegistryEntry[] | null> => {
+    try {
+      const response = await fetch('/store/registry');
+      if (!response.ok) return null;
+      const data = await response.json();
+      return (data.entries ?? []) as StoreRegistryEntry[];
+    } catch { return null; }
+  }, []);
+
+  const refreshStore = useCallback(async (): Promise<boolean> => {
+    const [registryEntries, downloadEntries] = await Promise.all([
+      fetchRegistry(),
+      fetchDownloads(),
+    ]);
+    if (registryEntries !== null) setStoreEntries(registryEntries);
+    if (downloadEntries !== null) setStoreDownloads(downloadEntries);
+
+    // A transient failure must keep the convergence loop alive. In particular,
+    // the store can finish a download just as the dashboard reloads; stopping on
+    // an empty downloads response while the registry request failed leaves a new
+    // user permanently looking at "0 models in store" until a manual refresh.
+    return registryEntries !== null
+      && downloadEntries !== null
+      && downloadEntries.length === 0;
+  }, [fetchDownloads, fetchRegistry]);
+
+  const scheduleStoreRefresh = useCallback(() => {
+    if (pollRef.current) return;
+
+    const poll = async () => {
+      const converged = await refreshStore();
+      if (converged) {
+        pollRef.current = undefined;
+        return;
+      }
+      pollRef.current = setTimeout(poll, 2000);
+    };
+
+    pollRef.current = setTimeout(poll, 2000);
+  }, [refreshStore]);
 
   const loadRegistry = useCallback(async () => {
     setStoreLoading(true);
     try {
-      const [regRes, dls] = await Promise.all([
-        fetch('/store/registry'),
-        fetchDownloads(),
-      ]);
-      if (regRes.ok) {
-        const data = await regRes.json();
-        setStoreEntries(data.entries ?? []);
-      }
-      setStoreDownloads(dls);
-
-      // Start polling if active downloads
-      if (dls.length > 0 && !pollRef.current) {
-        pollRef.current = setInterval(async () => {
-          const [newDls, regRefresh] = await Promise.all([
-            fetchDownloads(),
-            fetch('/store/registry'),
-          ]);
-          setStoreDownloads(newDls);
-          if (regRefresh.ok) {
-            const d = await regRefresh.json();
-            setStoreEntries(d.entries ?? []);
-          }
-          // Stop polling when done
-          if (newDls.length === 0 && pollRef.current) {
-            clearInterval(pollRef.current);
-            pollRef.current = undefined;
-          }
-        }, 2000);
-      }
-    } catch { /* ignore */ }
-    finally { setStoreLoading(false); }
-  }, [fetchDownloads]);
+      if (!(await refreshStore())) scheduleStoreRefresh();
+    } finally {
+      setStoreLoading(false);
+    }
+  }, [refreshStore, scheduleStoreRefresh]);
 
   // Load store registry on mount
   useEffect(() => {
@@ -322,7 +336,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
   // Cleanup polling on unmount
   useEffect(() => {
     return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
+      if (pollRef.current) clearTimeout(pollRef.current);
       if (optimizePollRef.current) clearInterval(optimizePollRef.current);
     };
   }, []);

--- a/dashboard-react/src/components/pages/DownloadsPage.tsx
+++ b/dashboard-react/src/components/pages/DownloadsPage.tsx
@@ -155,6 +155,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
   // can mark them as non-placeable instead of offering launch/placement/optiq.
   const [companionRoles, setCompanionRoles] = useState<Record<string, CompanionInfo>>({});
   const pollRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const storePollingDisposedRef = useRef(false);
   const optimizePollRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
   // Fetch authoritative model card info from /models API
@@ -292,6 +293,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
       fetchRegistry(),
       fetchDownloads(),
     ]);
+    if (storePollingDisposedRef.current) return true;
     if (registryEntries !== null) setStoreEntries(registryEntries);
     if (downloadEntries !== null) setStoreDownloads(downloadEntries);
 
@@ -305,11 +307,11 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
   }, [fetchDownloads, fetchRegistry]);
 
   const scheduleStoreRefresh = useCallback(() => {
-    if (pollRef.current) return;
+    if (storePollingDisposedRef.current || pollRef.current) return;
 
     const poll = async () => {
       const converged = await refreshStore();
-      if (converged) {
+      if (storePollingDisposedRef.current || converged) {
         pollRef.current = undefined;
         return;
       }
@@ -324,7 +326,7 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
     try {
       if (!(await refreshStore())) scheduleStoreRefresh();
     } finally {
-      setStoreLoading(false);
+      if (!storePollingDisposedRef.current) setStoreLoading(false);
     }
   }, [refreshStore, scheduleStoreRefresh]);
 
@@ -335,7 +337,9 @@ export function ModelStorePage({ topology, downloads, nodeDisk, instances, runne
 
   // Cleanup polling on unmount
   useEffect(() => {
+    storePollingDisposedRef.current = false;
     return () => {
+      storePollingDisposedRef.current = true;
       if (pollRef.current) clearTimeout(pollRef.current);
       if (optimizePollRef.current) clearInterval(optimizePollRef.current);
     };


### PR DESCRIPTION
## Summary

- retry transient model-store registry and download-status failures until both endpoints converge
- keep polling through the final-download race when the registry request fails
- add component regressions for initial-load and download-completion recovery
- document the user-visible fix in the unreleased changelog

## Validation

- `uv run basedpyright`
- `uv run ruff check .`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (2985 passed, 1 skipped, 228 deselected)
- `npm run test` (14 files, 68 tests)
- `npm run build`

## Live qualification evidence

A clean single-node NVIDIA fresh-install candidate run successfully downloaded and registered the required model, but a transient connection reset during dashboard reload left the page permanently showing an empty store. The retained trace showed later API polling recovered while the registry request was never retried. The cloud resource was deleted and confirmed absent before this fix was prepared.