### PR TITLE
Implement designated operator relay gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,11 @@ A single Skulk `Node` (src/skulk/main.py) runs multiple components:
   credentials while persisting encrypted state and token digests. Refresh
   rotates both credentials, bearer validation enforces canonical scopes, and
   authorized devices can list or revoke credential-free device projections.
+  `skulk operator configure-relay` persists one generated paired-WebSocket
+  route, creates a protected pinned TLS identity, and enables a bounded outbound
+  gateway lane pool. Relay lanes bridge opaque inner-TLS bytes to a separate
+  loopback listener serving the same canonical FastAPI app behind scoped bearer
+  validation; the ordinary dashboard/API listener remains unchanged.
   A dormant bounded service
   can drive one caller-selected proposal with deadlines, retries, accepted-value
   recovery, local durable commit, and catch-up broadcast; it is not started by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,9 +83,11 @@ This starts a Vite dev server on port 3000 with hot reload. The dev server proxi
 - `src/skulk/operator/` — Stable operator identity, quorum certification,
   crash-fault consensus, bounded dormant proposal lifecycle, and
   encrypted/public authority persistence. It also owns the designated-gateway
-  local key provider, `skulk operator pair` command, and single-use device
-  pairing plus credential lifecycle; the matching FastAPI routes live in
-  `src/skulk/api/operator_auth.py`. It is a
+  local key provider, paired-WebSocket relay configuration/connector,
+  `skulk operator pair` and `configure-relay` commands, and single-use device
+  pairing plus credential lifecycle; the matching FastAPI routes and relay-only
+  canonical API guard live in `src/skulk/api/operator_auth.py` and
+  `src/skulk/api/operator_gateway.py`. It is a
   separate security plane from event-sourced inference state; do not place its
   secrets or mutable authorization records in `State`, telemetry, diagnostics,
   or ordinary events.

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -10,6 +10,7 @@ import random
 import re
 import shutil
 import socket
+import sqlite3
 import time
 import weakref
 from collections.abc import (
@@ -1246,11 +1247,20 @@ class API:
     ) -> None:
         self.state = State()
         self._operator_pairing_service = operator_pairing_service
-        self._operator_relay_configuration: OperatorRelayConfiguration | None = (
-            operator_pairing_service.relay_configuration()
-            if operator_pairing_service is not None
-            else None
-        )
+        self._operator_relay_configuration: OperatorRelayConfiguration | None = None
+        if operator_pairing_service is not None:
+            try:
+                self._operator_relay_configuration = (
+                    operator_pairing_service.relay_configuration()
+                )
+            except (OSError, RuntimeError, ValueError, sqlite3.Error):
+                # Relay state is an optional ingress path. A damaged local
+                # authority record must fail remote access closed without
+                # turning that optional failure into cluster downtime.
+                logger.warning(
+                    "Operator relay configuration is unavailable; "
+                    "continuing with local API access only"
+                )
         # External extensions remain optional. Production nodes prepend
         # first-party provider facades that expose core services through the
         # same generic contracts without duplicating their runtimes.
@@ -7297,11 +7307,7 @@ class API:
                     self._operator_pairing_service is not None
                     and self._operator_relay_configuration is not None
                 ):
-                    operator_gateway = OperatorGatewayConnector(
-                        self._operator_relay_configuration
-                    )
-                    tg.start_soon(self.run_operator_api, shutdown_ev)
-                    tg.start_soon(operator_gateway.run)
+                    tg.start_soon(self.run_operator_remote_access, shutdown_ev)
                 try:
                     await anyio.sleep_forever()
                 finally:
@@ -7364,6 +7370,36 @@ class API:
                 cast(ASGIFramework, protected_app),
                 cfg,
                 shutdown_trigger=ev.wait,
+            )
+
+    async def run_operator_remote_access(self, ev: anyio.Event) -> None:
+        """Supervise optional relay ingress without coupling it to the local API.
+
+        Args:
+            ev: Shared API shutdown signal.
+
+        Side effects:
+            Starts the relay-only TLS listener and outbound carrier lanes. Any
+            startup or runtime failure disables remote access for this process
+            while the ordinary local API continues serving.
+        """
+
+        configuration = self._operator_relay_configuration
+        if configuration is None:
+            return
+        try:
+            async with anyio.create_task_group() as operator_task_group:
+                operator_gateway = OperatorGatewayConnector(configuration)
+                operator_task_group.start_soon(self.run_operator_api, ev)
+                operator_task_group.start_soon(operator_gateway.run)
+                await ev.wait()
+                operator_task_group.cancel_scope.cancel()
+        except Exception:
+            # Do not include exception text: relay paths and lower-level
+            # transport errors can contain private deployment metadata.
+            logger.warning(
+                "Operator remote access is unavailable; "
+                "the local API remains available"
             )
 
     def _maybe_compact_event_log(self) -> None:

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -107,6 +107,7 @@ from skulk.api.node_health import (
     live_skulk_build_mismatch,
 )
 from skulk.api.operator_auth import create_operator_auth_router
+from skulk.api.operator_gateway import OperatorGatewayAuthorization
 from skulk.api.performance_envelope import (
     ClusterPerformanceEnvelopes,
     GenerationOutcome,
@@ -268,6 +269,7 @@ from skulk.master.placement_utils import (
     usable_vram_by_node,
 )
 from skulk.operator.pairing import OperatorPairingService
+from skulk.operator.relay import OperatorGatewayConnector, OperatorRelayConfiguration
 from skulk.routing.provider_streams import ProviderStreamPacket
 from skulk.routing.realtime_audio import RealtimeAudioPacket
 from skulk.routing.speech_media import SpeechMediaPacket
@@ -1243,6 +1245,12 @@ class API:
         operator_pairing_service: OperatorPairingService | None = None,
     ) -> None:
         self.state = State()
+        self._operator_pairing_service = operator_pairing_service
+        self._operator_relay_configuration: OperatorRelayConfiguration | None = (
+            operator_pairing_service.relay_configuration()
+            if operator_pairing_service is not None
+            else None
+        )
         # External extensions remain optional. Production nodes prepend
         # first-party provider facades that expose core services through the
         # same generic contracts without duplicating their runtimes.
@@ -7285,6 +7293,15 @@ class API:
                 tg.start_soon(self._field_telemetry.flush_loop)
                 print_startup_banner(self.port)
                 tg.start_soon(self.run_api, shutdown_ev)
+                if (
+                    self._operator_pairing_service is not None
+                    and self._operator_relay_configuration is not None
+                ):
+                    operator_gateway = OperatorGatewayConnector(
+                        self._operator_relay_configuration
+                    )
+                    tg.start_soon(self.run_operator_api, shutdown_ev)
+                    tg.start_soon(operator_gateway.run)
                 try:
                     await anyio.sleep_forever()
                 finally:
@@ -7308,6 +7325,43 @@ class API:
         with anyio.CancelScope(shield=True):
             await serve(
                 cast(ASGIFramework, self.app),
+                cfg,
+                shutdown_trigger=ev.wait,
+            )
+
+    async def run_operator_api(self, ev: anyio.Event) -> None:
+        """Serve the canonical API through a relay-only authenticated TLS bind.
+
+        Args:
+            ev: Shared API shutdown signal.
+
+        Raises:
+            RuntimeError: Relay configuration or pairing service is absent.
+        """
+
+        configuration = self._operator_relay_configuration
+        service = self._operator_pairing_service
+        if configuration is None or service is None:
+            raise RuntimeError("operator relay API requires configured pairing")
+        # Validate protected TLS material before opening a listener or carrier
+        # lane. Hypercorn loads the same exact certificate and key paths below.
+        configuration.server_ssl_context()
+        cfg = Config()
+        cfg.bind = [f"127.0.0.1:{configuration.operator_api_port}"]
+        cfg.certfile = str(configuration.certificate_path)
+        cfg.keyfile = str(configuration.private_key_path)
+        cfg.accesslog = None
+        cfg.errorlog = "-"
+        cfg.logger_class = InterceptLogger
+        cfg.websocket_max_message_size = REALTIME_WEBSOCKET_MAX_MESSAGE_BYTES
+        cfg.websocket_ping_interval = 20.0
+        protected_app = OperatorGatewayAuthorization(
+            self.app,
+            service,
+        )
+        with anyio.CancelScope(shield=True):
+            await serve(
+                cast(ASGIFramework, protected_app),
                 cfg,
                 shutdown_trigger=ev.wait,
             )

