### PR TITLE
fix(dashboard): isolate realtime voice turns

### DIFF
--- a/dashboard-react/src/audio/realtimeTranscription.test.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.test.ts
@@ -236,7 +236,6 @@ describe('RealtimeConversationSocket', () => {
     });
 
     client.append(Float32Array.from([0, 0.25, 0.5, 0.75, 1]), 48_000);
-    socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
     client.commitTurn();
     expect(JSON.parse(socket.sent.at(-1)!)).toEqual({ type: 'input_audio_buffer.commit' });
     socket.serverEvent({
@@ -453,7 +452,7 @@ describe('RealtimeConversationSocket', () => {
     );
   });
 
-  it('does not commit post-transcription silence when a completed session is stopped', async () => {
+  it('does not recommit an already completed turn without new microphone frames', async () => {
     const socket = new FakeWebSocket();
     const client = new RealtimeConversationSocket({
       transcriptionModelId: 'org/stt',
@@ -464,13 +463,13 @@ describe('RealtimeConversationSocket', () => {
     const connected = client.connect();
     socket.serverEvent({ type: 'session.created' });
     await connected;
+    client.append(new Float32Array(2_401), 24_000);
     socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
     socket.serverEvent({ type: 'input_audio_buffer.speech_stopped' });
     socket.serverEvent({
       type: 'conversation.item.input_audio_transcription.completed',
       transcript: 'preserve this draft',
     });
-    client.append(new Float32Array(2_401), 24_000);
 
     expect(client.commitTurn()).toBe(false);
     expect(socket.sent.map((message) => JSON.parse(message)).filter(
@@ -489,6 +488,7 @@ describe('RealtimeConversationSocket', () => {
     const connected = client.connect();
     socket.serverEvent({ type: 'session.created' });
     await connected;
+    client.append(new Float32Array(2_401), 24_000);
     socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
     socket.serverEvent({ type: 'input_audio_buffer.speech_stopped' });
 

--- a/dashboard-react/src/audio/realtimeTranscription.test.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.test.ts
@@ -236,6 +236,7 @@ describe('RealtimeConversationSocket', () => {
     });
 
     client.append(Float32Array.from([0, 0.25, 0.5, 0.75, 1]), 48_000);
+    socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
     client.commitTurn();
     expect(JSON.parse(socket.sent.at(-1)!)).toEqual({ type: 'input_audio_buffer.commit' });
     socket.serverEvent({
@@ -451,6 +452,83 @@ describe('RealtimeConversationSocket', () => {
       new Array(4_800).fill(0),
     );
   });
+
+  it('does not commit post-transcription silence when a completed session is stopped', async () => {
+    const socket = new FakeWebSocket();
+    const client = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => socket as unknown as WebSocket,
+    });
+
+    const connected = client.connect();
+    socket.serverEvent({ type: 'session.created' });
+    await connected;
+    socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+    socket.serverEvent({ type: 'input_audio_buffer.speech_stopped' });
+    socket.serverEvent({
+      type: 'conversation.item.input_audio_transcription.completed',
+      transcript: 'preserve this draft',
+    });
+    client.append(new Float32Array(2_401), 24_000);
+
+    expect(client.commitTurn()).toBe(false);
+    expect(socket.sent.map((message) => JSON.parse(message)).filter(
+      (message) => message.type === 'input_audio_buffer.commit',
+    )).toHaveLength(0);
+  });
+
+  it('waits for an already VAD-committed transcript without sending a duplicate commit', async () => {
+    const socket = new FakeWebSocket();
+    const client = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => socket as unknown as WebSocket,
+    });
+
+    const connected = client.connect();
+    socket.serverEvent({ type: 'session.created' });
+    await connected;
+    socket.serverEvent({ type: 'input_audio_buffer.speech_started' });
+    socket.serverEvent({ type: 'input_audio_buffer.speech_stopped' });
+
+    expect(client.commitTurn()).toBe(true);
+    expect(socket.sent.map((message) => JSON.parse(message)).filter(
+      (message) => message.type === 'input_audio_buffer.commit',
+    )).toHaveLength(0);
+  });
+
+  it('suppresses microphone frames during submitted responses and explicit pauses', async () => {
+    const socket = new FakeWebSocket();
+    const client = new RealtimeConversationSocket({
+      transcriptionModelId: 'org/stt',
+      responseModelId: 'org/chat',
+      location: { protocol: 'https:', host: 'skulk.example' },
+      socketFactory: () => socket as unknown as WebSocket,
+    });
+
+    const connected = client.connect();
+    socket.serverEvent({ type: 'session.created' });
+    await connected;
+    const appendCount = () => socket.sent.map((message) => JSON.parse(message)).filter(
+      (message) => message.type === 'input_audio_buffer.append',
+    ).length;
+
+    client.append(new Float32Array(2_401), 24_000);
+    expect(appendCount()).toBe(1);
+    socket.serverEvent({ type: 'response.created', response: { status: 'in_progress' } });
+    client.append(new Float32Array(2_401), 24_000);
+    expect(appendCount()).toBe(1);
+    socket.serverEvent({ type: 'response.done', response: { status: 'completed' } });
+    client.append(new Float32Array(2_401), 24_000);
+    expect(appendCount()).toBe(2);
+    client.setInputPaused(true);
+    client.append(new Float32Array(2_401), 24_000);
+    expect(appendCount()).toBe(2);
+    client.setInputPaused(false);
+    client.append(new Float32Array(2_401), 24_000);
+    expect(appendCount()).toBe(3);
+  });
 });
 
 describe('RealtimePcmCapture', () => {
@@ -465,6 +543,7 @@ describe('RealtimePcmCapture', () => {
     const muteConnect = vi.fn();
     const muteDisconnect = vi.fn();
     const stopTrack = vi.fn();
+    const audioTrack = { enabled: true, stop: stopTrack };
     const source = { connect: sourceConnect, disconnect: sourceDisconnect };
     const mute = {
       gain: { value: 1 },
@@ -507,7 +586,8 @@ describe('RealtimePcmCapture', () => {
     vi.stubGlobal('AudioContext', FakeAudioContext);
     vi.stubGlobal('AudioWorkletNode', FakeAudioWorkletNode);
     const stream = {
-      getTracks: () => [{ stop: stopTrack }],
+      getTracks: () => [audioTrack],
+      getAudioTracks: () => [audioTrack],
     } as unknown as MediaStream;
     const received: Array<[Float32Array, number]> = [];
 
@@ -526,6 +606,11 @@ describe('RealtimePcmCapture', () => {
     expect(muteConnect).toHaveBeenCalledWith(destination);
     expect(mute.gain.value).toBe(0);
     expect(received).toEqual([[samples, 48_000]]);
+
+    capture.setEnabled(false);
+    expect(audioTrack.enabled).toBe(false);
+    capture.setEnabled(true);
+    expect(audioTrack.enabled).toBe(true);
 
     await capture.stop();
 

--- a/dashboard-react/src/audio/realtimeTranscription.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.ts
@@ -342,7 +342,8 @@ export class RealtimeConversationSocket {
   private readonly responses = new Map<string, string>();
   private connected = false;
   private acceptingAudio = true;
-  private turnHasAudio = false;
+  private turnHasSpeech = false;
+  private inputPaused = false;
   private responseActive = false;
   private terminal = false;
   private connectResolve: (() => void) | null = null;
@@ -386,7 +387,7 @@ export class RealtimeConversationSocket {
     if (!this.connected || !socket || socket.readyState !== 1) {
       throw new Error('realtime conversation socket is not connected');
     }
-    if (!this.acceptingAudio) return;
+    if (!this.acceptingAudio || this.inputPaused || this.responseActive) return;
     if (socket.bufferedAmount > MAX_SOCKET_BUFFERED_BYTES) {
       const error = new Error('Realtime conversation cannot keep up with microphone audio.');
       this.fail(error);
@@ -399,7 +400,6 @@ export class RealtimeConversationSocket {
       throw new Error('microphone sample rate changed during realtime conversation');
     }
     const resampled = this.resampler?.process(samples) ?? new Float32Array(0);
-    if (resampled.length > 0) this.turnHasAudio = true;
     for (const sample of resampled) this.pendingSamples.push(sample);
     while (this.pendingSamples.length >= TARGET_FRAME_SAMPLES) {
       this.sendSamples(Float32Array.from(
@@ -411,15 +411,24 @@ export class RealtimeConversationSocket {
   /** Flush microphone tail and ask the server to close the current turn. */
   commitTurn(): boolean {
     const socket = this.socket;
-    if (!this.connected || !socket || socket.readyState !== 1 || !this.turnHasAudio) {
+    if (!this.connected || !socket || socket.readyState !== 1 || !this.turnHasSpeech) {
       return false;
     }
+    if (!this.acceptingAudio) return true;
     if (this.pendingSamples.length > 0) {
       this.sendSamples(Float32Array.from(this.pendingSamples.splice(0)));
     }
     socket.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
     this.acceptingAudio = false;
     return true;
+  }
+
+  /** Pause microphone admission without closing the persistent conversation. */
+  setInputPaused(paused: boolean): void {
+    this.inputPaused = paused;
+    this.pendingSamples.length = 0;
+    this.resampler = null;
+    this.inputSampleRate = null;
   }
 
   /** Return whether assistant model or speech output is still draining. */
@@ -495,6 +504,7 @@ export class RealtimeConversationSocket {
     }
     const itemId = typeof payload.item_id === 'string' ? payload.item_id : null;
     if (payload.type === 'input_audio_buffer.speech_started') {
+      this.turnHasSpeech = true;
       this.options.onSpeechStarted?.();
       return;
     }
@@ -522,7 +532,7 @@ export class RealtimeConversationSocket {
     ) {
       this.transcripts.delete(itemId ?? 'current');
       this.acceptingAudio = true;
-      this.turnHasAudio = false;
+      this.turnHasSpeech = false;
       this.options.onTranscript?.(payload.transcript, true, itemId);
       return;
     }
@@ -627,6 +637,13 @@ export class RealtimePcmCapture {
       await context.close().catch(() => undefined);
       throw error;
     }
+  }
+
+  /** Enable or disable microphone tracks while preserving the capture graph. */
+  setEnabled(enabled: boolean): void {
+    this.stream.getAudioTracks().forEach((track) => {
+      track.enabled = enabled;
+    });
   }
 
   /** Stop microphone tracks and close the browser audio graph. */

--- a/dashboard-react/src/audio/realtimeTranscription.ts
+++ b/dashboard-react/src/audio/realtimeTranscription.ts
@@ -342,7 +342,7 @@ export class RealtimeConversationSocket {
   private readonly responses = new Map<string, string>();
   private connected = false;
   private acceptingAudio = true;
-  private turnHasSpeech = false;
+  private turnHasAudio = false;
   private inputPaused = false;
   private responseActive = false;
   private terminal = false;
@@ -400,6 +400,7 @@ export class RealtimeConversationSocket {
       throw new Error('microphone sample rate changed during realtime conversation');
     }
     const resampled = this.resampler?.process(samples) ?? new Float32Array(0);
+    if (resampled.length > 0) this.turnHasAudio = true;
     for (const sample of resampled) this.pendingSamples.push(sample);
     while (this.pendingSamples.length >= TARGET_FRAME_SAMPLES) {
       this.sendSamples(Float32Array.from(
@@ -411,7 +412,7 @@ export class RealtimeConversationSocket {
   /** Flush microphone tail and ask the server to close the current turn. */
   commitTurn(): boolean {
     const socket = this.socket;
-    if (!this.connected || !socket || socket.readyState !== 1 || !this.turnHasSpeech) {
+    if (!this.connected || !socket || socket.readyState !== 1 || !this.turnHasAudio) {
       return false;
     }
     if (!this.acceptingAudio) return true;
@@ -504,7 +505,6 @@ export class RealtimeConversationSocket {
     }
     const itemId = typeof payload.item_id === 'string' ? payload.item_id : null;
     if (payload.type === 'input_audio_buffer.speech_started') {
-      this.turnHasSpeech = true;
       this.options.onSpeechStarted?.();
       return;
     }
@@ -532,7 +532,7 @@ export class RealtimeConversationSocket {
     ) {
       this.transcripts.delete(itemId ?? 'current');
       this.acceptingAudio = true;
-      this.turnHasSpeech = false;
+      this.turnHasAudio = false;
       this.options.onTranscript?.(payload.transcript, true, itemId);
       return;
     }

--- a/dashboard-react/src/audio/streamingSpeechPlayback.test.ts
+++ b/dashboard-react/src/audio/streamingSpeechPlayback.test.ts
@@ -6,6 +6,7 @@ import {
   canUseStreamingSpeechPlayback,
   SpeechSentenceQueue,
   resyncVisibleSpeech,
+  speechTextFromMarkdown,
   splitPlaybackSamples,
   splitCompleteSpeechSentences,
   streamingSpeechPlaybackMode,
@@ -325,6 +326,30 @@ describe('splitCompleteSpeechSentences', () => {
       remainder: 'Version 1.2 is ready',
     });
   });
+
+  it('does not pronounce an ordered-list marker as its own sentence', () => {
+    expect(splitCompleteSpeechSentences('1. **First item.**\n2. Second item.')).toEqual({
+      sentences: ['1. **First item.**'],
+      remainder: '2. Second item.',
+    });
+  });
+});
+
+describe('speechTextFromMarkdown', () => {
+  it('removes presentation markup while preserving readable prose and pauses', () => {
+    expect(speechTextFromMarkdown([
+      '## **Summary**',
+      '1. Visit [the dashboard](https://example.test).',
+      '2. Run `skulk` and ~~ignore~~ inspect the result',
+    ].join('\n'))).toBe(
+      'Summary. Visit the dashboard. Run skulk and ignore inspect the result.',
+    );
+  });
+
+  it('drops fenced code rather than reading implementation punctuation aloud', () => {
+    expect(speechTextFromMarkdown('Before.\n```ts\nconst value = 1;\n```\nAfter.'))
+      .toBe('Before. After.');
+  });
 });
 
 describe('resyncVisibleSpeech', () => {
@@ -359,6 +384,19 @@ describe('SpeechSentenceQueue', () => {
     releaseFirst?.();
     await vi.waitFor(() => expect(calls).toEqual(['First.', 'Second.']));
     await vi.waitFor(() => expect(idle).toBe(true));
+  });
+
+  it('normalizes Markdown before selecting and synthesizing queued speech', async () => {
+    const calls: string[] = [];
+    const queue = new SpeechSentenceQueue(
+      async (text) => { calls.push(text); },
+      () => undefined,
+    );
+
+    queue.enqueue(['1. **First item.**', '- [Second item](https://example.test)']);
+    queue.finish();
+
+    await vi.waitFor(() => expect(calls).toEqual(['First item.', 'Second item.']));
   });
 
   it('starts the next synthesis before the shared playback session drains', async () => {

--- a/dashboard-react/src/audio/streamingSpeechPlayback.ts
+++ b/dashboard-react/src/audio/streamingSpeechPlayback.ts
@@ -192,6 +192,34 @@ class PlaybackFrameAccumulator {
   }
 }
 
+/** Convert rendered Markdown prose into stable text suitable for speech synthesis. */
+export function speechTextFromMarkdown(text: string): string {
+  const normalizedLines = text
+    .replace(/```[\s\S]*?```/g, ' ')
+    .split(/\r?\n/)
+    .map((line) => {
+      const structuralLine = /^\s*(?:#{1,6}\s+|>\s*|[-+*]\s+|\d+[.)]\s+)/.test(line);
+      let spoken = line
+        .replace(/^\s{0,3}(?:#{1,6}\s+|>\s*)/, '')
+        .replace(/^\s*(?:[-+*]|\d+[.)])\s+/, '')
+        .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+        .replace(/\[([^\]]+)]\([^)]*\)/g, '$1')
+        .replace(/<https?:\/\/[^>]+>/g, '')
+        .replace(/`([^`]+)`/g, '$1')
+        .replace(/(\*\*|__)(.*?)\1/g, '$2')
+        .replace(/(\*|_)(.*?)\1/g, '$2')
+        .replace(/~~(.*?)~~/g, '$1')
+        .replace(/<[^>]+>/g, '')
+        .replace(/[\\*_~]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if (structuralLine && spoken && !/[.!?]["')\]]*$/.test(spoken)) spoken += '.';
+      return spoken;
+    })
+    .filter(Boolean);
+  return normalizedLines.join(' ').replace(/\s+/g, ' ').trim();
+}
+
 /** Split visible text into complete synthesis sentences and one retained tail. */
 export function splitCompleteSpeechSentences(text: string): {
   sentences: string[];
@@ -199,8 +227,12 @@ export function splitCompleteSpeechSentences(text: string): {
 } {
   const sentences: string[] = [];
   let boundary = 0;
-  const matcher = /[.!?](?:["')\]]*)\s+/g;
+  const matcher = /[.!?](?:["')\]*_~]*)\s+/g;
   for (const match of text.matchAll(matcher)) {
+    const punctuation = match.index ?? 0;
+    const lineStart = text.lastIndexOf('\n', punctuation) + 1;
+    const linePrefix = text.slice(lineStart, punctuation + 1).trim();
+    if (/^(?:\d+|[A-Za-z])[.)]$/.test(linePrefix)) continue;
     const end = (match.index ?? 0) + match[0].length;
     const sentence = text.slice(boundary, end).trim();
     if (sentence) sentences.push(sentence);
@@ -559,7 +591,9 @@ export class SpeechSentenceQueue {
   /** Add complete visible sentences without starting overlapping synthesis calls. */
   enqueue(sentences: readonly string[]): void {
     if (this.stopped || this.inputFinished) return;
-    this.pending.push(...sentences.filter((sentence) => sentence.trim().length > 0));
+    this.pending.push(...sentences
+      .map(speechTextFromMarkdown)
+      .filter((sentence) => sentence.length > 0));
     void this.drain();
   }
 

--- a/dashboard-react/src/components/chat/ChatForm.test.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.test.tsx
@@ -32,6 +32,81 @@ async function renderChatForm(props: React.ComponentProps<typeof ChatForm>): Pro
   });
 }
 
+function installRealtimeBrowserFakes(): {
+  audioTrack: { enabled: boolean; stop: ReturnType<typeof vi.fn> };
+  sockets: Array<EventTarget & { sent: string[]; serverEvent: (payload: object) => void }>;
+} {
+  const sockets: Array<EventTarget & {
+    sent: string[];
+    serverEvent: (payload: object) => void;
+  }> = [];
+  class FakeWebSocket extends EventTarget {
+    readyState = 1;
+    bufferedAmount = 0;
+    readonly sent: string[] = [];
+
+    constructor(url: string) {
+      super();
+      void url;
+      sockets.push(this);
+    }
+
+    send(data: string): void {
+      this.sent.push(data);
+    }
+
+    close(code = 1000): void {
+      this.readyState = 3;
+      this.dispatchEvent(new CloseEvent('close', { code }));
+    }
+
+    serverEvent(payload: object): void {
+      this.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(payload) }));
+    }
+  }
+
+  class FakeAudioContext {
+    readonly sampleRate = 48_000;
+    readonly audioWorklet = { addModule: vi.fn().mockResolvedValue(undefined) };
+    readonly destination = {};
+
+    createMediaStreamSource(): MediaStreamAudioSourceNode {
+      return { connect: vi.fn(), disconnect: vi.fn() } as unknown as MediaStreamAudioSourceNode;
+    }
+
+    createGain(): GainNode {
+      return {
+        gain: { value: 1 },
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      } as unknown as GainNode;
+    }
+
+    resume = vi.fn().mockResolvedValue(undefined);
+    close = vi.fn().mockResolvedValue(undefined);
+  }
+
+  class FakeAudioWorkletNode {
+    readonly port = { onmessage: null as ((event: MessageEvent<unknown>) => void) | null };
+    connect = vi.fn();
+    disconnect = vi.fn();
+  }
+
+  const audioTrack = { enabled: true, stop: vi.fn() };
+  const stream = {
+    getTracks: () => [audioTrack],
+    getAudioTracks: () => [audioTrack],
+  } as unknown as MediaStream;
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+  vi.stubGlobal('AudioContext', FakeAudioContext);
+  vi.stubGlobal('AudioWorkletNode', FakeAudioWorkletNode);
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+  });
+  return { audioTrack, sockets };
+}
+
 afterEach(async () => {
   await act(async () => root?.unmount());
   container?.remove();
@@ -118,6 +193,107 @@ describe('ChatForm speech controls', () => {
       await userEvent.click(speakDraft!);
     });
     expect(onSpeakText).toHaveBeenCalledWith('Speak this response');
+  });
+
+  it('preserves a completed realtime draft and disables capture before manual send', async () => {
+    const { audioTrack, sockets } = installRealtimeBrowserFakes();
+    const onSend = vi.fn();
+    const transcriptionModel: ChatSpeechModelOption = {
+      modelId: 'org/realtime-stt',
+      label: 'Realtime STT',
+      supportsRealtime: true,
+    };
+    await renderChatForm({
+      onSend,
+      transcriptionModels: [transcriptionModel],
+      selectedTranscriptionModelId: transcriptionModel.modelId,
+      realtimeTranscriptionAvailable: true,
+      realtimeVoiceEnabled: true,
+      autoSubmitVoice: false,
+      realtimeResponseModelId: 'org/chat',
+    });
+
+    const microphone = container?.querySelector<HTMLButtonElement>(
+      '[aria-label="Start realtime transcription"]',
+    );
+    expect(microphone).not.toBeNull();
+    await act(async () => { microphone?.click(); });
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await act(async () => {
+      await Promise.resolve();
+      sockets[0].serverEvent({ type: 'session.created' });
+    });
+    await vi.waitFor(() => expect(
+      container?.querySelector('[aria-label="Stop recording"]'),
+    ).not.toBeNull());
+
+    await act(async () => {
+      sockets[0].serverEvent({ type: 'input_audio_buffer.speech_started' });
+      sockets[0].serverEvent({ type: 'input_audio_buffer.speech_stopped' });
+      sockets[0].serverEvent({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: 'Keep this transcript',
+      });
+      sockets[0].serverEvent({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: '',
+      });
+    });
+
+    const textarea = container?.querySelector<HTMLTextAreaElement>('[aria-label="Chat message"]');
+    expect(textarea?.value).toBe('Keep this transcript');
+    const send = container?.querySelector<HTMLButtonElement>('[aria-label="Send message"]');
+    await act(async () => { send?.click(); });
+
+    expect(onSend).toHaveBeenCalledWith('Keep this transcript', []);
+    expect(audioTrack.enabled).toBe(false);
+  });
+
+  it('disables capture as soon as Auto-send submits a completed utterance', async () => {
+    const { audioTrack, sockets } = installRealtimeBrowserFakes();
+    const onRealtimeTranscript = vi.fn();
+    const transcriptionModel: ChatSpeechModelOption = {
+      modelId: 'org/realtime-stt',
+      label: 'Realtime STT',
+      supportsRealtime: true,
+    };
+    await renderChatForm({
+      onSend: vi.fn(),
+      transcriptionModels: [transcriptionModel],
+      selectedTranscriptionModelId: transcriptionModel.modelId,
+      realtimeTranscriptionAvailable: true,
+      realtimeVoiceEnabled: true,
+      autoSubmitVoice: true,
+      realtimeResponseModelId: 'org/chat',
+      onRealtimeTranscript,
+    });
+
+    const microphone = container?.querySelector<HTMLButtonElement>(
+      '[aria-label="Start realtime transcription"]',
+    );
+    await act(async () => { microphone?.click(); });
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await act(async () => {
+      await Promise.resolve();
+      sockets[0].serverEvent({ type: 'session.created' });
+    });
+    await vi.waitFor(() => expect(
+      container?.querySelector('[aria-label="Stop recording"]'),
+    ).not.toBeNull());
+
+    await act(async () => {
+      sockets[0].serverEvent({ type: 'input_audio_buffer.speech_started' });
+      sockets[0].serverEvent({ type: 'input_audio_buffer.speech_stopped' });
+      sockets[0].serverEvent({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: 'Send this now',
+      });
+    });
+
+    expect(onRealtimeTranscript).toHaveBeenCalledWith('Send this now', true);
+    expect(audioTrack.enabled).toBe(false);
+    expect(container?.querySelector<HTMLTextAreaElement>('[aria-label="Chat message"]')?.value)
+      .toBe('');
   });
 
   it('renders discovered voices and preserves automatic language matching', async () => {

--- a/dashboard-react/src/components/chat/ChatForm.test.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.test.tsx
@@ -249,6 +249,53 @@ describe('ChatForm speech controls', () => {
     expect(audioTrack.enabled).toBe(false);
   });
 
+  it('finishes a stopped realtime turn when its final transcript is empty', async () => {
+    const { sockets } = installRealtimeBrowserFakes();
+    const transcriptionModel: ChatSpeechModelOption = {
+      modelId: 'org/realtime-stt',
+      label: 'Realtime STT',
+      supportsRealtime: true,
+    };
+    await renderChatForm({
+      onSend: vi.fn(),
+      transcriptionModels: [transcriptionModel],
+      selectedTranscriptionModelId: transcriptionModel.modelId,
+      realtimeTranscriptionAvailable: true,
+      realtimeVoiceEnabled: true,
+      autoSubmitVoice: false,
+      realtimeResponseModelId: 'org/chat',
+    });
+
+    const microphone = container?.querySelector<HTMLButtonElement>(
+      '[aria-label="Start realtime transcription"]',
+    );
+    await act(async () => { microphone?.click(); });
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await act(async () => {
+      await Promise.resolve();
+      sockets[0].serverEvent({ type: 'session.created' });
+    });
+    await vi.waitFor(() => expect(
+      container?.querySelector('[aria-label="Stop recording"]'),
+    ).not.toBeNull());
+    await act(async () => {
+      sockets[0].serverEvent({ type: 'input_audio_buffer.speech_started' });
+      sockets[0].serverEvent({ type: 'input_audio_buffer.speech_stopped' });
+    });
+
+    const stop = container?.querySelector<HTMLButtonElement>('[aria-label="Stop recording"]');
+    await act(async () => { stop?.click(); });
+    await act(async () => {
+      sockets[0].serverEvent({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: '   ',
+      });
+    });
+
+    expect(container?.querySelector('[aria-label="Start realtime transcription"]')).not.toBeNull();
+    expect(container?.textContent).not.toContain('Transcribing');
+  });
+
   it('disables capture as soon as Auto-send submits a completed utterance', async () => {
     const { audioTrack, sockets } = installRealtimeBrowserFakes();
     const onRealtimeTranscript = vi.fn();

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -463,6 +463,7 @@ export function ChatForm({
   const [isStartingRecording, setIsStartingRecording] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
+  const [isRealtimeResponseActive, setIsRealtimeResponseActive] = useState(false);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const [mediaError, setMediaError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -637,6 +638,12 @@ export function ChatForm({
           onSpeechStarted: onStopSpeaking,
           onTranscript: (text, final) => {
             if (realtimeConversationRef.current !== socket) return;
+            if (!text.trim()) return;
+            if (final && submitRealtimeTranscript) {
+              setIsRealtimeResponseActive(true);
+              socket.setInputPaused(true);
+              capture?.setEnabled(false);
+            }
             setMessage(final && submitRealtimeTranscript ? '' : text);
             onRealtimeTranscript?.(text, final);
             if (final && conversationStoppingRef.current && !submitRealtimeTranscript) {
@@ -650,12 +657,14 @@ export function ChatForm({
           },
           onResponseDone: (status) => {
             if (realtimeConversationRef.current !== socket) return;
+            setIsRealtimeResponseActive(false);
             onRealtimeResponseDone?.(status);
             if (conversationStoppingRef.current) finishConversation();
           },
           onError: (error) => {
             if (realtimeConversationRef.current !== socket) return;
             setMediaError(error.message);
+            setIsRealtimeResponseActive(false);
             finishConversation();
             stream.getTracks().forEach((track) => track.stop());
             void capture?.stop();
@@ -666,6 +675,7 @@ export function ChatForm({
           realtimeConversationRef.current = null;
           mediaStreamRef.current = null;
           conversationStoppingRef.current = false;
+          setIsRealtimeResponseActive(false);
           socket.close();
           stopRecordingTimer();
           setIsRecording(false);
@@ -1016,6 +1026,8 @@ export function ChatForm({
     (e?: React.FormEvent) => {
       e?.preventDefault();
       if (isLoading || !canSend) return;
+      realtimeConversationRef.current?.setInputPaused(true);
+      realtimeCaptureRef.current?.setEnabled(false);
       onSend(message.trim(), files);
       setMessage('');
       clearFiles();
@@ -1025,6 +1037,12 @@ export function ChatForm({
     },
     [isLoading, canSend, message, files, onSend, clearFiles],
   );
+
+  useEffect(() => {
+    const microphonePaused = isLoading || isSpeaking || isRealtimeResponseActive;
+    realtimeConversationRef.current?.setInputPaused(microphonePaused);
+    realtimeCaptureRef.current?.setEnabled(!microphonePaused);
+  }, [isLoading, isRealtimeResponseActive, isSpeaking]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -638,7 +638,12 @@ export function ChatForm({
           onSpeechStarted: onStopSpeaking,
           onTranscript: (text, final) => {
             if (realtimeConversationRef.current !== socket) return;
-            if (!text.trim()) return;
+            if (!text.trim()) {
+              if (final && conversationStoppingRef.current && !submitRealtimeTranscript) {
+                finishConversation();
+              }
+              return;
+            }
             if (final && submitRealtimeTranscript) {
               setIsRealtimeResponseActive(true);
               socket.setInputPaused(true);


### PR DESCRIPTION
## Summary
- pause and disable microphone capture while a submitted assistant response or TTS playback is active
- preserve completed realtime transcripts when recording stops without committing post-transcription silence
- normalize Markdown and list structure into readable prose before all dashboard TTS synthesis

## Validation
- `npm run test` (87 passed)
- `npm run build`
- changed-file ESLint
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`
- `uv run pytest` (3021 passed, 1 skipped, 228 deselected)
- rendered Storybook interaction and clean console check