### PR TITLE
chore: bump dev to 1.5.1 after the 1.5.0 promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-08-07
+
 ### Changed
 
 - Redesigned the dashboard's dark mode around the Foxlight operator design

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skulk"
-version = "1.5.0"
+version = "1.5.1"
 description = "Skulk: distributed AI inference across heterogeneous clusters (Apple Silicon MLX, AMD Vulkan, and NVIDIA CUDA nodes)"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Dev resumes carrying the next working version (1.5.1) per the version doctrine, and the changelog mirrors the [1.5.0] - 2026-08-07 rollover so dev and main agree on released history. Same post-promotion ceremony as the 1.4.2 bump after 1.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)