### PR TITLE
Steward universal floor: Qwen3.5-0.8B GGUF card + steward_models default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,8 @@ Optional resident operator assistant, config-gated (`intelligent_fabric` in
 skulk.yaml, default off). Identity = `BaseInstance.system_role` flagged
 placement (additive schema field); the master's `_maintain_steward_placement`
 planning-tick invariant keeps exactly one steward placed from the
-`steward_models` preference list (Qwen3.5-4B MLX/GGUF cards), tears down
+`steward_models` preference list (Qwen3.5-4B MLX/GGUF cards, then the
+Qwen3.5-0.8B GGUF universal floor so CPU-only fleets place one), tears down
 duplicates, and inherits failover from election since the invariant re-runs
 on every tick. Repair builders re-stamp `system_role` (same pattern as #658
 exclusions). `TextGeneration.target_instance_id` pins generation to one

--- a/resources/inference_model_cards/unsloth--Qwen3.5-0.8B-GGUF.toml
+++ b/resources/inference_model_cards/unsloth--Qwen3.5-0.8B-GGUF.toml
@@ -32,8 +32,13 @@ supports_tool_calling = true
 tool_call_format = "generic"
 
 [placement]
-compatible_backends = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_server-cpu", "llama_cpp-vulkan", "llama_cpp-cpu"]
-backend_preference = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_cpp-vulkan", "llama_server-cpu", "llama_cpp-cpu"]
+# The floor card lists every GGUF lane, including the in-process CUDA and
+# ROCm tags the 4B card omits: a node with llama-cpp-python but no
+# llama-server binary advertises only llama_cpp-<compute>, and the whole
+# point of this card is that no node class is left without a steward
+# candidate.
+compatible_backends = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_server-cpu", "llama_cpp-vulkan", "llama_cpp-cuda", "llama_cpp-rocm", "llama_cpp-cpu"]
+backend_preference = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_cpp-vulkan", "llama_cpp-cuda", "llama_cpp-rocm", "llama_server-cpu", "llama_cpp-cpu"]
 
 [storage_size]
 in_bytes = 532517120

--- a/resources/inference_model_cards/unsloth--Qwen3.5-0.8B-GGUF.toml
+++ b/resources/inference_model_cards/unsloth--Qwen3.5-0.8B-GGUF.toml
@@ -1,0 +1,39 @@
+# Qwen3.5-0.8B (dense) GGUF Q4_K_M, quantized from the instruct model. The
+# intelligent-fabric steward's universal-floor artifact: it serves on the
+# CPU-only llama.cpp lanes, so every fleet, including one with no GPU at
+# all, can place a steward (benched 0.75 strict on the hard tier at ~52 s
+# per episode on pure CPU; the 4B brain is preferred wherever it fits).
+# Architecture facts from the repo config's text_config (arch qwen3_5:
+# 24 layers, hidden 1024, 2 KV heads, 262144 ctx). Text-only through
+# Skulk for the same served-lane reasons as the 4B GGUF card.
+# supports_tensor = false: single-node on either GGUF engine.
+model_id = "unsloth/Qwen3.5-0.8B-GGUF"
+n_layers = 24
+hidden_size = 1024
+num_key_value_heads = 2
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "Q4_K_M"
+base_model = "Qwen3.5 0.8B"
+capabilities = ["text", "thinking", "thinking_toggle"]
+context_length = 262144
+gguf_file = "Qwen3.5-0.8B-Q4_K_M.gguf"
+trust_remote_code = false
+
+[reasoning]
+supports_toggle = true
+format = "token_delimited"
+default_effort = "medium"
+disabled_effort = "none"
+
+[tooling]
+supports_tool_calling = true
+tool_call_format = "generic"
+
+[placement]
+compatible_backends = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_server-cpu", "llama_cpp-vulkan", "llama_cpp-cpu"]
+backend_preference = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_cpp-vulkan", "llama_server-cpu", "llama_cpp-cpu"]
+
+[storage_size]
+in_bytes = 532517120

--- a/src/skulk/store/config.py
+++ b/src/skulk/store/config.py
@@ -397,9 +397,11 @@ class IntelligentFabricConfig(FrozenModel):
             establish the steward placement within one planning cycle.
         steward_models: Ordered model-card preference list for the steward
             brain. The master places the first card the cluster can serve.
-            The defaults are the benched steward class (Qwen3.5-4B in MLX
-            and GGUF form); operators may override with any bundled or
-            custom text model that supports tool calling.
+            The defaults are the benched steward class: Qwen3.5-4B in MLX
+            and GGUF form, then the Qwen3.5-0.8B GGUF as the universal
+            floor so every fleet, including CPU-only nodes, can place a
+            steward. Operators may override with any bundled or custom
+            text model that supports tool calling.
     """
 
     enabled: bool = False
@@ -410,6 +412,7 @@ class IntelligentFabricConfig(FrozenModel):
         default_factory=lambda: [
             "mlx-community/Qwen3.5-4B-MLX-4bit",
             "unsloth/Qwen3.5-4B-GGUF",
+            "unsloth/Qwen3.5-0.8B-GGUF",
         ]
     )
 

--- a/src/skulk/store/tests/test_config.py
+++ b/src/skulk/store/tests/test_config.py
@@ -172,6 +172,7 @@ def test_intelligent_fabric_config_defaults() -> None:
     assert parsed.intelligent_fabric.steward_models == [
         "mlx-community/Qwen3.5-4B-MLX-4bit",
         "unsloth/Qwen3.5-4B-GGUF",
+        "unsloth/Qwen3.5-0.8B-GGUF",
     ]
 
     # The documented YAML-sequence override must load (list, not tuple:

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -83,7 +83,9 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 ### Steward (intelligent fabric)
 
 - Config: `intelligent_fabric` in `skulk.yaml` (`enabled`, default false;
-  `steward_models` preference list, default Qwen3.5-4B MLX then GGUF).
+  `steward_models` preference list, default Qwen3.5-4B MLX, then the 4B
+  GGUF, then the Qwen3.5-0.8B GGUF universal floor so CPU-only fleets
+  still place a steward).
 - Identity: `BaseInstance.system_role = "steward" | None` (additive field;
   None on replayed old logs). Stamped from `PlaceInstance.system_role` at
   mint; all three repair builders re-stamp it from the instance.


### PR DESCRIPTION
## What

Workstream E4 of the platform-compliance extension: every fleet, including CPU-only nodes, should be able to place a steward.

- New bundled card `unsloth/Qwen3.5-0.8B-GGUF` (architecture facts from the repo config's text_config: 24 layers, hidden 1024, 2 KV heads, 262144 context; Q4_K_M at ~0.5 GB), tool calling declared with the generic format, GGUF lanes including the CPU floor in compatible_backends.
- The default `steward_models` preference list gains the 0.8B as its last entry: the 4B brain stays preferred wherever it fits, and the flashlight places only when nothing better can. On the hard-tier bench the 0.8B scored 0.75 strict at roughly 52 seconds per episode on pure CPU, which is a useful degraded-mode steward rather than a decorative one.
- Config docstring, default-list test, CLAUDE.md, and architecture-reference updated.

The E1 engine-lane audit runs after this merges, so its CPU-floor leg exercises this card end to end on a pod.

## Tests

Bundled-card invariant suite covers the new card; the config default-list test asserts the three-entry order. Full local gauntlet green (basedpyright 0, ruff, pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01262jKrQwepcSQtv1vk2chH