### PR TITLE
Add host-authorized operator pairing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,11 +113,15 @@ A single Skulk `Node` (src/skulk/main.py) runs multiple components:
   remains separate from event-sourced `State`, telemetry, diagnostics, and the
   public event log. Restart recovery reverifies the complete certificate and
   membership chain from immutable bootstrap anchors. The encrypted journal
-  requires an injected external data-key provider. A dormant bounded service
+  requires an injected external data-key provider. The v1 designated gateway
+  uses a protected local-file provider and `skulk operator pair` to create a
+  five-minute QR capability; the API exposes only device-key challenge and
+  exchange before authentication, returning one-time opaque access/refresh
+  credentials while persisting encrypted state and token digests. A dormant bounded service
   can drive one caller-selected proposal with deadlines, retries, accepted-value
   recovery, local durable commit, and catch-up broadcast; it is not started by
   `Node`. Authority leader selection, secret payload replication, OS key
-  wrapping, Node lifecycle integration, and gateway fencing remain later slices.
+  wrapping, automatic gateway failover, and gateway fencing remain later slices.
 
 ### Node Facts & capability derivation (#614)
 Detection creates capability; configuration overrides it; disagreement is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,10 @@ This starts a Vite dev server on port 3000 with hot reload. The dev server proxi
 - `src/skulk/store/` — Model store (registry, downloads, config, model optimizer)
 - `src/skulk/operator/` — Stable operator identity, quorum certification,
   crash-fault consensus, bounded dormant proposal lifecycle, and
-  encrypted/public authority persistence. It is a
+  encrypted/public authority persistence. It also owns the designated-gateway
+  local key provider, `skulk operator pair` command, and single-use device
+  pairing state machine; the matching pre-credential FastAPI routes live in
+  `src/skulk/api/operator_auth.py`. It is a
   separate security plane from event-sourced inference state; do not place its
   secrets or mutable authorization records in `State`, telemetry, diagnostics,
   or ordinary events.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ dependencies = [
   # This is a direct production dependency: secret storage must not rely on a
   # transitive dependency accidentally keeping cryptography installed.
   "cryptography>=46.0.3",
+  # Local operator pairing renders a terminal QR without requiring a browser.
+  "qrcode>=8.2",
   "webrtcvad-wheels>=2.0.14,<3",
   # Platform-conditional HARD dependency (#614): nothing optional may be
   # load-bearing. Without this binding an NVIDIA node silently loses VRAM

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -106,6 +106,7 @@ from skulk.api.node_health import (
     live_data_transports,
     live_skulk_build_mismatch,
 )
+from skulk.api.operator_auth import create_operator_auth_router
 from skulk.api.performance_envelope import (
     ClusterPerformanceEnvelopes,
     GenerationOutcome,
@@ -266,6 +267,7 @@ from skulk.master.placement_utils import (
     unified_memory_gpu_node_ids,
     usable_vram_by_node,
 )
+from skulk.operator.pairing import OperatorPairingService
 from skulk.routing.provider_streams import ProviderStreamPacket
 from skulk.routing.realtime_audio import RealtimeAudioPacket
 from skulk.routing.speech_media import SpeechMediaPacket
@@ -1061,6 +1063,10 @@ API_TAGS_METADATA = [
         "name": "Admin",
         "description": "Administrative operations such as node restart.",
     },
+    {
+        "name": "Authentication",
+        "description": "Host-authorized device pairing and operator credential lifecycle.",
+    },
 ]
 
 
@@ -1234,6 +1240,7 @@ class API:
         ) = None,
         extensions: LoadedExtensions | None = None,
         enable_builtin_providers: bool = False,
+        operator_pairing_service: OperatorPairingService | None = None,
     ) -> None:
         self.state = State()
         # External extensions remain optional. Production nodes prepend
@@ -1412,6 +1419,10 @@ class API:
         self._setup_exception_handlers()
         self._setup_cors()
         self._setup_routes()
+        if operator_pairing_service is not None:
+            self.app.include_router(
+                create_operator_auth_router(operator_pairing_service)
+            )
 
         # A headless/worker node may have no built dashboard assets
         # (DASHBOARD_DIR is None); serving the UI is then skipped so the node

--- a/src/skulk/api/operator_auth.py
+++ b/src/skulk/api/operator_auth.py
@@ -31,7 +31,7 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
     router = APIRouter(prefix="/v1/auth", tags=["Authentication"])
 
     @router.post(
-        "/pairing-sessions/{nonce}/challenge",
+        "/pairing-sessions/challenge",
         response_model=PairingChallengeResponse,
         summary="Bind a device key to a local pairing session",
         description=(
@@ -41,13 +41,12 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
         ),
     )
     def create_pairing_challenge(
-        nonce: str,
         request: PairingChallengeRequest,
     ) -> PairingChallengeResponse:
         """Create one device proof challenge for a pending pairing session."""
 
         try:
-            return service.create_challenge(nonce, request)
+            return service.create_challenge(request)
         except PairingGatewayNotInitializedError as exc:
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         except PairingSessionNotFoundError as exc:
@@ -60,7 +59,7 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     @router.post(
-        "/pairing-sessions/{nonce}/exchange",
+        "/pairing-sessions/exchange",
         response_model=PairingExchangeResponse,
         summary="Exchange a device-key proof for operator credentials",
         description=(
@@ -70,13 +69,12 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
         ),
     )
     def exchange_pairing_proof(
-        nonce: str,
         request: PairingExchangeRequest,
     ) -> PairingExchangeResponse:
         """Verify a candidate device and consume its pairing capability."""
 
         try:
-            return service.exchange(nonce, request)
+            return service.exchange(request)
         except PairingGatewayNotInitializedError as exc:
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         except PairingSessionNotFoundError as exc:

--- a/src/skulk/api/operator_auth.py
+++ b/src/skulk/api/operator_auth.py
@@ -1,0 +1,91 @@
+# pyright: reportUnusedFunction=false
+"""FastAPI routes for host-authorized Skulk device pairing."""
+
+from fastapi import APIRouter, HTTPException
+
+from skulk.operator.pairing import (
+    OperatorPairingService,
+    PairingChallengeRequest,
+    PairingChallengeResponse,
+    PairingExchangeRequest,
+    PairingExchangeResponse,
+    PairingGatewayNotInitializedError,
+    PairingProofError,
+    PairingSessionExpiredError,
+    PairingSessionNotFoundError,
+    PairingSessionStateError,
+)
+
+
+def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
+    """Create narrowly scoped pairing routes for one designated gateway.
+
+    Args:
+        service: Encrypted local pairing service owned by the API node.
+
+    Returns:
+        Router exposing only challenge and credential exchange before
+        authentication. General Skulk APIs are not added to this router.
+    """
+
+    router = APIRouter(prefix="/v1/auth", tags=["Authentication"])
+
+    @router.post(
+        "/pairing-sessions/{nonce}/challenge",
+        response_model=PairingChallengeResponse,
+        summary="Bind a device key to a local pairing session",
+        description=(
+            "Accept a candidate Ed25519 public key only when the nonce names an "
+            "unexpired host-created pairing session, then return one random "
+            "challenge for proof of possession."
+        ),
+    )
+    def create_pairing_challenge(
+        nonce: str,
+        request: PairingChallengeRequest,
+    ) -> PairingChallengeResponse:
+        """Create one device proof challenge for a pending pairing session."""
+
+        try:
+            return service.create_challenge(nonce, request)
+        except PairingGatewayNotInitializedError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        except PairingSessionNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except PairingSessionExpiredError as exc:
+            raise HTTPException(status_code=410, detail=str(exc)) from exc
+        except PairingSessionStateError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except PairingProofError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    @router.post(
+        "/pairing-sessions/{nonce}/exchange",
+        response_model=PairingExchangeResponse,
+        summary="Exchange a device-key proof for operator credentials",
+        description=(
+            "Verify the candidate device's Ed25519 signature, consume the "
+            "single-use session, and return short-lived access plus rotating "
+            "refresh credentials exactly once."
+        ),
+    )
+    def exchange_pairing_proof(
+        nonce: str,
+        request: PairingExchangeRequest,
+    ) -> PairingExchangeResponse:
+        """Verify a candidate device and consume its pairing capability."""
+
+        try:
+            return service.exchange(nonce, request)
+        except PairingGatewayNotInitializedError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        except PairingSessionNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except PairingSessionExpiredError as exc:
+            raise HTTPException(status_code=410, detail=str(exc)) from exc
+        except PairingSessionStateError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except PairingProofError as exc:
+            raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+    return router

--- a/src/skulk/api/tests/test_operator_auth.py
+++ b/src/skulk/api/tests/test_operator_auth.py
@@ -47,8 +47,12 @@ def test_pairing_routes_issue_credentials_and_reject_reuse(tmp_path: Path) -> No
     client = TestClient(app)
 
     challenge_response = client.post(
-        f"/v1/auth/pairing-sessions/{package.nonce}/challenge",
-        json={"deviceName": "Test phone", "devicePublicKey": _base64url(public_key)},
+        "/v1/auth/pairing-sessions/challenge",
+        json={
+            "nonce": package.nonce,
+            "deviceName": "Test phone",
+            "devicePublicKey": _base64url(public_key),
+        },
     )
     assert challenge_response.status_code == 200
     challenge_body = cast(dict[str, object], challenge_response.json())
