### PR TITLE
Add operator credential lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,10 @@ A single Skulk `Node` (src/skulk/main.py) runs multiple components:
   uses a protected local-file provider and `skulk operator pair` to create a
   five-minute QR capability; the API exposes only device-key challenge and
   exchange before authentication, returning one-time opaque access/refresh
-  credentials while persisting encrypted state and token digests. A dormant bounded service
+  credentials while persisting encrypted state and token digests. Refresh
+  rotates both credentials, bearer validation enforces canonical scopes, and
+  authorized devices can list or revoke credential-free device projections.
+  A dormant bounded service
   can drive one caller-selected proposal with deadlines, retries, accepted-value
   recovery, local durable commit, and catch-up broadcast; it is not started by
   `Node`. Authority leader selection, secret payload replication, OS key

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ This starts a Vite dev server on port 3000 with hot reload. The dev server proxi
   crash-fault consensus, bounded dormant proposal lifecycle, and
   encrypted/public authority persistence. It also owns the designated-gateway
   local key provider, `skulk operator pair` command, and single-use device
-  pairing state machine; the matching pre-credential FastAPI routes live in
+  pairing plus credential lifecycle; the matching FastAPI routes live in
   `src/skulk/api/operator_auth.py`. It is a
   separate security plane from event-sourced inference state; do not place its
   secrets or mutable authorization records in `State`, telemetry, diagnostics,

--- a/src/skulk/api/operator_auth.py
+++ b/src/skulk/api/operator_auth.py
@@ -1,10 +1,20 @@
 # pyright: reportUnusedFunction=false
-"""FastAPI routes for host-authorized Skulk device pairing."""
+"""FastAPI routes for Skulk operator pairing and credential lifecycle."""
 
-from fastapi import APIRouter, HTTPException
+from typing import Annotated, Never
+from uuid import UUID
+
+from fastapi import APIRouter, Header, HTTPException, Response, status
 
 from skulk.operator.pairing import (
+    OperatorCredentialExpiredError,
+    OperatorCredentialInvalidError,
+    OperatorDeviceNotFoundError,
+    OperatorDevicesResponse,
     OperatorPairingService,
+    OperatorScopeError,
+    OperatorTokenRequest,
+    OperatorTokenResponse,
     PairingChallengeRequest,
     PairingChallengeResponse,
     PairingExchangeRequest,
@@ -16,6 +26,44 @@ from skulk.operator.pairing import (
     PairingSessionStateError,
 )
 
+_BEARER_CHALLENGE = {"WWW-Authenticate": "Bearer"}
+
+
+def _require_bearer(authorization: str | None) -> str:
+    """Extract one opaque bearer token without accepting alternate schemes."""
+
+    if authorization is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="bearer credential is required",
+            headers=_BEARER_CHALLENGE,
+        )
+    scheme, separator, token = authorization.partition(" ")
+    if separator != " " or scheme.lower() != "bearer" or not token.strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="bearer credential is invalid",
+            headers=_BEARER_CHALLENGE,
+        )
+    return token.strip()
+
+
+def _raise_credential_http_error(exc: Exception) -> Never:
+    """Map safe credential-domain failures onto stable HTTP semantics."""
+
+    if isinstance(exc, OperatorScopeError):
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    if isinstance(
+        exc,
+        (OperatorCredentialInvalidError, OperatorCredentialExpiredError),
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+            headers=_BEARER_CHALLENGE,
+        ) from exc
+    raise exc
+
 
 def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
     """Create narrowly scoped pairing routes for one designated gateway.
@@ -24,8 +72,8 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
         service: Encrypted local pairing service owned by the API node.
 
     Returns:
-        Router exposing only challenge and credential exchange before
-        authentication. General Skulk APIs are not added to this router.
+        Router exposing pairing, refresh rotation, and paired-device
+        management. General Skulk model and inference APIs remain canonical.
     """
 
     router = APIRouter(prefix="/v1/auth", tags=["Authentication"])
@@ -85,5 +133,85 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except PairingProofError as exc:
             raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+    @router.post(
+        "/token",
+        response_model=OperatorTokenResponse,
+        summary="Rotate an operator refresh credential",
+        description=(
+            "Accept the current opaque refresh credential for one paired "
+            "device, invalidate its existing token pair, and return a fresh "
+            "short-lived access token plus rotating refresh token exactly once."
+        ),
+    )
+    def refresh_operator_token(request: OperatorTokenRequest) -> OperatorTokenResponse:
+        """Rotate the access and refresh credentials for one paired device."""
+
+        try:
+            return service.refresh(request)
+        except OperatorDeviceNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="refresh credential is invalid",
+                headers=_BEARER_CHALLENGE,
+            ) from exc
+        except (OperatorCredentialInvalidError, OperatorCredentialExpiredError) as exc:
+            _raise_credential_http_error(exc)
+        except PairingSessionStateError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    @router.get(
+        "/devices",
+        response_model=OperatorDevicesResponse,
+        summary="List paired operator devices",
+        description=(
+            "Return safe active and revoked device projections for a bearer "
+            "credential with device-management scope. Credential material is "
+            "never included."
+        ),
+    )
+    def list_operator_devices(
+        authorization: Annotated[str | None, Header()] = None,
+    ) -> OperatorDevicesResponse:
+        """List devices visible to an authorized operator."""
+
+        try:
+            return service.devices(_require_bearer(authorization))
+        except (
+            OperatorCredentialInvalidError,
+            OperatorCredentialExpiredError,
+            OperatorScopeError,
+        ) as exc:
+            _raise_credential_http_error(exc)
+
+    @router.delete(
+        "/devices/{device_id}",
+        status_code=status.HTTP_204_NO_CONTENT,
+        summary="Revoke a paired operator device",
+        description=(
+            "Immediately invalidate the target device's access and refresh "
+            "credentials. Repeating revocation for an already revoked device "
+            "is idempotent."
+        ),
+    )
+    def revoke_operator_device(
+        device_id: UUID,
+        authorization: Annotated[str | None, Header()] = None,
+    ) -> Response:
+        """Revoke one stable paired-device identity."""
+
+        try:
+            service.revoke_device(_require_bearer(authorization), device_id)
+        except OperatorDeviceNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except (
+            OperatorCredentialInvalidError,
+            OperatorCredentialExpiredError,
+            OperatorScopeError,
+        ) as exc:
+            _raise_credential_http_error(exc)
+        except PairingSessionStateError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     return router

