### PR TITLE
Fix realtime voice turn continuity and default voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,17 @@ This project records release notes here and mirrors public-facing notes in
   Jake, Kite, Rufus, Samson, Sydney, and Sylvie) for the validated Qwen Base,
   LongCat, and Fish voice-cloning cards. They appear through the ordinary voice
   catalog and resolve to local conditioning audio plus its exact transcript only
-  inside the selected worker. Qwen Base now ships the stable six-bit conversion;
-  the unstable 0.6B CustomVoice and four-bit Base cards are no longer offered.
+  inside the selected worker, with Kite as the shipped default. Qwen Base now
+  ships the stable six-bit conversion; the unstable 0.6B CustomVoice and
+  four-bit Base cards are no longer offered.
 
 ### Fixed
+
+- Dashboard realtime STT Auto-send now submits final transcripts through the
+  same chat-completions path as typed prompts. Voice turns retain the complete
+  dashboard conversation, use normal generation limits, and share the same
+  streaming, cancellation, and sentence-paced TTS behavior instead of creating
+  a separate socket-local conversation capped at 256 output tokens.
 
 - Omitted TTS `max_tokens` no longer inherits undersized upstream model
   defaults that hard-cut ordinary speech mid-word. Speech runners now apply a

--- a/dashboard-react/src/audio/speechVoiceSelection.test.ts
+++ b/dashboard-react/src/audio/speechVoiceSelection.test.ts
@@ -49,6 +49,10 @@ describe('speech language and voice selection', () => {
     expect(selectSpeechVoice('これは日本語です。', VOICES, null, 'serena')).toBe('ono_anna');
   });
 