@@ -62,8 +66,8 @@ def test_pairing_routes_issue_credentials_and_reject_reuse(tmp_path: Path) -> No
     )
 
     exchange_response = client.post(
-        f"/v1/auth/pairing-sessions/{package.nonce}/exchange",
-        json={"signature": _base64url(signature)},
+        "/v1/auth/pairing-sessions/exchange",
+        json={"nonce": package.nonce, "signature": _base64url(signature)},
     )
     assert exchange_response.status_code == 200
     exchange_body = cast(dict[str, object], exchange_response.json())
@@ -71,8 +75,8 @@ def test_pairing_routes_issue_credentials_and_reject_reuse(tmp_path: Path) -> No
     assert isinstance(exchange_body["refreshToken"], str)
 
     reused_response = client.post(
-        f"/v1/auth/pairing-sessions/{package.nonce}/exchange",
-        json={"signature": _base64url(signature)},
+        "/v1/auth/pairing-sessions/exchange",
+        json={"nonce": package.nonce, "signature": _base64url(signature)},
     )
     assert reused_response.status_code == 409
 
@@ -89,5 +93,5 @@ def test_pairing_routes_are_present_in_openapi(tmp_path: Path) -> None:
     app.include_router(create_operator_auth_router(service))
 
     paths = cast(dict[str, object], app.openapi()["paths"])
-    assert "/v1/auth/pairing-sessions/{nonce}/challenge" in paths
-    assert "/v1/auth/pairing-sessions/{nonce}/exchange" in paths
+    assert "/v1/auth/pairing-sessions/challenge" in paths
+    assert "/v1/auth/pairing-sessions/exchange" in paths

--- a/src/skulk/api/tests/test_operator_auth.py
+++ b/src/skulk/api/tests/test_operator_auth.py
@@ -1,0 +1,93 @@
+"""HTTP contract tests for host-authorized operator pairing."""
+
+import base64
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+from uuid import UUID
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from skulk.api.operator_auth import create_operator_auth_router
+from skulk.operator.authority import EncryptedAuthorityStore
+from skulk.operator.key_provider import LocalFileAuthorityKeyProvider
+from skulk.operator.pairing import (
+    OperatorPairingService,
+    pairing_signature_message,
+)
+
+
+def _base64url(value: bytes) -> str:
+    """Encode bytes for pairing JSON payloads."""
+
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def test_pairing_routes_issue_credentials_and_reject_reuse(tmp_path: Path) -> None:
+    """The HTTP path mirrors the single-use service state machine."""
+
+    now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "key.bin")
+    service = OperatorPairingService(
+        EncryptedAuthorityStore(provider, tmp_path / "authority.sqlite3"),
+        provider,
+        now=lambda: now,
+    )
+    package = service.create_session(exchange_url="https://example.invalid")
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    app = FastAPI()
+    app.include_router(create_operator_auth_router(service))
+    client = TestClient(app)
+
+    challenge_response = client.post(
+        f"/v1/auth/pairing-sessions/{package.nonce}/challenge",
+        json={"deviceName": "Test phone", "devicePublicKey": _base64url(public_key)},
+    )
+    assert challenge_response.status_code == 200
+    challenge_body = cast(dict[str, object], challenge_response.json())
+    challenge = str(challenge_body["challenge"])
+    signature = private_key.sign(
+        pairing_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            nonce=package.nonce,
+            challenge=challenge,
+        )
+    )
+
+    exchange_response = client.post(
+        f"/v1/auth/pairing-sessions/{package.nonce}/exchange",
+        json={"signature": _base64url(signature)},
+    )
+    assert exchange_response.status_code == 200
+    exchange_body = cast(dict[str, object], exchange_response.json())
+    assert isinstance(exchange_body["accessToken"], str)
+    assert isinstance(exchange_body["refreshToken"], str)
+
+    reused_response = client.post(
+        f"/v1/auth/pairing-sessions/{package.nonce}/exchange",
+        json={"signature": _base64url(signature)},
+    )
+    assert reused_response.status_code == 409
+
+
+def test_pairing_routes_are_present_in_openapi(tmp_path: Path) -> None:
+    """Both HTTP operations remain visible in the generated API contract."""
+
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "key.bin")
+    service = OperatorPairingService(
+        EncryptedAuthorityStore(provider, tmp_path / "authority.sqlite3"),
+        provider,
+    )
+    app = FastAPI()
+    app.include_router(create_operator_auth_router(service))
+
+    paths = cast(dict[str, object], app.openapi()["paths"])
+    assert "/v1/auth/pairing-sessions/{nonce}/challenge" in paths
+    assert "/v1/auth/pairing-sessions/{nonce}/exchange" in paths

--- a/src/skulk/main.py
+++ b/src/skulk/main.py
@@ -30,6 +30,7 @@ from skulk.download.coordinator import DownloadCoordinator
 from skulk.download.impl_shard_downloader import skulk_shard_downloader
 from skulk.extensions import load_extensions
 from skulk.master.main import Master
+from skulk.operator.pairing import OperatorPairingService
 from skulk.routing.event_router import EventRouter
 from skulk.routing.router import Router, TelemetrySender, get_node_id_keypair
 from skulk.routing.zenoh_status import ZenohPeerSampler
@@ -711,6 +712,7 @@ class Node:
                 # by the API and delegate to the existing core runtimes.
                 extensions=load_extensions(),
                 enable_builtin_providers=True,
+                operator_pairing_service=OperatorPairingService.from_default_paths(),
             )
         else:
             api = None
@@ -1316,6 +1318,11 @@ class Node:
 
 
 def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "operator":
+        # Operator commands are local administration and never launch a node.
+        from skulk.operator.cli import main as operator_main
+
+        sys.exit(operator_main(sys.argv[2:]))
     if len(sys.argv) > 1 and sys.argv[1] == "doctor":
         # `skulk doctor` is a standalone audit, not a node launch: dispatch
         # before Args.parse() so the node argument parser never sees it.

--- a/src/skulk/operator/authority.py
+++ b/src/skulk/operator/authority.py
@@ -382,6 +382,7 @@ class EncryptedAuthorityStore:
         self,
         *,
         expected_commit_index: int,
+        expected_record_commit_index: int | None = None,
         authority_term: int,
         record_type: str,
         record_id: str,
@@ -391,6 +392,9 @@ class EncryptedAuthorityStore:
 
         Args:
             expected_commit_index: Last commit index observed by the caller.
+            expected_record_commit_index: Last commit index observed for this
+                logical record. When supplied, the append also fails if that
+                record changed independently of unrelated journal activity.
             authority_term: Consensus term that authorized this append.
             record_type: Bounded non-secret semantic record type.
             record_id: Bounded non-secret opaque record identity.
@@ -417,6 +421,7 @@ class EncryptedAuthorityStore:
                 connection,
                 cluster_id=UUID(str(cluster_identity.cluster_id)),
                 expected_commit_index=expected_commit_index,
+                expected_record_commit_index=expected_record_commit_index,
                 authority_term=authority_term,
                 record_type=record_type,
                 record_id=record_id,