--- a/src/skulk/api/operator_gateway.py
+++ b/src/skulk/api/operator_gateway.py
@@ -1,0 +1,151 @@
+"""Authentication boundary for the relay-only canonical Skulk API listener."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Final, cast, final
+
+from fastapi.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from skulk.operator.pairing import (
+    OperatorCredentialExpiredError,
+    OperatorCredentialInvalidError,
+    OperatorPairingService,
+    OperatorScope,
+    OperatorScopeError,
+    PairingGatewayNotInitializedError,
+)
+
+_UNAUTHENTICATED_PATHS: Final = frozenset(
+    {
+        "/v1/auth/pairing-sessions/challenge",
+        "/v1/auth/pairing-sessions/exchange",
+        "/v1/auth/token",
+    }
+)
+_MODEL_PREFIXES: Final = ("/v1/models", "/models", "/model-store", "/v1/store")
+_INFERENCE_PREFIXES: Final = (
+    "/v1/chat",
+    "/v1/responses",
+    "/v1/embeddings",
+    "/v1/audio",
+    "/v1/images",
+    "/v1/realtime",
+    "/v1/fabric/chains",
+    "/bench/",
+)
+
+
+@final
+class OperatorGatewayAuthorization:
+    """Require scoped operator credentials on the relay-only ASGI listener.
+
+    The wrapper serves the existing FastAPI application without adding an
+    operator-specific model, inference, or command surface. Pairing challenge,
+    exchange, and refresh remain reachable before access-token validation.
+    """
+
+    def __init__(self, app: ASGIApp, service: OperatorPairingService) -> None:
+        """Wrap the canonical application with one pairing service."""
+
+        self._app = app
+        self._service = service
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Validate the request before invoking the canonical application."""
+
+        scope_type = cast(str, scope["type"])
+        if scope_type not in {"http", "websocket"}:
+            await self._app(scope, receive, send)
+            return
+        path = cast(str, scope.get("path", ""))
+        if path in _UNAUTHENTICATED_PATHS:
+            await self._app(scope, receive, send)
+            return
+        required_scopes = _required_scopes(scope)
+        try:
+            bearer = _bearer_from_scope(scope)
+            self._service.validate_access_token(
+                bearer,
+                required_scopes=required_scopes,
+            )
+        except PairingGatewayNotInitializedError:
+            await _deny(scope, receive, send, status_code=503, detail="operator gateway unavailable")
+            return
+        except OperatorScopeError:
+            await _deny(scope, receive, send, status_code=403, detail="operator scope denied")
+            return
+        except (OperatorCredentialInvalidError, OperatorCredentialExpiredError):
+            await _deny(scope, receive, send, status_code=401, detail="operator credential invalid")
+            return
+        await self._app(scope, receive, send)
+
+
+def _required_scopes(scope: Scope) -> Sequence[OperatorScope]:
+    """Map canonical routes onto the smallest existing operator scope."""
+
+    path = cast(str, scope.get("path", ""))
+    if path.startswith("/v1/auth/devices"):
+        return ("devices:manage",)
+    if path.startswith(_INFERENCE_PREFIXES):
+        return ("chat:write",)
+    if path.startswith(_MODEL_PREFIXES):
+        method = cast(str, scope.get("method", "GET")).upper()
+        return ("models:read",) if method in {"GET", "HEAD", "OPTIONS"} else (
+            "operations:write",
+        )
+    method = cast(str, scope.get("method", "GET")).upper()
+    if scope["type"] == "http" and method in {"GET", "HEAD", "OPTIONS"}:
+        return ("cluster:read",)
+    return ("operations:write",)
+
+
+def _bearer_from_scope(scope: Scope) -> str:
+    """Extract one exact bearer from raw ASGI headers."""
+
+    raw_authorization: bytes | None = None
+    headers = cast(Sequence[tuple[bytes, bytes]], scope.get("headers", ()))
+    for name, value in headers:
+        if name.lower() == b"authorization":
+            if raw_authorization is not None:
+                raise OperatorCredentialInvalidError(
+                    "multiple authorization headers are invalid"
+                )
+            raw_authorization = value
+    if raw_authorization is None:
+        raise OperatorCredentialInvalidError("operator bearer is required")
+    try:
+        authorization = raw_authorization.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise OperatorCredentialInvalidError("operator bearer is invalid") from exc
+    scheme, separator, token = authorization.partition(" ")
+    if separator != " " or scheme.lower() != "bearer" or not token.strip():
+        raise OperatorCredentialInvalidError("operator bearer is invalid")
+    return token.strip()
+
+
+async def _deny(
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+    *,
+    status_code: int,
+    detail: str,
+) -> None:
+    """Return a payload-safe denial for HTTP or WebSocket requests."""
+
+    if scope["type"] == "websocket":
+        message: Message = {
+            "type": "websocket.close",
+            "code": 1008,
+            "reason": detail,
+        }
+        await send(message)
+        return
+    response = JSONResponse(
+        {"detail": detail},
+        status_code=status_code,
+        headers={"WWW-Authenticate": "Bearer"} if status_code == 401 else None,
+    )
+    await response(scope, receive, send)

--- a/src/skulk/api/tests/test_operator_gateway.py
+++ b/src/skulk/api/tests/test_operator_gateway.py
@@ -1,0 +1,153 @@
+# pyright: reportUnusedFunction=false
+"""Tests for the authenticated relay-only canonical API boundary."""
+
+import base64
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from skulk.api.operator_gateway import OperatorGatewayAuthorization
+from skulk.operator.authority import EncryptedAuthorityStore
+from skulk.operator.key_provider import LocalFileAuthorityKeyProvider
+from skulk.operator.pairing import (
+    OperatorPairingService,
+    PairingChallengeRequest,
+    PairingExchangeRequest,
+    PairingExchangeResponse,
+    pairing_signature_message,
+)
+
+
+def _base64url(value: bytes) -> str:
+    """Encode device proof material for the pairing wire contract."""
+
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _paired_service(tmp_path: Path) -> tuple[OperatorPairingService, PairingExchangeResponse]:
+    """Return a pairing service and one fully scoped operator credential."""
+
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "authority-key.bin")
+    store = EncryptedAuthorityStore(provider, tmp_path / "authority.sqlite3")
+    service = OperatorPairingService(
+        store,
+        provider,
+        now=lambda: datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc),
+    )
+    package = service.create_session(exchange_url="https://example.invalid")
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    challenge = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            device_name="Phone",
+            device_public_key=_base64url(public_key),
+        )
+    )
+    signature = private_key.sign(
+        pairing_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            nonce=package.nonce,
+            challenge=challenge.challenge,
+        )
+    )
+    exchange = service.exchange(
+        PairingExchangeRequest(
+            nonce=package.nonce,
+            signature=_base64url(signature),
+        )
+    )
+    return service, exchange
+
+
+def test_remote_listener_reuses_canonical_routes_and_requires_scoped_bearer(
+    tmp_path: Path,
+) -> None:
+    """Reads and mutations reach one app only after bearer validation."""
+
+    service, exchange = _paired_service(tmp_path)
+    canonical = FastAPI()
+
+    @canonical.get("/state")
+    def state() -> dict[str, bool]:
+        return {"canonical": True}
+
+    @canonical.post("/place_instance")
+    def place() -> dict[str, bool]:
+        return {"placed": True}
+
+    client = TestClient(OperatorGatewayAuthorization(canonical, service))
+    assert client.get("/state").status_code == 401
+    assert client.get(
+        "/state",
+        headers={"Authorization": f"Bearer {exchange.access_token}"},
+    ).json() == {"canonical": True}
+    assert client.post(
+        "/place_instance",
+        headers={"Authorization": f"Bearer {exchange.access_token}"},
+    ).json() == {"placed": True}
+    assert client.get(
+        "/state",
+        headers={"Authorization": "Bearer wrong"},
+    ).status_code == 401
+
+
+def test_pairing_and_refresh_paths_remain_reachable_before_access_authentication(
+    tmp_path: Path,
+) -> None:
+    """The relay boundary does not block its own pairing bootstrap routes."""
+
+    service, _ = _paired_service(tmp_path)
+    canonical = FastAPI()
+
+    @canonical.post("/v1/auth/pairing-sessions/challenge")
+    def challenge() -> dict[str, bool]:
+        return {"open": True}
+
+    @canonical.post("/v1/auth/pairing-sessions/exchange")
+    def exchange() -> dict[str, bool]:
+        return {"open": True}
+
+    @canonical.post("/v1/auth/token")
+    def refresh() -> dict[str, bool]:
+        return {"open": True}
+
+    client = TestClient(OperatorGatewayAuthorization(canonical, service))
+    assert client.post("/v1/auth/pairing-sessions/challenge").status_code == 200
+    assert client.post("/v1/auth/pairing-sessions/exchange").status_code == 200
+    assert client.post("/v1/auth/token").status_code == 200
+
+
+def test_remote_websocket_requires_an_operator_bearer(tmp_path: Path) -> None:
+    """Canonical WebSockets share the same access-token boundary."""
+
+    service, exchange = _paired_service(tmp_path)
+    canonical = FastAPI()
+
+    @canonical.websocket("/v1/realtime")
+    async def realtime(websocket: WebSocket) -> None:
+        await websocket.accept()
+        await websocket.send_text("ready")
+        await websocket.close()
+
+    client = TestClient(OperatorGatewayAuthorization(canonical, service))
+    with (
+        pytest.raises(WebSocketDisconnect),
+        client.websocket_connect("/v1/realtime"),
+    ):
+        pass
+    with client.websocket_connect(
+        "/v1/realtime",
+        headers={"Authorization": f"Bearer {exchange.access_token}"},
+    ) as websocket:
+        assert websocket.receive_text() == "ready"

