### PR TITLE
Retry and expose bundled Node installer probe failures

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -249,7 +249,7 @@ run_bundled_npm() {
 
 if [[ "$HEADLESS" == "1" ]]; then
     log "skipping dashboard build (--headless); the API serves without the web UI"
-elif run_bundled_npm --version >/dev/null 2>&1; then
+elif run_bundled_npm --version; then
     log "building the dashboard with Skulk's bundled Node.js runtime"
     (
         cd dashboard-react

--- a/scripts/run_bundled_npm.py
+++ b/scripts/run_bundled_npm.py
@@ -5,11 +5,58 @@ from __future__ import annotations
 import os
 import shlex
 import sys
-from collections.abc import Sequence
+import time
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import nodejs_wheel
+
+_NPM_PROBE_ATTEMPTS = 3
+
+
+def run_npm_probe(
+    arguments: list[str],
+    *,
+    npm_runner: Callable[[list[str]], int],
+    sleep: Callable[[float], None],
+) -> int:
+    """Retry the read-only npm version probe and report every failure.
+
+    The dashboard installer uses this probe immediately after a large first
+    environment sync. A transient process-launch failure must not strand a
+    fresh install, while a persistent failure must retain enough evidence for
+    the operator to diagnose it.
+
+    Args:
+        arguments: npm arguments for the version probe.
+        npm_runner: Effect that invokes bundled npm and returns its exit status.
+        sleep: Effect used to pause between attempts.
+
+    Returns:
+        Zero after a successful attempt, otherwise the final failure status.
+
+    Side effects:
+        Writes failed-attempt diagnostics to stderr and invokes ``sleep``
+        between attempts.
+    """
+
+    final_status = 1
+    for attempt in range(1, _NPM_PROBE_ATTEMPTS + 1):
+        final_status = int(npm_runner(arguments))
+        if final_status == 0:
+            return 0
+        retrying = attempt < _NPM_PROBE_ATTEMPTS
+        suffix = "; retrying" if retrying else ""
+        print(
+            "bundled Node.js probe attempt "
+            f"{attempt}/{_NPM_PROBE_ATTEMPTS} failed with exit "
+            f"{final_status}{suffix}",
+            file=sys.stderr,
+        )
+        if retrying:
+            sleep(1.0)
+    return final_status
 
 
 def _write_node_launcher(
@@ -73,6 +120,12 @@ def main(arguments: Sequence[str] | None = None) -> int:
             if current_path
             else str(shim_directory)
         )
+        if resolved_arguments == ["--version"]:
+            return run_npm_probe(
+                resolved_arguments,
+                npm_runner=nodejs_wheel.npm,
+                sleep=time.sleep,
+            )
         return int(nodejs_wheel.npm(resolved_arguments))
 
 

--- a/scripts/run_bundled_npm.py
+++ b/scripts/run_bundled_npm.py
@@ -36,6 +36,9 @@ def run_npm_probe(
     Returns:
         Zero after a successful attempt, otherwise the final failure status.
 
+    Raises:
+        OSError: The final probe attempt could not launch the bundled process.
+
     Side effects:
         Writes failed-attempt diagnostics to stderr and invokes ``sleep``
         between attempts.
@@ -43,19 +46,30 @@ def run_npm_probe(
 
     final_status = 1
     for attempt in range(1, _NPM_PROBE_ATTEMPTS + 1):
-        final_status = int(npm_runner(arguments))
-        if final_status == 0:
-            return 0
+        launch_error: OSError | None = None
+        try:
+            final_status = int(npm_runner(arguments))
+        except OSError as error:
+            launch_error = error
+        else:
+            if final_status == 0:
+                return 0
         retrying = attempt < _NPM_PROBE_ATTEMPTS
         suffix = "; retrying" if retrying else ""
+        failure = (
+            f"launch error {launch_error!s}"
+            if launch_error is not None
+            else f"exit {final_status}"
+        )
         print(
             "bundled Node.js probe attempt "
-            f"{attempt}/{_NPM_PROBE_ATTEMPTS} failed with exit "
-            f"{final_status}{suffix}",
+            f"{attempt}/{_NPM_PROBE_ATTEMPTS} failed with {failure}{suffix}",
             file=sys.stderr,
         )
         if retrying:
             sleep(1.0)
+        elif launch_error is not None:
+            raise launch_error
     return final_status
 
 

--- a/src/skulk/tests/test_install_script.py
+++ b/src/skulk/tests/test_install_script.py
@@ -43,3 +43,11 @@ def test_generated_config_pins_safe_model_store_port() -> None:
     """The installer must materialize the same safe port as runtime defaults."""
 
     assert f"store_port: {DEFAULT_MODEL_STORE_PORT}" in _installer()
+
+
+def test_bundled_node_probe_keeps_retry_diagnostics_visible() -> None:
+    """Fresh-install Node probe failures must remain visible to operators."""
+
+    installer = _installer()
+    assert "elif run_bundled_npm --version; then" in installer
+    assert "run_bundled_npm --version >/dev/null" not in installer

--- a/tests/test_bundled_npm.py
+++ b/tests/test_bundled_npm.py
@@ -8,6 +8,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from scripts.run_bundled_npm import run_npm_probe
+
 
 def test_bundled_npm_exposes_node_to_lifecycle_scripts(tmp_path: Path) -> None:
     """npm scripts must find Node when the host has no system installation."""
@@ -42,3 +46,54 @@ def test_bundled_npm_exposes_node_to_lifecycle_scripts(tmp_path: Path) -> None:
 
     assert completed.returncode == 0, completed.stderr
     assert "v25." in completed.stdout
+
+
+def test_bundled_npm_probe_retries_a_transient_launch_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A one-off Node launch failure must not strand a fresh installation."""
+
+    statuses = iter((75, 0))
+    calls: list[list[str]] = []
+    sleeps: list[float] = []
+
+    def npm_runner(arguments: list[str]) -> int:
+        calls.append(arguments)
+        return next(statuses)
+
+    status = run_npm_probe(
+        ["--version"],
+        npm_runner=npm_runner,
+        sleep=sleeps.append,
+    )
+
+    assert status == 0
+    assert calls == [["--version"], ["--version"]]
+    assert sleeps == [1.0]
+    assert "attempt 1/3 failed with exit 75; retrying" in capsys.readouterr().err
+
+
+def test_bundled_npm_probe_preserves_a_persistent_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """All failed attempts still return failure with visible diagnostics."""
+
+    calls: list[list[str]] = []
+    sleeps: list[float] = []
+
+    def npm_runner(arguments: list[str]) -> int:
+        calls.append(arguments)
+        return 126
+
+    status = run_npm_probe(
+        ["--version"],
+        npm_runner=npm_runner,
+        sleep=sleeps.append,
+    )
+
+    assert status == 126
+    assert calls == [["--version"], ["--version"], ["--version"]]
+    assert sleeps == [1.0, 1.0]
+    error = capsys.readouterr().err
+    assert "attempt 1/3 failed with exit 126; retrying" in error
+    assert "attempt 3/3 failed with exit 126" in error

--- a/tests/test_bundled_npm.py
+++ b/tests/test_bundled_npm.py
@@ -73,6 +73,38 @@ def test_bundled_npm_probe_retries_a_transient_launch_failure(
     assert "attempt 1/3 failed with exit 75; retrying" in capsys.readouterr().err
 
 
+def test_bundled_npm_probe_retries_a_transient_launch_exception(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A transient inability to create the Node process must be retried."""
+
+    attempts = 0
+    sleeps: list[float] = []
+
+    def npm_runner(arguments: list[str]) -> int:
+        nonlocal attempts
+        assert arguments == ["--version"]
+        attempts += 1
+        if attempts == 1:
+            raise OSError(11, "resource temporarily unavailable")
+        return 0
+
+    status = run_npm_probe(
+        ["--version"],
+        npm_runner=npm_runner,
+        sleep=sleeps.append,
+    )
+
+    assert status == 0
+    assert attempts == 2
+    assert sleeps == [1.0]
+    assert (
+        "attempt 1/3 failed with launch error [Errno 11] resource temporarily "
+        "unavailable; retrying"
+        in capsys.readouterr().err
+    )
+
+
 def test_bundled_npm_probe_preserves_a_persistent_failure(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -97,3 +129,31 @@ def test_bundled_npm_probe_preserves_a_persistent_failure(
     error = capsys.readouterr().err
     assert "attempt 1/3 failed with exit 126; retrying" in error
     assert "attempt 3/3 failed with exit 126" in error
+
+
+def test_bundled_npm_probe_preserves_a_persistent_launch_exception(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A persistent launch exception is reported for every attempt and reraised."""
+
+    attempts = 0
+    sleeps: list[float] = []
+
+    def npm_runner(arguments: list[str]) -> int:
+        nonlocal attempts
+        assert arguments == ["--version"]
+        attempts += 1
+        raise OSError(11, "resource temporarily unavailable")
+
+    with pytest.raises(OSError, match="resource temporarily unavailable"):
+        run_npm_probe(
+            ["--version"],
+            npm_runner=npm_runner,
+            sleep=sleeps.append,
+        )
+
+    assert attempts == 3
+    assert sleeps == [1.0, 1.0]
+    error = capsys.readouterr().err
+    assert "attempt 1/3 failed with launch error" in error
+    assert "attempt 3/3 failed with launch error" in error


### PR DESCRIPTION
## Summary

- retry the read-only bundled npm version probe up to three times after the initial environment sync
- preserve a persistent nonzero exit instead of falling through as success
- stop suppressing probe output so installer logs retain the actual Node/npm failure
- cover transient recovery, persistent failure, and visible installer wiring

## Qualification finding

A clean release-candidate install completed Python and served-engine provisioning but failed its first bundled-Node probe, so the dashboard could not be built. The same literal clean install subsequently succeeded on the same hardware, establishing a transient probe failure. The current installer probes only once and redirects the only diagnostic to `/dev/null`; this makes fresh installs both brittle and opaque.

The retry applies only to the read-only `npm --version` probe. Package installation and dashboard build commands are never replayed. Persistent incompatibility still fails the install after three visible attempts.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (2,989 passed, 1 skipped, 228 deselected)
- `bash -n install.sh`
- `git diff --check`