@@ -472,9 +477,31 @@ class EncryptedAuthorityStore:
             AuthorityIntegrityError: Authenticated decryption or validation fails.
         """
 
+        _, payload = self.read_latest_record_payload(record_type, record_id)
+        return payload
+
+    def read_latest_record_payload(
+        self,
+        record_type: str,
+        record_id: str,
+    ) -> tuple[AuthorityRecord, dict[str, object]]:
+        """Read one logical record's metadata and payload atomically.
+
+        Args:
+            record_type: Exact record type.
+            record_id: Exact record identity.
+
+        Returns:
+            Public metadata and decrypted payload from the same journal row.
+
+        Raises:
+            AuthorityNotInitializedError: No matching record exists.
+            AuthorityIntegrityError: Authenticated decryption or validation fails.
+        """
+
         self._validate_record_identity(record_type, record_id)
         cluster_identity = self.cluster_identity()
-        return self._read_latest_payload_for_identity(
+        return self._read_latest_record_payload_for_identity(
             cluster_identity,
             record_type,
             record_id,
@@ -487,6 +514,21 @@ class EncryptedAuthorityStore:
         record_id: str,
     ) -> dict[str, object]:
         """Decrypt one record using already-validated identity metadata."""
+
+        _, payload = self._read_latest_record_payload_for_identity(
+            cluster_identity,
+            record_type,
+            record_id,
+        )
+        return payload
+
+    def _read_latest_record_payload_for_identity(
+        self,
+        cluster_identity: ClusterPublicIdentity,
+        record_type: str,
+        record_id: str,
+    ) -> tuple[AuthorityRecord, dict[str, object]]:
+        """Decrypt one record and retain metadata from the same selected row."""
 
         with closing(self._connect_existing()) as connection:
             row = self._fetch_one(
@@ -544,7 +586,17 @@ class EncryptedAuthorityStore:
                     "authority record must contain string object keys"
                 )
             result[key_name] = value
-        return result
+        record = self._record_from_row(
+            (
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[7],
+            )
+        )
+        return record, result
 
     def _insert_encrypted_record(
         self,
@@ -552,6 +604,7 @@ class EncryptedAuthorityStore:
         *,
         cluster_id: UUID,
         expected_commit_index: int,
+        expected_record_commit_index: int | None = None,
         authority_term: int,
         record_type: str,
         record_id: str,
@@ -565,6 +618,16 @@ class EncryptedAuthorityStore:
             raise AuthorityCommitConflictError(
                 "authority commit index changed before append"
             )
+        if expected_record_commit_index is not None:
+            latest_record_index = self._latest_record_commit_index(
+                connection,
+                record_type=record_type,
+                record_id=record_id,
+            )
+            if latest_record_index != expected_record_commit_index:
+                raise AuthorityCommitConflictError(
+                    "authority record changed before append"
+                )
         commit_index = current_index + 1
         key_id = self._key_provider.active_key_id
         key = self._load_data_key(key_id=key_id)
@@ -710,6 +773,32 @@ class EncryptedAuthorityStore:
         if row is None:
             return 0
         return EncryptedAuthorityStore._required_int(row[0], "commit_index")
+
+    @staticmethod
+    def _latest_record_commit_index(
+        connection: sqlite3.Connection,
+        *,
+        record_type: str,
+        record_id: str,
+    ) -> int:
+        """Return the newest commit index for one logical record, or zero."""
+
+        row = EncryptedAuthorityStore._fetch_one(
+            connection.execute(
+                """
+                SELECT COALESCE(MAX(commit_index), 0)
+                FROM authority_journal
+                WHERE record_type = ? AND record_id = ?
+                """,
+                (record_type, record_id),
+            )
+        )
+        if row is None:
+            return 0
+        return EncryptedAuthorityStore._required_int(
+            row[0],
+            "record commit index",
+        )
 
     @staticmethod
     def _validate_record_identity(record_type: str, record_id: str) -> None:

--- a/src/skulk/operator/cli.py
+++ b/src/skulk/operator/cli.py
@@ -50,7 +50,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     pair_parser.add_argument(
         "--exchange-url",
         required=True,
-        help="Direct or relayed HTTP(S) base URL the phone can reach.",
+        help="HTTPS base URL the phone can reach; HTTP is accepted only on loopback.",
     )
     pair_parser.add_argument(
         "--cluster-name",

--- a/src/skulk/operator/cli.py
+++ b/src/skulk/operator/cli.py
@@ -1,0 +1,77 @@
+"""Local operator commands for designating and pairing a Skulk gateway."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from typing import Literal
+
+from skulk.operator.pairing import OperatorPairingService
+from skulk.utils.pydantic_ext import FrozenModel
+
+
+class _PairArguments(FrozenModel):
+    """Strictly validated local pairing command arguments."""
+
+    command: Literal["pair"]
+    exchange_url: str
+    cluster_name: str
+
+
+def _print_pairing_qr(payload: str) -> None:
+    """Render a terminal QR code plus the exact fallback payload."""
+
+    import qrcode
+
+    code = qrcode.QRCode(border=2)
+    code.add_data(payload)
+    code.make(fit=True)
+    code.print_ascii(invert=True)
+    print(payload)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the local `skulk operator` command group.
+
+    Args:
+        argv: Arguments after the `operator` token. Defaults to process args.
+
+    Returns:
+        Conventional process exit status.
+    """
+
+    parser = argparse.ArgumentParser(prog="skulk operator")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    pair_parser = subparsers.add_parser(
+        "pair",
+        help="Create a five-minute host-authorized phone pairing QR code.",
+    )
+    pair_parser.add_argument(
+        "--exchange-url",
+        required=True,
+        help="Direct or relayed HTTP(S) base URL the phone can reach.",
+    )
+    pair_parser.add_argument(
+        "--cluster-name",
+        default="Cluster",
+        help="Initial cluster name when designating a gateway for the first time.",
+    )
+    parsed = parser.parse_args(list(argv) if argv is not None else None)
+    arguments = _PairArguments.model_validate(vars(parsed))
+    service = OperatorPairingService.from_default_paths()
+    package = service.create_session(
+        exchange_url=arguments.exchange_url,
+        cluster_name=arguments.cluster_name,
+    )
+    print(
+        f"Pair with {package.cluster_name} before "
+        f"{package.expires_at.isoformat()}."
+    )
+    print(f"Cluster fingerprint: {package.cluster_fingerprint}")
+    _print_pairing_qr(package.as_url())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/skulk/operator/key_provider.py
+++ b/src/skulk/operator/key_provider.py
@@ -1,0 +1,134 @@
+"""Protected local key provider for the single-gateway operator authority."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Final, final
+from uuid import uuid4
+
+from skulk.shared.constants import SKULK_CONFIG_HOME
+
+_LOCAL_KEY_ID: Final = "local-gateway-v1"
+_DATA_KEY_BYTES: Final = 32
+
+
+class AuthorityKeyUnavailableError(RuntimeError):
+    """Raised when the designated gateway has no usable local authority key."""
+
+
+@final
+class LocalFileAuthorityKeyProvider:
+    """Load one random authority data key from a protected local file.
+
+    This provider is the explicit v1 availability tradeoff: the designated
+    gateway owns its authority key and remote access is unavailable if that
+    host is unavailable. POSIX ownership and mode ``0600`` protect the key at
+    rest. Hardware-backed wrapping remains post-v1 hardening.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        """Create a provider for the default or explicitly supplied key path.
+
+        Args:
+            path: Key file used by the designated gateway. Tests may inject a
+                temporary path.
+        """
+
+        self._path = (
+            path
+            if path is not None
+            else SKULK_CONFIG_HOME / "operator" / "authority-key-v1.bin"
+        )
+
+    @property
+    def active_key_id(self) -> str:
+        """Return the stable identifier for the v1 local gateway key."""
+
+        return _LOCAL_KEY_ID
+
+    @property
+    def path(self) -> Path:
+        """Return the authority key file path."""
+
+        return self._path
+
+    def ensure_data_key(self) -> bytes:
+        """Load the local data key or create it atomically with mode ``0600``.
+
+        Returns:
+            The 32-byte authority data key.
+
+        Side effects:
+            Creates and fsyncs the protected operator directory and key file on
+            first use.
+        """
+
+        self._ensure_parent()
+        if self._path.exists():
+            return self.load_data_key(_LOCAL_KEY_ID)
+
+        key = os.urandom(_DATA_KEY_BYTES)
+        temporary_path = self._path.with_name(f".{self._path.name}.{uuid4().hex}.tmp")
+        try:
+            descriptor = os.open(
+                temporary_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            with os.fdopen(descriptor, "wb", closefd=True) as stream:
+                stream.write(key)
+                stream.flush()
+                os.fsync(stream.fileno())
+            try:
+                os.link(temporary_path, self._path)
+            except FileExistsError:
+                return self.load_data_key(_LOCAL_KEY_ID)
+            if os.name == "posix":
+                self._path.chmod(0o600)
+                parent_descriptor = os.open(self._path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(parent_descriptor)
+                finally:
+                    os.close(parent_descriptor)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+        return key
+
+    def load_data_key(self, key_id: str) -> bytes:
+        """Load the active local authority data key.
+
+        Args:
+            key_id: Persisted key identifier. Only the active v1 identifier is
+                accepted.
+
+        Returns:
+            The validated 32-byte authority data key.
+
+        Raises:
+            AuthorityKeyUnavailableError: The key is absent, has the wrong ID,
+                has unsafe POSIX permissions, or has invalid length.
+        """
+
+        if key_id != _LOCAL_KEY_ID:
+            raise AuthorityKeyUnavailableError("authority key version is unavailable")
+        try:
+            key = self._path.read_bytes()
+        except FileNotFoundError as exc:
+            raise AuthorityKeyUnavailableError(
+                "operator gateway is not initialized; run `skulk operator pair`"
+            ) from exc
+        if len(key) != _DATA_KEY_BYTES:
+            raise AuthorityKeyUnavailableError("operator authority key is malformed")
+        if os.name == "posix" and self._path.stat().st_mode & 0o077:
+            raise AuthorityKeyUnavailableError(
+                "operator authority key permissions must not grant group or other access"
+            )
+        return key
+
+    def _ensure_parent(self) -> None:
+        """Create and harden the authority key directory."""
+
+        self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if os.name == "posix":
+            self._path.parent.chmod(0o700)

--- a/src/skulk/operator/pairing.py
+++ b/src/skulk/operator/pairing.py
@@ -8,6 +8,7 @@ import json
 import secrets
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
+from ipaddress import ip_address
 from typing import Literal, cast, final
 from uuid import UUID, uuid4
 
@@ -97,6 +98,28 @@ class PairingPackage(FrozenModel):
             raise ValueError("expires_at must include a timezone")
         return value
 
+    @field_validator("exchange_url")
+    @classmethod
+    def _exchange_url_protects_remote_credentials(
+        cls,
+        value: AnyHttpUrl,
+    ) -> AnyHttpUrl:
+        """Require HTTPS except for explicitly local development URLs."""
+
+        if value.scheme == "https":
+            return value
+        if value.host is None:
+            raise ValueError("pairing exchange_url must include a host")
+        host = value.host.strip("[]")
+        if host == "localhost":
+            return value
+        try:
+            if ip_address(host).is_loopback:
+                return value
+        except ValueError:
+            pass
+        raise ValueError("remote pairing exchange_url must use HTTPS")
+
     def as_url(self) -> str:
         """Return the package as a compact custom-scheme QR payload."""
 
@@ -109,6 +132,11 @@ class PairingPackage(FrozenModel):
 class PairingChallengeRequest(FrozenModel):
     """Candidate device identity submitted before credential exchange."""
 
+    nonce: str = Field(
+        min_length=32,
+        max_length=128,
+        description="High-entropy single-use capability from the pairing QR.",
+    )
     device_name: str = Field(
         min_length=1,
         max_length=80,
@@ -143,6 +171,11 @@ class PairingChallengeResponse(FrozenModel):
 class PairingExchangeRequest(FrozenModel):
     """Device proof completing a pending pairing session."""
 
+    nonce: str = Field(
+        min_length=32,
+        max_length=128,
+        description="High-entropy single-use capability from the pairing QR.",
+    )
     signature: str = Field(
         min_length=80,
         max_length=100,
@@ -335,14 +368,12 @@ class OperatorPairingService:
 
     def create_challenge(
         self,
-        nonce: str,
         request: PairingChallengeRequest,
     ) -> PairingChallengeResponse:
         """Bind a candidate device key and issue one random challenge.
 
         Args:
-            nonce: Single-use pairing capability from the QR package.
-            request: Candidate device name and public key.
+            request: Pairing capability, candidate device name, and public key.
 
         Returns:
             Challenge that expires with the pairing session.
@@ -355,7 +386,7 @@ class OperatorPairingService:
         """
 
         self._decode_device_public_key(request.device_public_key)
-        nonce_hash = _opaque_digest(nonce)
+        nonce_hash = _opaque_digest(request.nonce)
         session, session_commit_index = self._load_session(nonce_hash)
         self._require_pending(session)
         challenge = _base64url_encode(secrets.token_bytes(32))
@@ -379,14 +410,12 @@ class OperatorPairingService:
 
     def exchange(
         self,
-        nonce: str,
         request: PairingExchangeRequest,
     ) -> PairingExchangeResponse:
         """Verify device-key possession and consume one pairing session.
 
         Args:
-            nonce: Single-use pairing capability from the QR package.
-            request: Ed25519 proof over the issued challenge.
+            request: Pairing capability and Ed25519 proof over the issued challenge.
 
         Returns:
             One-time access and refresh credentials.
@@ -397,7 +426,7 @@ class OperatorPairingService:
             PairingSessionExpiredError: The session expired.
         """
 
-        nonce_hash = _opaque_digest(nonce)
+        nonce_hash = _opaque_digest(request.nonce)
         session, session_commit_index = self._load_session(nonce_hash)
         self._require_unexpired(session)
         if (
@@ -416,7 +445,7 @@ class OperatorPairingService:
                 signature,
                 pairing_signature_message(
                     cluster_id=UUID(str(self._store.cluster_identity().cluster_id)),
-                    nonce=nonce,
+                    nonce=request.nonce,
                     challenge=session.challenge,
                 ),
             )

--- a/src/skulk/operator/pairing.py
+++ b/src/skulk/operator/pairing.py
@@ -1,0 +1,532 @@
+"""Single-use host-authorized pairing for one designated Skulk gateway."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+from collections.abc import Callable, Mapping
+from datetime import datetime, timedelta, timezone
+from typing import Literal, cast, final
+from uuid import UUID, uuid4
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from pydantic import AnyHttpUrl, Field, field_validator
+
+from skulk.operator.authority import (
+    AuthorityCommitConflictError,
+    AuthorityNotInitializedError,
+    EncryptedAuthorityStore,
+)
+from skulk.operator.identity import ClusterPublicIdentity, create_cluster_identity
+from skulk.operator.key_provider import LocalFileAuthorityKeyProvider
+from skulk.utils.pydantic_ext import FrozenModel
+
+_PAIRING_RECORD_TYPE = "operator_pairing_session"
+_PAIRING_LIFETIME = timedelta(minutes=5)
+_ACCESS_TOKEN_LIFETIME = timedelta(minutes=15)
+_REFRESH_TOKEN_LIFETIME = timedelta(days=30)
+_PAIRING_SIGNATURE_CONTEXT = b"skulk-device-pairing-v1\x00"
+
+type OperatorScope = Literal[
+    "cluster:read",
+    "models:read",
+    "chat:write",
+    "operations:write",
+]
+
+_DEFAULT_SCOPES: tuple[OperatorScope, ...] = (
+    "cluster:read",
+    "models:read",
+    "chat:write",
+    "operations:write",
+)
+
+
+class PairingError(RuntimeError):
+    """Base class for safe pairing failures."""
+
+
+class PairingSessionNotFoundError(PairingError):
+    """Raised when a pairing nonce does not name a pending session."""
+
+
+class PairingSessionExpiredError(PairingError):
+    """Raised when a pairing session has passed its five-minute lifetime."""
+
+
+class PairingSessionStateError(PairingError):
+    """Raised when a pairing transition is repeated or out of order."""
+
+
+class PairingProofError(PairingError):
+    """Raised when a device cannot prove possession of its proposed key."""
+
+
+class PairingGatewayNotInitializedError(PairingError):
+    """Raised when this API node has not been designated through local pairing."""
+
+
+class PairingPackage(FrozenModel):
+    """Short-lived public package encoded in a Skulk pairing QR code."""
+
+    version: Literal[1] = Field(description="Pairing package format version.")
+    cluster_id: UUID = Field(description="Stable identity of the target cluster.")
+    cluster_name: str = Field(description="Operator-visible cluster name.")
+    cluster_fingerprint: str = Field(
+        description="Display fingerprint of the cluster identity key."
+    )
+    exchange_url: AnyHttpUrl = Field(
+        description="Direct or relayed URL serving the pairing exchange."
+    )
+    expires_at: datetime = Field(description="UTC expiry of the pairing package.")
+    nonce: str = Field(
+        min_length=32,
+        max_length=128,
+        description="High-entropy single-use pairing capability.",
+    )
+
+    @field_validator("expires_at")
+    @classmethod
+    def _expiry_is_timezone_aware(cls, value: datetime) -> datetime:
+        """Reject ambiguous package expiries."""
+
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("expires_at must include a timezone")
+        return value
+
+    def as_url(self) -> str:
+        """Return the package as a compact custom-scheme QR payload."""
+
+        encoded = _base64url_encode(
+            self.model_dump_json(by_alias=True).encode("utf-8")
+        )
+        return f"skulk://pair?payload={encoded}"
+
+
+class PairingChallengeRequest(FrozenModel):
+    """Candidate device identity submitted before credential exchange."""
+
+    device_name: str = Field(
+        min_length=1,
+        max_length=80,
+        description="Operator-visible name of the candidate device.",
+    )
+    device_public_key: str = Field(
+        min_length=40,
+        max_length=64,
+        description="Unpadded URL-safe base64 Ed25519 device public key.",
+    )
+
+    @field_validator("device_name")
+    @classmethod
+    def _normalize_device_name(cls, value: str) -> str:
+        """Normalize device names while rejecting whitespace-only input."""
+
+        normalized = " ".join(value.split())
+        if not normalized:
+            raise ValueError("device_name must not be blank")
+        return normalized
+
+
+class PairingChallengeResponse(FrozenModel):
+    """Cluster challenge that the candidate device must sign."""
+
+    challenge: str = Field(
+        description="Unpadded URL-safe base64 random challenge."
+    )
+    expires_at: datetime = Field(description="UTC expiry inherited from the session.")
+
+
+class PairingExchangeRequest(FrozenModel):
+    """Device proof completing a pending pairing session."""
+
+    signature: str = Field(
+        min_length=80,
+        max_length=100,
+        description="Ed25519 signature over the domain-separated pairing challenge.",
+    )
+
+
+class PairingExchangeResponse(FrozenModel):
+    """One-time credential response returned after successful pairing."""
+
+    device_id: UUID = Field(description="Stable identifier assigned to the device.")
+    cluster: ClusterPublicIdentity = Field(
+        description="Validated cluster identity bound to the credential."
+    )
+    access_token: str = Field(
+        description="Opaque short-lived bearer credential returned only once."
+    )
+    access_token_expires_at: datetime = Field(
+        description="UTC expiry of the access credential."
+    )
+    refresh_token: str = Field(
+        description="Opaque rotating refresh credential returned only once."
+    )
+    refresh_token_expires_at: datetime = Field(
+        description="UTC expiry of the refresh credential."
+    )
+    scopes: tuple[OperatorScope, ...] = Field(
+        description="Canonical API scopes granted to the paired device."
+    )
+
+
+class _StoredPairingSession(FrozenModel):
+    """Encrypted durable state for one pairing capability and resulting device."""
+
+    state: Literal["pending", "challenged", "consumed", "revoked"]
+    nonce_hash: str
+    created_at: datetime
+    expires_at: datetime
+    exchange_url: str
+    device_name: str | None = None
+    device_public_key: str | None = None
+    challenge: str | None = None
+    device_id: UUID | None = None
+    access_token_hash: str | None = None
+    access_token_expires_at: datetime | None = None
+    refresh_token_hash: str | None = None
+    refresh_token_expires_at: datetime | None = None
+    scopes: tuple[OperatorScope, ...] = ()
+
+
+def _utc_now() -> datetime:
+    """Return the current timezone-aware UTC time."""
+
+    return datetime.now(tz=timezone.utc)
+
+
+def _base64url_encode(value: bytes) -> str:
+    """Encode bytes as unpadded URL-safe base64."""
+
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _base64url_decode(value: str) -> bytes:
+    """Decode strict unpadded URL-safe base64."""
+
+    padding = "=" * (-len(value) % 4)
+    return base64.b64decode(
+        f"{value}{padding}",
+        altchars=b"-_",
+        validate=True,
+    )
+
+
+def _opaque_digest(value: str) -> str:
+    """Return a non-reversible identifier for a bearer value."""
+
+    return _base64url_encode(hashlib.sha256(value.encode("ascii")).digest())
+
+
+def pairing_signature_message(
+    *,
+    cluster_id: UUID,
+    nonce: str,
+    challenge: str,
+) -> bytes:
+    """Build the exact message a candidate device signs during pairing.
+
+    Args:
+        cluster_id: Target cluster identity from the QR package.
+        nonce: Single-use pairing capability from the QR package.
+        challenge: Random challenge returned by the gateway.
+
+    Returns:
+        Domain-separated bytes suitable for Ed25519 signing.
+    """
+
+    return (
+        _PAIRING_SIGNATURE_CONTEXT
+        + str(cluster_id).encode("ascii")
+        + b"\x00"
+        + nonce.encode("ascii")
+        + b"\x00"
+        + challenge.encode("ascii")
+    )
+
+
+@final
+class OperatorPairingService:
+    """Persist and validate pairing sessions on one designated gateway."""
+
+    def __init__(
+        self,
+        store: EncryptedAuthorityStore,
+        key_provider: LocalFileAuthorityKeyProvider,
+        *,
+        now: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        """Create a pairing service with injected persistence and time.
+
+        Args:
+            store: Encrypted local authority journal.
+            key_provider: Local data-key provider used only during explicit
+                gateway initialization.
+            now: Time provider for deterministic expiry tests.
+        """
+
+        self._store = store
+        self._key_provider = key_provider
+        self._now = now
+
+    @classmethod
+    def from_default_paths(cls) -> "OperatorPairingService":
+        """Create the production service for the designated gateway paths."""
+
+        key_provider = LocalFileAuthorityKeyProvider()
+        return cls(EncryptedAuthorityStore(key_provider), key_provider)
+
+    def create_session(
+        self,
+        *,
+        exchange_url: str,
+        cluster_name: str = "Cluster",
+    ) -> PairingPackage:
+        """Create one host-authorized five-minute pairing package.
+
+        Args:
+            exchange_url: Direct or relayed base URL reachable by the phone.
+            cluster_name: Name used only when initializing a new gateway.
+
+        Returns:
+            Public package safe to render as a QR code.
+        """
+
+        if self._store.path.exists():
+            self._key_provider.load_data_key(self._key_provider.active_key_id)
+        else:
+            self._key_provider.ensure_data_key()
+        try:
+            identity = self._store.cluster_identity()
+        except AuthorityNotInitializedError:
+            material = create_cluster_identity(cluster_name)
+            self._store.initialize_cluster(
+                material.public_identity,
+                material.private_key,
+            )
+            identity = material.public_identity
+
+        now = self._now()
+        nonce = secrets.token_urlsafe(32)
+        nonce_hash = _opaque_digest(nonce)
+        expires_at = now + _PAIRING_LIFETIME
+        package = PairingPackage(
+            version=1,
+            cluster_id=UUID(str(identity.cluster_id)),
+            cluster_name=identity.name,
+            cluster_fingerprint=identity.fingerprint,
+            exchange_url=AnyHttpUrl(exchange_url),
+            expires_at=expires_at,
+            nonce=nonce,
+        )
+        session = _StoredPairingSession(
+            state="pending",
+            nonce_hash=nonce_hash,
+            created_at=now,
+            expires_at=expires_at,
+            exchange_url=str(package.exchange_url),
+        )
+        self._append_session(nonce_hash, session)
+        return package
+
+    def create_challenge(
+        self,
+        nonce: str,
+        request: PairingChallengeRequest,
+    ) -> PairingChallengeResponse:
+        """Bind a candidate device key and issue one random challenge.
+
+        Args:
+            nonce: Single-use pairing capability from the QR package.
+            request: Candidate device name and public key.
+
+        Returns:
+            Challenge that expires with the pairing session.
+
+        Raises:
+            PairingSessionNotFoundError: The nonce is unknown.
+            PairingSessionExpiredError: The session expired.
+            PairingSessionStateError: A challenge was already issued or used.
+            PairingProofError: The proposed public key is malformed.
+        """
+
+        self._decode_device_public_key(request.device_public_key)
+        nonce_hash = _opaque_digest(nonce)
+        session, session_commit_index = self._load_session(nonce_hash)
+        self._require_pending(session)
+        challenge = _base64url_encode(secrets.token_bytes(32))
+        updated = session.model_copy(
+            update={
+                "state": "challenged",
+                "device_name": request.device_name,
+                "device_public_key": request.device_public_key,
+                "challenge": challenge,
+            }
+        )
+        self._append_session(
+            nonce_hash,
+            updated,
+            expected_record_commit_index=session_commit_index,
+        )
+        return PairingChallengeResponse(
+            challenge=challenge,
+            expires_at=session.expires_at,
+        )
+
+    def exchange(
+        self,
+        nonce: str,
+        request: PairingExchangeRequest,
+    ) -> PairingExchangeResponse:
+        """Verify device-key possession and consume one pairing session.
+
+        Args:
+            nonce: Single-use pairing capability from the QR package.
+            request: Ed25519 proof over the issued challenge.
+
+        Returns:
+            One-time access and refresh credentials.
+
+        Raises:
+            PairingProofError: Signature validation fails.
+            PairingSessionStateError: The session is not awaiting exchange.
+            PairingSessionExpiredError: The session expired.
+        """
+
+        nonce_hash = _opaque_digest(nonce)
+        session, session_commit_index = self._load_session(nonce_hash)
+        self._require_unexpired(session)
+        if (
+            session.state != "challenged"
+            or session.device_public_key is None
+            or session.challenge is None
+            or session.device_name is None
+        ):
+            raise PairingSessionStateError(
+                "pairing session is not awaiting device proof"
+            )
+        public_key = self._decode_device_public_key(session.device_public_key)
+        try:
+            signature = _base64url_decode(request.signature)
+            public_key.verify(
+                signature,
+                pairing_signature_message(
+                    cluster_id=UUID(str(self._store.cluster_identity().cluster_id)),
+                    nonce=nonce,
+                    challenge=session.challenge,
+                ),
+            )
+        except (InvalidSignature, ValueError, UnicodeError) as exc:
+            raise PairingProofError("device pairing proof is invalid") from exc
+
+        now = self._now()
+        device_id = uuid4()
+        access_token = secrets.token_urlsafe(32)
+        refresh_token = secrets.token_urlsafe(48)
+        access_expires_at = now + _ACCESS_TOKEN_LIFETIME
+        refresh_expires_at = now + _REFRESH_TOKEN_LIFETIME
+        consumed = session.model_copy(
+            update={
+                "state": "consumed",
+                "device_id": device_id,
+                "access_token_hash": _opaque_digest(access_token),
+                "access_token_expires_at": access_expires_at,
+                "refresh_token_hash": _opaque_digest(refresh_token),
+                "refresh_token_expires_at": refresh_expires_at,
+                "scopes": _DEFAULT_SCOPES,
+            }
+        )
+        self._append_session(
+            nonce_hash,
+            consumed,
+            expected_record_commit_index=session_commit_index,
+        )
+        return PairingExchangeResponse(
+            device_id=device_id,
+            cluster=self._store.cluster_identity(),
+            access_token=access_token,
+            access_token_expires_at=access_expires_at,
+            refresh_token=refresh_token,
+            refresh_token_expires_at=refresh_expires_at,
+            scopes=_DEFAULT_SCOPES,
+        )
+
+    def _load_session(self, nonce_hash: str) -> tuple[_StoredPairingSession, int]:
+        """Load and validate one encrypted session by its nonce digest."""
+
+        try:
+            record, payload = self._store.read_latest_record_payload(
+                _PAIRING_RECORD_TYPE,
+                nonce_hash,
+            )
+        except AuthorityNotInitializedError as exc:
+            if not self._store.path.exists():
+                raise PairingGatewayNotInitializedError(
+                    "operator gateway is not initialized"
+                ) from exc
+            raise PairingSessionNotFoundError("pairing session was not found") from exc
+        try:
+            session = _StoredPairingSession.model_validate_json(
+                json.dumps(payload, separators=(",", ":"), allow_nan=False)
+            )
+        except ValueError as exc:
+            raise PairingError("stored pairing session is invalid") from exc
+        return session, record.commit_index
+
+    def _append_session(
+        self,
+        nonce_hash: str,
+        session: _StoredPairingSession,
+        *,
+        expected_record_commit_index: int = 0,
+    ) -> None:
+        """Append one encrypted session transition with local CAS."""
+
+        records = self._store.records()
+        expected_index = records[-1].commit_index if records else 1
+        payload = cast(
+            Mapping[str, object],
+            session.model_dump(mode="json", by_alias=True),
+        )
+        try:
+            self._store.append(
+                expected_commit_index=expected_index,
+                expected_record_commit_index=expected_record_commit_index,
+                authority_term=1,
+                record_type=_PAIRING_RECORD_TYPE,
+                record_id=nonce_hash,
+                payload=payload,
+            )
+        except AuthorityCommitConflictError as exc:
+            raise PairingSessionStateError(
+                "pairing state changed concurrently; restart pairing"
+            ) from exc
+
+    def _require_pending(self, session: _StoredPairingSession) -> None:
+        """Require an unexpired session that has not issued a challenge."""
+
+        self._require_unexpired(session)
+        if session.state != "pending":
+            raise PairingSessionStateError("pairing session was already used")
+
+    def _require_unexpired(self, session: _StoredPairingSession) -> None:
+        """Reject an expired session without modifying its durable record."""
+
+        if self._now() >= session.expires_at:
+            raise PairingSessionExpiredError("pairing session expired")
+
+    @staticmethod
+    def _decode_device_public_key(value: str) -> Ed25519PublicKey:
+        """Decode and validate one raw Ed25519 device public key."""
+
+        try:
+            raw = _base64url_decode(value)
+            if len(raw) != 32:
+                raise ValueError("wrong key length")
+            return Ed25519PublicKey.from_public_bytes(raw)
+        except (ValueError, UnicodeError) as exc:
+            raise PairingProofError("device public key is invalid") from exc

--- a/src/skulk/operator/tests/test_authority.py
+++ b/src/skulk/operator/tests/test_authority.py
@@ -152,6 +152,46 @@ def test_append_requires_exact_commit_index(tmp_path: Path) -> None:
     assert b"secret-verifier" not in persisted
 
 
+def test_append_rejects_stale_logical_record_after_unrelated_activity(
+    tmp_path: Path,
+) -> None:
+    """A fresh global index cannot authorize a stale logical transition."""
+
+    store = _store(tmp_path)
+    material = create_cluster_identity()
+    store.initialize_cluster(material.public_identity, material.private_key)
+    original = store.append(
+        expected_commit_index=1,
+        expected_record_commit_index=0,
+        authority_term=1,
+        record_type="pairing",
+        record_id="session-1",
+        payload={"state": "pending"},
+    )
+    store.append(
+        expected_commit_index=2,
+        expected_record_commit_index=original.commit_index,
+        authority_term=1,
+        record_type="pairing",
+        record_id="session-1",
+        payload={"state": "consumed"},
+    )
+
+    with pytest.raises(AuthorityCommitConflictError, match="record changed"):
+        store.append(
+            expected_commit_index=3,
+            expected_record_commit_index=original.commit_index,
+            authority_term=1,
+            record_type="pairing",
+            record_id="session-1",
+            payload={"state": "challenged"},
+        )
+
+    assert store.read_latest_payload("pairing", "session-1") == {
+        "state": "consumed"
+    }
+
+
 def test_old_records_remain_readable_during_data_key_rotation(tmp_path: Path) -> None:
     """The provider selects key versions per record during staged rotation."""
 

--- a/src/skulk/operator/tests/test_key_provider.py
+++ b/src/skulk/operator/tests/test_key_provider.py
@@ -1,0 +1,52 @@
+"""Tests for the designated gateway's protected local authority key."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from skulk.operator.key_provider import (
+    AuthorityKeyUnavailableError,
+    LocalFileAuthorityKeyProvider,
+)
+
+
+def test_local_key_provider_creates_and_reuses_protected_key(tmp_path: Path) -> None:
+    """First use creates one 32-byte key and later calls reuse it."""
+
+    key_path = tmp_path / "operator" / "authority-key.bin"
+    provider = LocalFileAuthorityKeyProvider(key_path)
+
+    first = provider.ensure_data_key()
+    second = provider.ensure_data_key()
+
+    assert len(first) == 32
+    assert second == first
+    assert provider.load_data_key(provider.active_key_id) == first
+    if os.name == "posix":
+        assert key_path.stat().st_mode & 0o777 == 0o600
+        assert key_path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_local_key_provider_rejects_wrong_version(tmp_path: Path) -> None:
+    """A record cannot silently decrypt under a different key identifier."""
+
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "key.bin")
+    provider.ensure_data_key()
+
+    with pytest.raises(AuthorityKeyUnavailableError, match="version"):
+        provider.load_data_key("future-key")
+
+
+def test_local_key_provider_rejects_broad_permissions(tmp_path: Path) -> None:
+    """POSIX group or other access fails closed."""
+
+    if os.name != "posix":
+        pytest.skip("POSIX permission semantics are unavailable")
+    key_path = tmp_path / "key.bin"
+    provider = LocalFileAuthorityKeyProvider(key_path)
+    provider.ensure_data_key()
+    key_path.chmod(0o644)
+
+    with pytest.raises(AuthorityKeyUnavailableError, match="permissions"):
+        provider.load_data_key(provider.active_key_id)

--- a/src/skulk/operator/tests/test_pairing.py
+++ b/src/skulk/operator/tests/test_pairing.py
@@ -1,0 +1,180 @@
+"""Tests for host-authorized single-gateway pairing."""
+
+import base64
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from skulk.operator.authority import EncryptedAuthorityStore
+from skulk.operator.key_provider import (
+    AuthorityKeyUnavailableError,
+    LocalFileAuthorityKeyProvider,
+)
+from skulk.operator.pairing import (
+    OperatorPairingService,
+    PairingChallengeRequest,
+    PairingExchangeRequest,
+    PairingProofError,
+    PairingSessionExpiredError,
+    PairingSessionStateError,
+    pairing_signature_message,
+)
+
+
+def _base64url(value: bytes) -> str:
+    """Encode test key material like the wire contract."""
+
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _service(
+    tmp_path: Path,
+    clock: list[datetime],
+) -> OperatorPairingService:
+    """Build an isolated pairing service with a mutable deterministic clock."""
+
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "authority-key.bin")
+    store = EncryptedAuthorityStore(provider, tmp_path / "authority.sqlite3")
+    return OperatorPairingService(store, provider, now=lambda: clock[0])
+
+
+def _device_key() -> tuple[Ed25519PrivateKey, str]:
+    """Return one candidate private key and its wire public key."""
+
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return private_key, _base64url(public_key)
+
+
+def test_pairing_challenge_exchange_consumes_session(tmp_path: Path) -> None:
+    """A device proves its key and receives credentials exactly once."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    package = service.create_session(
+        exchange_url="https://example.invalid/operator",
+        cluster_name="Fox Den",
+    )
+    private_key, public_key = _device_key()
+
+    challenge = service.create_challenge(
+        package.nonce,
+        PairingChallengeRequest(
+            device_name="  Tom's   iPhone  ",
+            device_public_key=public_key,
+        ),
+    )
+    signature = private_key.sign(
+        pairing_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            nonce=package.nonce,
+            challenge=challenge.challenge,
+        )
+    )
+    result = service.exchange(
+        package.nonce,
+        PairingExchangeRequest(signature=_base64url(signature)),
+    )
+
+    assert result.cluster.name == "Fox Den"
+    assert result.access_token
+    assert result.refresh_token
+    assert result.access_token != result.refresh_token
+    assert result.scopes == (
+        "cluster:read",
+        "models:read",
+        "chat:write",
+        "operations:write",
+    )
+    assert package.nonce.encode("ascii") not in (
+        tmp_path / "authority.sqlite3"
+    ).read_bytes()
+    with pytest.raises(PairingSessionStateError, match="not awaiting"):
+        service.exchange(
+            package.nonce,
+            PairingExchangeRequest(signature=_base64url(signature)),
+        )
+
+
+def test_pairing_rejects_wrong_device_proof(tmp_path: Path) -> None:
+    """A signature from a key other than the challenged key is rejected."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    package = service.create_session(exchange_url="https://example.invalid")
+    _, public_key = _device_key()
+    wrong_private_key, _ = _device_key()
+    challenge = service.create_challenge(
+        package.nonce,
+        PairingChallengeRequest(
+            device_name="Phone",
+            device_public_key=public_key,
+        ),
+    )
+    signature = wrong_private_key.sign(
+        pairing_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            nonce=package.nonce,
+            challenge=challenge.challenge,
+        )
+    )
+
+    with pytest.raises(PairingProofError, match="invalid"):
+        service.exchange(
+            package.nonce,
+            PairingExchangeRequest(signature=_base64url(signature)),
+        )
+
+
+def test_pairing_expires_after_five_minutes(tmp_path: Path) -> None:
+    """Expired QR capabilities cannot bind a device key."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    package = service.create_session(exchange_url="https://example.invalid")
+    _, public_key = _device_key()
+    clock[0] += timedelta(minutes=5)
+
+    with pytest.raises(PairingSessionExpiredError, match="expired"):
+        service.create_challenge(
+            package.nonce,
+            PairingChallengeRequest(
+                device_name="Phone",
+                device_public_key=public_key,
+            ),
+        )
+
+
+def test_pairing_package_contains_no_durable_credential(tmp_path: Path) -> None:
+    """The QR carries identity and one short-lived capability only."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    package = _service(tmp_path, clock).create_session(
+        exchange_url="https://example.invalid"
+    )
+    payload = package.model_dump(mode="json", by_alias=True)
+
+    assert "accessToken" not in payload
+    assert "refreshToken" not in payload
+    assert package.as_url().startswith("skulk://pair?payload=")
+
+
+def test_existing_authority_fails_closed_when_local_key_is_lost(
+    tmp_path: Path,
+) -> None:
+    """An existing authority database never receives a replacement data key."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    service.create_session(exchange_url="https://example.invalid")
+    (tmp_path / "authority-key.bin").unlink()
+
+    with pytest.raises(AuthorityKeyUnavailableError, match="not initialized"):
+        service.create_session(exchange_url="https://example.invalid")