+  it('prefers the card default among voices matching the response language', () => {
+    expect(selectSpeechVoice('This is English.', VOICES, null, 'aiden')).toBe('aiden');
+  });
+
   it('does not misclassify Latin text when the catalog has multiple Latin languages', () => {
     const multilingualVoices: ChatVoiceOption[] = [
       ...VOICES,

--- a/dashboard-react/src/audio/speechVoiceSelection.ts
+++ b/dashboard-react/src/audio/speechVoiceSelection.ts
@@ -96,6 +96,14 @@ export function selectSpeechVoice(
     containsLatinScript(text) ? soleCatalogLatinLanguage(voices) : null
   );
   if (language) {
+    const defaultOption = defaultVoice
+      ? voices.find((voice) => voice.id === defaultVoice)
+      : undefined;
+    if (defaultOption?.preferredLanguages.some(
+      (candidate) => primaryLanguage(candidate) === language,
+    )) {
+      return defaultOption.id;
+    }
     const match = voices.find((voice) => voice.preferredLanguages.some(
       (candidate) => primaryLanguage(candidate) === language,
     ));

--- a/dashboard-react/src/components/chat/ChatForm.stories.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.stories.tsx
@@ -96,7 +96,6 @@ export const RealtimeStt: Story = {
     realtimeTranscriptionAvailable: true,
     realtimeVoiceEnabled: true,
     autoSubmitVoice: true,
-    realtimeResponseModelId: 'mlx-community/Qwen3-30B-A3B-4bit',
     onTranscribeAudio: async () => 'batch fallback transcript',
     onRealtimeVoiceEnabledChange: () => {},
     onAutoSubmitVoiceChange: () => {},

--- a/dashboard-react/src/components/chat/ChatForm.test.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.test.tsx
@@ -32,6 +32,16 @@ async function renderChatForm(props: React.ComponentProps<typeof ChatForm>): Pro
   });
 }
 
+async function rerenderChatForm(props: React.ComponentProps<typeof ChatForm>): Promise<void> {
+  await act(async () => {
+    root?.render(
+      <ThemeProvider theme={darkTheme}>
+        <ChatForm {...props} />
+      </ThemeProvider>,
+    );
+  });
+}
+
 function installRealtimeBrowserFakes(): {
   audioTrack: { enabled: boolean; stop: ReturnType<typeof vi.fn> };
   sockets: Array<EventTarget & { sent: string[]; serverEvent: (payload: object) => void }>;
@@ -349,6 +359,52 @@ describe('ChatForm speech controls', () => {
     expect(audioTrack.enabled).toBe(false);
     expect(container?.querySelector<HTMLTextAreaElement>('[aria-label="Chat message"]')?.value)
       .toBe('');
+  });
+
+  it('retains a buffered final transcript that arrives after chat starts loading', async () => {
+    const { audioTrack, sockets } = installRealtimeBrowserFakes();
+    const onRealtimeTranscript = vi.fn();
+    const transcriptionModel: ChatSpeechModelOption = {
+      modelId: 'org/realtime-stt',
+      label: 'Realtime STT',
+      supportsRealtime: true,
+    };
+    const props: React.ComponentProps<typeof ChatForm> = {
+      onSend: vi.fn(),
+      transcriptionModels: [transcriptionModel],
+      selectedTranscriptionModelId: transcriptionModel.modelId,
+      realtimeTranscriptionAvailable: true,
+      realtimeVoiceEnabled: true,
+      autoSubmitVoice: true,
+      onRealtimeTranscript,
+    };
+    await renderChatForm(props);
+
+    const microphone = container?.querySelector<HTMLButtonElement>(
+      '[aria-label="Start realtime transcription"]',
+    );
+    await act(async () => { microphone?.click(); });
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await act(async () => {
+      await Promise.resolve();
+      sockets[0].serverEvent({ type: 'session.created' });
+    });
+    await vi.waitFor(() => expect(
+      container?.querySelector('[aria-label="Stop recording"]'),
+    ).not.toBeNull());
+
+    await rerenderChatForm({ ...props, isLoading: true });
+    await act(async () => {
+      sockets[0].serverEvent({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: 'Keep this draft',
+      });
+    });
+
+    expect(onRealtimeTranscript).toHaveBeenCalledWith('Keep this draft', true);
+    expect(audioTrack.enabled).toBe(false);
+    expect(container?.querySelector<HTMLTextAreaElement>('[aria-label="Chat message"]')?.value)
+      .toBe('Keep this draft');
   });
 
   it('renders discovered voices and preserves automatic language matching', async () => {

--- a/dashboard-react/src/components/chat/ChatForm.test.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.test.tsx
@@ -155,7 +155,6 @@ describe('ChatForm speech controls', () => {
       realtimeTranscriptionAvailable: true,
       realtimeVoiceEnabled: true,
       autoSubmitVoice: false,
-      realtimeResponseModelId: 'org/chat',
       speechModels: [speechModel],
       selectedSpeechModelId: speechModel.modelId,
       onRealtimeVoiceEnabledChange,
@@ -210,7 +209,6 @@ describe('ChatForm speech controls', () => {
       realtimeTranscriptionAvailable: true,
       realtimeVoiceEnabled: true,
       autoSubmitVoice: false,
-      realtimeResponseModelId: 'org/chat',
     });
 
     const microphone = container?.querySelector<HTMLButtonElement>(
@@ -223,6 +221,10 @@ describe('ChatForm speech controls', () => {
       await Promise.resolve();
       sockets[0].serverEvent({ type: 'session.created' });
     });
+    const sessionUpdate = JSON.parse(sockets[0].sent[0]) as {
+      session: { response?: unknown };
+    };
+    expect(sessionUpdate.session.response).toBeUndefined();
     await vi.waitFor(() => expect(
       container?.querySelector('[aria-label="Stop recording"]'),
     ).not.toBeNull());
@@ -263,7 +265,6 @@ describe('ChatForm speech controls', () => {
       realtimeTranscriptionAvailable: true,
       realtimeVoiceEnabled: true,
       autoSubmitVoice: false,
-      realtimeResponseModelId: 'org/chat',
     });
 
     const microphone = container?.querySelector<HTMLButtonElement>(
@@ -275,6 +276,10 @@ describe('ChatForm speech controls', () => {
       await Promise.resolve();
       sockets[0].serverEvent({ type: 'session.created' });
     });
+    const sessionUpdate = JSON.parse(sockets[0].sent[0]) as {
+      session: { response?: unknown };
+    };
+    expect(sessionUpdate.session.response).toBeUndefined();
     await vi.waitFor(() => expect(
       container?.querySelector('[aria-label="Stop recording"]'),
     ).not.toBeNull());
@@ -311,7 +316,6 @@ describe('ChatForm speech controls', () => {
       realtimeTranscriptionAvailable: true,
       realtimeVoiceEnabled: true,
       autoSubmitVoice: true,
-      realtimeResponseModelId: 'org/chat',
       onRealtimeTranscript,
     });
 
@@ -324,6 +328,10 @@ describe('ChatForm speech controls', () => {
       await Promise.resolve();
       sockets[0].serverEvent({ type: 'session.created' });
     });
+    const sessionUpdate = JSON.parse(sockets[0].sent[0]) as {
+      session: { response?: unknown };
+    };
+    expect(sessionUpdate.session.response).toBeUndefined();
     await vi.waitFor(() => expect(
       container?.querySelector('[aria-label="Stop recording"]'),
     ).not.toBeNull());

--- a/dashboard-react/src/components/chat/ChatForm.test.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.test.tsx
@@ -364,6 +364,7 @@ describe('ChatForm speech controls', () => {
   it('retains a buffered final transcript that arrives after chat starts loading', async () => {
     const { audioTrack, sockets } = installRealtimeBrowserFakes();
     const onRealtimeTranscript = vi.fn();
+    const onLateRealtimeTranscript = vi.fn();
     const transcriptionModel: ChatSpeechModelOption = {
       modelId: 'org/realtime-stt',
       label: 'Realtime STT',
@@ -393,7 +394,11 @@ describe('ChatForm speech controls', () => {
       container?.querySelector('[aria-label="Stop recording"]'),
     ).not.toBeNull());
 
-    await rerenderChatForm({ ...props, isLoading: true });
+    await rerenderChatForm({
+      ...props,
+      isLoading: true,
+      onRealtimeTranscript: onLateRealtimeTranscript,
+    });
     await act(async () => {
       sockets[0].serverEvent({
         type: 'conversation.item.input_audio_transcription.completed',
@@ -401,7 +406,8 @@ describe('ChatForm speech controls', () => {
       });
     });
 
-    expect(onRealtimeTranscript).toHaveBeenCalledWith('Keep this draft', true);
+    expect(onRealtimeTranscript).not.toHaveBeenCalled();
+    expect(onLateRealtimeTranscript).toHaveBeenCalledWith('Keep this draft', true);
     expect(audioTrack.enabled).toBe(false);
     expect(container?.querySelector<HTMLTextAreaElement>('[aria-label="Chat message"]')?.value)
       .toBe('Keep this draft');

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -473,6 +473,7 @@ export function ChatForm({
   const recordingStartingRef = useRef(false);
   const conversationStoppingRef = useRef(false);
   const componentMountedRef = useRef(true);
+  const onRealtimeTranscriptRef = useRef(onRealtimeTranscript);
   const submitRealtimeTranscriptRef = useRef(false);
   const recordingStartedAtRef = useRef(0);
   const recordingTimerRef = useRef<number | null>(null);
@@ -514,6 +515,9 @@ export function ChatForm({
   useEffect(() => {
     submitRealtimeTranscriptRef.current = submitRealtimeTranscript;
   }, [submitRealtimeTranscript]);
+  useEffect(() => {
+    onRealtimeTranscriptRef.current = onRealtimeTranscript;
+  }, [onRealtimeTranscript]);
   const recordingUnavailableReason = !secureRecordingContext
     ? t('chat.form.voiceErrors.secureContextRequired', 'Microphone requires HTTPS or localhost.')
     : !browserRecordingAvailable
@@ -643,7 +647,7 @@ export function ChatForm({
               capture?.setEnabled(false);
             }
             setMessage(final && shouldSubmit ? '' : text);
-            onRealtimeTranscript?.(text, final);
+            onRealtimeTranscriptRef.current?.(text, final);
             if (final && conversationStoppingRef.current) {
               finishConversation();
             }
@@ -857,7 +861,6 @@ export function ChatForm({
     t,
     transcriptionReady,
     captureMode,
-    onRealtimeTranscript,
     onStopSpeaking,
     useRealtimeConversation,
     useRealtimeCapture,

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -64,10 +64,8 @@ export interface ChatFormProps {
   autoSpeakAssistant?: boolean;
   /** Enable a persistent server-VAD conversation instead of push-to-transcribe. */
   realtimeVoiceEnabled?: boolean;
-  /** Route final realtime transcripts directly to the selected chat model. */
+  /** Submit final realtime transcripts through the dashboard chat flow. */
   autoSubmitVoice?: boolean;
-  /** Mounted chat model used for automatic realtime responses. */
-  realtimeResponseModelId?: string | null;
   /** Whether a dashboard-managed audio playback is active. */
   isSpeaking?: boolean;
   /** Speech-related API error surfaced from the page container. */
@@ -87,8 +85,6 @@ export interface ChatFormProps {
   onRealtimeVoiceEnabledChange?: (enabled: boolean) => void;
   onAutoSubmitVoiceChange?: (enabled: boolean) => void;
   onRealtimeTranscript?: (text: string, final: boolean) => void;
-  onRealtimeAssistantText?: (text: string, final: boolean) => void;
-  onRealtimeResponseDone?: (status: string) => void;
   /** Transcribe a browser-recorded audio blob and return transcript text. */
   onTranscribeAudio?: (audio: Blob) => Promise<string>;
   /** Speak the current draft text with the selected TTS model. */
@@ -437,7 +433,6 @@ export function ChatForm({
   autoSpeakAssistant = false,
   realtimeVoiceEnabled = true,
   autoSubmitVoice = false,
-  realtimeResponseModelId = null,
   isSpeaking = false,
   voiceError = null,
   onSelectTranscriptionModel,
@@ -449,8 +444,6 @@ export function ChatForm({
   onRealtimeVoiceEnabledChange,
   onAutoSubmitVoiceChange,
   onRealtimeTranscript,
-  onRealtimeAssistantText,
-  onRealtimeResponseDone,
   onTranscribeAudio,
   onSpeakText,
   onStopSpeaking,
@@ -463,7 +456,6 @@ export function ChatForm({
   const [isStartingRecording, setIsStartingRecording] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
-  const [isRealtimeResponseActive, setIsRealtimeResponseActive] = useState(false);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const [mediaError, setMediaError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -517,9 +509,7 @@ export function ChatForm({
   const browserRecordingAvailable = captureMode !== null;
   const useRealtimeCapture = captureMode === 'realtime';
   const useRealtimeConversation = useRealtimeCapture && realtimeVoiceEnabled;
-  const submitRealtimeTranscript = autoSubmitVoice
-    && canSendMessages
-    && realtimeResponseModelId !== null;
+  const submitRealtimeTranscript = autoSubmitVoice && canSendMessages;
   const recordingUnavailableReason = !secureRecordingContext
     ? t('chat.form.voiceErrors.secureContextRequired', 'Microphone requires HTTPS or localhost.')
     : !browserRecordingAvailable
@@ -634,42 +624,28 @@ export function ChatForm({
         let capture: RealtimePcmCapture | null = null;
         const socket = new RealtimeConversationSocket({
           transcriptionModelId: selectedTranscriptionId,
-          responseModelId: submitRealtimeTranscript ? realtimeResponseModelId : null,
           onSpeechStarted: onStopSpeaking,
           onTranscript: (text, final) => {
             if (realtimeConversationRef.current !== socket) return;
             if (!text.trim()) {
-              if (final && conversationStoppingRef.current && !submitRealtimeTranscript) {
+              if (final && conversationStoppingRef.current) {
                 finishConversation();
               }
               return;
             }
             if (final && submitRealtimeTranscript) {
-              setIsRealtimeResponseActive(true);
               socket.setInputPaused(true);
               capture?.setEnabled(false);
             }
             setMessage(final && submitRealtimeTranscript ? '' : text);
             onRealtimeTranscript?.(text, final);
-            if (final && conversationStoppingRef.current && !submitRealtimeTranscript) {
+            if (final && conversationStoppingRef.current) {
               finishConversation();
             }
-          },
-          onAssistantText: (text, final) => {
-            if (realtimeConversationRef.current === socket) {
-              onRealtimeAssistantText?.(text, final);
-            }
-          },
-          onResponseDone: (status) => {
-            if (realtimeConversationRef.current !== socket) return;
-            setIsRealtimeResponseActive(false);
-            onRealtimeResponseDone?.(status);
-            if (conversationStoppingRef.current) finishConversation();
           },
           onError: (error) => {
             if (realtimeConversationRef.current !== socket) return;
             setMediaError(error.message);
-            setIsRealtimeResponseActive(false);
             finishConversation();
             stream.getTracks().forEach((track) => track.stop());
             void capture?.stop();
@@ -680,7 +656,6 @@ export function ChatForm({
           realtimeConversationRef.current = null;
           mediaStreamRef.current = null;
           conversationStoppingRef.current = false;
-          setIsRealtimeResponseActive(false);
           socket.close();
           stopRecordingTimer();
           setIsRecording(false);
@@ -878,11 +853,8 @@ export function ChatForm({
     transcriptionReady,
     captureMode,
     submitRealtimeTranscript,
-    onRealtimeAssistantText,
-    onRealtimeResponseDone,
     onRealtimeTranscript,
     onStopSpeaking,
-    realtimeResponseModelId,
     useRealtimeConversation,
     useRealtimeCapture,
   ]);
@@ -1044,10 +1016,10 @@ export function ChatForm({
   );
 
   useEffect(() => {
-    const microphonePaused = isLoading || isSpeaking || isRealtimeResponseActive;
+    const microphonePaused = isLoading || isSpeaking;
     realtimeConversationRef.current?.setInputPaused(microphonePaused);
     realtimeCaptureRef.current?.setEnabled(!microphonePaused);
-  }, [isLoading, isRealtimeResponseActive, isSpeaking]);
+  }, [isLoading, isSpeaking]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/dashboard-react/src/components/chat/ChatForm.tsx
+++ b/dashboard-react/src/components/chat/ChatForm.tsx
@@ -473,6 +473,7 @@ export function ChatForm({
   const recordingStartingRef = useRef(false);
   const conversationStoppingRef = useRef(false);
   const componentMountedRef = useRef(true);
+  const submitRealtimeTranscriptRef = useRef(false);
   const recordingStartedAtRef = useRef(0);
   const recordingTimerRef = useRef<number | null>(null);
 
@@ -509,7 +510,10 @@ export function ChatForm({
   const browserRecordingAvailable = captureMode !== null;
   const useRealtimeCapture = captureMode === 'realtime';
   const useRealtimeConversation = useRealtimeCapture && realtimeVoiceEnabled;
-  const submitRealtimeTranscript = autoSubmitVoice && canSendMessages;
+  const submitRealtimeTranscript = autoSubmitVoice && canSendMessages && !isLoading;
+  useEffect(() => {
+    submitRealtimeTranscriptRef.current = submitRealtimeTranscript;
+  }, [submitRealtimeTranscript]);
   const recordingUnavailableReason = !secureRecordingContext
     ? t('chat.form.voiceErrors.secureContextRequired', 'Microphone requires HTTPS or localhost.')
     : !browserRecordingAvailable
@@ -627,17 +631,18 @@ export function ChatForm({
           onSpeechStarted: onStopSpeaking,
           onTranscript: (text, final) => {
             if (realtimeConversationRef.current !== socket) return;
+            const shouldSubmit = submitRealtimeTranscriptRef.current;
             if (!text.trim()) {
               if (final && conversationStoppingRef.current) {
                 finishConversation();
               }
               return;
             }
-            if (final && submitRealtimeTranscript) {
+            if (final && shouldSubmit) {
               socket.setInputPaused(true);
               capture?.setEnabled(false);
             }
-            setMessage(final && submitRealtimeTranscript ? '' : text);
+            setMessage(final && shouldSubmit ? '' : text);
             onRealtimeTranscript?.(text, final);
             if (final && conversationStoppingRef.current) {
               finishConversation();
@@ -852,7 +857,6 @@ export function ChatForm({
     t,
     transcriptionReady,
     captureMode,
-    submitRealtimeTranscript,
     onRealtimeTranscript,
     onStopSpeaking,
     useRealtimeConversation,

--- a/dashboard-react/src/components/pages/ChatView.realtimeSpeech.test.tsx
+++ b/dashboard-react/src/components/pages/ChatView.realtimeSpeech.test.tsx
@@ -6,7 +6,6 @@ import { Provider } from 'react-redux';
 import { ThemeProvider } from 'styled-components';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { StreamingSpeechPlayback } from '../../audio/streamingSpeechPlayback';
 import { store } from '../../store';
 import { chatActions } from '../../store/slices/chatSlice';
 import { darkTheme } from '../../theme/theme';
@@ -14,26 +13,22 @@ import { ChatView } from './ChatView';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-type RealtimeAssistantTextHandler = (text: string, final: boolean) => void;
+type RealtimeTranscriptHandler = (text: string, final: boolean) => void;
 
 const chatFormCapture = vi.hoisted(() => ({
-  onRealtimeAssistantText: null as RealtimeAssistantTextHandler | null,
-  speechModelCount: 0,
-  selectedSpeechModelId: null as string | null,
-  autoSpeakAssistant: false,
+  onRealtimeTranscript: null as RealtimeTranscriptHandler | null,
+  autoSubmitVoice: false,
+  propNames: [] as string[],
 }));
 
 vi.mock('../chat/ChatForm', () => ({
   ChatForm: (props: {
-    onRealtimeAssistantText?: RealtimeAssistantTextHandler;
-    speechModels?: readonly unknown[];
-    selectedSpeechModelId?: string | null;
-    autoSpeakAssistant?: boolean;
+    onRealtimeTranscript?: RealtimeTranscriptHandler;
+    autoSubmitVoice?: boolean;
   }) => {
-    chatFormCapture.onRealtimeAssistantText = props.onRealtimeAssistantText ?? null;
-    chatFormCapture.speechModelCount = props.speechModels?.length ?? 0;
-    chatFormCapture.selectedSpeechModelId = props.selectedSpeechModelId ?? null;
-    chatFormCapture.autoSpeakAssistant = props.autoSpeakAssistant ?? false;
+    chatFormCapture.onRealtimeTranscript = props.onRealtimeTranscript ?? null;
+    chatFormCapture.autoSubmitVoice = props.autoSubmitVoice ?? false;
+    chatFormCapture.propNames = Object.keys(props);
     return null;
   },
 }));
@@ -53,7 +48,9 @@ async function waitFor(predicate: () => boolean, message: string): Promise<void>
   const deadline = performance.now() + 5000;
   while (performance.now() < deadline) {
     if (predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
   }
   throw new Error(message);
 }
@@ -63,81 +60,61 @@ afterEach(async () => {
   for (const conversationId of Object.keys(store.getState().chat.conversations)) {
     store.dispatch(chatActions.deleteConversation(conversationId));
   }
-  store.dispatch(chatActions.selectSpeechModel(null));
-  store.dispatch(chatActions.setAutoSpeakAssistant(false));
+  store.dispatch(chatActions.setAutoSubmitVoice(false));
   container?.remove();
   root = null;
   container = null;
-  chatFormCapture.onRealtimeAssistantText = null;
-  chatFormCapture.speechModelCount = 0;
-  chatFormCapture.selectedSpeechModelId = null;
-  chatFormCapture.autoSpeakAssistant = false;
-  vi.restoreAllMocks();
+  chatFormCapture.onRealtimeTranscript = null;
+  chatFormCapture.autoSubmitVoice = false;
+  chatFormCapture.propNames = [];
   vi.unstubAllGlobals();
 });
 
-describe('ChatView realtime speech playback', () => {
-  it('creates a fresh sentence queue for every completed realtime response', async () => {
-    let speechRequests = 0;
-    const requestedUrls: string[] = [];
-    vi.stubGlobal('AudioContext', class FakeAudioContext {});
-    vi.spyOn(StreamingSpeechPlayback.prototype, 'append').mockResolvedValue();
-    const finishPlayback = vi
-      .spyOn(StreamingSpeechPlayback.prototype, 'finish')
-      .mockResolvedValue();
-    vi.spyOn(StreamingSpeechPlayback.prototype, 'stop').mockImplementation(() => undefined);
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+describe('ChatView realtime voice auto-send', () => {
+  it('submits the final transcript through normal chat with dashboard history', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    vi.stubGlobal('fetch', vi.fn(async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
       const url = String(input);
-      requestedUrls.push(url);
       if (url === '/models') {
         return new Response(JSON.stringify({
-          data: [
-            {
-              id: 'org/chat-model',
-              tasks: ['TextGeneration'],
-              audio: {
-                default_response_format: 'pcm',
-                response_formats: ['pcm'],
-                supports_streaming: true,
-              },
-              resolved_capabilities: {
-                family: 'generic',
-                supports_thinking: false,
-                supports_thinking_toggle: false,
-                supports_thinking_budget: false,
-                default_reasoning_effort: 'none',
-                disabled_reasoning_effort: 'none',
-                thinking_format: 'none',
-                supports_image_input: false,
-                supports_audio_input: false,
-                supports_speech_synthesis: true,
-                supports_transcription: false,
-                supports_speech_translation: false,
-                supports_audio_output: true,
-                supports_realtime_audio: false,
-                default_audio_response_format: 'pcm',
-                audio_response_formats: ['pcm'],
-                supports_tool_calling: false,
-                builtin_tools: [],
-                tool_call_format: 'none',
-                prompt_renderer: 'generic',
-                output_parser: 'generic',
-                supports_native_multimodal: false,
-              },
+          data: [{
+            id: 'org/chat-model',
+            tasks: ['TextGeneration'],
+            resolved_capabilities: {
+              supports_thinking_toggle: false,
+              supports_image_input: false,
             },
-          ],
+          }],
         }), { status: 200 });
       }
-      if (url === '/v1/audio/speech') {
-        speechRequests += 1;
-        return new Response(new Uint8Array([0, 0]), { status: 200 });
+      if (url === '/v1/chat/completions') {
+        capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"Complete voice reply."}}]}\n\ndata: [DONE]\n\n',
+          { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+        );
       }
       throw new Error(`unexpected request: ${url}`);
     }));
 
     store.dispatch(chatActions.selectModel('org/chat-model'));
-    store.dispatch(chatActions.selectSpeechModel('org/chat-model'));
-    store.dispatch(chatActions.setAutoSpeakAssistant(true));
+    store.dispatch(chatActions.setAutoSubmitVoice(true));
+    store.dispatch(chatActions.addMessage({
+      id: 'earlier-user',
+      role: 'user',
+      content: 'Earlier context.',
+      timestamp: 1,
+    }));
+    store.dispatch(chatActions.addMessage({
+      id: 'earlier-assistant',
+      role: 'assistant',
+      content: 'Earlier answer.',
+      timestamp: 2,
+    }));
+
     container = document.createElement('div');
     document.body.append(container);
     root = createRoot(container);
@@ -145,53 +122,52 @@ describe('ChatView realtime speech playback', () => {
       root?.render(
         <Provider store={store}>
           <ThemeProvider theme={darkTheme}>
-            <ChatView readyInstances={[
-              {
-                instanceId: 'chat-instance',
-                modelId: 'org/chat-model',
-                sharding: 'Pipeline',
-                instanceType: 'MlxRing',
-                engine: 'mlx',
-                nodeStatuses: [],
-                status: 'ready',
-              },
-            ]} />
+            <ChatView readyInstances={[{
+              instanceId: 'chat-instance',
+              modelId: 'org/chat-model',
+              sharding: 'Pipeline',
+              instanceType: 'MlxRing',
+              engine: 'mlx',
+              nodeStatuses: [],
+              status: 'ready',
+            }]} />
           </ThemeProvider>
         </Provider>,
       );
     });
-    await act(async () => { await Promise.resolve(); });
+
     await waitFor(
-      () => chatFormCapture.speechModelCount === 1
-        && chatFormCapture.selectedSpeechModelId === 'org/chat-model'
-        && chatFormCapture.autoSpeakAssistant
-        && chatFormCapture.onRealtimeAssistantText !== null,
-      `realtime speech callback did not become ready (speech models: ${chatFormCapture.speechModelCount}, selected speech model: ${chatFormCapture.selectedSpeechModelId}, auto speak: ${chatFormCapture.autoSpeakAssistant}, callback: ${chatFormCapture.onRealtimeAssistantText !== null}, requests: ${requestedUrls.join(', ')})`,
+      () => chatFormCapture.autoSubmitVoice
+        && chatFormCapture.onRealtimeTranscript !== null,
+      'realtime transcript callback did not become ready',
     );
+    await act(async () => {
+      chatFormCapture.onRealtimeTranscript?.('Continue that', false);
+      await Promise.resolve();
+    });
+    expect(capturedBody).toBeNull();
 
     await act(async () => {
-      chatFormCapture.onRealtimeAssistantText?.('First sentence. ', false);
+      chatFormCapture.onRealtimeTranscript?.('Continue that thought.', true);
       await Promise.resolve();
     });
-    await waitFor(() => speechRequests === 1, 'first sentence was not synthesized');
-    await act(async () => {
-      chatFormCapture.onRealtimeAssistantText?.('First sentence.', true);
-      await Promise.resolve();
-    });
-    await waitFor(() => finishPlayback.mock.calls.length === 1, 'first response did not finish');
+    await waitFor(() => capturedBody !== null, 'voice transcript was not sent to chat');
 
-    await act(async () => {
-      chatFormCapture.onRealtimeAssistantText?.('Second sentence. ', false);
-      await Promise.resolve();
-    });
-    await waitFor(() => speechRequests === 2, 'second sentence was not synthesized');
-    await act(async () => {
-      chatFormCapture.onRealtimeAssistantText?.('Second sentence.', true);
-      await Promise.resolve();
-    });
-    await waitFor(() => finishPlayback.mock.calls.length === 2, 'second response did not finish');
-
-    expect(speechRequests).toBe(2);
-    expect(finishPlayback).toHaveBeenCalledTimes(2);
+    const request = capturedBody as Record<string, unknown>;
+    expect(request).not.toHaveProperty('max_tokens');
+    expect(request.messages).toEqual([
+      { role: 'user', content: 'Earlier context.' },
+      { role: 'assistant', content: 'Earlier answer.' },
+      { role: 'user', content: 'Continue that thought.' },
+    ]);
+    expect(chatFormCapture.propNames).not.toContain('realtimeResponseModelId');
+    expect(chatFormCapture.propNames).not.toContain('onRealtimeAssistantText');
+    expect(chatFormCapture.propNames).not.toContain('onRealtimeResponseDone');
+    await waitFor(
+      () => store.getState().chat.conversations[
+        store.getState().chat.activeConversationId ?? ''
+      ]?.messages.at(-1)?.content === 'Complete voice reply.',
+      'normal chat response was not retained in dashboard history',
+    );
   });
 });

--- a/dashboard-react/src/components/pages/ChatView.tsx
+++ b/dashboard-react/src/components/pages/ChatView.tsx
@@ -625,8 +625,6 @@ export function ChatView({
   const audioObjectUrlRef = useRef<string | null>(null);
   const streamingPlaybackRef = useRef<StreamingSpeechPlayback | null>(null);
   const speechSentenceQueueRef = useRef<SpeechSentenceQueue | null>(null);
-  const realtimeSpeechTextRef = useRef('');
-  const realtimeSpeechTailRef = useRef('');
 
   // Restore scroll position after store hydration + DOM render
   const dispatch = useAppDispatch();
@@ -1557,121 +1555,8 @@ export function ChatView({
 
   const handleRealtimeTranscript = useCallback((text: string, final: boolean) => {
     if (!final || !autoSubmitVoice || !canSendMessages || !text.trim()) return;
-    addMessage({
-      id: uuidv4(),
-      role: 'user',
-      content: text.trim(),
-      timestamp: Date.now(),
-    });
-  }, [addMessage, autoSubmitVoice, canSendMessages]);
-
-  const handleRealtimeAssistantText = useCallback((text: string, final: boolean) => {
-    const visibleText = text.trimStart();
-    if (!final) {
-      setStreamingContent(visibleText);
-      if (
-        autoSpeakAssistant
-        && selectedSpeechModelId
-        && voiceCatalogReady
-        && selectedSpeechOption?.supportsStreaming
-        && selectedSpeechOption.responseFormats.includes('pcm')
-        && canUseStreamingSpeechPlayback()
-      ) {
-        if (!speechSentenceQueueRef.current) {
-          const selectResponseVoice = createPinnedSpeechVoiceSelector(
-            voiceOptions,
-            effectiveSelectedVoice,
-            selectedSpeechOption.defaultVoice ?? null,
-          );
-          const responseSession: StreamingSpeechResponseSession = {
-            playback: new StreamingSpeechPlayback(),
-            useEncodedFallback: false,
-          };
-          streamingPlaybackRef.current = responseSession.playback;
-          const responseQueue = new SpeechSentenceQueue(
-            (sentence, signal) => playSpeechSegment(
-              sentence,
-              null,
-              signal,
-              selectResponseVoice(sentence),
-              responseSession,
-            ),
-            (error) => {
-              setSpeechError(error instanceof Error
-                ? error.message
-                : t('chat.view.errors.speechSynthesisFailed', 'Speech synthesis failed.'));
-            },
-            () => {
-              if (speechSentenceQueueRef.current === responseQueue) {
-                speechSentenceQueueRef.current = null;
-              }
-              if (streamingPlaybackRef.current === responseSession.playback) {
-                streamingPlaybackRef.current = null;
-              }
-              setIsAutoSpeaking(false);
-            },
-            () => responseSession.playback.finish(),
-            () => responseSession.playback.stop(),
-          );
-          speechSentenceQueueRef.current = responseQueue;
-        }
-        if (visibleText.startsWith(realtimeSpeechTextRef.current)) {
-          const delta = visibleText.slice(realtimeSpeechTextRef.current.length);
-          const split = splitCompleteSpeechSentences(realtimeSpeechTailRef.current + delta);
-          realtimeSpeechTailRef.current = split.remainder;
-          if (split.sentences.length > 0) {
-            setIsAutoSpeaking(true);
-            speechSentenceQueueRef.current.enqueue(split.sentences);
-          }
-        }
-        realtimeSpeechTextRef.current = visibleText;
-      }
-      return;
-    }
-
-    const finalText = text.trim();
-    setStreamingContent(null);
-    if (!finalText) {
-      speechSentenceQueueRef.current?.finish();
-      return;
-    }
-    const assistantMessage: ChatMessage = {
-      id: uuidv4(),
-      role: 'assistant',
-      content: finalText,
-      timestamp: Date.now(),
-    };
-    addMessage(assistantMessage);
-    const queue = speechSentenceQueueRef.current;
-    if (autoSpeakAssistant && queue && realtimeSpeechTailRef.current.trim()) {
-      setIsAutoSpeaking(true);
-      queue.enqueue([realtimeSpeechTailRef.current.trim()]);
-    } else if (autoSpeakAssistant && selectedSpeechModelId && !queue) {
-      void speakText(finalText, assistantMessage.id);
-    }
-    queue?.finish();
-    realtimeSpeechTextRef.current = '';
-    realtimeSpeechTailRef.current = '';
-  }, [
-    addMessage,
-    autoSpeakAssistant,
-    effectiveSelectedVoice,
-    playSpeechSegment,
-    selectedSpeechModelId,
-    selectedSpeechOption,
-    speakText,
-    t,
-    voiceCatalogReady,
-    voiceOptions,
-  ]);
-
-  const handleRealtimeResponseDone = useCallback((status: string) => {
-    if (status === 'completed') return;
-    setStreamingContent(null);
-    realtimeSpeechTextRef.current = '';
-    realtimeSpeechTailRef.current = '';
-    stopSpeechPlayback();
-  }, [stopSpeechPlayback]);
+    void handleSend(text.trim(), []);
+  }, [autoSubmitVoice, canSendMessages, handleSend]);
 
   if (readyModels.length === 0 && readyTranscriptionModels.length === 0 && readySpeechModels.length === 0) {
     return (
@@ -1745,7 +1630,6 @@ export function ChatView({
           autoSpeakAssistant={autoSpeakAssistant}
           realtimeVoiceEnabled={realtimeVoiceEnabled}
           autoSubmitVoice={autoSubmitVoice}
-          realtimeResponseModelId={selectedModelId}
           isSpeaking={speakingMessageId !== null || isAutoSpeaking}
           voiceError={voiceCatalogError ?? speechError}
           onSelectTranscriptionModel={selectTranscriptionModel}
@@ -1757,8 +1641,6 @@ export function ChatView({
           onRealtimeVoiceEnabledChange={setRealtimeVoiceEnabled}
           onAutoSubmitVoiceChange={setAutoSubmitVoice}
           onRealtimeTranscript={handleRealtimeTranscript}
-          onRealtimeAssistantText={handleRealtimeAssistantText}
-          onRealtimeResponseDone={handleRealtimeResponseDone}
           onTranscribeAudio={transcribeAudio}
           onSpeakText={(text) => { void speakText(text, 'draft'); }}
           onStopSpeaking={stopSpeechPlayback}

--- a/resources/speech_model_cards/mlx-community--LongCat-AudioDiT-1B-4bit.toml
+++ b/resources/speech_model_cards/mlx-community--LongCat-AudioDiT-1B-4bit.toml
@@ -17,7 +17,7 @@ supports_streaming = false
 supports_realtime = false
 supports_voice_listing = true
 voices = ["angus", "ember", "hannah", "ian", "jake", "kite", "rufus", "samson", "sydney", "sylvie"]
-default_voice = "angus"
+default_voice = "kite"
 supports_reference_audio = true
 sample_rates = [24000]
 

--- a/resources/speech_model_cards/mlx-community--Qwen3-TTS-12Hz-0.6B-Base-6bit.toml
+++ b/resources/speech_model_cards/mlx-community--Qwen3-TTS-12Hz-0.6B-Base-6bit.toml
@@ -20,7 +20,7 @@ supports_streaming = true
 supports_realtime = false
 supports_voice_listing = true
 voices = ["angus", "ember", "hannah", "ian", "jake", "kite", "rufus", "samson", "sydney", "sylvie"]
-default_voice = "angus"
+default_voice = "kite"
 supports_reference_audio = true
 sample_rates = [24000]
 

--- a/resources/speech_model_cards/mlx-community--fish-audio-s2-pro-8bit.toml
+++ b/resources/speech_model_cards/mlx-community--fish-audio-s2-pro-8bit.toml
@@ -17,7 +17,7 @@ supports_streaming = false
 supports_realtime = false
 supports_voice_listing = true
 voices = ["angus", "ember", "hannah", "ian", "jake", "kite", "rufus", "samson", "sydney", "sylvie"]
-default_voice = "angus"
+default_voice = "kite"
 supports_reference_audio = true
 sample_rates = [44100]
 

--- a/src/skulk/shared/tests/test_bundled_model_cards.py
+++ b/src/skulk/shared/tests/test_bundled_model_cards.py
@@ -261,7 +261,7 @@ def test_reference_capable_cards_expose_shared_voice_catalog(card_name: str) -> 
     assert card.audio is not None
     assert card.audio.supports_reference_audio is True
     assert card.audio.supports_voice_listing is True
-    assert card.audio.default_voice == "angus"
+    assert card.audio.default_voice == "kite"
     assert card.audio.voices == tuple(profile.id for profile in profiles)
     assert tuple(voice.id for voice in card.audio.voice_catalog) == card.audio.voices
     assert tuple(voice.name for voice in card.audio.voice_catalog) == tuple(

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -2055,8 +2055,12 @@ samples, the dashboard continuously resamples them to 24 kHz PCM16, and the
 client aggregates worklet callbacks into 100 ms transport frames before the
 mic control commits the socket when recording stops. Realtime mode can retain
 the socket across server-VAD turns, show partial transcripts in the editable
-draft, and optionally auto-send final transcripts through the selected mounted
-chat model. If either capability truth is absent, chat retains the batch `MediaRecorder` plus
+draft, and optionally auto-send final transcripts through the same dashboard
+`POST /v1/chat/completions` flow used by typed prompts. This preserves the full
+dashboard conversation and its ordinary generation, cancellation, and TTS
+semantics; the WebSocket's optional `response` participant remains available to
+API clients but is not a second dashboard conversation. If either capability
+truth is absent, chat retains the batch `MediaRecorder` plus
 `POST /v1/audio/transcriptions` path.
 
 When `response` is configured, the API node that owns the WebSocket retains the

--- a/website/docs/speech-fabric-realtime.md
+++ b/website/docs/speech-fabric-realtime.md
@@ -190,10 +190,11 @@ model and local node advertise the required capabilities.
   under pressure, preserve sentence order, and propagate stop to queued and
   active requests.
 - For cards with voice discovery, the dashboard lists the mounted catalog and
-  defaults to automatic language matching. It chooses the first catalog voice
-  whose preferred language matches the response text, then pins that voice for
-  every sentence request in the response. An explicit user selection overrides
-  automatic matching but remains pinned for the same response.
+  defaults to automatic language matching. It prefers the card's default voice
+  when that voice matches the response language, otherwise chooses the first
+  matching catalog voice, then pins that voice for every sentence request in
+  the response. An explicit user selection overrides automatic matching but
+  remains pinned for the same response.
 - Batch-only TTS models retain complete-response encoded playback.
 
 The dashboard falls back to batch transcription when realtime model or node

--- a/website/docs/speech-fabric-realtime.md
+++ b/website/docs/speech-fabric-realtime.md
@@ -177,9 +177,10 @@ model and local node advertise the required capabilities.
 - Capture callbacks are aggregated into bounded 100 ms transport frames.
 - Realtime mode keeps one multi-turn socket open, uses server VAD for automatic
   turn boundaries, and shows partial transcripts in the editable chat draft.
-- Auto-send optionally routes final transcripts to the selected chat model;
-  assistant text remains visible while it streams and barge-in cancels active
-  response playback.
+- Auto-send submits final transcripts through the dashboard's ordinary chat
+  request path. Voice and typed turns therefore share one persisted
+  conversation, the same generation limits, streaming, cancellation, and
+  sentence-paced TTS behavior. The microphone pauses while that turn drains.
 - Batch-only models retain the `MediaRecorder` upload flow.
 - Transcription results populate the chat draft for review or submission.
 - Streaming-capable TTS models use sentence-sized raw PCM requests. The


### PR DESCRIPTION
## Summary

- submit final realtime STT transcripts through the normal dashboard chat-completions path
- preserve dashboard conversation history, generation limits, streaming, cancellation, and sentence-paced TTS for voice turns
- keep the WebSocket response participant available for API clients without using it as a second dashboard conversation
- make Kite the shipped default across the bundled Qwen Base, LongCat, and Fish reference-voice cards, including language-aware dashboard Auto selection

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` — 3,021 passed, 1 skipped
- `npm run test` — 90 passed
- `npm run build`
- changed-file ESLint — 0 errors
- production dashboard build rendered without console errors; API-dependent content correctly reported reconnecting when served without a backend
