### PR TITLE
Add bounded operator authority lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ If `nix fmt` changes any files, stage them before committing. The CI runs `nix f
 
 ### Node Composition
 A single Skulk `Node` (src/skulk/main.py) runs multiple components:
-- **Router**: libp2p-based pub/sub messaging via Rust bindings (`skulk_pyo3_bindings`). `TELEMETRY` uses bounded latest-value admission, a one-packet Python egress queue, and its own gossipsub protocol/handler queues; `ELECTION_MESSAGES` has a separate Python egress queue and isolated protocol/handler queues. `AUTHORITY_MESSAGES` has a distinct bounded Python egress queue and carries only signed public consensus metadata on the default authenticated gossipsub behavior. Ordinary Python control backlog cannot queue ahead of election or authority traffic, and telemetry pressure cannot consume election capacity. Election alone carries a temporary legacy-protocol copy. Peer discovery tries all mDNS addresses once, then slows link-local retries to one minute after another path connects; socket liveness requires three consecutive five-second ping failures. Live authenticated libp2p sessions are also recorded as `session=True` topology edges (refcounted per peer, seeded across worker recreation), keeping NAT'd/proxied remote members visible and placeable; placement host selection skips session edges, and advertised addresses that fail three consecutive probe sweeps back off to every sixth sweep while no-longer-advertised addresses still delete their edges (#662). Telemetry publishes that reach no subscribed peers are counted (`noPeerPublishes` in `GET /v1/diagnostics/telemetry`) and, sustained on a connected node, warn that the node will be invisible to membership (#660).
+- **Router**: libp2p-based pub/sub messaging via Rust bindings (`skulk_pyo3_bindings`). `TELEMETRY` uses bounded latest-value admission, a one-packet Python egress queue, and its own gossipsub protocol/handler queues; `ELECTION_MESSAGES` has a separate Python egress queue and isolated protocol/handler queues. `AUTHORITY_MESSAGES` has bounded producer admission plus a distinct bounded Python egress queue and carries only signed public consensus metadata on the default authenticated gossipsub behavior. Ordinary Python control backlog cannot queue ahead of election or authority traffic, and telemetry pressure cannot consume election capacity. Election alone carries a temporary legacy-protocol copy. Peer discovery tries all mDNS addresses once, then slows link-local retries to one minute after another path connects; socket liveness requires three consecutive five-second ping failures. Live authenticated libp2p sessions are also recorded as `session=True` topology edges (refcounted per peer, seeded across worker recreation), keeping NAT'd/proxied remote members visible and placeable; placement host selection skips session edges, and advertised addresses that fail three consecutive probe sweeps back off to every sixth sweep while no-longer-advertised addresses still delete their edges (#662). Telemetry publishes that reach no subscribed peers are counted (`noPeerPublishes` in `GET /v1/diagnostics/telemetry`) and, sustained on a connected node, warn that the node will be invisible to membership (#660).
 - **Worker**: Handles inference tasks, downloads models, manages runner processes
 - **Master**: Coordinates cluster state, places model instances across nodes; retained event-log replay is coalesced onto one asynchronously paced worker, and sustained idle-state event-log growth emits an operator warning
 - **Election**: Bully algorithm for master election, carried on the isolated election gossipsub behavior with duplicate candidate suppression during protocol migration
@@ -113,9 +113,11 @@ A single Skulk `Node` (src/skulk/main.py) runs multiple components:
   remains separate from event-sourced `State`, telemetry, diagnostics, and the
   public event log. Restart recovery reverifies the complete certificate and
   membership chain from immutable bootstrap anchors. The encrypted journal
-  requires an injected external data-key provider. Leader/retry orchestration,
-  secret payload replication, OS key wrapping, Node lifecycle integration, and
-  gateway fencing remain later slices.
+  requires an injected external data-key provider. A dormant bounded service
+  can drive one caller-selected proposal with deadlines, retries, accepted-value
+  recovery, local durable commit, and catch-up broadcast; it is not started by
+  `Node`. Authority leader selection, secret payload replication, OS key
+  wrapping, Node lifecycle integration, and gateway fencing remain later slices.
 
 ### Node Facts & capability derivation (#614)
 Detection creates capability; configuration overrides it; disagreement is
@@ -308,8 +310,9 @@ The system uses event sourcing for state management:
   - `model_cards.py`: declarative model cards, including optional advanced capability sections; machine-generated custom cards carry `generator_revision`, and a stamped card older than `CARD_GENERATOR_REVISION` loses override power against the bundled card for the same id (unstamped = hand-authored, keeps #652 override)
   - `capabilities.py`: normalized runtime capability profiles derived from model cards plus conservative family defaults
 - `src/skulk/operator/`: stable operator identity, deterministic quorum
-  certification, crash-fault consensus and recovery, separate public consensus
-  persistence, and encrypted authority persistence. Runtime libp2p `NodeId`
+  certification, crash-fault consensus and recovery, bounded dormant proposal
+  lifecycle, separate public consensus persistence, and encrypted authority
+  persistence. Runtime libp2p `NodeId`
   remains unsuitable for mobile history, device membership, or authorization
   subjects.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,8 @@ This starts a Vite dev server on port 3000 with hot reload. The dev server proxi
 - `src/skulk/worker/` — Worker node (inference, runner management, download coordination)
 - `src/skulk/store/` — Model store (registry, downloads, config, model optimizer)
 - `src/skulk/operator/` — Stable operator identity, quorum certification,
-  crash-fault consensus, and encrypted/public authority persistence. It is a
+  crash-fault consensus, bounded dormant proposal lifecycle, and
+  encrypted/public authority persistence. It is a
   separate security plane from event-sourced inference state; do not place its
   secrets or mutable authorization records in `State`, telemetry, diagnostics,
   or ordinary events.

--- a/src/skulk/operator/__init__.py
+++ b/src/skulk/operator/__init__.py
@@ -67,6 +67,16 @@ from skulk.operator.replication import (
     validate_authority_descriptor,
     verify_quorum_certificate,
 )
+from skulk.operator.service import (
+    AuthorityConsensusService,
+    AuthorityProposalBusyError,
+    AuthorityProposalConfigurationError,
+    AuthorityProposalUnavailableError,
+    AuthorityServiceDiagnostics,
+    AuthorityServiceError,
+    AuthorityServiceNotRunningError,
+    AuthorityTransitionRequest,
+)
 from skulk.operator.transport import AuthorityChannelTransport
 
 __all__ = [
@@ -90,6 +100,7 @@ __all__ = [
     "AuthorityConsensusNotInitializedError",
     "AuthorityConsensusParticipant",
     "AuthorityConsensusRepository",
+    "AuthorityConsensusService",
     "AuthorityConsensusSnapshot",
     "AuthorityConsensusState",
     "AuthorityEnvelopeError",
@@ -98,11 +109,18 @@ __all__ = [
     "AuthorityMembership",
     "AuthorityNetworkEnvelope",
     "AuthorityPrepareMessage",
+    "AuthorityProposalBusyError",
+    "AuthorityProposalConfigurationError",
+    "AuthorityProposalUnavailableError",
     "AuthorityPromiseMessage",
     "AuthorityQuorumCertificate",
     "AuthorityRecord",
     "AuthorityRejectedMessage",
+    "AuthorityServiceDiagnostics",
+    "AuthorityServiceError",
+    "AuthorityServiceNotRunningError",
     "AuthorityTransport",
+    "AuthorityTransitionRequest",
     "AuthorityVote",
     "AuthorityVoteCollector",
     "ClusterIdentityMaterial",

--- a/src/skulk/operator/consensus_store.py
+++ b/src/skulk/operator/consensus_store.py
@@ -224,9 +224,22 @@ class SqliteAuthorityConsensusRepository:
         connection.execute("PRAGMA journal_mode = WAL")
         connection.execute("PRAGMA synchronous = FULL")
         connection.execute("PRAGMA busy_timeout = 5000")
-        if os.name == "posix":
-            os.chmod(self._path, 0o600)
+        self._harden_database_files()
         return connection
+
+    def _harden_database_files(self) -> None:
+        """Repair database, WAL, and shared-memory sidecar permissions."""
+
+        if os.name != "posix":
+            return
+        for suffix in ("", "-wal", "-shm"):
+            candidate = Path(f"{self._path}{suffix}")
+            try:
+                os.chmod(candidate, 0o600)
+            except FileNotFoundError:
+                # SQLite creates and removes sidecars with connection lifetime.
+                # Missing files are normal; every later open re-runs this repair.
+                continue
 
     @staticmethod
     def _create_schema(connection: sqlite3.Connection) -> None:

--- a/src/skulk/operator/service.py
+++ b/src/skulk/operator/service.py
@@ -1,0 +1,592 @@
+# pyright: reportUnusedFunction=false
+"""Bounded runtime lifecycle for the dormant operator-authority protocol.
+
+The consensus types remain deterministic and storage-backed. This module adds
+the asynchronous machinery that receives participant messages and drives one
+serialized proposal at a time without exposing an API route or starting the
+service from :class:`skulk.main.Node`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Literal, final
+from uuid import UUID
+
+from anyio import Event, Lock, WouldBlock, create_task_group, move_on_after, sleep
+from loguru import logger
+from pydantic import Field, model_validator
+
+from skulk.operator.consensus import (
+    AuthorityAcceptedMessage,
+    AuthorityAcceptMessage,
+    AuthorityBallot,
+    AuthorityCommitMessage,
+    AuthorityCommittedEntry,
+    AuthorityConsensusError,
+    AuthorityConsensusParticipant,
+    AuthorityNetworkEnvelope,
+    AuthorityPrepareMessage,
+    AuthorityPromiseMessage,
+    AuthorityRejectedMessage,
+    AuthorityTransport,
+    AuthorityVoteCollector,
+)
+from skulk.operator.replication import (
+    AuthorityCertificateError,
+    AuthorityCommitDescriptor,
+    AuthorityMembership,
+    authority_membership_digest,
+)
+from skulk.utils.channels import channel
+from skulk.utils.pydantic_ext import FrozenModel
+
+_DEFAULT_RUNTIME_QUEUE_CAPACITY = 128
+_DEFAULT_PHASE_TIMEOUT_SECONDS = 2.0
+_DEFAULT_RETRY_BACKOFF_SECONDS = 0.05
+_DEFAULT_MAX_ATTEMPTS = 3
+
+
+class AuthorityServiceError(RuntimeError):
+    """Base class for fail-closed authority runtime failures."""
+
+
+class AuthorityServiceNotRunningError(AuthorityServiceError):
+    """Raised when a proposal is attempted outside the service lifecycle."""
+
+
+class AuthorityProposalBusyError(AuthorityServiceError):
+    """Raised when another local proposal already owns the single admission slot."""
+
+
+class AuthorityProposalUnavailableError(AuthorityServiceError):
+    """Raised when a proposal cannot reach a safe quorum within bounded retries."""
+
+
+class AuthorityProposalConfigurationError(AuthorityServiceError):
+    """Raised when authenticated voters reject the requested configuration."""
+
+
+@final
+class AuthorityTransitionRequest(FrozenModel):
+    """Non-secret semantic intent for one replicated authority transition."""
+
+    record_type: str = Field(
+        min_length=1,
+        max_length=80,
+        description="Bounded non-secret authority record type.",
+    )
+    record_id: str = Field(
+        min_length=1,
+        max_length=160,
+        description="Stable opaque record identity; never secret-bearing data.",
+    )
+    payload_digest: str = Field(
+        min_length=1,
+        description="Digest of the separately encrypted authority payload.",
+    )
+    memberships: tuple[AuthorityMembership, ...] | None = Field(
+        default=None,
+        min_length=1,
+        max_length=2,
+        description=(
+            "Explicit active or joint configurations, or null to use the "
+            "participant's current committed membership on each attempt."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _request_is_canonical(self) -> "AuthorityTransitionRequest":
+        """Reject ambiguous record types and unordered explicit memberships."""
+
+        if any(character.isspace() for character in self.record_type):
+            raise ValueError("record_type must not contain whitespace")
+        if self.memberships is not None:
+            ordered = tuple(
+                sorted(self.memberships, key=lambda membership: membership.generation)
+            )
+            if self.memberships != ordered:
+                raise ValueError("authority memberships must be generation ordered")
+        return self
+
+
+@final
+class AuthorityServiceDiagnostics(FrozenModel):
+    """Payload-free counters and queue depths for one authority runtime."""
+
+    running: bool = Field(description="Whether the single-use runtime is active.")
+    outbound_queue_depth: int = Field(
+        ge=0,
+        description="Signed envelopes awaiting transport delivery.",
+    )
+    response_queue_depth: int = Field(
+        ge=0,
+        description="Leader-side responses awaiting the active proposal.",
+    )
+    rejected_envelopes: int = Field(
+        ge=0,
+        description="Authenticated or routing-invalid envelopes rejected locally.",
+    )
+    dropped_outbound_envelopes: int = Field(
+        ge=0,
+        description="Responses dropped because bounded outbound admission was full.",
+    )
+    dropped_response_envelopes: int = Field(
+        ge=0,
+        description="Leader responses dropped because bounded admission was full.",
+    )
+    stale_response_envelopes: int = Field(
+        ge=0,
+        description="Late responses ignored after their proposal attempt ended.",
+    )
+    completed_proposals: int = Field(
+        ge=0,
+        description="Requested transitions committed by this runtime.",
+    )
+    failed_proposals: int = Field(
+        ge=0,
+        description="Locally admitted proposals that failed closed.",
+    )
+
+
+type _ProposalPhase = Literal["prepare", "accept"]
+
+
+class _RetryAuthorityRoundError(RuntimeError):
+    """Internal signal that a higher ballot or timeout requires another attempt."""
+
+
+@final
+class AuthorityConsensusService:
+    """Run one bounded authority participant and serialize local proposals.
+
+    The service is deliberately not wired into node startup yet. Production
+    activation depends on the later OS-protected key, encrypted payload, and
+    gateway-fencing slices. A caller must run :meth:`run` in a task group before
+    invoking :meth:`propose`.
+    """
+
+    def __init__(
+        self,
+        participant: AuthorityConsensusParticipant,
+        transport: AuthorityTransport,
+        *,
+        queue_capacity: int = _DEFAULT_RUNTIME_QUEUE_CAPACITY,
+        phase_timeout_seconds: float = _DEFAULT_PHASE_TIMEOUT_SECONDS,
+        retry_backoff_seconds: float = _DEFAULT_RETRY_BACKOFF_SECONDS,
+        max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+    ) -> None:
+        """Create a dormant authority runtime around injected effects.
+
+        Args:
+            participant: Storage-backed deterministic consensus participant.
+            transport: Signed-envelope delivery boundary.
+            queue_capacity: Maximum pending outbound and leader-response frames.
+            phase_timeout_seconds: Deadline for each prepare and accept phase.
+            retry_backoff_seconds: Base delay between failed ballot attempts.
+            max_attempts: Maximum ballot attempts before failing closed.
+
+        Raises:
+            ValueError: A bound or timeout is not positive.
+        """
+
+        if queue_capacity < 1:
+            raise ValueError("authority queue_capacity must be positive")
+        if phase_timeout_seconds <= 0:
+            raise ValueError("authority phase_timeout_seconds must be positive")
+        if retry_backoff_seconds < 0:
+            raise ValueError("authority retry_backoff_seconds cannot be negative")
+        if max_attempts < 1:
+            raise ValueError("authority max_attempts must be positive")
+        self._participant = participant
+        self._transport = transport
+        self._phase_timeout_seconds = phase_timeout_seconds
+        self._retry_backoff_seconds = retry_backoff_seconds
+        self._max_attempts = max_attempts
+        self._outbound_send, self._outbound_receive = channel[
+            AuthorityNetworkEnvelope
+        ](queue_capacity)
+        self._response_send, self._response_receive = channel[
+            AuthorityNetworkEnvelope
+        ](queue_capacity)
+        self._participant_lock = Lock()
+        self._proposal_lock = Lock()
+        self._started = Event()
+        self._running = False
+        self._has_run = False
+        self._rejected_envelopes = 0
+        self._dropped_outbound_envelopes = 0
+        self._dropped_response_envelopes = 0
+        self._stale_response_envelopes = 0
+        self._completed_proposals = 0
+        self._failed_proposals = 0
+
+    async def run(self) -> None:
+        """Receive, validate, and deliver authority messages until cancelled.
+
+        Raises:
+            RuntimeError: This single-use service is started more than once.
+        """
+
+        if self._has_run:
+            raise RuntimeError("authority consensus service is single-use")
+        self._has_run = True
+        self._running = True
+        self._started.set()
+        try:
+            async with create_task_group() as task_group:
+                task_group.start_soon(self._receive_loop)
+                task_group.start_soon(self._outbound_loop)
+        finally:
+            self._running = False
+
+    async def wait_started(self) -> None:
+        """Wait until :meth:`run` has entered its active lifecycle."""
+
+        await self._started.wait()
+
+    def diagnostics(self) -> AuthorityServiceDiagnostics:
+        """Return bounded operational counters without authority payload data."""
+
+        return AuthorityServiceDiagnostics(
+            running=self._running,
+            outbound_queue_depth=self._outbound_send.statistics().current_buffer_used,
+            response_queue_depth=self._response_send.statistics().current_buffer_used,
+            rejected_envelopes=self._rejected_envelopes,
+            dropped_outbound_envelopes=self._dropped_outbound_envelopes,
+            dropped_response_envelopes=self._dropped_response_envelopes,
+            stale_response_envelopes=self._stale_response_envelopes,
+            completed_proposals=self._completed_proposals,
+            failed_proposals=self._failed_proposals,
+        )
+
+    async def propose(
+        self,
+        request: AuthorityTransitionRequest,
+    ) -> AuthorityCommittedEntry:
+        """Commit one transition or fail closed after bounded retries.
+
+        A prior leader's accepted value may be recovered and committed first.
+        The service then advances to the next index and retries the caller's
+        semantic intent. Concurrent local proposals are rejected rather than
+        accumulated in an unbounded waiter queue.
+
+        Args:
+            request: Non-secret transition identity and payload digest.
+
+        Returns:
+            Certified entry that committed the requested semantic transition.
+
+        Raises:
+            AuthorityServiceNotRunningError: The runtime is not active.
+            AuthorityProposalBusyError: Another local proposal is active.
+            AuthorityProposalConfigurationError: Voters reject the membership.
+            AuthorityProposalUnavailableError: A safe quorum is unavailable.
+        """
+
+        if not self._running:
+            raise AuthorityServiceNotRunningError(
+                "authority consensus service is not running"
+            )
+        try:
+            self._proposal_lock.acquire_nowait()
+        except WouldBlock as exc:
+            raise AuthorityProposalBusyError(
+                "another authority proposal is already active"
+            ) from exc
+        try:
+            for attempt in range(self._max_attempts):
+                try:
+                    entry = await self._attempt(request)
+                except _RetryAuthorityRoundError:
+                    if attempt + 1 == self._max_attempts:
+                        raise AuthorityProposalUnavailableError(
+                            "authority proposal exhausted bounded retries"
+                        ) from None
+                    if self._retry_backoff_seconds > 0:
+                        await sleep(self._retry_backoff_seconds * (attempt + 1))
+                    continue
+                if self._entry_matches_request(entry, request):
+                    self._completed_proposals += 1
+                    return entry
+                if attempt + 1 == self._max_attempts:
+                    raise AuthorityProposalUnavailableError(
+                        "authority recovery consumed bounded proposal attempts"
+                    )
+            raise AssertionError("authority proposal attempts were not exhausted")
+        except AuthorityServiceError:
+            self._failed_proposals += 1
+            raise
+        except AuthorityConsensusError as exc:
+            self._failed_proposals += 1
+            raise AuthorityProposalUnavailableError(
+                "authority consensus rejected the local proposal"
+            ) from exc
+        finally:
+            self._proposal_lock.release()
+
+    async def _attempt(
+        self,
+        request: AuthorityTransitionRequest,
+    ) -> AuthorityCommittedEntry:
+        """Drive one prepare, accept, and local durable commit attempt."""
+
+        snapshot = self._participant.snapshot
+        state = snapshot.state
+        memberships = (
+            request.memberships
+            if request.memberships is not None
+            else (state.active_membership,)
+        )
+        promised_counter = (
+            state.promised_ballot.counter if state.promised_ballot is not None else 0
+        )
+        accepted_counter = (
+            state.accepted_ballot.counter if state.accepted_ballot is not None else 0
+        )
+        ballot = AuthorityBallot(
+            counter=max(
+                state.position.authority_term,
+                promised_counter,
+                accepted_counter,
+            )
+            + 1,
+            proposer_node_install_id=self._participant.node_install_id,
+        )
+        try:
+            descriptor = AuthorityCommitDescriptor(
+                cluster_id=state.position.cluster_id,
+                authority_term=ballot.counter,
+                commit_index=state.position.commit_index + 1,
+                previous_commit_digest=state.position.commit_digest,
+                record_type=request.record_type,
+                record_id=request.record_id,
+                payload_digest=request.payload_digest,
+                required_membership_digests=tuple(
+                    sorted(authority_membership_digest(item) for item in memberships)
+                ),
+            )
+            collector = AuthorityVoteCollector(
+                ballot,
+                descriptor,
+                memberships,
+                state.position,
+            )
+        except (AuthorityCertificateError, ValueError) as exc:
+            raise AuthorityProposalConfigurationError(
+                "authority transition does not match committed membership"
+            ) from exc
+        await self._send_phase(
+            collector.prepare_message(),
+            collector.prepare_targets,
+            collector,
+            "prepare",
+        )
+        accept_message = collector.accept_message()
+        await self._send_phase(
+            accept_message,
+            collector.accept_targets,
+            collector,
+            "accept",
+        )
+        entry = collector.committed_entry()
+        commit = AuthorityCommitMessage(
+            cluster_id=entry.certificate.descriptor.cluster_id,
+            request_id=collector.request_id,
+            entry=entry,
+        )
+        await self._commit_locally(commit)
+        self._broadcast_commit(commit, entry.memberships)
+        return entry
+
+    async def _send_phase(
+        self,
+        payload: AuthorityPrepareMessage | AuthorityAcceptMessage,
+        targets: frozenset[UUID],
+        collector: AuthorityVoteCollector,
+        phase: _ProposalPhase,
+    ) -> None:
+        """Address one phase to every voter and await its required quorums."""
+
+        for target in sorted(targets, key=lambda item: item.int):
+            envelope = self._participant.envelope_for(target, payload)
+            if target == self._participant.node_install_id:
+                responses = await self._handle_locally(envelope)
+                if len(responses) != 1:
+                    raise AuthorityProposalUnavailableError(
+                        "local authority voter returned an invalid response count"
+                    )
+                self._record_phase_response(collector, phase, responses[0])
+            else:
+                self._offer_outbound(envelope, required=True)
+        await self._await_phase_quorum(collector, phase)
+
+    async def _await_phase_quorum(
+        self,
+        collector: AuthorityVoteCollector,
+        phase: _ProposalPhase,
+    ) -> None:
+        """Collect only the active round until quorum or its deadline."""
+
+        ready = (
+            (lambda: collector.prepare_ready)
+            if phase == "prepare"
+            else (lambda: collector.accept_ready)
+        )
+        if ready():
+            return
+        with move_on_after(self._phase_timeout_seconds) as timeout_scope:
+            while not ready():
+                envelope = await self._response_receive.receive()
+                if envelope.payload.request_id != collector.request_id:
+                    self._stale_response_envelopes += 1
+                    continue
+                try:
+                    self._record_phase_response(collector, phase, envelope)
+                except AuthorityConsensusError:
+                    self._rejected_envelopes += 1
+                    continue
+                self._raise_for_rejection(collector)
+        if timeout_scope.cancel_called:
+            raise _RetryAuthorityRoundError
+
+    @staticmethod
+    def _record_phase_response(
+        collector: AuthorityVoteCollector,
+        phase: _ProposalPhase,
+        envelope: AuthorityNetworkEnvelope,
+    ) -> None:
+        """Record one phase-specific authenticated response."""
+
+        if phase == "prepare":
+            collector.record_prepare_response(envelope)
+        else:
+            collector.record_accept_response(envelope)
+
+    @staticmethod
+    def _raise_for_rejection(collector: AuthorityVoteCollector) -> None:
+        """Convert authenticated fail-closed responses into lifecycle decisions."""
+
+        for _, rejection in collector.rejections:
+            if rejection.code == "conflicting_accept":
+                raise AuthorityProposalConfigurationError(
+                    "authority voters rejected the requested configuration"
+                )
+            if rejection.code in {"stale_ballot", "stale_position"}:
+                raise _RetryAuthorityRoundError
+
+    async def _commit_locally(self, commit: AuthorityCommitMessage) -> None:
+        """Persist the certified entry on the proposer before reporting success."""
+
+        envelope = self._participant.envelope_for(
+            self._participant.node_install_id,
+            commit,
+        )
+        responses = await self._handle_locally(envelope)
+        if responses:
+            raise AuthorityProposalUnavailableError(
+                "local authority commit required unexpected catch-up"
+            )
+
+    def _broadcast_commit(
+        self,
+        commit: AuthorityCommitMessage,
+        memberships: tuple[AuthorityMembership, ...],
+    ) -> None:
+        """Offer a certified commit to every remote voter and learner."""
+
+        for target in self._member_union(memberships):
+            if target == self._participant.node_install_id:
+                continue
+            self._offer_outbound(
+                self._participant.envelope_for(target, commit),
+                required=False,
+            )
+
+    async def _handle_locally(
+        self,
+        envelope: AuthorityNetworkEnvelope,
+    ) -> tuple[AuthorityNetworkEnvelope, ...]:
+        """Serialize access to participant state shared with the receive loop."""
+
+        async with self._participant_lock:
+            return self._participant.handle(envelope)
+
+    async def _receive_loop(self) -> None:
+        """Route leader responses or handle participant messages indefinitely."""
+
+        while True:
+            envelope = await self._transport.receive()
+            if isinstance(
+                envelope.payload,
+                (
+                    AuthorityPromiseMessage,
+                    AuthorityAcceptedMessage,
+                    AuthorityRejectedMessage,
+                ),
+            ):
+                try:
+                    self._response_send.send_nowait(envelope)
+                except WouldBlock:
+                    self._dropped_response_envelopes += 1
+                continue
+            try:
+                responses = await self._handle_locally(envelope)
+            except AuthorityConsensusError as exc:
+                self._rejected_envelopes += 1
+                logger.warning(
+                    "Rejected operator authority envelope ({})",
+                    type(exc).__name__,
+                )
+                continue
+            for response in responses:
+                self._offer_outbound(response, required=False)
+
+    async def _outbound_loop(self) -> None:
+        """Drain bounded signed-envelope admission into the transport."""
+
+        with self._outbound_receive as outbound_envelopes:
+            async for envelope in outbound_envelopes:
+                await self._transport.send(envelope)
+
+    def _offer_outbound(
+        self,
+        envelope: AuthorityNetworkEnvelope,
+        *,
+        required: bool,
+    ) -> None:
+        """Admit one envelope without allowing producer-side growth."""
+
+        try:
+            self._outbound_send.send_nowait(envelope)
+        except WouldBlock as exc:
+            self._dropped_outbound_envelopes += 1
+            if required:
+                raise _RetryAuthorityRoundError from exc
+
+    @staticmethod
+    def _member_union(
+        memberships: Iterable[AuthorityMembership],
+    ) -> tuple[UUID, ...]:
+        """Return all configured voter and learner IDs in stable order."""
+
+        member_ids = {
+            UUID(str(member.node_install_id))
+            for membership in memberships
+            for member in membership.members
+        }
+        return tuple(sorted(member_ids, key=lambda member_id: member_id.int))
+
+    @staticmethod
+    def _entry_matches_request(
+        entry: AuthorityCommittedEntry,
+        request: AuthorityTransitionRequest,
+    ) -> bool:
+        """Return whether a recovered or new entry satisfies caller intent."""
+
+        descriptor = entry.certificate.descriptor
+        return (
+            descriptor.record_type == request.record_type
+            and descriptor.record_id == request.record_id
+            and descriptor.payload_digest == request.payload_digest
+        )

--- a/src/skulk/operator/tests/test_architecture_boundary.py
+++ b/src/skulk/operator/tests/test_architecture_boundary.py
@@ -10,6 +10,7 @@ import skulk.operator.consensus as consensus_module
 import skulk.operator.consensus_store as consensus_store_module
 import skulk.operator.identity as identity_module
 import skulk.operator.replication as replication_module
+import skulk.operator.service as service_module
 import skulk.operator.transport as transport_module
 
 
@@ -46,3 +47,29 @@ def test_operator_persistence_does_not_import_inference_or_logging_planes() -> N
                 or imported_module.startswith(f"{forbidden_import}.")
                 for forbidden_import in forbidden_imports
             )
+
+
+def test_operator_runtime_does_not_import_inference_state_planes() -> None:
+    """Authority lifecycle metadata cannot enter inference replication planes."""
+
+    forbidden_imports = (
+        "skulk.shared.types.events",
+        "skulk.shared.types.state",
+        "skulk.shared.types.telemetry",
+    )
+    syntax_tree = ast.parse(
+        Path(service_module.__file__).read_text(encoding="utf-8")
+    )
+    imported_modules: set[str] = set()
+    for node in ast.walk(syntax_tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.add(node.module)
+
+    for imported_module in imported_modules:
+        assert not any(
+            imported_module == forbidden_import
+            or imported_module.startswith(f"{forbidden_import}.")
+            for forbidden_import in forbidden_imports
+        )

--- a/src/skulk/operator/tests/test_consensus_store.py
+++ b/src/skulk/operator/tests/test_consensus_store.py
@@ -275,7 +275,7 @@ def test_restart_reverifies_persisted_certificate_signatures(tmp_path: Path) -> 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX permission semantics only")
 def test_repository_repairs_directory_and_database_permissions(tmp_path: Path) -> None:
-    """Every open repairs permissive authority metadata paths."""
+    """Every open repairs permissive authority metadata and sidecar paths."""
 
     directory = tmp_path / "operator"
     path = directory / "authority.sqlite3"
@@ -284,8 +284,19 @@ def test_repository_repairs_directory_and_database_permissions(tmp_path: Path) -
     repository.initialize(state)
     os.chmod(directory, 0o777)
     os.chmod(path, 0o666)
+    with sqlite3.connect(path) as sidecar_owner:
+        sidecar_owner.execute("PRAGMA journal_mode = WAL")
+        sidecar_owner.execute("BEGIN IMMEDIATE")
+        wal_path = Path(f"{path}-wal")
+        shared_memory_path = Path(f"{path}-shm")
+        assert wal_path.exists()
+        assert shared_memory_path.exists()
+        os.chmod(wal_path, 0o666)
+        os.chmod(shared_memory_path, 0o666)
 
-    repository.load()
+        repository.load()
 
-    assert stat.S_IMODE(directory.stat().st_mode) == 0o700
-    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(wal_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(shared_memory_path.stat().st_mode) == 0o600

--- a/src/skulk/operator/tests/test_service.py
+++ b/src/skulk/operator/tests/test_service.py
@@ -1,0 +1,421 @@
+"""Lifecycle and failure tests for the bounded authority consensus service."""
+
+from __future__ import annotations
+
+from typing import final
+from uuid import UUID, uuid4
+
+import anyio
+import pytest
+from anyio.abc import TaskGroup
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from skulk.operator.consensus import (
+    AuthorityBallot,
+    AuthorityCommittedEntry,
+    AuthorityConsensusConflictError,
+    AuthorityConsensusParticipant,
+    AuthorityConsensusRepository,
+    AuthorityConsensusSnapshot,
+    AuthorityConsensusState,
+    AuthorityNetworkEnvelope,
+    AuthorityVoteCollector,
+)
+from skulk.operator.identity import create_cluster_identity
+from skulk.operator.replication import (
+    AuthorityCommitDescriptor,
+    AuthorityMember,
+    AuthorityMembership,
+    authority_bootstrap_position,
+    authority_membership_digest,
+    authority_payload_digest,
+    create_authority_member,
+)
+from skulk.operator.service import (
+    AuthorityConsensusService,
+    AuthorityProposalBusyError,
+    AuthorityProposalUnavailableError,
+    AuthorityServiceNotRunningError,
+    AuthorityTransitionRequest,
+)
+from skulk.utils.channels import Receiver, Sender, channel
+
+
+@final
+class _MemoryConsensusRepository(AuthorityConsensusRepository):
+    """Revisioned in-memory repository used by asynchronous lifecycle tests."""
+
+    def __init__(self, state: AuthorityConsensusState) -> None:
+        self._snapshot = AuthorityConsensusSnapshot(revision=0, state=state)
+
+    def load(self) -> AuthorityConsensusSnapshot:
+        """Return the latest immutable snapshot."""
+
+        return self._snapshot
+
+    def compare_and_set(
+        self,
+        expected_revision: int,
+        state: AuthorityConsensusState,
+    ) -> AuthorityConsensusSnapshot:
+        """Persist one revision or report a simulated concurrent transition."""
+
+        if self._snapshot.revision != expected_revision:
+            raise AuthorityConsensusConflictError("test repository CAS conflict")
+        self._snapshot = AuthorityConsensusSnapshot(
+            revision=expected_revision + 1,
+            state=state,
+        )
+        return self._snapshot
+
+
+@final
+class _MemoryAuthorityTransport:
+    """One node's endpoint on a bounded in-memory authority network."""
+
+    def __init__(self, node_install_id: UUID, network: "_MemoryAuthorityNetwork"):
+        self._node_install_id = node_install_id
+        self._network = network
+
+    async def send(self, envelope: AuthorityNetworkEnvelope) -> None:
+        """Deliver one envelope through the shared deterministic network."""
+
+        if UUID(str(envelope.source_node_install_id)) != self._node_install_id:
+            raise ValueError("test transport cannot send for another member")
+        await self._network.send(envelope)
+
+    async def receive(self) -> AuthorityNetworkEnvelope:
+        """Return the next envelope addressed to this endpoint."""
+
+        return await self._network.receive(self._node_install_id)
+
+
+@final
+class _MemoryAuthorityNetwork:
+    """Bounded test network with explicit node and one-shot frame loss controls."""
+
+    def __init__(self, member_ids: tuple[UUID, ...]) -> None:
+        endpoints = {
+            member_id: channel[AuthorityNetworkEnvelope](256)
+            for member_id in member_ids
+        }
+        self._senders: dict[UUID, Sender[AuthorityNetworkEnvelope]] = {
+            member_id: endpoint[0] for member_id, endpoint in endpoints.items()
+        }
+        self._receivers: dict[UUID, Receiver[AuthorityNetworkEnvelope]] = {
+            member_id: endpoint[1] for member_id, endpoint in endpoints.items()
+        }
+        self._blocked_nodes: set[UUID] = set()
+        self._drop_once: set[tuple[str, UUID]] = set()
+
+    def transport(self, member_id: UUID) -> _MemoryAuthorityTransport:
+        """Return one stable member's transport endpoint."""
+
+        return _MemoryAuthorityTransport(member_id, self)
+
+    def block(self, member_id: UUID) -> None:
+        """Drop every frame to and from one simulated unavailable member."""
+
+        self._blocked_nodes.add(member_id)
+
+    def drop_once(self, kind: str, target: UUID) -> None:
+        """Drop the next matching payload kind sent to one member."""
+
+        self._drop_once.add((kind, target))
+
+    async def send(self, envelope: AuthorityNetworkEnvelope) -> None:
+        """Apply fault rules, then deliver one frame to its bounded endpoint."""
+
+        source = UUID(str(envelope.source_node_install_id))
+        target = UUID(str(envelope.target_node_install_id))
+        if source in self._blocked_nodes or target in self._blocked_nodes:
+            return
+        drop_key = (envelope.payload.kind, target)
+        if drop_key in self._drop_once:
+            self._drop_once.remove(drop_key)
+            return
+        await self._senders[target].send(envelope)
+
+    async def receive(self, member_id: UUID) -> AuthorityNetworkEnvelope:
+        """Return one frame from the selected member's endpoint."""
+
+        return await self._receivers[member_id].receive()
+
+
+@final
+class _ServiceHarness:
+    """Create matching participants, services, and an in-memory network."""
+
+    def __init__(
+        self,
+        voter_count: int,
+        *,
+        phase_timeout_seconds: float = 0.05,
+        max_attempts: int = 3,
+    ) -> None:
+        identity = create_cluster_identity("Service Test").public_identity
+        position = authority_bootstrap_position(identity)
+        keys: dict[UUID, bytes] = {}
+        members: list[AuthorityMember] = []
+        for _ in range(voter_count):
+            member_id = uuid4()
+            private_key = _private_key()
+            keys[member_id] = private_key
+            members.append(create_authority_member(member_id, private_key))
+        self.membership = AuthorityMembership(generation=1, members=tuple(members))
+        self.keys = keys
+        self.member_ids = tuple(keys)
+        self.repositories = {
+            member_id: _MemoryConsensusRepository(
+                AuthorityConsensusState.bootstrap(position, self.membership)
+            )
+            for member_id in self.member_ids
+        }
+        self.participants = {
+            member_id: AuthorityConsensusParticipant(
+                member_id,
+                keys[member_id],
+                self.repositories[member_id],
+            )
+            for member_id in self.member_ids
+        }
+        self.network = _MemoryAuthorityNetwork(self.member_ids)
+        self.services = {
+            member_id: AuthorityConsensusService(
+                self.participants[member_id],
+                self.network.transport(member_id),
+                phase_timeout_seconds=phase_timeout_seconds,
+                retry_backoff_seconds=0,
+                max_attempts=max_attempts,
+            )
+            for member_id in self.member_ids
+        }
+
+    def request(self, record_id: str) -> AuthorityTransitionRequest:
+        """Return one valid semantic transition against current membership."""
+
+        return AuthorityTransitionRequest(
+            record_type="device",
+            record_id=record_id,
+            payload_digest=authority_payload_digest({"recordId": record_id}),
+        )
+
+    async def start(
+        self,
+        task_group: TaskGroup,
+        *member_ids: UUID,
+    ) -> None:
+        """Start selected services and wait for their receive loops."""
+
+        selected = member_ids if member_ids else self.member_ids
+        for member_id in selected:
+            task_group.start_soon(self.services[member_id].run)
+        for member_id in selected:
+            await self.services[member_id].wait_started()
+
+
+def _private_key() -> bytes:
+    """Return one raw Ed25519 key for an authority test member."""
+
+    return Ed25519PrivateKey.generate().private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+async def _wait_for_commit_index(
+    harness: _ServiceHarness,
+    member_id: UUID,
+    commit_index: int,
+) -> None:
+    """Wait briefly for an asynchronously broadcast commit or catch-up page."""
+
+    with anyio.fail_after(1):
+        while (
+            harness.repositories[member_id].load().state.position.commit_index
+            < commit_index
+        ):
+            await anyio.sleep(0)
+
+
+async def test_proposal_requires_active_service() -> None:
+    """A dormant service cannot mutate consensus state through its API."""
+
+    harness = _ServiceHarness(1)
+    member_id = harness.member_ids[0]
+
+    with pytest.raises(AuthorityServiceNotRunningError):
+        await harness.services[member_id].propose(harness.request("device-1"))
+    assert harness.repositories[member_id].load().state.position.commit_index == 1
+
+
+async def test_one_voter_service_commits_durably() -> None:
+    """The single-voter profile uses the full lifecycle without network peers."""
+
+    harness = _ServiceHarness(1)
+    member_id = harness.member_ids[0]
+    entry: AuthorityCommittedEntry | None = None
+
+    async with anyio.create_task_group() as task_group:
+        await harness.start(task_group)
+        entry = await harness.services[member_id].propose(
+            harness.request("device-1")
+        )
+        task_group.cancel_scope.cancel()
+
+    assert entry is not None
+    assert entry.certificate.descriptor.commit_index == 2
+    assert entry.certificate.descriptor.record_id == "device-1"
+    assert harness.repositories[member_id].load().state.position.commit_index == 2
+    diagnostics = harness.services[member_id].diagnostics()
+    assert diagnostics.completed_proposals == 1
+    assert diagnostics.failed_proposals == 0
+    assert not diagnostics.running
+
+
+async def test_three_voters_commit_with_one_unavailable_member() -> None:
+    """A three-voter authority makes progress with one crash-faulted voter."""
+
+    harness = _ServiceHarness(3)
+    leader_id, follower_id, unavailable_id = harness.member_ids
+    harness.network.block(unavailable_id)
+    entry: AuthorityCommittedEntry | None = None
+
+    async with anyio.create_task_group() as task_group:
+        await harness.start(task_group, leader_id, follower_id)
+        entry = await harness.services[leader_id].propose(harness.request("device-1"))
+        await _wait_for_commit_index(harness, follower_id, 2)
+        task_group.cancel_scope.cancel()
+
+    assert entry is not None
+    assert entry.certificate.descriptor.commit_index == 2
+    assert harness.repositories[leader_id].load().state.position.commit_index == 2
+    assert harness.repositories[follower_id].load().state.position.commit_index == 2
+    assert harness.repositories[unavailable_id].load().state.position.commit_index == 1
+
+
+async def test_two_voters_fail_closed_when_one_is_unavailable() -> None:
+    """The two-voter profile cannot imply failover when either voter is lost."""
+
+    harness = _ServiceHarness(2, phase_timeout_seconds=0.01, max_attempts=2)
+    leader_id, unavailable_id = harness.member_ids
+    harness.network.block(unavailable_id)
+
+    async with anyio.create_task_group() as task_group:
+        await harness.start(task_group, leader_id)
+        with pytest.raises(AuthorityProposalUnavailableError):
+            await harness.services[leader_id].propose(harness.request("blocked"))
+        task_group.cancel_scope.cancel()
+
+    assert harness.repositories[leader_id].load().state.position.commit_index == 1
+    assert harness.services[leader_id].diagnostics().failed_proposals == 1
+
+
+async def test_commit_gap_triggers_bounded_catch_up_through_service() -> None:
+    """A replica missing one commit catches up when it observes the next index."""
+
+    harness = _ServiceHarness(3)
+    leader_id, _, lagging_id = harness.member_ids
+    harness.network.drop_once("commit", lagging_id)
+
+    async with anyio.create_task_group() as task_group:
+        await harness.start(task_group)
+        await harness.services[leader_id].propose(harness.request("device-1"))
+        assert harness.repositories[lagging_id].load().state.position.commit_index == 1
+
+        await harness.services[leader_id].propose(harness.request("device-2"))
+        await _wait_for_commit_index(harness, lagging_id, 3)
+        task_group.cancel_scope.cancel()
+
+    lagging_state = harness.repositories[lagging_id].load().state
+    assert lagging_state.position.commit_index == 3
+    assert tuple(
+        entry.certificate.descriptor.record_id
+        for entry in lagging_state.committed_entries
+    ) == ("device-1", "device-2")
+
+
+async def test_new_proposer_recovers_accepted_value_before_its_request() -> None:
+    """Leader replacement commits accepted history before advancing its intent."""
+
+    harness = _ServiceHarness(3)
+    first_leader, replacement_leader, third_voter = harness.member_ids
+    position = harness.repositories[first_leader].load().state.position
+    descriptor = AuthorityCommitDescriptor(
+        cluster_id=position.cluster_id,
+        authority_term=2,
+        commit_index=2,
+        previous_commit_digest=position.commit_digest,
+        record_type="device",
+        record_id="must-survive",
+        payload_digest=authority_payload_digest({"recordId": "must-survive"}),
+        required_membership_digests=(
+            authority_membership_digest(harness.membership),
+        ),
+    )
+    interrupted = AuthorityVoteCollector(
+        AuthorityBallot(
+            counter=2,
+            proposer_node_install_id=first_leader,
+        ),
+        descriptor,
+        (harness.membership,),
+        position,
+    )
+    prepare = interrupted.prepare_message()
+    for target in (first_leader, replacement_leader):
+        response = harness.participants[target].handle(
+            harness.participants[first_leader].envelope_for(target, prepare)
+        )
+        interrupted.record_prepare_response(response[0])
+    accept = interrupted.accept_message()
+    for target in (first_leader, replacement_leader):
+        response = harness.participants[target].handle(
+            harness.participants[first_leader].envelope_for(target, accept)
+        )
+        interrupted.record_accept_response(response[0])
+    assert interrupted.accept_ready
+    requested: AuthorityCommittedEntry | None = None
+
+    async with anyio.create_task_group() as task_group:
+        await harness.start(task_group)
+        requested = await harness.services[replacement_leader].propose(
+            harness.request("replacement-intent")
+        )
+        await _wait_for_commit_index(harness, third_voter, 3)
+        task_group.cancel_scope.cancel()
+
+    assert requested is not None
+    assert requested.certificate.descriptor.record_id == "replacement-intent"
+    replacement_state = harness.repositories[replacement_leader].load().state
+    assert tuple(
+        entry.certificate.descriptor.record_id
+        for entry in replacement_state.committed_entries
+    ) == ("must-survive", "replacement-intent")
+
+
+async def test_concurrent_local_proposal_is_rejected_without_queueing() -> None:
+    """Only one local proposal is admitted while a quorum attempt is active."""
+
+    harness = _ServiceHarness(2, phase_timeout_seconds=0.1, max_attempts=1)
+    leader_id, unavailable_id = harness.member_ids
+    harness.network.block(unavailable_id)
+    first_finished = anyio.Event()
+
+    async def first_proposal() -> None:
+        """Hold the proposal slot until the intentionally missing quorum times out."""
+
+        with pytest.raises(AuthorityProposalUnavailableError):
+            await harness.services[leader_id].propose(harness.request("first"))
+        first_finished.set()
+
+    async with anyio.create_task_group() as task_group:
+        await harness.start(task_group, leader_id)
+        task_group.start_soon(first_proposal)
+        await anyio.sleep(0)
+        with pytest.raises(AuthorityProposalBusyError):
+            await harness.services[leader_id].propose(harness.request("second"))
+        await first_finished.wait()
+        task_group.cancel_scope.cancel()

--- a/src/skulk/routing/router.py
+++ b/src/skulk/routing/router.py
@@ -659,12 +659,22 @@ class Router:
                 ),
             )
         else:
+            if topic.topic == VISION_MEDIA.topic:
+                producer_buffer_size = 0
+            elif topic.topic == AUTHORITY_MESSAGES.topic:
+                # Authority admission must be bounded before serialization as
+                # well as after it. Otherwise callers can fill TopicRouter's
+                # producer queue without limit while the dedicated egress
+                # queue is correctly applying backpressure downstream.
+                producer_buffer_size = _AUTHORITY_OUTBOUND_BUFFER
+            else:
+                producer_buffer_size = inf
             router = TopicRouter[T](
                 topic,
                 send,
                 # Vision producer admission is a rendezvous: packet retention
                 # lives only in the bounded, observable egress/stream queues.
-                max_buffer_size=0 if topic.topic == VISION_MEDIA.topic else inf,
+                max_buffer_size=producer_buffer_size,
                 local_routing_key=local_routing_key,
                 data_plane_egress_observer=(
                     self._vision_media_egress_observer

--- a/src/skulk/routing/tests/test_zenoh_routing.py
+++ b/src/skulk/routing/tests/test_zenoh_routing.py
@@ -384,6 +384,10 @@ async def test_authority_egress_uses_a_dedicated_bounded_channel() -> None:
         authority_router.networking_sender.statistics().max_buffer_size
         == _AUTHORITY_OUTBOUND_BUFFER
     )
+    assert (
+        authority_router.receiver.statistics().max_buffer_size
+        == _AUTHORITY_OUTBOUND_BUFFER
+    )
 
 
 def test_data_owner_key_addresses_owning_node() -> None:

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -99,7 +99,7 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 - **Lives in:** `src/skulk/operator/identity.py`,
   `src/skulk/operator/authority.py`, `src/skulk/operator/replication.py`,
   `src/skulk/operator/consensus.py`, `src/skulk/operator/consensus_store.py`,
-  and `src/skulk/operator/transport.py`; focused tests live in
+  `src/skulk/operator/service.py`, and `src/skulk/operator/transport.py`; focused tests live in
   `src/skulk/operator/tests/`.
 - **Stable node identity:** `NodeInstallationIdentity.node_install_id` is a
   persisted UUIDv4 under the protected operator configuration directory. It is
@@ -137,21 +137,29 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   anchors permit every restart to reverify the complete signature, quorum,
   digest, index, and membership chain. Writes use revisioned compare-and-set in
   one SQLite transaction; secret authority payloads and keys are not accepted.
+- **Dormant runtime:** `AuthorityConsensusService` serializes local proposal
+  admission, drives prepare/accept/commit with phase deadlines and bounded
+  retries, recovers a previously accepted value before advancing caller intent,
+  and keeps outbound and response queues bounded. It persists the local commit
+  before success and broadcasts the certificate to voters and learners. Runtime
+  diagnostics expose payload-free queue depths and counters.
 - **Network boundary:** `AUTHORITY_MESSAGES` carries Ed25519-signed envelopes
   binding stable source and target installation IDs, message ID, and one typed
-  public protocol payload. It has a dedicated bounded Python egress queue and
-  currently rides the default authenticated libp2p gossipsub behavior.
+  public protocol payload. Producer admission and the dedicated Python egress
+  queue are both bounded, and traffic currently rides the default authenticated
+  libp2p gossipsub behavior.
   `AuthorityChannelTransport` discards broadcasts for other targets before
-  consensus. The topic is registered, but no authority service lifecycle or API
-  authorization consumer starts in this slice.
+  consensus. The topic is registered, but neither the dormant authority service
+  nor an API authorization consumer starts from `Node` in this slice.
 - **Key boundary:** `AuthorityKeyProvider` supplies the active unwrapped 32-byte
   data key and immutable key-version ID. Production OS-wrapping providers and
   replicated key envelopes are later S1 slices; this store never writes the
   plaintext data key itself.
-- **Critical boundary:** deterministic network vote collection and certified
-  log recovery are implemented, but leader selection/retry orchestration,
-  encrypted payload replication, OS-protected key wrapping, gateway leases,
-  and Node lifecycle integration are later slices. No remotely authenticated
+- **Critical boundary:** deterministic network vote collection, certified log
+  recovery, and caller-selected bounded proposal orchestration are implemented,
+  but authority leader selection, encrypted payload replication, OS-protected
+  key wrapping, gateway leases, and Node lifecycle integration are later slices.
+  No remotely authenticated
   request may treat an uncertified local SQLite commit as a distributed
   authorization decision. None of these records enters `State`, telemetry,
   diagnostics, or the API event log.

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -927,14 +927,24 @@ state in a separate SQLite WAL database. Promise and accepted state, immutable
 bootstrap anchors, and an append-only certificate log commit atomically through
 compare-and-set revisions. On every load the repository re-verifies the full
 signature, quorum, digest, index, and membership chain from bootstrap; it never
-stores secret-bearing payloads or encryption keys.
+stores secret-bearing payloads or encryption keys. Every open also repairs the
+database, WAL, and shared-memory sidecar modes on POSIX.
 `src/skulk/operator/transport.py` filters the broadcast authority topic by
 stable target identity before a participant sees it.
 
-Leader selection and retry scheduling, encrypted authority-payload replication,
-OS-protected key wrapping, gateway fencing leases, and Node lifecycle
-orchestration remain later slices. The registered `AUTHORITY_MESSAGES` topic and
-deterministic participant do not authorize any API route by themselves.
+`src/skulk/operator/service.py` provides a still-dormant asynchronous lifecycle
+around that deterministic participant. It admits one local proposal at a time,
+uses bounded outbound and response queues, applies explicit phase deadlines and
+bounded retries, recovers a prior proposer's accepted value before advancing the
+caller's intent, persists the local certificate before reporting success, and
+broadcasts commits to voters and learners for bounded catch-up. Its diagnostics
+contain queue depths and counters only. Authority producer admission is bounded
+both before serialization and in the dedicated network egress queue.
+
+Authority leader selection, encrypted authority-payload replication,
+OS-protected key wrapping, gateway fencing leases, and Node startup integration
+remain later slices. The registered `AUTHORITY_MESSAGES` topic, participant, and
+dormant service do not authorize any API route by themselves.
 Operator identity and authorization records never enter `State`, telemetry,
 diagnostics, or the public event log.
 


### PR DESCRIPTION
## Summary

- add a dormant `AuthorityConsensusService` that serializes local proposal admission, drives prepare/accept/commit with explicit deadlines and bounded retries, and recovers accepted values before advancing caller intent
- bound authority producer admission before serialization as well as in dedicated network egress, expose payload-free lifecycle diagnostics, and harden SQLite WAL/shared-memory sidecar permissions
- cover one-, two-, and three-voter behavior, quorum loss, leader replacement, bounded catch-up, concurrent admission, security-plane isolation, and public architecture documentation

## Boundary

- starts no authority service from `Node` and adds no HTTP or WebSocket route
- authorizes no dashboard, app, gateway, relay, pairing, credential, or command traffic
- replicates public consensus metadata only; encrypted authority payload replication, OS-protected key wrapping, authority leader selection, gateway fencing, and node lifecycle integration remain later slices
- uses only local deterministic and in-memory fault validation; no fleet or cluster was touched

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` — 3,144 passed, 1 skipped, 231 deselected