--- a/src/skulk/operator/tests/test_pairing.py
+++ b/src/skulk/operator/tests/test_pairing.py
@@ -65,8 +65,8 @@ def test_pairing_challenge_exchange_consumes_session(tmp_path: Path) -> None:
     private_key, public_key = _device_key()
 
     challenge = service.create_challenge(
-        package.nonce,
         PairingChallengeRequest(
+            nonce=package.nonce,
             device_name="  Tom's   iPhone  ",
             device_public_key=public_key,
         ),
@@ -79,8 +79,10 @@ def test_pairing_challenge_exchange_consumes_session(tmp_path: Path) -> None:
         )
     )
     result = service.exchange(
-        package.nonce,
-        PairingExchangeRequest(signature=_base64url(signature)),
+        PairingExchangeRequest(
+            nonce=package.nonce,
+            signature=_base64url(signature),
+        ),
     )
 
     assert result.cluster.name == "Fox Den"
@@ -98,8 +100,10 @@ def test_pairing_challenge_exchange_consumes_session(tmp_path: Path) -> None:
     ).read_bytes()
     with pytest.raises(PairingSessionStateError, match="not awaiting"):
         service.exchange(
-            package.nonce,
-            PairingExchangeRequest(signature=_base64url(signature)),
+            PairingExchangeRequest(
+                nonce=package.nonce,
+                signature=_base64url(signature),
+            ),
         )
 
 