--- a/src/skulk/api/operator_auth.py
+++ b/src/skulk/api/operator_auth.py
@@ -51,6 +51,8 @@ def _require_bearer(authorization: str | None) -> str:
 def _raise_credential_http_error(exc: Exception) -> Never:
     """Map safe credential-domain failures onto stable HTTP semantics."""
 
+    if isinstance(exc, PairingGatewayNotInitializedError):
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     if isinstance(exc, OperatorScopeError):
         raise HTTPException(status_code=403, detail=str(exc)) from exc
     if isinstance(
@@ -155,7 +157,11 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
                 detail="refresh credential is invalid",
                 headers=_BEARER_CHALLENGE,
             ) from exc
-        except (OperatorCredentialInvalidError, OperatorCredentialExpiredError) as exc:
+        except (
+            OperatorCredentialInvalidError,
+            OperatorCredentialExpiredError,
+            PairingGatewayNotInitializedError,
+        ) as exc:
             _raise_credential_http_error(exc)
         except PairingSessionStateError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
@@ -181,6 +187,7 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
             OperatorCredentialInvalidError,
             OperatorCredentialExpiredError,
             OperatorScopeError,
+            PairingGatewayNotInitializedError,
         ) as exc:
             _raise_credential_http_error(exc)
 
@@ -208,6 +215,7 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
             OperatorCredentialInvalidError,
             OperatorCredentialExpiredError,
             OperatorScopeError,
+            PairingGatewayNotInitializedError,
         ) as exc:
             _raise_credential_http_error(exc)
         except PairingSessionStateError as exc:

--- a/src/skulk/api/tests/test_operator_auth.py
+++ b/src/skulk/api/tests/test_operator_auth.py
@@ -195,3 +195,25 @@ def test_token_rotation_and_device_revocation_http_contract(tmp_path: Path) -> N
         "/v1/auth/devices",
         headers={"Authorization": f"Bearer {next_access_token}"},
     ).status_code == 401
+
+
+def test_lifecycle_routes_fail_closed_on_an_uninitialized_gateway(
+    tmp_path: Path,
+) -> None:
+    """A non-designated API node returns 503 instead of leaking an error 500."""
+
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "key.bin")
+    service = OperatorPairingService(
+        EncryptedAuthorityStore(provider, tmp_path / "authority.sqlite3"),
+        provider,
+    )
+    app = FastAPI()
+    app.include_router(create_operator_auth_router(service))
+    client = TestClient(app)
+
+    listed = client.get(
+        "/v1/auth/devices",
+        headers={"Authorization": "Bearer unknown-access-token"},
+    )
+    assert listed.status_code == 503
+    assert listed.json() == {"detail": "operator gateway is not initialized"}

--- a/src/skulk/api/tests/test_operator_auth.py
+++ b/src/skulk/api/tests/test_operator_auth.py
@@ -26,6 +26,45 @@ def _base64url(value: bytes) -> str:
     return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
 
 
+def _pair_device(
+    client: TestClient,
+    service: OperatorPairingService,
+    *,
+    device_name: str = "Test phone",
+) -> dict[str, object]:
+    """Pair one generated device through the public HTTP contract."""
+
+    package = service.create_session(exchange_url="https://example.invalid")
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    challenge_response = client.post(
+        "/v1/auth/pairing-sessions/challenge",
+        json={
+            "nonce": package.nonce,
+            "deviceName": device_name,
+            "devicePublicKey": _base64url(public_key),
+        },
+    )
+    assert challenge_response.status_code == 200
+    challenge_body = cast(dict[str, object], challenge_response.json())
+    signature = private_key.sign(
+        pairing_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            nonce=package.nonce,
+            challenge=str(challenge_body["challenge"]),
+        )
+    )
+    exchange_response = client.post(
+        "/v1/auth/pairing-sessions/exchange",
+        json={"nonce": package.nonce, "signature": _base64url(signature)},
+    )
+    assert exchange_response.status_code == 200
+    return cast(dict[str, object], exchange_response.json())
+
+
 def test_pairing_routes_issue_credentials_and_reject_reuse(tmp_path: Path) -> None:
     """The HTTP path mirrors the single-use service state machine."""
 
