### PR TITLE
Fix completed-message speech replay pacing

### DIFF
--- a/dashboard-react/src/components/pages/ChatView.test.tsx
+++ b/dashboard-react/src/components/pages/ChatView.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { store } from '../../store';
 import { chatActions } from '../../store/slices/chatSlice';
+import { StreamingSpeechPlayback } from '../../audio/streamingSpeechPlayback';
 import { darkTheme } from '../../theme/theme';
 import { ChatView } from './ChatView';
 
@@ -57,6 +58,20 @@ async function waitFor(
   while (performance.now() < deadline) {
     if (predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(message);
+}
+
+async function waitForReact(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = performance.now() + 5000;
+  while (performance.now() < deadline) {
+    if (predicate()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
   }
   throw new Error(message);
 }
@@ -157,5 +172,104 @@ describe('ChatView multimodal requests', () => {
     expect(
       container?.querySelector('[aria-label="User message"] img[alt="qualification.png"]'),
     ).not.toBeNull();
+  });
+});
+
+describe('ChatView completed-message speech', () => {
+  it('replays a completed assistant turn as serial sentence requests', async () => {
+    const requestedInputs: string[] = [];
+    vi.stubGlobal('AudioContext', class FakeAudioContext {});
+    vi.spyOn(StreamingSpeechPlayback.prototype, 'append').mockResolvedValue();
+    const finishPlayback = vi
+      .spyOn(StreamingSpeechPlayback.prototype, 'finish')
+      .mockResolvedValue();
+    vi.spyOn(StreamingSpeechPlayback.prototype, 'stop').mockImplementation(() => undefined);
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url === '/models') {
+        return new Response(JSON.stringify({
+          data: [{
+            id: 'org/speech-model',
+            tasks: ['TextGeneration'],
+            audio: {
+              default_response_format: 'pcm',
+              response_formats: ['pcm'],
+              supports_streaming: true,
+            },
+            resolved_capabilities: {
+              supports_speech_synthesis: true,
+              default_audio_response_format: 'pcm',
+              audio_response_formats: ['pcm'],
+            },
+          }],
+        }), { status: 200 });
+      }
+      if (url === '/v1/audio/speech') {
+        const body = JSON.parse(String(init?.body)) as { input: string };
+        requestedInputs.push(body.input);
+        return new Response(new Uint8Array([0, 0]), { status: 200 });
+      }
+      throw new Error(`unexpected request: ${url}`);
+    }));
+
+    store.dispatch(chatActions.selectModel('org/speech-model'));
+    store.dispatch(chatActions.selectSpeechModel('org/speech-model'));
+    store.dispatch(chatActions.addMessage({
+      id: 'assistant-message',
+      role: 'assistant',
+      content: 'First sentence. Second sentence! Final tail',
+      timestamp: Date.now(),
+    }));
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        <Provider store={store}>
+          <ThemeProvider theme={darkTheme}>
+            <ChatView readyInstances={[{
+              instanceId: 'speech-instance',
+              modelId: 'org/speech-model',
+              sharding: 'Pipeline',
+              instanceType: 'MlxRing',
+              engine: 'mlx',
+              nodeStatuses: [],
+              status: 'ready',
+            }]} />
+          </ThemeProvider>
+        </Provider>,
+      );
+    });
+
+    await waitForReact(
+      () => container?.querySelector<HTMLButtonElement>(
+        '[aria-label="Speak message"]',
+      ) !== null,
+      'assistant replay button did not become ready',
+    );
+    const replay = container?.querySelector<HTMLButtonElement>(
+      '[aria-label="Speak message"]',
+    );
+    if (!replay) throw new Error('assistant replay button was not rendered');
+    await act(async () => {
+      await userEvent.click(replay);
+    });
+
+    await waitForReact(
+      () => requestedInputs.length === 3,
+      'completed message was not synthesized sentence by sentence',
+    );
+    await waitForReact(
+      () => finishPlayback.mock.calls.length === 1,
+      'completed message playback did not drain its shared timeline',
+    );
+    expect(requestedInputs).toEqual([
+      'First sentence.',
+      'Second sentence!',
+      'Final tail',
+    ]);
   });
 });

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -624,7 +624,6 @@ export function ChatView({
   const audioPlaybackRef = useRef<HTMLAudioElement | null>(null);
   const audioObjectUrlRef = useRef<string | null>(null);
   const streamingPlaybackRef = useRef<StreamingSpeechPlayback | null>(null);
-  const speechAbortRef = useRef<AbortController | null>(null);
   const speechSentenceQueueRef = useRef<SpeechSentenceQueue | null>(null);
   const realtimeSpeechTextRef = useRef('');
   const realtimeSpeechTailRef = useRef('');
@@ -862,8 +861,6 @@ export function ChatView({
   const stopSpeechPlayback = useCallback(() => {
     speechSentenceQueueRef.current?.stop();
     speechSentenceQueueRef.current = null;
-    speechAbortRef.current?.abort();
-    speechAbortRef.current = null;
     streamingPlaybackRef.current?.stop();
     streamingPlaybackRef.current = null;
     audioPlaybackRef.current?.pause();
@@ -1008,36 +1005,82 @@ export function ChatView({
     t,
   ]);
 
-  const speakText = useCallback(async (text: string, messageId: string | null = 'draft') => {
+  const createSpeechSentenceQueue = useCallback((
+    messageId: string | null,
+    selectVoice: (text: string) => string | null,
+  ): SpeechSentenceQueue => {
+    const useContinuousStreaming = Boolean(
+      selectedSpeechOption?.supportsStreaming
+      && selectedSpeechOption.responseFormats.includes('pcm')
+      && canUseStreamingSpeechPlayback()
+    );
+    const responseSession: StreamingSpeechResponseSession | null = useContinuousStreaming
+      ? {
+          playback: new StreamingSpeechPlayback(),
+          useEncodedFallback: false,
+        }
+      : null;
+    if (responseSession) streamingPlaybackRef.current = responseSession.playback;
+
+    const queue = new SpeechSentenceQueue(
+      (sentence, signal) => playSpeechSegment(
+        sentence,
+        messageId,
+        signal,
+        selectVoice(sentence),
+        responseSession,
+      ),
+      (error) => {
+        const message = error instanceof Error
+          ? error.message
+          : t('chat.view.errors.speechSynthesisFailed', 'Speech synthesis failed.');
+        setSpeechError(message);
+      },
+      () => {
+        const isCurrentQueue = speechSentenceQueueRef.current === queue;
+        if (isCurrentQueue) {
+          speechSentenceQueueRef.current = null;
+          setSpeakingMessageId(null);
+          setIsAutoSpeaking(false);
+        }
+        if (
+          responseSession
+          && streamingPlaybackRef.current === responseSession.playback
+        ) {
+          streamingPlaybackRef.current = null;
+        }
+      },
+      responseSession ? () => responseSession.playback.finish() : undefined,
+      responseSession ? () => responseSession.playback.stop() : undefined,
+    );
+    speechSentenceQueueRef.current = queue;
+    setSpeakingMessageId(messageId);
+    setIsAutoSpeaking(messageId === null);
+    return queue;
+  }, [playSpeechSegment, selectedSpeechOption, t]);
+
+  const speakText = useCallback((text: string, messageId: string | null = 'draft') => {
     const input = text.trim();
     if (!input || !selectedSpeechModelId) return;
     setSpeechError(null);
     stopSpeechPlayback();
-    const abortController = new AbortController();
-    speechAbortRef.current = abortController;
     const selectVoice = createPinnedSpeechVoiceSelector(
       voiceOptions,
       effectiveSelectedVoice,
       selectedSpeechOption?.defaultVoice ?? null,
     );
-    try {
-      await playSpeechSegment(input, messageId, abortController.signal, selectVoice(input));
-      if (speechAbortRef.current === abortController) stopSpeechPlayback();
-    } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') return;
-      const messageText = error instanceof Error
-        ? error.message
-        : t('chat.view.errors.speechSynthesisFailed', 'Speech synthesis failed.');
-      setSpeechError(messageText);
-      stopSpeechPlayback();
-    }
+    const split = splitCompleteSpeechSentences(input);
+    const sentences = [...split.sentences];
+    if (split.remainder.trim()) sentences.push(split.remainder.trim());
+    const queue = createSpeechSentenceQueue(messageId, selectVoice);
+    queue.enqueue(sentences);
+    queue.finish();
   }, [
-    playSpeechSegment,
+    createSpeechSentenceQueue,
     effectiveSelectedVoice,
     selectedSpeechModelId,
     selectedSpeechOption?.defaultVoice,
     stopSpeechPlayback,
-    t,
     voiceOptions,
   ]);
 
@@ -1161,38 +1204,7 @@ export function ChatView({
       && canUseStreamingSpeechPlayback()
     )
       ? (() => {
-          const responseSession: StreamingSpeechResponseSession = {
-            playback: new StreamingSpeechPlayback(),
-            useEncodedFallback: false,
-          };
-          streamingPlaybackRef.current = responseSession.playback;
-          const responseQueue = new SpeechSentenceQueue(
-            (sentence, signal) => playSpeechSegment(
-              sentence,
-              null,
-              signal,
-              selectResponseVoice(sentence),
-              responseSession,
-            ),
-            (error) => {
-              const message = error instanceof Error
-                ? error.message
-                : t('chat.view.errors.speechSynthesisFailed', 'Speech synthesis failed.');
-              setSpeechError(message);
-            },
-            () => {
-              if (speechSentenceQueueRef.current === responseQueue) {
-                speechSentenceQueueRef.current = null;
-              }
-              if (streamingPlaybackRef.current === responseSession.playback) {
-                streamingPlaybackRef.current = null;
-              }
-              setIsAutoSpeaking(false);
-            },
-            () => responseSession.playback.finish(),
-            () => responseSession.playback.stop(),
-          );
-          return responseQueue;
+          return createSpeechSentenceQueue(null, selectResponseVoice);
         })()
       : null;
     speechSentenceQueueRef.current = sentenceQueue;
@@ -1468,13 +1480,13 @@ export function ChatView({
     addMessage,
     autoSpeakAssistant,
     canSendMessages,
+    createSpeechSentenceQueue,
     effectiveSelectedVoice,
     isLoading,
     selectedBuiltinTools,
     selectedModelId,
     selectedSpeechModelId,
     selectedSpeechOption,
-    playSpeechSegment,
     speakText,
     stopSpeechPlayback,
     supportsThinking,


### PR DESCRIPTION
## Summary

- route completed-message and draft speech through the same sentence queue used by live assistant speech
- preserve serial synthesis with one continuous PCM playback timeline
- keep cancellation and stale-queue cleanup safe when playback is replaced
- add a browser regression test that clicks the assistant replay control and verifies one request per sentence

## Root cause

The replay control passed an entire completed turn directly to a single speech request, bypassing the sentence scheduler used while a response was streaming. Long turns therefore reached the TTS model as one block and could accelerate or drift in cadence.

## Validation

- `npm run test` (78 passed)
- `npm run build`
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (3021 passed, 1 skipped, 228 deselected)