@@ -112,8 +116,8 @@ def test_pairing_rejects_wrong_device_proof(tmp_path: Path) -> None:
     _, public_key = _device_key()
     wrong_private_key, _ = _device_key()
     challenge = service.create_challenge(
-        package.nonce,
         PairingChallengeRequest(
+            nonce=package.nonce,
             device_name="Phone",
             device_public_key=public_key,
         ),
@@ -128,8 +132,10 @@ def test_pairing_rejects_wrong_device_proof(tmp_path: Path) -> None:
 
     with pytest.raises(PairingProofError, match="invalid"):
         service.exchange(
-            package.nonce,
-            PairingExchangeRequest(signature=_base64url(signature)),
+            PairingExchangeRequest(
+                nonce=package.nonce,
+                signature=_base64url(signature),
+            ),
         )
 
 
@@ -144,8 +150,8 @@ def test_pairing_expires_after_five_minutes(tmp_path: Path) -> None:
 
     with pytest.raises(PairingSessionExpiredError, match="expired"):
         service.create_challenge(
-            package.nonce,
             PairingChallengeRequest(
+                nonce=package.nonce,
                 device_name="Phone",
                 device_public_key=public_key,
             ),
@@ -164,6 +170,31 @@ def test_pairing_package_contains_no_durable_credential(tmp_path: Path) -> None:
     assert "accessToken" not in payload
     assert "refreshToken" not in payload
     assert package.as_url().startswith("skulk://pair?payload=")
+
+
+def test_pairing_rejects_cleartext_non_loopback_exchange_url(
+    tmp_path: Path,
+) -> None:
+    """Remote pairing credentials cannot be issued over cleartext HTTP."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+
+    with pytest.raises(ValueError, match="must use HTTPS"):
+        service.create_session(exchange_url="http://gateway.example.invalid")
+
+
+def test_pairing_allows_cleartext_loopback_for_local_development(
+    tmp_path: Path,
+) -> None:
+    """Loopback remains available for isolated local development."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    package = _service(tmp_path, clock).create_session(
+        exchange_url="http://127.0.0.1:52415"
+    )
+
+    assert str(package.exchange_url) == "http://127.0.0.1:52415/"
 
 
 def test_existing_authority_fails_closed_when_local_key_is_lost(

--- a/uv.lock
+++ b/uv.lock
@@ -2610,6 +2610,15 @@ wheels = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
+]
+
+[[package]]
 name = "readme-renderer"
 version = "44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3072,6 +3081,7 @@ dependencies = [
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "python-multipart", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "qrcode", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "rustworkx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "skulk-pyo3-bindings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tiktoken", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -3132,6 +3142,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "python-multipart", specifier = ">=0.0.21" },
     { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "qrcode", specifier = ">=8.2" },
     { name = "rustworkx", specifier = ">=0.17.1" },
     { name = "skulk-pyo3-bindings", editable = "rust/skulk_pyo3_bindings" },
     { name = "tiktoken", specifier = ">=0.12.0" },

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -36,6 +36,7 @@ token.
 - Placement and launch: [Placement and Instance Management](#placement-and-instance-management)
 - Store and config: [Model Store Endpoints](#model-store-endpoints) and [Configuration Endpoints](#configuration-endpoints)
 - Debugging: [State, Events, and Tracing](#state-events-and-tracing)
+- Pair a device: [Operator Device Pairing](#operator-device-pairing)
 
 ## First Success Flow
 
@@ -184,6 +185,11 @@ The Ollama group also serves alias paths (`/ollama/api/api/...`,
 - `POST /v1/capabilities/stream`
 - `POST /v1/capabilities/stream/cancel`
 
+### Operator Authentication
+
+- `POST /v1/auth/pairing-sessions/{nonce}/challenge`
+- `POST /v1/auth/pairing-sessions/{nonce}/exchange`
+
 The node diagnostics bundle includes the node's own Tailscale state
 (`tailscale`: running flag, tailnet IP, hostname, MagicDNS name), probed on
 the node the bundle describes, so the per-node cluster endpoint reports the
@@ -192,6 +198,76 @@ request. The probe is best-effort: a node without a working `tailscale` CLI
 reports `running: false`, and `null` marks only an unexpected probe failure.
 
 For the full interactive reference with request/response schemas, see the [API Reference](/api/skulk-api).
+
+## Operator Device Pairing
+
+Operator pairing is explicitly started on the host that will act as the
+designated remote gateway. It does not expose an HTTP endpoint that creates
+pairing sessions:
+
+```bash
+uv run skulk operator pair \
+  --exchange-url https://gateway.example.invalid \
+  --cluster-name "Cluster"
+```
+
+The command initializes the gateway's encrypted local authority store when
+needed, creates one high-entropy session that expires after five minutes, and
+prints a terminal QR code plus the exact `skulk://pair?...` fallback payload.
+The QR contains cluster identity, fingerprint, exchange URL, expiry, and the
+single-use nonce. It never contains an access or refresh credential.
+
+### Create a device challenge
+
+**POST** `/v1/auth/pairing-sessions/{nonce}/challenge`
+
+Parameters:
+
+- `nonce` (path, required): high-entropy capability from the QR package.
+- JSON body `deviceName` (required): operator-visible device label, 1–80
+  characters after whitespace normalization.
+- JSON body `devicePublicKey` (required): unpadded URL-safe base64 containing
+  one raw 32-byte Ed25519 public key.
+
+Behavior:
+
+- accepts only a host-created, unused, unexpired session;
+- binds the proposed device key to the session;
+- returns a random base64url `challenge` and the session `expiresAt`;
+- returns `404` for an unknown nonce, `410` after expiry, `409` after another
+  transition already used the session, `422` for an invalid public key, and
+  `503` on an API node that has not been initialized as a gateway.
+
+The device signs the domain-separated message defined by
+`pairing_signature_message` in `src/skulk/operator/pairing.py`. Clients should
+consume the generated contract rather than reconstructing the message from
+this prose.
+
+### Exchange device proof
+
+**POST** `/v1/auth/pairing-sessions/{nonce}/exchange`
+
+Parameters:
+
+- `nonce` (path, required): the same pairing capability.
+- JSON body `signature` (required): unpadded URL-safe base64 Ed25519 signature
+  produced by the challenged device key.
+
+Behavior:
+
+- verifies possession of the exact device key bound during the challenge;
+- atomically consumes the session;
+- returns a stable `deviceId`, the validated cluster identity, a 15-minute
+  opaque access token, a 30-day rotating refresh token, their expiries, and the
+  granted canonical API scopes;
+- stores only encrypted session/device state and one-way token digests;
+- never returns either credential again;
+- returns `401` for an invalid proof, `409` for reuse or an out-of-order
+  exchange, `410` after expiry, and `503` on a non-designated node.
+
+These two endpoints are the complete pre-credential HTTP surface. The tokens
+are not yet accepted by general API routes in this increment; canonical API
+authentication, refresh rotation, and revocation are the next pairing slice.
 
 ## OpenAI Chat Completions
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -187,8 +187,8 @@ The Ollama group also serves alias paths (`/ollama/api/api/...`,
 
 ### Operator Authentication
 
-- `POST /v1/auth/pairing-sessions/{nonce}/challenge`
-- `POST /v1/auth/pairing-sessions/{nonce}/exchange`
+- `POST /v1/auth/pairing-sessions/challenge`
+- `POST /v1/auth/pairing-sessions/exchange`
 
 The node diagnostics bundle includes the node's own Tailscale state
 (`tailscale`: running flag, tailnet IP, hostname, MagicDNS name), probed on
@@ -215,15 +215,19 @@ The command initializes the gateway's encrypted local authority store when
 needed, creates one high-entropy session that expires after five minutes, and
 prints a terminal QR code plus the exact `skulk://pair?...` fallback payload.
 The QR contains cluster identity, fingerprint, exchange URL, expiry, and the
-single-use nonce. It never contains an access or refresh credential.
+single-use nonce. It never contains an access or refresh credential. Remote
+exchange URLs must use HTTPS; cleartext HTTP is accepted only for loopback
+development URLs.
 
 ### Create a device challenge
 
-**POST** `/v1/auth/pairing-sessions/{nonce}/challenge`
+**POST** `/v1/auth/pairing-sessions/challenge`
 
 Parameters:
 
-- `nonce` (path, required): high-entropy capability from the QR package.
+- JSON body `nonce` (required): high-entropy capability from the QR package.
+  It is deliberately excluded from the URL so normal request-path logs cannot
+  retain it.
 - JSON body `deviceName` (required): operator-visible device label, 1–80
   characters after whitespace normalization.
 - JSON body `devicePublicKey` (required): unpadded URL-safe base64 containing
@@ -245,11 +249,12 @@ this prose.
 
 ### Exchange device proof
 
-**POST** `/v1/auth/pairing-sessions/{nonce}/exchange`
+**POST** `/v1/auth/pairing-sessions/exchange`
 
 Parameters:
 
-- `nonce` (path, required): the same pairing capability.
+- JSON body `nonce` (required): the same pairing capability. It is deliberately
+  excluded from the URL so normal request-path logs cannot retain it.
 - JSON body `signature` (required): unpadded URL-safe base64 Ed25519 signature
   produced by the challenged device key.
 

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -99,8 +99,11 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 - **Lives in:** `src/skulk/operator/identity.py`,
   `src/skulk/operator/authority.py`, `src/skulk/operator/replication.py`,
   `src/skulk/operator/consensus.py`, `src/skulk/operator/consensus_store.py`,
-  `src/skulk/operator/service.py`, and `src/skulk/operator/transport.py`; focused tests live in
-  `src/skulk/operator/tests/`.
+  `src/skulk/operator/service.py`, `src/skulk/operator/transport.py`,
+  `src/skulk/operator/key_provider.py`, `src/skulk/operator/pairing.py`, and
+  `src/skulk/operator/cli.py`; the two pre-credential routes live in
+  `src/skulk/api/operator_auth.py`, and focused tests live in
+  `src/skulk/operator/tests/` and `src/skulk/api/tests/test_operator_auth.py`.
 - **Stable node identity:** `NodeInstallationIdentity.node_install_id` is a
   persisted UUIDv4 under the protected operator configuration directory. It is
   intentionally independent of the currently ephemeral libp2p `NodeId`.
@@ -149,20 +152,30 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   queue are both bounded, and traffic currently rides the default authenticated
   libp2p gossipsub behavior.
   `AuthorityChannelTransport` discards broadcasts for other targets before
-  consensus. The topic is registered, but neither the dormant authority service
-  nor an API authorization consumer starts from `Node` in this slice.
+  consensus. The topic and consensus service remain dormant. API nodes do
+  construct the independent local pairing service, which never uses this
+  network topic.
+- **V1 pairing:** `skulk operator pair --exchange-url ...` explicitly
+  designates the local host, initializes the encrypted store when needed, and
+  emits one five-minute QR capability. Challenge binds a proposed Ed25519
+  device key; exchange verifies a domain-separated signature, consumes the
+  session, and returns one access/refresh credential pair. The journal stores
+  encrypted state and one-way token digests, not raw nonces or tokens. General
+  API authorization, refresh, and revocation remain the next slice.
 - **Key boundary:** `AuthorityKeyProvider` supplies the active unwrapped 32-byte
-  data key and immutable key-version ID. Production OS-wrapping providers and
-  replicated key envelopes are later S1 slices; this store never writes the
-  plaintext data key itself.
+  data key and immutable key-version ID. V1's
+  `LocalFileAuthorityKeyProvider` creates one random local key protected by
+  POSIX mode `0600` on the designated gateway. Hardware-backed wrapping and
+  replicated key envelopes are later hardening; the authority SQLite database
+  never writes the plaintext data key itself.
 - **Critical boundary:** deterministic network vote collection, certified log
   recovery, and caller-selected bounded proposal orchestration are implemented,
   but authority leader selection, encrypted payload replication, OS-protected
   key wrapping, gateway leases, and Node lifecycle integration are later slices.
-  No remotely authenticated
-  request may treat an uncertified local SQLite commit as a distributed
-  authorization decision. None of these records enters `State`, telemetry,
-  diagnostics, or the API event log.
+  V1 explicitly claims no automatic authority failover: local pairing state is
+  authoritative only for the designated gateway and remote access is
+  unavailable when that host is unavailable. None of these records enters
+  `State`, telemetry, diagnostics, or the API event log.
 
 ### Extensions (plugins)
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -948,6 +948,25 @@ dormant service do not authorize any API route by themselves.
 Operator identity and authorization records never enter `State`, telemetry,
 diagnostics, or the public event log.
 
+The first usable remote-operator slice deliberately chooses a simpler
+availability contract. One API-capable host is designated by running
+`skulk operator pair`. `LocalFileAuthorityKeyProvider` creates a random
+32-byte key in the protected Skulk configuration directory and
+`OperatorPairingService` persists pairing transitions in the encrypted local
+journal. POSIX mode `0600` protects the local key; hardware-backed wrapping and
+automatic gateway failover are later hardening, not prerequisites for pairing.
+If this gateway is down, remote operator access is down while local cluster and
+dashboard operation continue.
+
+The local command creates a five-minute QR capability. The API exposes only
+challenge and exchange before authentication: a phone proposes an Ed25519 key,
+signs a domain-separated random challenge, and receives opaque access and
+refresh credentials once. Raw nonces and tokens are never stored in plaintext;
+the authority journal contains encrypted state and one-way token digests. This
+slice issues credentials but does not yet authorize general routes. The next
+slice adds refresh, revocation, and one canonical API authorization policy
+shared by remote clients without creating parallel model or inference APIs.
+
 ### Event log
 
 `src/skulk/utils/disk_event_log.py` is an append-only log: the live file (`events.bin`) is uncompressed length-prefixed msgpack records (4-byte big-endian length + msgpack payload). When the log rotates or the master shuts down, the live file is zstd-compressed into a rotated archive (`events.*.bin.zst`); only the rotated archives are compressed, not the active write target. Every indexed event passes through here. Followers replay from this log on bootstrap. Snapshots can be written periodically; events older than a snapshot can be compacted (with a guarded rollout window, see "State and events" above).


### PR DESCRIPTION
## Summary

- add `skulk operator pair` to designate one gateway and render a five-minute, single-use QR capability
- bind an Ed25519 device key through challenge/proof and issue opaque access plus refresh credentials exactly once
- persist encrypted pairing/device state and only token/nonce digests behind a protected local gateway key
- expose and document the two pre-credential FastAPI operations without creating a parallel model or inference API
- enforce HTTPS for remote exchange URLs and keep the bearer nonce out of request paths
- add logical-record compare-and-set so concurrent exchanges cannot both consume stale session state

## Scope boundary

This increment issues credentials but does not yet authorize general API routes, rotate refresh credentials, revoke paired devices, or add relay transport. Those are the next working-product slices. No live fleet access or mutation was used for validation.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` — 3,120 passed, 1 skipped, 231 deselected
- focused pairing/API tests — 9 passed after review fixes
- `uv run python scripts/export_openapi.py`
- isolated terminal QR smoke test