--- a/src/skulk/api/tests/test_operator_relay_isolation.py
+++ b/src/skulk/api/tests/test_operator_relay_isolation.py
@@ -1,0 +1,113 @@
+# pyright: reportPrivateUsage=false
+"""Tests that optional relay ingress cannot take down the local API."""
+
+from typing import cast, final
+
+import anyio
+import pytest
+from fastapi.testclient import TestClient
+
+import skulk.api.main as api_main
+from skulk.api.main import API
+from skulk.operator.key_provider import AuthorityKeyUnavailableError
+from skulk.operator.pairing import OperatorPairingService
+from skulk.operator.relay import OperatorRelayConfiguration
+from skulk.shared.election import ElectionMessage
+from skulk.shared.types.commands import ForwarderCommand, ForwarderDownloadCommand
+from skulk.shared.types.common import NodeId
+from skulk.shared.types.events import IndexedEvent
+from skulk.utils.channels import channel
+
+
+@final
+class _UnavailablePairingService:
+    """Pairing-service stand-in with unreadable protected relay state."""
+
+    def relay_configuration(self) -> OperatorRelayConfiguration | None:
+        """Raise the expected protected-key availability failure."""
+
+        raise AuthorityKeyUnavailableError("credential-shaped-secret")
+
+
+def _build_api(pairing_service: OperatorPairingService | None = None) -> API:
+    """Create a minimal API component for relay-isolation tests."""
+
+    command_sender, _ = channel[ForwarderCommand]()
+    download_sender, _ = channel[ForwarderDownloadCommand]()
+    _, event_receiver = channel[IndexedEvent]()
+    _, election_receiver = channel[ElectionMessage]()
+    return API(
+        NodeId("local-node"),
+        port=52415,
+        event_receiver=event_receiver,
+        command_sender=command_sender,
+        download_command_sender=download_sender,
+        election_receiver=election_receiver,
+        enable_event_log=False,
+        mount_dashboard=False,
+        operator_pairing_service=pairing_service,
+    )
+
+
+def test_unreadable_relay_state_does_not_prevent_local_api_startup(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Damaged optional authority material leaves canonical local reads usable."""
+
+    service = cast(
+        OperatorPairingService,
+        cast(object, _UnavailablePairingService()),
+    )
+    api = _build_api(service)
+
+    assert api._operator_relay_configuration is None
+    assert TestClient(api.app).get("/state").status_code == 200
+    assert "credential-shaped-secret" not in caplog.text
+
+
+async def test_operator_listener_failure_is_isolated_from_local_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relay listener failure cancels its lanes and returns without raising."""
+
+    api = _build_api()
+    configuration = cast(OperatorRelayConfiguration, object())
+    api._operator_relay_configuration = configuration
+    api._operator_pairing_service = cast(OperatorPairingService, object())
+    connector_started = anyio.Event()
+    connector_stopped = anyio.Event()
+
+    @final
+    class _BlockingConnector:
+        """Connector stand-in that records sibling cancellation."""
+
+        async def run(self) -> None:
+            """Block until the supervising task group cancels this lane."""
+
+            connector_started.set()
+            try:
+                await anyio.sleep_forever()
+            finally:
+                connector_stopped.set()
+
+    async def _failing_operator_api(_event: anyio.Event) -> None:
+        await connector_started.wait()
+        raise OSError("private-listener-detail")
+
+    def _connector_factory(
+        received: OperatorRelayConfiguration,
+    ) -> _BlockingConnector:
+        assert received is configuration
+        return _BlockingConnector()
+
+    monkeypatch.setattr(api, "run_operator_api", _failing_operator_api)
+    monkeypatch.setattr(
+        api_main,
+        "OperatorGatewayConnector",
+        _connector_factory,
+    )
+
+    await api.run_operator_remote_access(anyio.Event())
+
+    assert connector_stopped.is_set()
+    assert TestClient(api.app).get("/state").status_code == 200

--- a/src/skulk/operator/__init__.py
+++ b/src/skulk/operator/__init__.py
@@ -48,6 +48,16 @@ from skulk.operator.identity import (
     OperatorIdentityRepository,
     create_cluster_identity,
 )
+from skulk.operator.relay import (
+    OperatorGatewayConnector,
+    OperatorRelayAlreadyConfiguredError,
+    OperatorRelayConfiguration,
+    OperatorRelayConfigurationRepository,
+    OperatorRelayError,
+    OperatorRelayProvisioning,
+    OperatorRelayUnavailableError,
+    OperatorRemoteAccessMaterial,
+)
 from skulk.operator.replication import (
     AuthorityAppliedCommit,
     AuthorityCertificateError,
@@ -127,7 +137,15 @@ __all__ = [
     "ClusterPublicIdentity",
     "EncryptedAuthorityStore",
     "NodeInstallationIdentity",
+    "OperatorGatewayConnector",
     "OperatorIdentityRepository",
+    "OperatorRelayAlreadyConfiguredError",
+    "OperatorRelayConfiguration",
+    "OperatorRelayConfigurationRepository",
+    "OperatorRelayError",
+    "OperatorRelayProvisioning",
+    "OperatorRelayUnavailableError",
+    "OperatorRemoteAccessMaterial",
     "SqliteAuthorityConsensusRepository",
     "apply_quorum_certified_payload",
     "authority_bootstrap_position",

--- a/src/skulk/operator/cli.py
+++ b/src/skulk/operator/cli.py
@@ -98,8 +98,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             provisioning = OperatorRelayProvisioning.model_validate_json(
                 arguments.provisioning_file.read_text(encoding="utf-8")
             )
-        except (OSError, ValueError) as exc:
-            parser.error(f"invalid relay provisioning file: {exc}")
+        except (OSError, ValueError):
+            # Validation errors may echo the rejected credential-bearing input.
+            # The command reports only the safe failure class to stderr.
+            parser.error("relay provisioning file is unreadable or invalid")
         configuration = service.configure_relay(
             provisioning,
             operator_api_port=arguments.operator_api_port,

--- a/src/skulk/operator/cli.py
+++ b/src/skulk/operator/cli.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
-from typing import Literal
+from pathlib import Path
+from typing import Literal, cast
 
 from skulk.operator.pairing import OperatorPairingService
+from skulk.operator.relay import OperatorRelayProvisioning
 from skulk.utils.pydantic_ext import FrozenModel
 
 
@@ -16,6 +18,15 @@ class _PairArguments(FrozenModel):
 
     command: Literal["pair"]
     exchange_url: str
+    cluster_name: str
+
+
+class _ConfigureRelayArguments(FrozenModel):
+    """Strictly validated local relay-provisioning command arguments."""
+
+    command: Literal["configure-relay"]
+    provisioning_file: Path
+    operator_api_port: int
     cluster_name: str
 
 
@@ -57,9 +68,50 @@ def main(argv: Sequence[str] | None = None) -> int:
         default="Cluster",
         help="Initial cluster name when designating a gateway for the first time.",
     )
+    relay_parser = subparsers.add_parser(
+        "configure-relay",
+        help="Install generated relay material on the designated gateway.",
+    )
+    relay_parser.add_argument(
+        "--provisioning-file",
+        required=True,
+        type=Path,
+        help="Protected JSON provisioning file received from the relay service.",
+    )
+    relay_parser.add_argument(
+        "--operator-api-port",
+        default=52416,
+        type=int,
+        help="Loopback-only authenticated TLS API port (default: 52416).",
+    )
+    relay_parser.add_argument(
+        "--cluster-name",
+        default="Cluster",
+        help="Initial cluster name when designating a gateway for the first time.",
+    )
     parsed = parser.parse_args(list(argv) if argv is not None else None)
-    arguments = _PairArguments.model_validate(vars(parsed))
+    parsed_values = cast(dict[str, object], vars(parsed))
     service = OperatorPairingService.from_default_paths()
+    if parsed_values.get("command") == "configure-relay":
+        arguments = _ConfigureRelayArguments.model_validate(parsed_values)
+        try:
+            provisioning = OperatorRelayProvisioning.model_validate_json(
+                arguments.provisioning_file.read_text(encoding="utf-8")
+            )
+        except (OSError, ValueError) as exc:
+            parser.error(f"invalid relay provisioning file: {exc}")
+        configuration = service.configure_relay(
+            provisioning,
+            operator_api_port=arguments.operator_api_port,
+            cluster_name=arguments.cluster_name,
+        )
+        print(
+            "Configured the designated gateway with "
+            f"{configuration.lane_count} relay lanes. Restart Skulk to connect."
+        )
+        return 0
+
+    arguments = _PairArguments.model_validate(parsed_values)
     package = service.create_session(
         exchange_url=arguments.exchange_url,
         cluster_name=arguments.cluster_name,

--- a/src/skulk/operator/pairing.py
+++ b/src/skulk/operator/pairing.py
@@ -24,6 +24,12 @@ from skulk.operator.authority import (
 )
 from skulk.operator.identity import ClusterPublicIdentity, create_cluster_identity
 from skulk.operator.key_provider import LocalFileAuthorityKeyProvider
+from skulk.operator.relay import (
+    OperatorRelayConfiguration,
+    OperatorRelayConfigurationRepository,
+    OperatorRelayProvisioning,
+    OperatorRemoteAccessMaterial,
+)
 from skulk.utils.pydantic_ext import FrozenModel
 
 _PAIRING_RECORD_TYPE = "operator_pairing_session"
@@ -216,6 +222,13 @@ class PairingExchangeResponse(FrozenModel):
     scopes: tuple[OperatorScope, ...] = Field(
         description="Canonical API scopes granted to the paired device."
     )
+    remote_access: OperatorRemoteAccessMaterial | None = Field(
+        default=None,
+        description=(
+            "One-time relay and pinned inner-TLS material when this gateway "
+            "has remote access configured."
+        ),
+    )
 
 
 class OperatorTokenRequest(FrozenModel):
@@ -395,6 +408,7 @@ class OperatorPairingService:
         store: EncryptedAuthorityStore,
         key_provider: LocalFileAuthorityKeyProvider,
         *,
+        relay_repository: OperatorRelayConfigurationRepository | None = None,
         now: Callable[[], datetime] = _utc_now,
     ) -> None:
         """Create a pairing service with injected persistence and time.
@@ -403,11 +417,15 @@ class OperatorPairingService:
             store: Encrypted local authority journal.
             key_provider: Local data-key provider used only during explicit
                 gateway initialization.
+            relay_repository: Encrypted designated-gateway relay repository.
             now: Time provider for deterministic expiry tests.
         """
 
         self._store = store
         self._key_provider = key_provider
+        self._relay_repository = relay_repository or OperatorRelayConfigurationRepository(
+            store
+        )
         self._now = now
 
     @classmethod
@@ -415,7 +433,56 @@ class OperatorPairingService:
         """Create the production service for the designated gateway paths."""
 
         key_provider = LocalFileAuthorityKeyProvider()
-        return cls(EncryptedAuthorityStore(key_provider), key_provider)
+        store = EncryptedAuthorityStore(key_provider)
+        return cls(
+            store,
+            key_provider,
+            relay_repository=OperatorRelayConfigurationRepository(store),
+        )
+
+    def initialize_gateway(self, cluster_name: str = "Cluster") -> ClusterPublicIdentity:
+        """Load or create the single designated gateway identity.
+
+        Args:
+            cluster_name: Initial operator-visible name for a new gateway.
+
+        Returns:
+            Stable public cluster identity owned by this gateway.
+        """
+
+        if self._store.path.exists():
+            self._key_provider.load_data_key(self._key_provider.active_key_id)
+        else:
+            self._key_provider.ensure_data_key()
+        try:
+            return self._store.cluster_identity()
+        except AuthorityNotInitializedError:
+            material = create_cluster_identity(cluster_name)
+            self._store.initialize_cluster(
+                material.public_identity,
+                material.private_key,
+            )
+            return material.public_identity
+
+    def configure_relay(
+        self,
+        provisioning: OperatorRelayProvisioning,
+        *,
+        operator_api_port: int,
+        cluster_name: str = "Cluster",
+    ) -> OperatorRelayConfiguration:
+        """Persist one generated relay route for this designated gateway."""
+
+        self.initialize_gateway(cluster_name)
+        return self._relay_repository.configure(
+            provisioning,
+            operator_api_port=operator_api_port,
+        )
+
+    def relay_configuration(self) -> OperatorRelayConfiguration | None:
+        """Return the configured designated-gateway route, when present."""
+
+        return self._relay_repository.load()
 
     def create_session(
         self,
@@ -434,19 +501,7 @@ class OperatorPairingService:
         """
 
         validated_exchange_url = _validate_exchange_url(exchange_url)
-        if self._store.path.exists():
-            self._key_provider.load_data_key(self._key_provider.active_key_id)
-        else:
-            self._key_provider.ensure_data_key()
-        try:
-            identity = self._store.cluster_identity()
-        except AuthorityNotInitializedError:
-            material = create_cluster_identity(cluster_name)
-            self._store.initialize_cluster(
-                material.public_identity,
-                material.private_key,
-            )
-            identity = material.public_identity
+        identity = self.initialize_gateway(cluster_name)
 
         now = self._now()
         nonce = secrets.token_urlsafe(32)
@@ -557,6 +612,13 @@ class OperatorPairingService:
         except (InvalidSignature, ValueError, UnicodeError) as exc:
             raise PairingProofError("device pairing proof is invalid") from exc
 
+        relay_configuration = self._relay_repository.load()
+        remote_access = (
+            relay_configuration.device_material()
+            if relay_configuration is not None
+            else None
+        )
+
         now = self._now()
         device_id = uuid4()
         access_token = secrets.token_urlsafe(32)
@@ -587,6 +649,7 @@ class OperatorPairingService:
             refresh_token=refresh_token,
             refresh_token_expires_at=refresh_expires_at,
             scopes=_DEFAULT_SCOPES,
+            remote_access=remote_access,
         )
 
     def refresh(self, request: OperatorTokenRequest) -> OperatorTokenResponse:

--- a/src/skulk/operator/relay.py
+++ b/src/skulk/operator/relay.py
@@ -1,0 +1,576 @@
+"""Designated-gateway material and outbound relay connector for operator access."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import ipaddress
+import json
+import os
+import ssl
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Final, Literal, cast, final
+from urllib.parse import urlsplit
+
+import aiohttp
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+from loguru import logger
+from pydantic import Field, field_validator, model_validator
+
+from skulk.operator.authority import (
+    AuthorityNotInitializedError,
+    EncryptedAuthorityStore,
+)
+from skulk.shared.constants import SKULK_CONFIG_HOME
+from skulk.utils.pydantic_ext import FrozenModel
+
+_RELAY_RECORD_TYPE: Final = "operator_relay_configuration"
+_RELAY_RECORD_ID: Final = "designated_gateway_v1"
+_CARRIER_VALUE_BYTES: Final = 32
+_ENCODED_CARRIER_VALUE_LENGTH: Final = 43
+_DEFAULT_FRAME_BYTES: Final = 1024 * 1024
+_MINIMUM_RECONNECT_SECONDS: Final = 0.25
+_MAXIMUM_RECONNECT_SECONDS: Final = 5.0
+_TLS_VALIDITY: Final = timedelta(days=3650)
+_TLS_CLOCK_SKEW: Final = timedelta(minutes=5)
+_ROUTE_HEADER: Final = "x-skulk-relay-route"
+
+
+class OperatorRelayError(RuntimeError):
+    """Base class for safe designated-gateway relay failures."""
+
+
+class OperatorRelayAlreadyConfiguredError(OperatorRelayError):
+    """Raised when v1 relay material already exists for this gateway."""
+
+
+class OperatorRelayUnavailableError(OperatorRelayError):
+    """Raised when persisted relay or TLS material cannot be used safely."""
+
+
+class OperatorRelayProvisioning(FrozenModel):
+    """One generated relay route delivered to the designated gateway."""
+
+    version: Literal[1] = Field(description="Provisioning document format version.")
+    app_websocket_url: str = Field(
+        description="Outer WebSocket endpoint used by paired operator apps."
+    )
+    gateway_websocket_url: str = Field(
+        description="Outer WebSocket endpoint used by gateway lanes."
+    )
+    routing_locator: str = Field(
+        min_length=_ENCODED_CARRIER_VALUE_LENGTH,
+        max_length=_ENCODED_CARRIER_VALUE_LENGTH,
+        description="Opaque unpadded base64url relay route locator.",
+    )
+    app_carrier_credential: str = Field(
+        min_length=_ENCODED_CARRIER_VALUE_LENGTH,
+        max_length=_ENCODED_CARRIER_VALUE_LENGTH,
+        description="Opaque app-role carrier bearer returned only during pairing.",
+    )
+    gateway_carrier_credential: str = Field(
+        min_length=_ENCODED_CARRIER_VALUE_LENGTH,
+        max_length=_ENCODED_CARRIER_VALUE_LENGTH,
+        description="Opaque gateway-role carrier bearer retained only by Skulk.",
+    )
+    lane_count: int = Field(
+        default=4,
+        ge=1,
+        le=32,
+        description="Number of independent waiting gateway WebSocket lanes.",
+    )
+
+    @field_validator("routing_locator", "app_carrier_credential", "gateway_carrier_credential")
+    @classmethod
+    def _carrier_values_are_canonical(cls, value: str) -> str:
+        """Require exact 256-bit unpadded base64url relay values."""
+
+        _decode_carrier_value(value)
+        return value
+
+    @field_validator("app_websocket_url")
+    @classmethod
+    def _app_url_is_safe(cls, value: str) -> str:
+        """Require the fixed app carrier endpoint over safe transport."""
+
+        return _validate_carrier_url(value, expected_path="/v1/carrier/app")
+
+    @field_validator("gateway_websocket_url")
+    @classmethod
+    def _gateway_url_is_safe(cls, value: str) -> str:
+        """Require the fixed gateway carrier endpoint over safe transport."""
+
+        return _validate_carrier_url(value, expected_path="/v1/carrier/gateway")
+
+    @model_validator(mode="after")
+    def _roles_are_separate_on_one_relay(self) -> "OperatorRelayProvisioning":
+        """Keep both role endpoints co-located and their credentials distinct."""
+
+        app = urlsplit(self.app_websocket_url)
+        gateway = urlsplit(self.gateway_websocket_url)
+        if (app.scheme, app.hostname, app.port) != (
+            gateway.scheme,
+            gateway.hostname,
+            gateway.port,
+        ):
+            raise ValueError("app and gateway carrier endpoints must share one relay origin")
+        if self.app_carrier_credential == self.gateway_carrier_credential:
+            raise ValueError("app and gateway carrier credentials must be distinct")
+        return self
+
+
+class OperatorRemoteAccessMaterial(FrozenModel):
+    """Device-side relay and inner-TLS material returned once after pairing."""
+
+    transport: Literal["paired_websocket_v1"] = Field(
+        description="Selected remote carrier contract."
+    )
+    app_websocket_url: str = Field(
+        description="Outer WebSocket endpoint used for each independent request."
+    )
+    routing_locator: str = Field(description="Opaque relay route locator.")
+    app_carrier_credential: str = Field(
+        description="Opaque app-role carrier bearer stored in platform secure storage."
+    )
+    gateway_server_name: str = Field(
+        description="Inner TLS server name authenticated by the pinned certificate."
+    )
+    gateway_ca_certificate_pem: str = Field(
+        description="PEM trust anchor for end-to-end TLS terminating at Skulk."
+    )
+
+
+class OperatorRelayConfiguration(FrozenModel):
+    """Encrypted designated-gateway configuration plus protected TLS paths."""
+
+    version: Literal[1] = Field(description="Persisted relay configuration version.")
+    app_websocket_url: str = Field(description="Paired app carrier endpoint.")
+    gateway_websocket_url: str = Field(description="Outbound gateway carrier endpoint.")
+    routing_locator: str = Field(description="Opaque 256-bit relay locator.")
+    app_carrier_credential: str = Field(description="App-role outer carrier bearer.")
+    gateway_carrier_credential: str = Field(
+        description="Gateway-role outer carrier bearer."
+    )
+    lane_count: int = Field(
+        ge=1,
+        le=32,
+        description="Independent outbound gateway lanes to maintain.",
+    )
+    operator_api_port: int = Field(
+        ge=1,
+        le=65535,
+        description="Loopback TLS port serving the scoped canonical API.",
+    )
+    gateway_server_name: str = Field(description="Pinned inner-TLS DNS name.")
+    certificate_path: Path = Field(description="Protected gateway certificate path.")
+    private_key_path: Path = Field(description="Owner-only gateway private-key path.")
+
+    def device_material(self) -> OperatorRemoteAccessMaterial:
+        """Load the public TLS certificate and project device-safe material.
+
+        Returns:
+            Relay app role, locator, and pinned inner-TLS trust material.
+
+        Raises:
+            OperatorRelayUnavailableError: The protected TLS files are absent
+                or have unsafe private-key permissions.
+        """
+
+        _require_private_file(self.private_key_path)
+        try:
+            certificate = self.certificate_path.read_text(encoding="ascii")
+        except (FileNotFoundError, OSError, UnicodeError) as exc:
+            raise OperatorRelayUnavailableError(
+                "operator gateway TLS certificate is unavailable"
+            ) from exc
+        try:
+            x509.load_pem_x509_certificate(certificate.encode("ascii"))
+        except ValueError as exc:
+            raise OperatorRelayUnavailableError(
+                "operator gateway TLS certificate is malformed"
+            ) from exc
+        return OperatorRemoteAccessMaterial(
+            transport="paired_websocket_v1",
+            app_websocket_url=self.app_websocket_url,
+            routing_locator=self.routing_locator,
+            app_carrier_credential=self.app_carrier_credential,
+            gateway_server_name=self.gateway_server_name,
+            gateway_ca_certificate_pem=certificate,
+        )
+
+    def server_ssl_context(self) -> ssl.SSLContext:
+        """Build the TLS 1.3 server context for the relay-only API listener."""
+
+        _require_private_file(self.private_key_path)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.minimum_version = ssl.TLSVersion.TLSv1_3
+        try:
+            context.load_cert_chain(self.certificate_path, self.private_key_path)
+        except (OSError, ssl.SSLError) as exc:
+            raise OperatorRelayUnavailableError(
+                "operator gateway TLS identity is unavailable"
+            ) from exc
+        return context
+
+
+@final
+class OperatorRelayConfigurationRepository:
+    """Persist one relay route in the encrypted local authority journal."""
+
+    def __init__(
+        self,
+        store: EncryptedAuthorityStore,
+        *,
+        certificate_path: Path | None = None,
+        private_key_path: Path | None = None,
+    ) -> None:
+        """Create a repository with injected authority and TLS file paths."""
+
+        operator_directory = SKULK_CONFIG_HOME / "operator"
+        self._store = store
+        self._certificate_path = certificate_path or operator_directory / "relay-tls-v1.pem"
+        self._private_key_path = private_key_path or operator_directory / "relay-tls-v1-key.pem"
+
+    def configure(
+        self,
+        provisioning: OperatorRelayProvisioning,
+        *,
+        operator_api_port: int,
+    ) -> OperatorRelayConfiguration:
+        """Create protected TLS identity and persist one generated relay route.
+
+        Args:
+            provisioning: Generated route and role credentials from the relay.
+            operator_api_port: Loopback-only TLS listener port used by this gateway.
+
+        Returns:
+            Persisted designated-gateway relay configuration.
+
+        Raises:
+            OperatorRelayAlreadyConfiguredError: A v1 route already exists.
+            OperatorRelayUnavailableError: TLS files cannot be created safely.
+        """
+
+        if not 1 <= operator_api_port <= 65535:
+            raise ValueError("operator_api_port must be between 1 and 65535")
+        if self.load() is not None:
+            raise OperatorRelayAlreadyConfiguredError(
+                "operator relay is already configured; rotation is a later operation"
+            )
+        server_name = _gateway_server_name(provisioning.routing_locator)
+        certificate_pem, private_key_pem = _generate_tls_identity(server_name)
+        _write_create_only(self._private_key_path, private_key_pem, mode=0o600)
+        try:
+            _write_create_only(self._certificate_path, certificate_pem, mode=0o600)
+            configuration = OperatorRelayConfiguration(
+                version=1,
+                app_websocket_url=provisioning.app_websocket_url,
+                gateway_websocket_url=provisioning.gateway_websocket_url,
+                routing_locator=provisioning.routing_locator,
+                app_carrier_credential=provisioning.app_carrier_credential,
+                gateway_carrier_credential=provisioning.gateway_carrier_credential,
+                lane_count=provisioning.lane_count,
+                operator_api_port=operator_api_port,
+                gateway_server_name=server_name,
+                certificate_path=self._certificate_path,
+                private_key_path=self._private_key_path,
+            )
+            records = self._store.records()
+            expected_commit_index = records[-1].commit_index
+            self._store.append(
+                expected_commit_index=expected_commit_index,
+                expected_record_commit_index=0,
+                authority_term=1,
+                record_type=_RELAY_RECORD_TYPE,
+                record_id=_RELAY_RECORD_ID,
+                payload=cast(
+                    Mapping[str, object],
+                    configuration.model_dump(mode="json", by_alias=True),
+                ),
+            )
+        except Exception:
+            self._certificate_path.unlink(missing_ok=True)
+            self._private_key_path.unlink(missing_ok=True)
+            raise
+        return configuration
+
+    def load(self) -> OperatorRelayConfiguration | None:
+        """Return the configured relay route, or ``None`` before provisioning."""
+
+        try:
+            payload = self._store.read_latest_payload(
+                _RELAY_RECORD_TYPE,
+                _RELAY_RECORD_ID,
+            )
+        except AuthorityNotInitializedError:
+            return None
+        try:
+            return OperatorRelayConfiguration.model_validate_json(
+                json.dumps(payload, separators=(",", ":"), allow_nan=False)
+            )
+        except ValueError as exc:
+            raise OperatorRelayUnavailableError(
+                "operator relay configuration is malformed"
+            ) from exc
+
+
+@final
+class OperatorGatewayConnector:
+    """Maintain bounded outbound WebSocket lanes to the content-blind relay."""
+
+    def __init__(
+        self,
+        configuration: OperatorRelayConfiguration,
+        *,
+        frame_bytes: int = _DEFAULT_FRAME_BYTES,
+    ) -> None:
+        """Create one connector for a persisted designated-gateway route."""
+
+        if not 1 <= frame_bytes <= _DEFAULT_FRAME_BYTES:
+            raise ValueError("frame_bytes must be between 1 and 1048576")
+        self._configuration = configuration
+        self._frame_bytes = frame_bytes
+
+    async def run(self) -> None:
+        """Maintain the configured number of independent one-request lanes.
+
+        Cancellation closes every lane and the shared HTTP client. Individual
+        carrier or loopback failures reconnect with bounded exponential delay.
+        """
+
+        timeout = aiohttp.ClientTimeout(total=None, sock_connect=10.0, sock_read=None)
+        async with (
+            aiohttp.ClientSession(timeout=timeout) as session,
+            asyncio.TaskGroup() as group,
+        ):
+            for lane_index in range(self._configuration.lane_count):
+                group.create_task(
+                    self._maintain_lane(session),
+                    name=f"operator-relay-lane-{lane_index}",
+                )
+
+    async def _maintain_lane(self, session: aiohttp.ClientSession) -> None:
+        """Reconnect one gateway lane until its owning task is cancelled."""
+
+        delay = _MINIMUM_RECONNECT_SECONDS
+        while True:
+            try:
+                await self._serve_lane(session)
+                delay = _MINIMUM_RECONNECT_SECONDS
+            except asyncio.CancelledError:
+                raise
+            except (aiohttp.ClientError, OSError, OperatorRelayError):
+                logger.warning("Operator relay gateway lane disconnected; retrying")
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, _MAXIMUM_RECONNECT_SECONDS)
+
+    async def _serve_lane(self, session: aiohttp.ClientSession) -> None:
+        """Bridge one relay WebSocket to the authenticated local TLS API."""
+
+        headers = {
+            "Authorization": f"Bearer {self._configuration.gateway_carrier_credential}",
+            _ROUTE_HEADER: self._configuration.routing_locator,
+        }
+        async with session.ws_connect(
+            self._configuration.gateway_websocket_url,
+            headers=headers,
+            heartbeat=20.0,
+            autoping=True,
+            autoclose=True,
+            max_msg_size=self._frame_bytes,
+        ) as websocket:
+            reader, writer = await asyncio.open_connection(
+                "127.0.0.1",
+                self._configuration.operator_api_port,
+            )
+            try:
+                websocket_to_tls = asyncio.create_task(
+                    self._websocket_to_tls(websocket, writer)
+                )
+                tls_to_websocket = asyncio.create_task(
+                    self._tls_to_websocket(reader, websocket)
+                )
+                tasks = (websocket_to_tls, tls_to_websocket)
+                _, pending = await asyncio.wait(
+                    tasks,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in pending:
+                    task.cancel()
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                for result in results:
+                    if isinstance(result, asyncio.CancelledError):
+                        continue
+                    if isinstance(result, BaseException):
+                        raise OperatorRelayError(
+                            "operator relay lane forwarding failed"
+                        ) from result
+            finally:
+                writer.close()
+                await writer.wait_closed()
+
+    async def _websocket_to_tls(
+        self,
+        websocket: aiohttp.ClientWebSocketResponse,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Copy opaque binary WebSocket messages into the inner TLS stream."""
+
+        async for message in websocket:
+            if message.type is aiohttp.WSMsgType.BINARY:
+                payload = cast(bytes, message.data)
+                if len(payload) > self._frame_bytes:
+                    raise OperatorRelayError("operator relay frame exceeded its bound")
+                writer.write(payload)
+                await writer.drain()
+                continue
+            if message.type in {
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.ERROR,
+            }:
+                return
+            if message.type is aiohttp.WSMsgType.TEXT:
+                raise OperatorRelayError("operator relay sent a non-binary frame")
+
+    async def _tls_to_websocket(
+        self,
+        reader: asyncio.StreamReader,
+        websocket: aiohttp.ClientWebSocketResponse,
+    ) -> None:
+        """Copy inner TLS records into bounded binary WebSocket messages."""
+
+        while payload := await reader.read(self._frame_bytes):
+            await websocket.send_bytes(payload)
+
+
+def _decode_carrier_value(value: str) -> bytes:
+    """Decode an exact unpadded 256-bit relay value."""
+
+    if len(value) != _ENCODED_CARRIER_VALUE_LENGTH or "=" in value:
+        raise ValueError("relay values must be unpadded base64url-encoded 32-byte values")
+    try:
+        decoded = base64.b64decode(
+            f"{value}=",
+            altchars=b"-_",
+            validate=True,
+        )
+    except (ValueError, UnicodeError) as exc:
+        raise ValueError(
+            "relay values must be unpadded base64url-encoded 32-byte values"
+        ) from exc
+    if len(decoded) != _CARRIER_VALUE_BYTES:
+        raise ValueError("relay values must decode to exactly 32 bytes")
+    return decoded
+
+
+def _validate_carrier_url(value: str, *, expected_path: str) -> str:
+    """Require WSS except for loopback-only generated development relays."""
+
+    parsed = urlsplit(value)
+    if (
+        parsed.path != expected_path
+        or parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.hostname is None
+    ):
+        raise ValueError(f"relay URL must be an origin plus {expected_path}")
+    if parsed.scheme == "wss":
+        return value
+    if parsed.scheme != "ws":
+        raise ValueError("relay URL must use wss")
+    try:
+        loopback = ipaddress.ip_address(parsed.hostname).is_loopback
+    except ValueError:
+        loopback = parsed.hostname == "localhost"
+    if not loopback:
+        raise ValueError("cleartext relay URL is allowed only on loopback")
+    return value
+
+
+def _gateway_server_name(routing_locator: str) -> str:
+    """Derive a stable private inner-TLS name without exposing the locator."""
+
+    digest = hashlib.sha256(_decode_carrier_value(routing_locator)).hexdigest()
+    return f"skulk-{digest[:32]}.remote"
+
+
+def _generate_tls_identity(server_name: str) -> tuple[bytes, bytes]:
+    """Generate one self-signed pinned TLS 1.3 gateway identity."""
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    now = datetime.now(tz=timezone.utc)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, server_name)])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - _TLS_CLOCK_SKEW)
+        .not_valid_after(now + _TLS_VALIDITY)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(server_name)]),
+            critical=False,
+        )
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+            critical=False,
+        )
+        .sign(private_key, hashes.SHA256())
+    )
+    certificate_pem = certificate.public_bytes(serialization.Encoding.PEM)
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return certificate_pem, private_key_pem
+
+
+def _write_create_only(path: Path, payload: bytes, *, mode: int) -> None:
+    """Create one protected file without replacing existing material."""
+
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if os.name == "posix":
+        path.parent.chmod(0o700)
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    except OSError as exc:
+        raise OperatorRelayUnavailableError(
+            "operator gateway TLS identity already exists or cannot be created"
+        ) from exc
+    try:
+        with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except Exception:
+        path.unlink(missing_ok=True)
+        raise
+    if os.name == "posix":
+        path.chmod(mode)
+
+
+def _require_private_file(path: Path) -> None:
+    """Require a present TLS private key with owner-only POSIX permissions."""
+
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise OperatorRelayUnavailableError(
+            "operator gateway TLS private key is unavailable"
+        ) from exc
+    if os.name == "posix" and metadata.st_mode & 0o077:
+        raise OperatorRelayUnavailableError(
+            "operator gateway TLS private key permissions are unsafe"
+        )

--- a/src/skulk/operator/tests/test_architecture_boundary.py
+++ b/src/skulk/operator/tests/test_architecture_boundary.py
@@ -9,6 +9,7 @@ import skulk.operator.authority as authority_module
 import skulk.operator.consensus as consensus_module
 import skulk.operator.consensus_store as consensus_store_module
 import skulk.operator.identity as identity_module
+import skulk.operator.relay as relay_module
 import skulk.operator.replication as replication_module
 import skulk.operator.service as service_module
 import skulk.operator.transport as transport_module
@@ -57,19 +58,21 @@ def test_operator_runtime_does_not_import_inference_state_planes() -> None:
         "skulk.shared.types.state",
         "skulk.shared.types.telemetry",
     )
-    syntax_tree = ast.parse(
-        Path(service_module.__file__).read_text(encoding="utf-8")
-    )
-    imported_modules: set[str] = set()
-    for node in ast.walk(syntax_tree):
-        if isinstance(node, ast.Import):
-            imported_modules.update(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module is not None:
-            imported_modules.add(node.module)
+    for module_path in (
+        Path(service_module.__file__),
+        Path(relay_module.__file__),
+    ):
+        syntax_tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        imported_modules: set[str] = set()
+        for node in ast.walk(syntax_tree):
+            if isinstance(node, ast.Import):
+                imported_modules.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported_modules.add(node.module)
 
-    for imported_module in imported_modules:
-        assert not any(
-            imported_module == forbidden_import
-            or imported_module.startswith(f"{forbidden_import}.")
-            for forbidden_import in forbidden_imports
-        )
+        for imported_module in imported_modules:
+            assert not any(
+                imported_module == forbidden_import
+                or imported_module.startswith(f"{forbidden_import}.")
+                for forbidden_import in forbidden_imports
+            )

--- a/src/skulk/operator/tests/test_relay.py
+++ b/src/skulk/operator/tests/test_relay.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import socket
 import ssl
 from collections.abc import Awaitable, Callable
@@ -20,6 +21,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from skulk.operator.authority import EncryptedAuthorityStore
+from skulk.operator.cli import main as operator_cli_main
 from skulk.operator.key_provider import LocalFileAuthorityKeyProvider
 from skulk.operator.pairing import (
     OperatorPairingService,
@@ -153,6 +155,34 @@ def test_relay_provisioning_rejects_unsafe_or_ambiguous_material(
     payload[field] = value
     with pytest.raises(ValueError):
         OperatorRelayProvisioning.model_validate(payload)
+
+
+def test_configure_relay_cli_never_echoes_rejected_secret_material(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Invalid provisioning reports no credential-bearing validation detail."""
+
+    secret = _base64url(bytes(range(32, 64)))
+    provisioning_path = tmp_path / "invalid-provisioning.json"
+    provisioning_path.write_text(
+        json.dumps(
+            {
+                **_provisioning().model_dump(mode="json"),
+                "app_carrier_credential": f"invalid-{secret}",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        operator_cli_main(
+            ["configure-relay", "--provisioning-file", str(provisioning_path)]
+        )
+
+    captured = capsys.readouterr()
+    assert "unreadable or invalid" in captured.err
+    assert secret not in captured.err
 
 
 class _SyntheticRelay:

--- a/src/skulk/operator/tests/test_relay.py
+++ b/src/skulk/operator/tests/test_relay.py
@@ -1,0 +1,418 @@
+"""Tests for designated-gateway relay provisioning and opaque lane bridging."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import socket
+import ssl
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+from uuid import UUID
+
+import aiohttp
+import pytest
+from aiohttp import web
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from skulk.operator.authority import EncryptedAuthorityStore
+from skulk.operator.key_provider import LocalFileAuthorityKeyProvider
+from skulk.operator.pairing import (
+    OperatorPairingService,
+    PairingChallengeRequest,
+    PairingExchangeRequest,
+    pairing_signature_message,
+)
+from skulk.operator.relay import (
+    OperatorGatewayConnector,
+    OperatorRelayAlreadyConfiguredError,
+    OperatorRelayConfigurationRepository,
+    OperatorRelayProvisioning,
+)
+
+
+def _base64url(value: bytes) -> str:
+    """Encode exact test carrier and device values."""
+
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _provisioning(origin: str = "ws://127.0.0.1:41000") -> OperatorRelayProvisioning:
+    """Return one valid generated relay route."""
+
+    return OperatorRelayProvisioning(
+        version=1,
+        app_websocket_url=f"{origin}/v1/carrier/app",
+        gateway_websocket_url=f"{origin}/v1/carrier/gateway",
+        routing_locator=_base64url(bytes(range(32))),
+        app_carrier_credential=_base64url(bytes(range(32, 64))),
+        gateway_carrier_credential=_base64url(bytes(range(64, 96))),
+        lane_count=1,
+    )
+
+
+def _service(
+    tmp_path: Path,
+) -> tuple[OperatorPairingService, OperatorRelayConfigurationRepository]:
+    """Create one isolated designated-gateway pairing and relay repository."""
+
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "authority-key.bin")
+    store = EncryptedAuthorityStore(provider, tmp_path / "authority.sqlite3")
+    repository = OperatorRelayConfigurationRepository(
+        store,
+        certificate_path=tmp_path / "relay-cert.pem",
+        private_key_path=tmp_path / "relay-key.pem",
+    )
+    return (
+        OperatorPairingService(
+            store,
+            provider,
+            relay_repository=repository,
+            now=lambda: datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc),
+        ),
+        repository,
+    )
+
+
+def test_relay_configuration_is_encrypted_and_returned_once_with_pairing(
+    tmp_path: Path,
+) -> None:
+    """Pairing returns app material while gateway credentials stay encrypted."""
+
+    service, repository = _service(tmp_path)
+    provisioning = _provisioning()
+    configuration = service.configure_relay(
+        provisioning,
+        operator_api_port=52416,
+        cluster_name="Fox Den",
+    )
+    assert repository.load() == configuration
+    assert configuration.private_key_path.stat().st_mode & 0o077 == 0
+    authority_bytes = (tmp_path / "authority.sqlite3").read_bytes()
+    assert provisioning.app_carrier_credential.encode("ascii") not in authority_bytes
+    assert provisioning.gateway_carrier_credential.encode("ascii") not in authority_bytes
+
+    package = service.create_session(exchange_url="https://example.invalid")
+    device_private_key = Ed25519PrivateKey.generate()
+    device_public_key = device_private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    challenge = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            device_name="Phone",
+            device_public_key=_base64url(device_public_key),
+        )
+    )
+    signature = device_private_key.sign(
+        pairing_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            nonce=package.nonce,
+            challenge=challenge.challenge,
+        )
+    )
+    exchange = service.exchange(
+        PairingExchangeRequest(
+            nonce=package.nonce,
+            signature=_base64url(signature),
+        )
+    )
+
+    assert exchange.remote_access is not None
+    assert exchange.remote_access.app_carrier_credential == (
+        provisioning.app_carrier_credential
+    )
+    assert exchange.remote_access.routing_locator == provisioning.routing_locator
+    assert "BEGIN CERTIFICATE" in exchange.remote_access.gateway_ca_certificate_pem
+    assert provisioning.gateway_carrier_credential not in exchange.model_dump_json()
+    with pytest.raises(OperatorRelayAlreadyConfiguredError):
+        service.configure_relay(provisioning, operator_api_port=52416)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("gateway_websocket_url", "ws://relay.example/v1/carrier/gateway"),
+        ("app_websocket_url", "wss://relay.example/wrong"),
+        ("routing_locator", "short"),
+        ("gateway_carrier_credential", _base64url(bytes(range(32, 64)))),
+    ),
+)
+def test_relay_provisioning_rejects_unsafe_or_ambiguous_material(
+    field: str,
+    value: str,
+) -> None:
+    """Provisioning fails closed before any secret is persisted."""
+
+    payload = _provisioning().model_dump(mode="json")
+    payload[field] = value
+    with pytest.raises(ValueError):
+        OperatorRelayProvisioning.model_validate(payload)
+
+
+class _SyntheticRelay:
+    """Minimal paired-WebSocket relay used only for connector integration."""
+
+    def __init__(self, provisioning: OperatorRelayProvisioning) -> None:
+        self._provisioning = provisioning
+        self._gateway_queue: asyncio.Queue[
+            tuple[web.WebSocketResponse, asyncio.Event]
+        ] = asyncio.Queue()
+        self.captured_app_bytes = bytearray()
+
+    def use_provisioning(self, provisioning: OperatorRelayProvisioning) -> None:
+        """Replace the placeholder with the route bound to the started port."""
+
+        self._provisioning = provisioning
+
+    async def gateway(self, request: web.Request) -> web.WebSocketResponse:
+        """Admit one authenticated waiting gateway lane."""
+
+        self._assert_headers(request, self._provisioning.gateway_carrier_credential)
+        websocket = web.WebSocketResponse(max_msg_size=1024 * 1024)
+        await websocket.prepare(request)
+        completed = asyncio.Event()
+        await self._gateway_queue.put((websocket, completed))
+        await completed.wait()
+        return websocket
+
+    async def app(self, request: web.Request) -> web.WebSocketResponse:
+        """Pair one authenticated app socket with the oldest gateway lane."""
+
+        self._assert_headers(request, self._provisioning.app_carrier_credential)
+        app = web.WebSocketResponse(max_msg_size=1024 * 1024)
+        await app.prepare(request)
+        gateway, completed = await asyncio.wait_for(
+            self._gateway_queue.get(),
+            timeout=2.0,
+        )
+        app_to_gateway = asyncio.create_task(
+            self._copy(app, gateway, capture=self.captured_app_bytes)
+        )
+        gateway_to_app = asyncio.create_task(self._copy(gateway, app))
+        tasks = (app_to_gateway, gateway_to_app)
+        try:
+            _, pending = await asyncio.wait(
+                tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+        finally:
+            completed.set()
+            await app.close()
+            await gateway.close()
+        return app
+
+    def _assert_headers(self, request: web.Request, credential: str) -> None:
+        """Require the generated locator and role bearer."""
+
+        assert request.headers["x-skulk-relay-route"] == (
+            self._provisioning.routing_locator
+        )
+        assert request.headers["Authorization"] == f"Bearer {credential}"
+
+    @staticmethod
+    async def _copy(
+        source: web.WebSocketResponse,
+        destination: web.WebSocketResponse,
+        *,
+        capture: bytearray | None = None,
+    ) -> None:
+        """Forward binary messages without interpreting their contents."""
+
+        async for message in source:
+            if message.type is not aiohttp.WSMsgType.BINARY:
+                return
+            payload = cast(bytes, message.data)
+            if capture is not None:
+                capture.extend(payload)
+            await destination.send_bytes(payload)
+
+
+async def _start_socket_server(
+    handler: Callable[
+        [asyncio.StreamReader, asyncio.StreamWriter],
+        Awaitable[None],
+    ],
+    *,
+    ssl_context: ssl.SSLContext | None = None,
+) -> tuple[asyncio.AbstractServer, int]:
+    """Start one loopback server on an operating-system-selected port."""
+
+    server = await asyncio.start_server(
+        handler,
+        host="127.0.0.1",
+        port=0,
+        ssl=ssl_context,
+    )
+    sockets = server.sockets
+    assert sockets is not None and len(sockets) == 1
+    return server, cast(tuple[str, int], sockets[0].getsockname())[-1]
+
+
+async def _start_relay(
+    relay: _SyntheticRelay,
+) -> tuple[web.AppRunner, int]:
+    """Start the synthetic relay on a pre-bound loopback socket."""
+
+    application = web.Application()
+    application.router.add_get("/v1/carrier/app", relay.app)
+    application.router.add_get("/v1/carrier/gateway", relay.gateway)
+    runner = web.AppRunner(application)
+    await runner.setup()
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    listener.setblocking(False)
+    port = cast(tuple[str, int], listener.getsockname())[-1]
+    await web.SockSite(runner, listener).start()
+    return runner, port
+
+
+@pytest.mark.asyncio
+async def test_gateway_connector_carries_real_inner_tls_without_plaintext_visibility(
+    tmp_path: Path,
+) -> None:
+    """A canonical HTTP request crosses paired WebSockets under inner TLS."""
+
+    service, _ = _service(tmp_path)
+    initial = service.configure_relay(
+        _provisioning(),
+        operator_api_port=52416,
+    )
+
+    async def api_handler(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        request = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=2.0)
+        assert b"GET /state HTTP/1.1" in request
+        assert b"Authorization: Bearer inner-operator-token" in request
+        body = b'{"cluster":"connector-proof"}'
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+            + f"Content-Length: {len(body)}\r\nConnection: close\r\n\r\n".encode()
+            + body
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    operator_api, operator_api_port = await _start_socket_server(
+        api_handler,
+        ssl_context=initial.server_ssl_context(),
+    )
+    placeholder = _provisioning()
+    synthetic_relay = _SyntheticRelay(placeholder)
+    relay_runner, relay_port = await _start_relay(synthetic_relay)
+    provisioning = _provisioning(f"ws://127.0.0.1:{relay_port}")
+    synthetic_relay.use_provisioning(provisioning)
+    configuration = initial.model_copy(
+        update={
+            "app_websocket_url": provisioning.app_websocket_url,
+            "gateway_websocket_url": provisioning.gateway_websocket_url,
+            "operator_api_port": operator_api_port,
+        }
+    )
+    connector_task = asyncio.create_task(OperatorGatewayConnector(configuration).run())
+
+    async with aiohttp.ClientSession() as app_session:
+
+        async def app_adapter(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            headers = {
+                "Authorization": f"Bearer {provisioning.app_carrier_credential}",
+                "x-skulk-relay-route": provisioning.routing_locator,
+            }
+            async with app_session.ws_connect(
+                provisioning.app_websocket_url,
+                headers=headers,
+                max_msg_size=1024 * 1024,
+            ) as websocket:
+                tcp_to_websocket = asyncio.create_task(
+                    _tcp_to_websocket(reader, websocket)
+                )
+                websocket_to_tcp = asyncio.create_task(
+                    _websocket_to_tcp(websocket, writer)
+                )
+                tasks = (tcp_to_websocket, websocket_to_tcp)
+                _, pending = await asyncio.wait(
+                    tasks,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+            writer.close()
+            await writer.wait_closed()
+
+        adapter, adapter_port = await _start_socket_server(app_adapter)
+        client_context = ssl.create_default_context(
+            cadata=configuration.device_material().gateway_ca_certificate_pem
+        )
+        client_context.minimum_version = ssl.TLSVersion.TLSv1_3
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(
+                    "127.0.0.1",
+                    adapter_port,
+                    ssl=client_context,
+                    server_hostname=configuration.gateway_server_name,
+                ),
+                timeout=5.0,
+            )
+            writer.write(
+                b"GET /state HTTP/1.1\r\nHost: operator\r\n"
+                b"Authorization: Bearer inner-operator-token\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            await writer.drain()
+            response = await asyncio.wait_for(reader.read(), timeout=5.0)
+            assert b"HTTP/1.1 200 OK" in response
+            assert b"connector-proof" in response
+            assert b"inner-operator-token" not in synthetic_relay.captured_app_bytes
+            assert b"GET /state" not in synthetic_relay.captured_app_bytes
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            adapter.close()
+            await adapter.wait_closed()
+
+    connector_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await connector_task
+    operator_api.close()
+    await operator_api.wait_closed()
+    await relay_runner.cleanup()
+
+
+async def _tcp_to_websocket(
+    reader: asyncio.StreamReader,
+    websocket: aiohttp.ClientWebSocketResponse,
+) -> None:
+    """Copy local adapter bytes into app-role binary messages."""
+
+    while payload := await reader.read(1024 * 1024):
+        await websocket.send_bytes(payload)
+
+
+async def _websocket_to_tcp(
+    websocket: aiohttp.ClientWebSocketResponse,
+    writer: asyncio.StreamWriter,
+) -> None:
+    """Copy app-role binary messages into the local TLS client stream."""
+
+    async for message in websocket:
+        if message.type is not aiohttp.WSMsgType.BINARY:
+            return
+        writer.write(cast(bytes, message.data))
+        await writer.drain()

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -209,6 +209,23 @@ designated remote gateway. It does not expose an HTTP endpoint that creates
 pairing sessions:
 
 ```bash
+uv run skulk operator configure-relay \
+  --provisioning-file /protected/path/relay-v1.json \
+  --operator-api-port 52416 \
+  --cluster-name "Cluster"
+```
+
+The generated provisioning document is supplied by the Foxlight relay service
+and contains `version`, `appWebsocketUrl`, `gatewayWebsocketUrl`,
+`routingLocator`, distinct `appCarrierCredential` and
+`gatewayCarrierCredential` values, and `laneCount`. Treat the file as a secret:
+it contains both outer carrier roles. Skulk validates exact fixed carrier paths,
+requires WSS except for loopback development, stores the route and credentials
+inside the encrypted authority journal, generates an owner-only pinned TLS
+identity, and refuses silent replacement. Restart Skulk after initial
+configuration so the designated gateway opens its bounded outbound lane pool.
+
+```bash
 uv run skulk operator pair \
   --exchange-url https://gateway.example.invalid \
   --cluster-name "Cluster"
@@ -268,16 +285,23 @@ Behavior:
 - returns a stable `deviceId`, the validated cluster identity, a 15-minute
   opaque access token, a 30-day rotating refresh token, their expiries, and the
   granted canonical API scopes;
+- when relay access is configured, also returns one-time `remoteAccess` material:
+  `transport=paired_websocket_v1`, app WebSocket URL, opaque route locator,
+  app-role carrier credential, inner-TLS server name, and pinned gateway CA
+  certificate. The gateway-role carrier credential is never returned;
 - stores only encrypted session/device state and one-way token digests;
 - never returns either credential again;
 - returns `401` for an invalid proof, `409` for reuse or an out-of-order
   exchange, `410` after expiry, and `503` on a non-designated node.
 
-These two endpoints are the complete pre-credential HTTP surface. The access
-token is accepted by the device-management routes below. Protecting selected
-canonical cluster, model, chat, and operation routes with the same validator is
-a subsequent slice; Skulk does not create parallel mobile-only model or
-inference APIs.
+Together with refresh rotation, these are the complete pre-access-token HTTP
+surface on the relay-only listener. That listener serves the existing canonical
+Skulk app rather than a parallel mobile API: safe reads require `cluster:read`
+or `models:read`, inference/WebSocket routes require `chat:write`, mutations
+require `operations:write`, and device routes require `devices:manage`. The
+existing local listener and dashboard remain unchanged for direct clients; only
+the separate loopback TLS listener connected to the relay applies this bearer
+boundary.
 
 ### Rotate operator credentials
 
@@ -301,7 +325,9 @@ Behavior:
 
 The client must replace both stored credentials as one operation. A response
 lost after the gateway commits rotation requires pairing again because replaying
-the previous refresh token is intentionally rejected.
+the previous refresh token is intentionally rejected. Relay and pinned TLS
+material are not repeated during refresh; the app retains them in platform
+secure storage until it disconnects or pairs again.
 
 ### List paired devices
 

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -100,10 +100,12 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   `src/skulk/operator/authority.py`, `src/skulk/operator/replication.py`,
   `src/skulk/operator/consensus.py`, `src/skulk/operator/consensus_store.py`,
   `src/skulk/operator/service.py`, `src/skulk/operator/transport.py`,
-  `src/skulk/operator/key_provider.py`, `src/skulk/operator/pairing.py`, and
-  `src/skulk/operator/cli.py`; pairing and credential-lifecycle routes live in
-  `src/skulk/api/operator_auth.py`, and focused tests live in
-  `src/skulk/operator/tests/` and `src/skulk/api/tests/test_operator_auth.py`.
+  `src/skulk/operator/key_provider.py`, `src/skulk/operator/pairing.py`,
+  `src/skulk/operator/relay.py`, and `src/skulk/operator/cli.py`; pairing and
+  credential-lifecycle routes live in `src/skulk/api/operator_auth.py`, the
+  relay-only canonical API guard lives in `src/skulk/api/operator_gateway.py`,
+  and focused tests live in `src/skulk/operator/tests/` and
+  `src/skulk/api/tests/`.
 - **Stable node identity:** `NodeInstallationIdentity.node_install_id` is a
   persisted UUIDv4 under the protected operator configuration directory. It is
   intentionally independent of the currently ephemeral libp2p `NodeId`.
@@ -162,22 +164,34 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   session, and returns one access/refresh credential pair. The journal stores
   encrypted state and one-way token digests, not raw nonces or tokens. Refresh
   rotates both tokens atomically; bearer validation enforces typed scopes; and
-  device list/revoke routes expose no credential material. Applying that same
-  validator to selected canonical model, inference, and command routes remains
-  the next slice; no mobile-only replacement surface is introduced.
+  device list/revoke routes expose no credential material. A relay-configured
+  exchange also returns the app-role carrier credential, opaque locator, and
+  pinned inner-TLS trust once; the gateway role never leaves Skulk.
+- **V1 remote carrier:** `skulk operator configure-relay --provisioning-file`
+  validates one generated paired-WebSocket route, encrypts locator and distinct
+  app/gateway carrier credentials in the local journal, and creates a protected
+  pinned TLS identity. `OperatorGatewayConnector` maintains 1–32 independent
+  outbound gateway lanes with bounded frames and reconnect delay. Each lane is
+  an opaque byte bridge to a loopback TLS listener serving the same FastAPI app.
+  `OperatorGatewayAuthorization` leaves pairing/refresh bootstrap reachable and
+  maps every other canonical route onto existing cluster/model/chat/operation/
+  device scopes. The ordinary local API/dashboard listener is unchanged and is
+  not relay-accessible; no mobile-only replacement surface exists.
 - **Key boundary:** `AuthorityKeyProvider` supplies the active unwrapped 32-byte
   data key and immutable key-version ID. V1's
   `LocalFileAuthorityKeyProvider` creates one random local key protected by
   POSIX mode `0600` on the designated gateway. Hardware-backed wrapping and
   replicated key envelopes are later hardening; the authority SQLite database
   never writes the plaintext data key itself.
-- **Critical boundary:** deterministic network vote collection, certified log
+- **Critical boundary:** local pairing, scoped canonical relay ingress, and the
+  outbound designated-gateway lane pool are active when provisioned.
+  Deterministic network vote collection, certified log
   recovery, and caller-selected bounded proposal orchestration are implemented,
   but authority leader selection, encrypted payload replication, OS-protected
   key wrapping, gateway leases, and Node lifecycle integration are later slices.
-  V1 explicitly claims no automatic authority failover: local pairing state is
-  authoritative only for the designated gateway and remote access is
-  unavailable when that host is unavailable. None of these records enters
+  V1 explicitly claims no automatic authority or gateway failover: local
+  pairing and relay state are authoritative only for the designated gateway,
+  and remote access is unavailable when that host is unavailable. None of these records enters
   `State`, telemetry, diagnostics, or the API event log.
 
 ### Extensions (plugins)

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -191,8 +191,11 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   key wrapping, gateway leases, and Node lifecycle integration are later slices.
   V1 explicitly claims no automatic authority or gateway failover: local
   pairing and relay state are authoritative only for the designated gateway,
-  and remote access is unavailable when that host is unavailable. None of these records enters
-  `State`, telemetry, diagnostics, or the API event log.
+  and remote access is unavailable when that host is unavailable. Relay state
+  loading and the relay listener/connector are isolated from the ordinary local
+  API, so damaged protected material or carrier startup failure disables only
+  remote access. None of these records enters `State`, telemetry, diagnostics,
+  or the API event log.
 
 ### Extensions (plugins)
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -965,9 +965,27 @@ refresh credentials once. Raw nonces and tokens are never stored in plaintext;
 the authority journal contains encrypted state and one-way token digests.
 Refresh rotates and invalidates the prior access/refresh pair atomically. The
 same service validates short-lived bearer access, exposes credential-free
-paired-device projections, and makes revocation immediate. These lifecycle
-routes prove the authorization boundary before selected canonical Skulk APIs
-adopt it; they do not create parallel model, inference, or command APIs.
+paired-device projections, and makes revocation immediate. The relay-only
+listener applies these scopes to the existing canonical routes; Skulk does not
+create parallel model, inference, or command APIs.
+
+`skulk operator configure-relay` installs one generated paired-WebSocket route
+before normal public operation. The app and gateway use distinct 256-bit outer
+carrier credentials and one opaque locator; all are encrypted in the local
+authority journal, while the generated inner-TLS private key is an owner-only
+file. Pairing returns only the app role plus the pinned self-signed gateway
+certificate. On startup the designated gateway maintains a bounded pool of
+outbound WebSockets. Each lane bridges opaque binary messages to a separate
+loopback TLS listener serving the existing FastAPI application. The relay never
+terminates that inner TLS connection.
+
+The loopback TLS listener wraps the canonical application with operator bearer
+validation: reads, model views, inference/WebSockets, mutations, and device
+management map onto the existing scopes. Pairing challenge/exchange and refresh
+remain reachable before access-token validation. The ordinary port-52415 local
+listener remains unchanged for the dashboard and existing direct clients; it is
+never the relay connector's destination. If the designated gateway or relay is
+unavailable, remote access fails while local cluster operation continues.
 
 ### Event log
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -985,7 +985,11 @@ management map onto the existing scopes. Pairing challenge/exchange and refresh
 remain reachable before access-token validation. The ordinary port-52415 local
 listener remains unchanged for the dashboard and existing direct clients; it is
 never the relay connector's destination. If the designated gateway or relay is
-unavailable, remote access fails while local cluster operation continues.
+unavailable, remote access fails while local cluster operation continues. Relay
+configuration loading, the loopback TLS listener, and the outbound connector
+are supervised as an optional ingress unit: corrupt authority/TLS material,
+bind failures, and connector failures are reported with sanitized messages and
+cannot cancel or prevent startup of the ordinary local API.
 
 ### Event log
 


### PR DESCRIPTION
## Summary
- persist generated relay route material in the encrypted operator authority store and generate a pinned inner-TLS identity
- maintain bounded outbound gateway WebSocket lanes and bridge opaque TLS records to a loopback-only listener
- protect the existing canonical Skulk API with existing operator scopes on the relay listener, without creating a parallel app API
- return device-safe relay and pinned-certificate material once during pairing exchange
- add the local relay configuration command, integration coverage, and operator/API architecture documentation

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` — 3,136 passed, 1 skipped
- `uv run python scripts/export_openapi.py`
- `uv run python scripts/build_docs.py`
- generated local paired-WebSocket integration test verifies a real inner-TLS HTTP request while the relay capture contains neither the canonical route nor inner bearer

## Scope
- no live fleet or model operations were used
- the normal local API/dashboard listener remains unchanged
- initial pairing remains host-authorized; the relay becomes the normal path after exchange