### PR TITLE
Finalize the 1.5.0 release notes on dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Documentation](https://img.shields.io/badge/docs-documentation-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/)
 [![Build & Runtime Paths](https://img.shields.io/badge/docs-build_%26_runtime-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/build-and-runtime/)
-[![Release Notes](https://img.shields.io/badge/release_notes-v1.4.1-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/release-notes/1.4.1/)
+[![Release Notes](https://img.shields.io/badge/release_notes-v1.5.0-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/release-notes/1.5.0/)
 [![Architecture](https://img.shields.io/badge/docs-architecture-2ea44f?style=flat-square&logo=readthedocs&logoColor=white)](https://foxlight-foundation.github.io/Skulk/architecture/)
 
   <br>

--- a/website/docs/release-notes/1.0.2.md
+++ b/website/docs/release-notes/1.0.2.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.0.2
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.0.3.md
+++ b/website/docs/release-notes/1.0.3.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.0.3
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.1.0.md
+++ b/website/docs/release-notes/1.1.0.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.1.0
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.2.0.md
+++ b/website/docs/release-notes/1.2.0.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.2.0
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.3.0.md
+++ b/website/docs/release-notes/1.3.0.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.3.0
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.3.1.md
+++ b/website/docs/release-notes/1.3.1.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.3.1
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.4.0.md
+++ b/website/docs/release-notes/1.4.0.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.4.0
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.4.1.md
+++ b/website/docs/release-notes/1.4.1.md
@@ -1,6 +1,6 @@
 ---
 title: Release Notes 1.4.1
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 <!-- Copyright 2025 Foxlight Foundation -->

--- a/website/docs/release-notes/1.5.0.md
+++ b/website/docs/release-notes/1.5.0.md
@@ -5,10 +5,6 @@ sidebar_position: 1
 
 <!-- Copyright 2025 Foxlight Foundation -->
 
-Status: release candidate. Publication remains pending human acceptance and
-the post-promotion shipping qualification against the literal public `main`
-installer.
-
 Skulk 1.5.0 makes first installation, heterogeneous serving, and the dashboard
 one coherent product path. Hardware and engine capability are detected rather
 than assumed, fresh installations use the same Zenoh data plane and model cards
@@ -44,11 +40,25 @@ and API experience on Apple Silicon, AMD Linux, and clean NVIDIA infrastructure.
 - **Speech is a first-class fabric capability.** OpenAI-compatible TTS,
   transcription, translation, voice discovery, realtime transcription, VAD,
   reference audio, and the dashboard voice loop share the same placement and
-  bounded media paths as the rest of Skulk. Ten checksummed bundled reference
+  bounded media paths as the rest of Skulk. Spoken output is prepared
+  structurally from the rendered Markdown: titles and headings arrive as
+  their own utterances with sentence-final prosody, emoji are stripped
+  rather than read, fenced code is never spoken, a horizontal rule becomes a
+  brief audible pause, and a deterministic per-sentence seed keeps replays
+  identical. Ten checksummed bundled reference
   voices provide the same named catalog across validated Qwen Base, LongCat,
   and Fish voice-cloning models without exposing local media paths or bytes to
   cluster state. Translation is now standard when a mounted card declares
   support.
+
+- **The dashboard wears its own design.** Dark mode moves to the Foxlight
+  operator design system's Den palette: indigo surfaces over a deep night
+  canvas, a starlight accent for everyday interaction, and amber reserved for
+  work actually in flight, such as the memory a model is holding or a
+  download in progress. Every palette decision lives in theme tokens, an
+  optional build flag (`VITE_NIGHT_SKY=1`) crowns the night with the brand
+  valley's star field, and the topology view now shows each machine's make at
+  a glance across mixed Apple, AMD, and NVIDIA fleets.
 
 - **Linux serving is detected and concurrent by default.** Managed
   llama-server wheels support AMD Vulkan and NVIDIA CUDA. The served engine
@@ -80,6 +90,9 @@ model-card fix creates a new candidate and repeats the automated gate.
 
 ## Upgrade notes
 
+- All nodes in a cluster must run the same Skulk version before serving
+  workloads, and 1.5.0 changes wire behavior, so upgrade the whole fleet
+  together: 1.4.x and 1.5.0 nodes do not interoperate.
 - Fresh installs use Zenoh by default. Set `SKULK_ZENOH_DATA_PLANE=0` only for
   an explicit compatibility fallback.
 - Fresh served llama.cpp installations use 16 concurrent slots. Set


### PR DESCRIPTION
## Summary

Lands the content half of the 1.5.0 release ceremony on dev first, per the branch doctrine that every change reaches dev before the release branch: the 1.5.0 release-notes page finalization (release-candidate banner removed; dashboard-design and speech-prosody highlights added; whole-fleet same-version upgrade note recorded), sidebar-position shifts for older notes, and the README release-notes badge bump to v1.5.0.

After this merges, dev merges into release/1.5.0 so the promotion branch's only unique change is the CHANGELOG rollover, which mirrors onto dev post-promotion as with prior releases (the 1.4.2 pattern).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)