@@ -95,3 +134,64 @@ def test_pairing_routes_are_present_in_openapi(tmp_path: Path) -> None:
     paths = cast(dict[str, object], app.openapi()["paths"])
     assert "/v1/auth/pairing-sessions/challenge" in paths
     assert "/v1/auth/pairing-sessions/exchange" in paths
+    assert "/v1/auth/token" in paths
+    assert "/v1/auth/devices" in paths
+    assert "/v1/auth/devices/{device_id}" in paths
+
+
+def test_token_rotation_and_device_revocation_http_contract(tmp_path: Path) -> None:
+    """Bearer routes rotate credentials and make revocation immediate."""
+
+    now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "key.bin")
+    service = OperatorPairingService(
+        EncryptedAuthorityStore(provider, tmp_path / "authority.sqlite3"),
+        provider,
+        now=lambda: now,
+    )
+    app = FastAPI()
+    app.include_router(create_operator_auth_router(service))
+    client = TestClient(app)
+    paired = _pair_device(client, service)
+    device_id = str(paired["deviceId"])
+    access_token = str(paired["accessToken"])
+    refresh_token = str(paired["refreshToken"])
+
+    missing_bearer = client.get("/v1/auth/devices")
+    assert missing_bearer.status_code == 401
+    assert missing_bearer.headers["www-authenticate"] == "Bearer"
+
+    listed = client.get(
+        "/v1/auth/devices",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert listed.status_code == 200
+    listed_body = cast(dict[str, object], listed.json())
+    assert isinstance(listed_body["devices"], list)
+
+    rotated = client.post(
+        "/v1/auth/token",
+        json={"deviceId": device_id, "refreshToken": refresh_token},
+    )
+    assert rotated.status_code == 200, rotated.text
+    rotated_body = cast(dict[str, object], rotated.json())
+    next_access_token = str(rotated_body["accessToken"])
+
+    assert client.get(
+        "/v1/auth/devices",
+        headers={"Authorization": f"Bearer {access_token}"},
+    ).status_code == 401
+    assert client.post(
+        "/v1/auth/token",
+        json={"deviceId": device_id, "refreshToken": refresh_token},
+    ).status_code == 401
+
+    revoked = client.delete(
+        f"/v1/auth/devices/{device_id}",
+        headers={"Authorization": f"Bearer {next_access_token}"},
+    )
+    assert revoked.status_code == 204
+    assert client.get(
+        "/v1/auth/devices",
+        headers={"Authorization": f"Bearer {next_access_token}"},
+    ).status_code == 401

--- a/src/skulk/operator/pairing.py
+++ b/src/skulk/operator/pairing.py
@@ -769,7 +769,13 @@ class OperatorPairingService:
 
         latest_record_ids: list[str] = []
         seen: set[str] = set()
-        for record in reversed(self._store.records()):
+        try:
+            records = self._store.records()
+        except AuthorityNotInitializedError as exc:
+            raise PairingGatewayNotInitializedError(
+                "operator gateway is not initialized"
+            ) from exc
+        for record in reversed(records):
             if record.record_type != _PAIRING_RECORD_TYPE or record.record_id in seen:
                 continue
             seen.add(record.record_id)

--- a/src/skulk/operator/pairing.py
+++ b/src/skulk/operator/pairing.py
@@ -6,8 +6,9 @@ import base64
 import hashlib
 import json
 import secrets
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
+from hmac import compare_digest
 from ipaddress import ip_address
 from typing import Literal, cast, final
 from uuid import UUID, uuid4
@@ -36,6 +37,7 @@ type OperatorScope = Literal[
     "models:read",
     "chat:write",
     "operations:write",
+    "devices:manage",
 ]
 
 _DEFAULT_SCOPES: tuple[OperatorScope, ...] = (
@@ -43,6 +45,7 @@ _DEFAULT_SCOPES: tuple[OperatorScope, ...] = (
     "models:read",
     "chat:write",
     "operations:write",
+    "devices:manage",
 )
 
 
@@ -68,6 +71,26 @@ class PairingProofError(PairingError):
 
 class PairingGatewayNotInitializedError(PairingError):
     """Raised when this API node has not been designated through local pairing."""
+
+
+class OperatorCredentialError(RuntimeError):
+    """Base class for safe operator credential failures."""
+
+
+class OperatorCredentialInvalidError(OperatorCredentialError):
+    """Raised when an access or refresh credential is unknown or revoked."""
+
+
+class OperatorCredentialExpiredError(OperatorCredentialError):
+    """Raised when an otherwise valid operator credential has expired."""
+
+
+class OperatorScopeError(OperatorCredentialError):
+    """Raised when a credential lacks a required canonical API scope."""
+
+
+class OperatorDeviceNotFoundError(OperatorCredentialError):
+    """Raised when a stable paired-device identity is unknown."""
 
 
 class PairingPackage(FrozenModel):
@@ -106,19 +129,7 @@ class PairingPackage(FrozenModel):
     ) -> AnyHttpUrl:
         """Require HTTPS except for explicitly local development URLs."""
 
-        if value.scheme == "https":
-            return value
-        if value.host is None:
-            raise ValueError("pairing exchange_url must include a host")
-        host = value.host.strip("[]")
-        if host == "localhost":
-            return value
-        try:
-            if ip_address(host).is_loopback:
-                return value
-        except ValueError:
-            pass
-        raise ValueError("remote pairing exchange_url must use HTTPS")
+        return _validate_exchange_url(value)
 
     def as_url(self) -> str:
         """Return the package as a compact custom-scheme QR payload."""
@@ -207,6 +218,80 @@ class PairingExchangeResponse(FrozenModel):
     )
 
 
