### PR TITLE
Prevent omitted TTS budgets from truncating speech

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- Omitted TTS `max_tokens` no longer inherits undersized upstream model
+  defaults that hard-cut ordinary speech mid-word. Speech runners now apply a
+  4096-token serving budget only to models that explicitly declare the control,
+  while preserving caller-supplied limits and leaving unsupported models alone.
+
 - The dashboard model-store page now retries transient registry and download
   request failures until it has both a successful registry snapshot and no
   active downloads. A brief API connection reset during a fresh-install model

--- a/src/skulk/api/types/api.py
+++ b/src/skulk/api/types/api.py
@@ -1105,7 +1105,11 @@ class AudioSpeechRequest(BaseModel):
     max_tokens: int | None = Field(
         default=None,
         gt=0,
-        description="Optional model-specific maximum generation token budget.",
+        description=(
+            "Optional model-specific maximum generation token budget. When omitted, "
+            "the speech runner supplies 4096 only to generators that explicitly "
+            "declare this control."
+        ),
     )
     reference_audio: str | None = Field(
         default=None,

--- a/src/skulk/worker/runner/speech/runner.py
+++ b/src/skulk/worker/runner/speech/runner.py
@@ -68,6 +68,7 @@ from skulk.utils.channels import MpReceiver, MpSender
 from skulk.worker.runner.bootstrap import logger
 
 _DEFAULT_STAGED_TTS_VOICE = "af_heart"
+_DEFAULT_TTS_MAX_TOKENS = 4096
 _AUDIO_BINARY_CHUNK_SIZE = max(1, (SKULK_MAX_CHUNK_SIZE // 4) * 3)
 _CANARY_MASK_COMPAT_MARKER = "_skulk_mask_dtype_compat"
 _FFMPEG_AUDIO_RESPONSE_FORMATS = frozenset(
@@ -112,6 +113,23 @@ def _filter_kwargs(fn: Callable[..., Any], kwargs: dict[str, Any]) -> dict[str, 
     if accepted is None or accepted.accepts_var_kwargs:
         return {k: v for k, v in kwargs.items() if v is not None}
     return {k: v for k, v in kwargs.items() if v is not None and k in accepted.params}
+
+
+def _tts_max_tokens(fn: Callable[..., Any], requested: int | None) -> int | None:
+    """Resolve a safe omitted TTS budget only for models declaring the control.
+
+    Upstream TTS defaults are not a stable serving contract. Fish S2's 1024-token
+    default, for example, hard-cuts an ordinary seven-word utterance at roughly
+    five seconds. Keep explicit caller limits intact and avoid injecting an
+    unknown keyword into models that expose only loose ``**kwargs``.
+    """
+
+    if requested is not None:
+        return requested
+    accepted = _callable_parameters(fn)
+    if accepted is None or "max_tokens" not in accepted.params:
+        return None
+    return _DEFAULT_TTS_MAX_TOKENS
 
 
 def _install_attention_mask_dtype_compat(attention_type: type[Any]) -> None:
@@ -1325,6 +1343,7 @@ class Runner:
                 ) as reference_file:
                     reference_file.write(params.reference_audio_data)
                     reference_path = reference_file.name
+            generate = self.model.generate
             generate_kwargs = {
                 "voice": _resolve_staged_voice_path(
                     self.local_model_path, params.voice
@@ -1340,9 +1359,8 @@ class Runner:
                 "repetition_penalty": params.repetition_penalty,
                 "stream": stream,
                 "streaming_interval": params.streaming_interval if stream else None,
-                "max_tokens": params.max_tokens,
+                "max_tokens": _tts_max_tokens(generate, params.max_tokens),
             }
-            generate = self.model.generate
             filtered_kwargs = _filter_kwargs(generate, generate_kwargs)
 
             generated = generate(params.input_text, **filtered_kwargs)

--- a/src/skulk/worker/runner/speech/tests/test_speech_runner.py
+++ b/src/skulk/worker/runner/speech/tests/test_speech_runner.py
@@ -958,6 +958,44 @@ def test_speech_synthesis_handles_single_numpy_result(
     assert encoded_calls == [([0.7, 0.8], 24000)]
 
 
+def test_tts_generation_uses_safe_default_and_preserves_explicit_budget() -> None:
+    """Omitted TTS limits must not inherit a model default that truncates speech."""
+
+    class _BudgetSpeechModel:
+        def __init__(self) -> None:
+            self.max_token_calls: list[int] = []
+
+        def generate(
+            self,
+            text: str,
+            *,
+            max_tokens: int = 1024,
+        ) -> list[_FakeSpeechResult]:
+            assert text == "hello budget"
+            self.max_token_calls.append(max_tokens)
+            return [_FakeSpeechResult()]
+
+    runner, _sender = _make_runner()
+    model = _BudgetSpeechModel()
+    runner.model = model
+
+    def task(max_tokens: int | None) -> SpeechSynthesis:
+        return SpeechSynthesis(
+            instance_id=InstanceId("speech-instance-1"),
+            command_id=CommandId(f"speech-budget-{max_tokens}"),
+            task_params=SpeechSynthesisTaskParams(
+                model=ModelId("mlx-community/fish-test"),
+                input_text="hello budget",
+                response_format=AudioResponseFormat.Wav,
+                max_tokens=max_tokens,
+            ),
+        )
+
+    assert list(runner._iter_tts_results(task(None), stream=False))
+    assert list(runner._iter_tts_results(task(2048), stream=False))
+    assert model.max_token_calls == [4096, 2048]
+
+
 def test_speech_synthesis_uses_staged_voice_assets(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -605,7 +605,8 @@ Request fields:
 | `stream` | boolean | Optional. When `true`, Skulk returns a chunked HTTP response and yields MP3 or raw PCM bytes as the speech runner emits them; accepted only when the mounted TTS card explicitly declares `audio.supports_streaming = true` and every routable instance of the requested model has a ready runner |
 | `streaming_interval` | number or null | Optional positive model-specific streaming cadence hint, accepted only with `stream=true` |
 | `instruct`, `lang_code` | string or null | Optional model-specific generation hints |
-| `temperature`, `top_p`, `top_k`, `repetition_penalty`, `max_tokens` | number or integer | Optional model-specific sampling controls |
+| `temperature`, `top_p`, `top_k`, `repetition_penalty` | number | Optional model-specific sampling controls |
+| `max_tokens` | integer or null | Optional model-specific generation ceiling. An explicit value is preserved. When omitted and the mounted model explicitly declares this control, Skulk uses a 4096-token serving default instead of inheriting a potentially truncating upstream library default. Models that do not declare the control receive no injected keyword. |
 | `reference_audio` | multipart file or null | Optional request-scoped voice-conditioning audio. Accepted only as a multipart upload for a mounted card declaring `audio.supports_reference_audio = true`; server-local paths are rejected |
 | `reference_text` | string or null | Optional transcript of `reference_audio`; accepted only when the multipart upload is present |
 


### PR DESCRIPTION
## Summary

- apply a 4096-token serving default when a TTS generator explicitly declares `max_tokens`
- preserve explicit caller limits and avoid injecting unsupported keywords
- document the API behavior and cover both omitted and explicit budgets

## Why

A configured E2E semantic speech roundtrip reproduced deterministic hard truncation at roughly five seconds for an ordinary seven-word utterance. The upstream generator default was 1024 tokens. A causal probe with an explicit 2048-token budget completed naturally and passed the same roundtrip, confirming the omitted upstream default as the failure source.

## Validation

- `uv run python scripts/export_openapi.py`
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest -q` — 2,986 passed, 1 skipped, 228 deselected
- focused speech runner tests — 31 passed
- `git diff --check`