+class OperatorTokenRequest(FrozenModel):
+    """Rotating refresh credential presented for a new token pair."""
+
+    device_id: UUID = Field(description="Stable paired-device identity.")
+    refresh_token: str = Field(
+        min_length=40,
+        max_length=128,
+        description="Current opaque refresh credential returned only once.",
+    )
+
+    @field_validator("device_id", mode="before")
+    @classmethod
+    def _parse_wire_device_id(cls, value: object) -> object:
+        """Convert the JSON UUID representation before strict validation."""
+
+        if not isinstance(value, str):
+            return value
+        try:
+            return UUID(value)
+        except ValueError as exc:
+            raise ValueError("device_id must be a UUID") from exc
+
+
+class OperatorTokenResponse(FrozenModel):
+    """Fresh rotating access and refresh credentials."""
+
+    access_token: str = Field(description="New short-lived bearer credential.")
+    access_token_expires_at: datetime = Field(
+        description="UTC expiry of the new access credential."
+    )
+    refresh_token: str = Field(description="New rotating refresh credential.")
+    refresh_token_expires_at: datetime = Field(
+        description="UTC expiry of the new refresh credential."
+    )
+    scopes: tuple[OperatorScope, ...] = Field(
+        description="Canonical API scopes retained by the device."
+    )
+
+
+class OperatorAccessContext(FrozenModel):
+    """Validated device identity and scopes for one bearer request."""
+
+    device_id: UUID = Field(description="Stable paired-device identity.")
+    device_name: str = Field(description="Operator-visible device name.")
+    scopes: tuple[OperatorScope, ...] = Field(
+        description="Canonical API scopes authorized for the request."
+    )
+
+
+class OperatorDevice(FrozenModel):
+    """Safe operator-visible projection of one paired device."""
+
+    device_id: UUID = Field(description="Stable paired-device identity.")
+    name: str = Field(description="Operator-visible device name.")
+    paired_at: datetime = Field(description="UTC pairing-session creation time.")
+    refresh_expires_at: datetime | None = Field(
+        description="UTC refresh expiry, absent after revocation."
+    )
+    state: Literal["active", "revoked"] = Field(
+        description="Whether credentials can still authorize the device."
+    )
+    current: bool = Field(
+        description="Whether this row represents the requesting device."
+    )
+
+
+class OperatorDevicesResponse(FrozenModel):
+    """Paired devices visible to an authorized operator."""
+
+    devices: tuple[OperatorDevice, ...] = Field(
+        description="Stable paired-device projections in pairing order."
+    )
+
+
 class _StoredPairingSession(FrozenModel):
     """Encrypted durable state for one pairing capability and resulting device."""
 
@@ -252,7 +337,26 @@ def _base64url_decode(value: str) -> bytes:
 def _opaque_digest(value: str) -> str:
     """Return a non-reversible identifier for a bearer value."""
 
-    return _base64url_encode(hashlib.sha256(value.encode("ascii")).digest())
+    return _base64url_encode(hashlib.sha256(value.encode("utf-8")).digest())
+
+
+def _validate_exchange_url(value: str | AnyHttpUrl) -> AnyHttpUrl:
+    """Validate that a pairing exchange cannot expose credentials in cleartext."""
+
+    url = value if isinstance(value, AnyHttpUrl) else AnyHttpUrl(value)
+    if url.scheme == "https":
+        return url
+    if url.host is None:
+        raise ValueError("pairing exchange_url must include a host")
+    host = url.host.strip("[]")
+    if host == "localhost":
+        return url
+    try:
+        if ip_address(host).is_loopback:
+            return url
+    except ValueError:
+        pass
+    raise ValueError("remote pairing exchange_url must use HTTPS")
 
 
 def pairing_signature_message(
@@ -329,6 +433,7 @@ class OperatorPairingService:
             Public package safe to render as a QR code.
         """
 
+        validated_exchange_url = _validate_exchange_url(exchange_url)
         if self._store.path.exists():
             self._key_provider.load_data_key(self._key_provider.active_key_id)
         else:
@@ -352,7 +457,7 @@ class OperatorPairingService:
             cluster_id=UUID(str(identity.cluster_id)),
             cluster_name=identity.name,
             cluster_fingerprint=identity.fingerprint,
-            exchange_url=AnyHttpUrl(exchange_url),
+            exchange_url=validated_exchange_url,
             expires_at=expires_at,
             nonce=nonce,
         )
@@ -483,6 +588,218 @@ class OperatorPairingService:
             refresh_token_expires_at=refresh_expires_at,
             scopes=_DEFAULT_SCOPES,
         )
+
+    def refresh(self, request: OperatorTokenRequest) -> OperatorTokenResponse:
+        """Rotate one valid refresh credential and its access token.
+
+        Args:
+            request: Stable device identity and current refresh credential.
+
+        Returns:
+            A fresh access and refresh pair returned exactly once.
+
+        Raises:
+            OperatorCredentialInvalidError: The token is unknown or revoked.
+            OperatorCredentialExpiredError: The refresh lifetime elapsed.
+            OperatorDeviceNotFoundError: The device identity is unknown.
+            PairingSessionStateError: Concurrent authority state changed.
+        """
+
+        record_id, session, session_commit_index = self._load_device_session(
+            request.device_id
+        )
+        self._require_active_device(session)
+        if (
+            session.refresh_token_hash is None
+            or not compare_digest(
+                session.refresh_token_hash,
+                _opaque_digest(request.refresh_token),
+            )
+        ):
+            raise OperatorCredentialInvalidError("refresh credential is invalid")
+        if (
+            session.refresh_token_expires_at is None
+            or self._now() >= session.refresh_token_expires_at
+        ):
+            raise OperatorCredentialExpiredError("refresh credential expired")
+
+        now = self._now()
+        access_token = secrets.token_urlsafe(32)
+        refresh_token = secrets.token_urlsafe(48)
+        access_expires_at = now + _ACCESS_TOKEN_LIFETIME
+        refresh_expires_at = now + _REFRESH_TOKEN_LIFETIME
+        updated = session.model_copy(
+            update={
+                "access_token_hash": _opaque_digest(access_token),
+                "access_token_expires_at": access_expires_at,
+                "refresh_token_hash": _opaque_digest(refresh_token),
+                "refresh_token_expires_at": refresh_expires_at,
+            }
+        )
+        self._append_session(
+            record_id,
+            updated,
+            expected_record_commit_index=session_commit_index,
+        )
+        return OperatorTokenResponse(
+            access_token=access_token,
+            access_token_expires_at=access_expires_at,
+            refresh_token=refresh_token,
+            refresh_token_expires_at=refresh_expires_at,
+            scopes=session.scopes,
+        )
+
+    def validate_access_token(
+        self,
+        token: str,
+        *,
+        required_scopes: Sequence[OperatorScope] = (),
+    ) -> OperatorAccessContext:
+        """Validate one bearer credential and enforce required scopes.
+
+        Args:
+            token: Opaque bearer access credential.
+            required_scopes: Canonical scopes required by the target route.
+
+        Returns:
+            Validated device identity and granted scopes.
+
+        Raises:
+            OperatorCredentialInvalidError: The token is unknown or revoked.
+            OperatorCredentialExpiredError: The access lifetime elapsed.
+            OperatorScopeError: A required scope is absent.
+        """
+
+        token_hash = _opaque_digest(token)
+        matched_session: _StoredPairingSession | None = None
+        for _, session, _ in self._latest_device_sessions():
+            if session.access_token_hash is not None and compare_digest(
+                session.access_token_hash,
+                token_hash,
+            ):
+                matched_session = session
+        if matched_session is None or matched_session.state != "consumed":
+            raise OperatorCredentialInvalidError("access credential is invalid")
+        if (
+            matched_session.access_token_expires_at is None
+            or self._now() >= matched_session.access_token_expires_at
+        ):
+            raise OperatorCredentialExpiredError("access credential expired")
+        missing_scopes = set(required_scopes).difference(matched_session.scopes)
+        if missing_scopes:
+            raise OperatorScopeError("access credential lacks a required scope")
+        if matched_session.device_id is None or matched_session.device_name is None:
+            raise PairingError("stored paired device is invalid")
+        return OperatorAccessContext(
+            device_id=matched_session.device_id,
+            device_name=matched_session.device_name,
+            scopes=matched_session.scopes,
+        )
+
+    def devices(self, access_token: str) -> OperatorDevicesResponse:
+        """List safe paired-device projections for an authorized device.
+
+        Args:
+            access_token: Bearer credential requiring device-management scope.
+
+        Returns:
+            Active and revoked device records without credential material.
+        """
+
+        context = self.validate_access_token(
+            access_token,
+            required_scopes=("devices:manage",),
+        )
+        devices: list[OperatorDevice] = []
+        for _, session, _ in self._latest_device_sessions():
+            if session.device_id is None or session.device_name is None:
+                continue
+            devices.append(
+                OperatorDevice(
+                    device_id=session.device_id,
+                    name=session.device_name,
+                    paired_at=session.created_at,
+                    refresh_expires_at=session.refresh_token_expires_at,
+                    state="revoked" if session.state == "revoked" else "active",
+                    current=session.device_id == context.device_id,
+                )
+            )
+        devices.sort(key=lambda device: (device.paired_at, str(device.device_id)))
+        return OperatorDevicesResponse(devices=tuple(devices))
+
+    def revoke_device(self, access_token: str, device_id: UUID) -> None:
+        """Revoke one paired device immediately and idempotently.
+
+        Args:
+            access_token: Bearer credential requiring device-management scope.
+            device_id: Stable identity of the device to revoke.
+
+        Raises:
+            OperatorCredentialError: The requesting bearer is invalid.
+            OperatorDeviceNotFoundError: The target device is unknown.
+            PairingSessionStateError: Concurrent authority state changed.
+        """
+
+        self.validate_access_token(
+            access_token,
+            required_scopes=("devices:manage",),
+        )
+        record_id, session, session_commit_index = self._load_device_session(device_id)
+        if session.state == "revoked":
+            return
+        revoked = session.model_copy(
+            update={
+                "state": "revoked",
+                "access_token_hash": None,
+                "access_token_expires_at": None,
+                "refresh_token_hash": None,
+                "refresh_token_expires_at": None,
+            }
+        )
+        self._append_session(
+            record_id,
+            revoked,
+            expected_record_commit_index=session_commit_index,
+        )
+
+    def _latest_device_sessions(
+        self,
+    ) -> tuple[tuple[str, _StoredPairingSession, int], ...]:
+        """Return the newest durable session record for every paired device."""
+
+        latest_record_ids: list[str] = []
+        seen: set[str] = set()
+        for record in reversed(self._store.records()):
+            if record.record_type != _PAIRING_RECORD_TYPE or record.record_id in seen:
+                continue
+            seen.add(record.record_id)
+            latest_record_ids.append(record.record_id)
+        sessions: list[tuple[str, _StoredPairingSession, int]] = []
+        for record_id in reversed(latest_record_ids):
+            session, commit_index = self._load_session(record_id)
+            if session.device_id is not None:
+                sessions.append((record_id, session, commit_index))
+        return tuple(sessions)
+
+    def _load_device_session(
+        self,
+        device_id: UUID,
+    ) -> tuple[str, _StoredPairingSession, int]:
+        """Load the newest credential state for one stable device identity."""
+
+        for record_id, session, commit_index in self._latest_device_sessions():
+            if session.device_id == device_id:
+                return record_id, session, commit_index
+        raise OperatorDeviceNotFoundError("paired device was not found")
+
+    @staticmethod
+    def _require_active_device(session: _StoredPairingSession) -> None:
+        """Reject a revoked or structurally incomplete device record."""
+
+        if session.state != "consumed":
+            raise OperatorCredentialInvalidError("device credential is revoked")
+        if session.device_id is None or session.device_name is None:
+            raise PairingError("stored paired device is invalid")
 
     def _load_session(self, nonce_hash: str) -> tuple[_StoredPairingSession, int]:
         """Load and validate one encrypted session by its nonce digest."""

--- a/src/skulk/operator/tests/test_pairing.py
+++ b/src/skulk/operator/tests/test_pairing.py
@@ -23,6 +23,7 @@ from skulk.operator.pairing import (
     PairingChallengeRequest,
     PairingExchangeRequest,
     PairingExchangeResponse,
+    PairingGatewayNotInitializedError,
     PairingProofError,
     PairingSessionExpiredError,
     PairingSessionStateError,
@@ -353,3 +354,13 @@ def test_malformed_unicode_credentials_fail_safely(tmp_path: Path) -> None:
 
     with pytest.raises(OperatorCredentialInvalidError, match="access"):
         service.validate_access_token("snowman-☃")
+
+
+def test_lifecycle_rejects_an_uninitialized_gateway_safely(tmp_path: Path) -> None:
+    """Credential operations never leak a missing authority store as an error 500."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+
+    with pytest.raises(PairingGatewayNotInitializedError, match="not initialized"):
+        service.validate_access_token("unknown-access-token")

--- a/src/skulk/operator/tests/test_pairing.py
+++ b/src/skulk/operator/tests/test_pairing.py
@@ -15,9 +15,14 @@ from skulk.operator.key_provider import (
     LocalFileAuthorityKeyProvider,
 )
 from skulk.operator.pairing import (
+    OperatorCredentialExpiredError,
+    OperatorCredentialInvalidError,
+    OperatorDeviceNotFoundError,
     OperatorPairingService,
+    OperatorTokenRequest,
     PairingChallengeRequest,
     PairingExchangeRequest,
+    PairingExchangeResponse,
     PairingProofError,
     PairingSessionExpiredError,
     PairingSessionStateError,
@@ -51,6 +56,37 @@ def _device_key() -> tuple[Ed25519PrivateKey, str]:
         format=serialization.PublicFormat.Raw,
     )
     return private_key, _base64url(public_key)
+
+
+def _complete_pairing(
+    service: OperatorPairingService,
+    *,
+    device_name: str = "Phone",
+) -> PairingExchangeResponse:
+    """Complete one host-authorized pairing against the service."""
+
+    package = service.create_session(exchange_url="https://example.invalid")
+    private_key, public_key = _device_key()
+    challenge = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            device_name=device_name,
+            device_public_key=public_key,
+        )
+    )
+    signature = private_key.sign(
+        pairing_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            nonce=package.nonce,
+            challenge=challenge.challenge,
+        )
+    )
+    return service.exchange(
+        PairingExchangeRequest(
+            nonce=package.nonce,
+            signature=_base64url(signature),
+        )
+    )
 
 
 def test_pairing_challenge_exchange_consumes_session(tmp_path: Path) -> None:
@@ -94,6 +130,7 @@ def test_pairing_challenge_exchange_consumes_session(tmp_path: Path) -> None:
         "models:read",
         "chat:write",
         "operations:write",
+        "devices:manage",
     )
     assert package.nonce.encode("ascii") not in (
         tmp_path / "authority.sqlite3"
@@ -183,6 +220,9 @@ def test_pairing_rejects_cleartext_non_loopback_exchange_url(
     with pytest.raises(ValueError, match="must use HTTPS"):
         service.create_session(exchange_url="http://gateway.example.invalid")
 
+    assert not (tmp_path / "authority-key.bin").exists()
+    assert not (tmp_path / "authority.sqlite3").exists()
+
 
 def test_pairing_allows_cleartext_loopback_for_local_development(
     tmp_path: Path,
@@ -209,3 +249,107 @@ def test_existing_authority_fails_closed_when_local_key_is_lost(
 
     with pytest.raises(AuthorityKeyUnavailableError, match="not initialized"):
         service.create_session(exchange_url="https://example.invalid")
+
+
+def test_refresh_rotates_both_credentials_and_rejects_replay(tmp_path: Path) -> None:
+    """Refresh rotation invalidates both members of the previous token pair."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    paired = _complete_pairing(service)
+
+    refreshed = service.refresh(
+        OperatorTokenRequest(
+            device_id=paired.device_id,
+            refresh_token=paired.refresh_token,
+        )
+    )
+
+    assert refreshed.access_token != paired.access_token
+    assert refreshed.refresh_token != paired.refresh_token
+    with pytest.raises(OperatorCredentialInvalidError, match="access"):
+        service.validate_access_token(paired.access_token)
+    with pytest.raises(OperatorCredentialInvalidError, match="refresh"):
+        service.refresh(
+            OperatorTokenRequest(
+                device_id=paired.device_id,
+                refresh_token=paired.refresh_token,
+            )
+        )
+    context = service.validate_access_token(
+        refreshed.access_token,
+        required_scopes=("cluster:read", "devices:manage"),
+    )
+    assert context.device_id == paired.device_id
+
+
+def test_access_and_refresh_credentials_expire_independently(tmp_path: Path) -> None:
+    """The service enforces the short access and longer refresh lifetimes."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    paired = _complete_pairing(service)
+    clock[0] += timedelta(minutes=15)
+
+    with pytest.raises(OperatorCredentialExpiredError, match="access"):
+        service.validate_access_token(paired.access_token)
+
+    refreshed = service.refresh(
+        OperatorTokenRequest(
+            device_id=paired.device_id,
+            refresh_token=paired.refresh_token,
+        )
+    )
+    clock[0] += timedelta(days=30)
+    with pytest.raises(OperatorCredentialExpiredError, match="refresh"):
+        service.refresh(
+            OperatorTokenRequest(
+                device_id=paired.device_id,
+                refresh_token=refreshed.refresh_token,
+            )
+        )
+
+
+def test_device_listing_and_revocation_expose_no_credentials(tmp_path: Path) -> None:
+    """An authorized device can inspect and immediately revoke a peer."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    first = _complete_pairing(service, device_name="First phone")
+    clock[0] += timedelta(seconds=1)
+    second = _complete_pairing(service, device_name="Second phone")
+
+    before = service.devices(second.access_token)
+    assert [device.name for device in before.devices] == [
+        "First phone",
+        "Second phone",
+    ]
+    assert [device.current for device in before.devices] == [False, True]
+
+    service.revoke_device(second.access_token, first.device_id)
+    after = service.devices(second.access_token)
+    revoked = next(device for device in after.devices if device.device_id == first.device_id)
+    assert revoked.state == "revoked"
+    assert revoked.refresh_expires_at is None
+    with pytest.raises(OperatorCredentialInvalidError, match="access"):
+        service.validate_access_token(first.access_token)
+    with pytest.raises(OperatorCredentialInvalidError, match="revoked"):
+        service.refresh(
+            OperatorTokenRequest(
+                device_id=first.device_id,
+                refresh_token=first.refresh_token,
+            )
+        )
+    with pytest.raises(OperatorDeviceNotFoundError, match="not found"):
+        service.revoke_device(second.access_token, UUID(int=0))
+
+
+def test_malformed_unicode_credentials_fail_safely(tmp_path: Path) -> None:
+    """Unexpected Unicode bearer material is unknown rather than a server error."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    _complete_pairing(service)
+
+    with pytest.raises(OperatorCredentialInvalidError, match="access"):
+        service.validate_access_token("snowman-☃")

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -189,6 +189,9 @@ The Ollama group also serves alias paths (`/ollama/api/api/...`,
 
 - `POST /v1/auth/pairing-sessions/challenge`
 - `POST /v1/auth/pairing-sessions/exchange`
+- `POST /v1/auth/token`
+- `GET /v1/auth/devices`
+- `DELETE /v1/auth/devices/{device_id}`
 
 The node diagnostics bundle includes the node's own Tailscale state
 (`tailscale`: running flag, tailnet IP, hostname, MagicDNS name), probed on
@@ -270,9 +273,72 @@ Behavior:
 - returns `401` for an invalid proof, `409` for reuse or an out-of-order
   exchange, `410` after expiry, and `503` on a non-designated node.
 
-These two endpoints are the complete pre-credential HTTP surface. The tokens
-are not yet accepted by general API routes in this increment; canonical API
-authentication, refresh rotation, and revocation are the next pairing slice.
+These two endpoints are the complete pre-credential HTTP surface. The access
+token is accepted by the device-management routes below. Protecting selected
+canonical cluster, model, chat, and operation routes with the same validator is
+a subsequent slice; Skulk does not create parallel mobile-only model or
+inference APIs.
+
+### Rotate operator credentials
+
+**POST** `/v1/auth/token`
+
+Parameters:
+
+- JSON body `deviceId` (required): stable paired-device UUID returned by the
+  exchange.
+- JSON body `refreshToken` (required): current opaque rotating refresh
+  credential.
+
+Behavior:
+
+- validates the device and current refresh-token digest;
+- atomically invalidates both members of the previous token pair;
+- returns a fresh 15-minute access token and 30-day refresh token, their
+  expiries, and the device's unchanged scopes;
+- returns `401` for an unknown, revoked, expired, or replayed credential and
+  `409` if concurrent credential state changed.
+
+The client must replace both stored credentials as one operation. A response
+lost after the gateway commits rotation requires pairing again because replaying
+the previous refresh token is intentionally rejected.
+
+### List paired devices
+
+**GET** `/v1/auth/devices`
+
+Parameters:
+
+- `Authorization: Bearer <access-token>` (required): a valid credential with
+  `devices:manage` scope.
+
+Behavior:
+
+- returns stable device IDs, display names, pairing times, refresh expiries,
+  active/revoked state, and which row represents the caller;
+- never returns device public keys, token digests, raw credentials, or pairing
+  nonces;
+- returns `401` for a missing, malformed, unknown, revoked, or expired bearer
+  and `403` when the bearer lacks device-management scope.
+
+### Revoke a paired device
+
+**DELETE** `/v1/auth/devices/{device_id}`
+
+Parameters:
+
+- path `device_id` (required): stable paired-device UUID to revoke;
+- `Authorization: Bearer <access-token>` (required): a valid credential with
+  `devices:manage` scope.
+
+Behavior:
+
+- atomically clears the target's access and refresh digests and expiries;
+- returns `204` after successful revocation and when an authorized caller
+  repeats revocation for the same already-revoked target;
+- makes both credentials unusable immediately;
+- returns `401` for an invalid caller, `403` for insufficient scope, `404` for
+  an unknown target device, and `409` if concurrent credential state changed.
 
 ## OpenAI Chat Completions
 

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -101,7 +101,7 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   `src/skulk/operator/consensus.py`, `src/skulk/operator/consensus_store.py`,
   `src/skulk/operator/service.py`, `src/skulk/operator/transport.py`,
   `src/skulk/operator/key_provider.py`, `src/skulk/operator/pairing.py`, and
-  `src/skulk/operator/cli.py`; the two pre-credential routes live in
+  `src/skulk/operator/cli.py`; pairing and credential-lifecycle routes live in
   `src/skulk/api/operator_auth.py`, and focused tests live in
   `src/skulk/operator/tests/` and `src/skulk/api/tests/test_operator_auth.py`.
 - **Stable node identity:** `NodeInstallationIdentity.node_install_id` is a
@@ -160,8 +160,11 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   emits one five-minute QR capability. Challenge binds a proposed Ed25519
   device key; exchange verifies a domain-separated signature, consumes the
   session, and returns one access/refresh credential pair. The journal stores
-  encrypted state and one-way token digests, not raw nonces or tokens. General
-  API authorization, refresh, and revocation remain the next slice.
+  encrypted state and one-way token digests, not raw nonces or tokens. Refresh
+  rotates both tokens atomically; bearer validation enforces typed scopes; and
+  device list/revoke routes expose no credential material. Applying that same
+  validator to selected canonical model, inference, and command routes remains
+  the next slice; no mobile-only replacement surface is introduced.
 - **Key boundary:** `AuthorityKeyProvider` supplies the active unwrapped 32-byte
   data key and immutable key-version ID. V1's
   `LocalFileAuthorityKeyProvider` creates one random local key protected by

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -962,10 +962,12 @@ The local command creates a five-minute QR capability. The API exposes only
 challenge and exchange before authentication: a phone proposes an Ed25519 key,
 signs a domain-separated random challenge, and receives opaque access and
 refresh credentials once. Raw nonces and tokens are never stored in plaintext;
-the authority journal contains encrypted state and one-way token digests. This
-slice issues credentials but does not yet authorize general routes. The next
-slice adds refresh, revocation, and one canonical API authorization policy
-shared by remote clients without creating parallel model or inference APIs.
+the authority journal contains encrypted state and one-way token digests.
+Refresh rotates and invalidates the prior access/refresh pair atomically. The
+same service validates short-lived bearer access, exposes credential-free
+paired-device projections, and makes revocation immediate. These lifecycle
+routes prove the authorization boundary before selected canonical Skulk APIs
+adopt it; they do not create parallel model, inference, or command APIs.
 
 ### Event log
 


### PR DESCRIPTION
## Summary
- rotate operator access and refresh credentials atomically
- validate bearer tokens with typed scopes and add safe paired-device list/revocation routes
- document the HTTP contract and authorization boundary without creating mobile-only model or inference APIs

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (3,125 passed, 1 skipped, 231 deselected)
- `uv run python scripts/export_openapi.py`

## Scope
This remains a single-gateway v1 lifecycle. It does not alter the existing dashboard or canonical model, inference, and command APIs, and it does not add automatic gateway failover.