### PR TITLE
feat: bootstrap operator pairing through relay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,10 @@ A single Skulk `Node` (src/skulk/main.py) runs multiple components:
   membership chain from immutable bootstrap anchors. The encrypted journal
   requires an injected external data-key provider. The v1 designated gateway
   uses a protected local-file provider and `skulk operator pair` to create a
-  five-minute QR capability; the API exposes only device-key challenge and
-  exchange before authentication, returning one-time opaque access/refresh
+  five-minute QR capability. A relay-configured gateway includes app-role
+  carrier and pinned inner-TLS bootstrap material in the version-two QR while
+  retaining `--exchange-url` as a direct fallback; the API exposes only
+  device-key challenge and exchange before authentication, returning one-time opaque access/refresh
   credentials while persisting encrypted state and token digests. Refresh
   rotates both credentials, bearer validation enforces canonical scopes, and
   authorized devices can list or revoke credential-free device projections.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,8 @@ A single Skulk `Node` (src/skulk/main.py) runs multiple components:
   uses a protected local-file provider and `skulk operator pair` to create a
   five-minute QR capability. A relay-configured gateway includes app-role
   carrier and pinned inner-TLS bootstrap material in the version-two QR while
-  retaining `--exchange-url` as a direct fallback; the API exposes only
+  retaining `--exchange-url` as a direct fallback. Relay packages use bounded,
+  zlib-compressed compact JSON so terminal QRs remain scannable; the API exposes only
   device-key challenge and exchange before authentication, returning one-time opaque access/refresh
   credentials while persisting encrypted state and token digests. Refresh
   rotates both credentials, bearer validation enforces canonical scopes, and

--- a/src/skulk/operator/cli.py
+++ b/src/skulk/operator/cli.py
@@ -17,7 +17,7 @@ class _PairArguments(FrozenModel):
     """Strictly validated local pairing command arguments."""
 
     command: Literal["pair"]
-    exchange_url: str
+    exchange_url: str | None
     cluster_name: str
 
 
@@ -60,8 +60,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     pair_parser.add_argument(
         "--exchange-url",
-        required=True,
-        help="HTTPS base URL the phone can reach; HTTP is accepted only on loopback.",
+        help=(
+            "Optional direct HTTPS base URL; a configured relay is used by default. "
+            "HTTP is accepted only on loopback."
+        ),
     )
     pair_parser.add_argument(
         "--cluster-name",
@@ -114,10 +116,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     arguments = _PairArguments.model_validate(parsed_values)
-    package = service.create_session(
-        exchange_url=arguments.exchange_url,
-        cluster_name=arguments.cluster_name,
-    )
+    try:
+        package = service.create_session(
+            exchange_url=arguments.exchange_url,
+            cluster_name=arguments.cluster_name,
+        )
+    except ValueError:
+        parser.error(
+            "pairing requires a configured relay or an explicit --exchange-url"
+        )
     print(
         f"Pair with {package.cluster_name} before "
         f"{package.expires_at.isoformat()}."

--- a/src/skulk/operator/cli.py
+++ b/src/skulk/operator/cli.py
@@ -8,7 +8,10 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal, cast
 
-from skulk.operator.pairing import OperatorPairingService
+from skulk.operator.pairing import (
+    OperatorPairingService,
+    PairingPackageTooLargeError,
+)
 from skulk.operator.relay import OperatorRelayProvisioning
 from skulk.utils.pydantic_ext import FrozenModel
 
@@ -34,8 +37,12 @@ def _print_pairing_qr(payload: str) -> None:
     """Render a terminal QR code plus the exact fallback payload."""
 
     import qrcode
+    from qrcode.constants import ERROR_CORRECT_L
 
-    code = qrcode.QRCode(border=2)
+    code = qrcode.QRCode(
+        border=2,
+        error_correction=ERROR_CORRECT_L,
+    )
     code.add_data(payload)
     code.make(fit=True)
     code.print_ascii(invert=True)
@@ -121,6 +128,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             exchange_url=arguments.exchange_url,
             cluster_name=arguments.cluster_name,
         )
+    except PairingPackageTooLargeError:
+        parser.error("relay pairing package is too large for a reliable QR code")
     except ValueError:
         parser.error(
             "pairing requires a configured relay or an explicit --exchange-url"

--- a/src/skulk/operator/pairing.py
+++ b/src/skulk/operator/pairing.py
@@ -15,7 +15,7 @@ from uuid import UUID, uuid4
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-from pydantic import AnyHttpUrl, Field, field_validator
+from pydantic import AnyHttpUrl, Field, field_validator, model_validator
 
 from skulk.operator.authority import (
     AuthorityCommitConflictError,
@@ -102,7 +102,7 @@ class OperatorDeviceNotFoundError(OperatorCredentialError):
 class PairingPackage(FrozenModel):
     """Short-lived public package encoded in a Skulk pairing QR code."""
 
-    version: Literal[1] = Field(description="Pairing package format version.")
+    version: Literal[1, 2] = Field(description="Pairing package format version.")
     cluster_id: UUID = Field(description="Stable identity of the target cluster.")
     cluster_name: str = Field(description="Operator-visible cluster name.")
     cluster_fingerprint: str = Field(
@@ -116,6 +116,13 @@ class PairingPackage(FrozenModel):
         min_length=32,
         max_length=128,
         description="High-entropy single-use pairing capability.",
+    )
+    remote_access: OperatorRemoteAccessMaterial | None = Field(
+        default=None,
+        description=(
+            "Relay and pinned inner-TLS material used only to reach the "
+            "pairing routes when version is two."
+        ),
     )
 
     @field_validator("expires_at")
@@ -137,11 +144,19 @@ class PairingPackage(FrozenModel):
 
         return _validate_exchange_url(value)
 
+    @model_validator(mode="after")
+    def _version_matches_transport(self) -> "PairingPackage":
+        """Keep legacy direct packages distinct from relay bootstrap packages."""
+
+        if (self.version == 1) != (self.remote_access is None):
+            raise ValueError("pairing package version does not match remote access")
+        return self
+
     def as_url(self) -> str:
         """Return the package as a compact custom-scheme QR payload."""
 
         encoded = _base64url_encode(
-            self.model_dump_json(by_alias=True).encode("utf-8")
+            self.model_dump_json(by_alias=True, exclude_none=True).encode("utf-8")
         )
         return f"skulk://pair?payload={encoded}"
 
@@ -487,34 +502,52 @@ class OperatorPairingService:
     def create_session(
         self,
         *,
-        exchange_url: str,
+        exchange_url: str | None = None,
         cluster_name: str = "Cluster",
     ) -> PairingPackage:
         """Create one host-authorized five-minute pairing package.
 
         Args:
-            exchange_url: Direct or relayed base URL reachable by the phone.
+            exchange_url: Optional direct HTTPS base URL. When omitted, a
+                configured relay supplies the inner gateway origin.
             cluster_name: Name used only when initializing a new gateway.
 
         Returns:
             Public package safe to render as a QR code.
+
+        Raises:
+            ValueError: No protected direct URL or configured relay is available.
         """
 
+        relay_configuration = self._relay_repository.load()
+        use_relay = exchange_url is None
+        if exchange_url is None:
+            if relay_configuration is None:
+                raise ValueError(
+                    "exchange_url is required until operator relay is configured"
+                )
+            exchange_url = f"https://{relay_configuration.gateway_server_name}"
         validated_exchange_url = _validate_exchange_url(exchange_url)
         identity = self.initialize_gateway(cluster_name)
+        remote_access = (
+            relay_configuration.device_material()
+            if use_relay and relay_configuration is not None
+            else None
+        )
 
         now = self._now()
         nonce = secrets.token_urlsafe(32)
         nonce_hash = _opaque_digest(nonce)
         expires_at = now + _PAIRING_LIFETIME
         package = PairingPackage(
-            version=1,
+            version=2 if remote_access is not None else 1,
             cluster_id=UUID(str(identity.cluster_id)),
             cluster_name=identity.name,
             cluster_fingerprint=identity.fingerprint,
             exchange_url=validated_exchange_url,
             expires_at=expires_at,
             nonce=nonce,
+            remote_access=remote_access,
         )
         session = _StoredPairingSession(
             state="pending",

--- a/src/skulk/operator/pairing.py
+++ b/src/skulk/operator/pairing.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import json
 import secrets
+import zlib
 from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from hmac import compare_digest
@@ -37,6 +38,7 @@ _PAIRING_LIFETIME = timedelta(minutes=5)
 _ACCESS_TOKEN_LIFETIME = timedelta(minutes=15)
 _REFRESH_TOKEN_LIFETIME = timedelta(days=30)
 _PAIRING_SIGNATURE_CONTEXT = b"skulk-device-pairing-v1\x00"
+_MAXIMUM_RELAY_PAIRING_URL_BYTES = 1_170
 
 type OperatorScope = Literal[
     "cluster:read",
@@ -77,6 +79,10 @@ class PairingProofError(PairingError):
 
 class PairingGatewayNotInitializedError(PairingError):
     """Raised when this API node has not been designated through local pairing."""
+
+
+class PairingPackageTooLargeError(PairingError):
+    """Raised before persisting relay pairing material that will not scan reliably."""
 
 
 class OperatorCredentialError(RuntimeError):
@@ -154,6 +160,35 @@ class PairingPackage(FrozenModel):
 
     def as_url(self) -> str:
         """Return the package as a compact custom-scheme QR payload."""
+
+        if self.version == 2:
+            remote_access = cast(OperatorRemoteAccessMaterial, self.remote_access)
+            compact_payload = {
+                "v": self.version,
+                "i": str(self.cluster_id),
+                "n": self.cluster_name,
+                "f": self.cluster_fingerprint,
+                "u": str(self.exchange_url),
+                "e": self.expires_at.isoformat(),
+                "o": self.nonce,
+                "r": {
+                    "t": remote_access.transport,
+                    "w": remote_access.app_websocket_url,
+                    "l": remote_access.routing_locator,
+                    "c": remote_access.app_carrier_credential,
+                    "s": remote_access.gateway_server_name,
+                    "p": remote_access.gateway_ca_certificate_pem,
+                },
+            }
+            compressed = zlib.compress(
+                json.dumps(
+                    compact_payload,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ).encode("utf-8"),
+                level=9,
+            )
+            return f"skulk://pair?z={_base64url_encode(compressed)}"
 
         encoded = _base64url_encode(
             self.model_dump_json(by_alias=True, exclude_none=True).encode("utf-8")
@@ -549,6 +584,14 @@ class OperatorPairingService:
             nonce=nonce,
             remote_access=remote_access,
         )
+        if (
+            package.version == 2
+            and len(package.as_url().encode("utf-8"))
+            > _MAXIMUM_RELAY_PAIRING_URL_BYTES
+        ):
+            raise PairingPackageTooLargeError(
+                "relay pairing package exceeds the supported QR size"
+            )
         session = _StoredPairingSession(
             state="pending",
             nonce_hash=nonce_hash,

--- a/src/skulk/operator/tests/test_pairing.py
+++ b/src/skulk/operator/tests/test_pairing.py
@@ -197,7 +197,7 @@ def test_pairing_expires_after_five_minutes(tmp_path: Path) -> None:
 
 
 def test_pairing_package_contains_no_durable_credential(tmp_path: Path) -> None:
-    """The QR carries identity and one short-lived capability only."""
+    """A direct QR carries identity and one short-lived capability only."""
 
     clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
     package = _service(tmp_path, clock).create_session(
@@ -207,7 +207,34 @@ def test_pairing_package_contains_no_durable_credential(tmp_path: Path) -> None:
 
     assert "accessToken" not in payload
     assert "refreshToken" not in payload
+    assert package.version == 1
+    assert package.remote_access is None
     assert package.as_url().startswith("skulk://pair?payload=")
+    assert "remoteAccess" not in _pairing_url_payload(package.as_url())
+
+
+def test_pairing_requires_direct_url_before_relay_configuration(
+    tmp_path: Path,
+) -> None:
+    """A host cannot print an unreachable pairing package before provisioning."""
+
+    clock = [datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+
+    with pytest.raises(ValueError, match="exchange_url is required"):
+        service.create_session()
+
+    assert not (tmp_path / "authority-key.bin").exists()
+    assert not (tmp_path / "authority.sqlite3").exists()
+
+
+def _pairing_url_payload(value: str) -> str:
+    """Decode a generated QR URL for wire-shape assertions."""
+
+    encoded = value.split("payload=", maxsplit=1)[1]
+    return base64.urlsafe_b64decode(f"{encoded}{'=' * (-len(encoded) % 4)}").decode(
+        "utf-8"
+    )
 
 
 def test_pairing_rejects_cleartext_non_loopback_exchange_url(

--- a/src/skulk/operator/tests/test_relay.py
+++ b/src/skulk/operator/tests/test_relay.py
@@ -20,8 +20,8 @@ from aiohttp import web
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
+import skulk.operator.cli as operator_cli
 from skulk.operator.authority import EncryptedAuthorityStore
-from skulk.operator.cli import main as operator_cli_main
 from skulk.operator.key_provider import LocalFileAuthorityKeyProvider
 from skulk.operator.pairing import (
     OperatorPairingService,
@@ -98,7 +98,24 @@ def test_relay_configuration_is_encrypted_and_returned_once_with_pairing(
     assert provisioning.app_carrier_credential.encode("ascii") not in authority_bytes
     assert provisioning.gateway_carrier_credential.encode("ascii") not in authority_bytes
 
-    package = service.create_session(exchange_url="https://example.invalid")
+    package = service.create_session()
+    assert package.version == 2
+    assert package.remote_access is not None
+    assert package.remote_access.app_carrier_credential == (
+        provisioning.app_carrier_credential
+    )
+    assert package.remote_access.routing_locator == provisioning.routing_locator
+    assert str(package.exchange_url) == (
+        f"https://{configuration.gateway_server_name}/"
+    )
+    assert len(package.as_url()) < 8_192
+    assert provisioning.gateway_carrier_credential not in package.model_dump_json()
+
+    direct_package = service.create_session(
+        exchange_url="https://gateway.example.invalid"
+    )
+    assert direct_package.version == 1
+    assert direct_package.remote_access is None
     device_private_key = Ed25519PrivateKey.generate()
     device_public_key = device_private_key.public_key().public_bytes(
         encoding=serialization.Encoding.Raw,
@@ -176,13 +193,42 @@ def test_configure_relay_cli_never_echoes_rejected_secret_material(
     )
 
     with pytest.raises(SystemExit):
-        operator_cli_main(
+        operator_cli.main(
             ["configure-relay", "--provisioning-file", str(provisioning_path)]
         )
 
     captured = capsys.readouterr()
     assert "unreadable or invalid" in captured.err
     assert secret not in captured.err
+
+
+def test_pair_cli_uses_configured_relay_without_direct_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Normal pairing needs no manually supplied phone-reachable URL."""
+
+    service, _ = _service(tmp_path)
+    service.configure_relay(_provisioning(), operator_api_port=52416)
+    payloads: list[str] = []
+
+    def service_from_default_paths(
+        _service_type: type[OperatorPairingService],
+    ) -> OperatorPairingService:
+        """Return the isolated configured service for this CLI invocation."""
+
+        return service
+
+    monkeypatch.setattr(
+        OperatorPairingService,
+        "from_default_paths",
+        classmethod(service_from_default_paths),
+    )
+    monkeypatch.setattr(operator_cli, "_print_pairing_qr", payloads.append)
+
+    assert operator_cli.main(["pair"]) == 0
+    assert len(payloads) == 1
+    assert payloads[0].startswith("skulk://pair?payload=")
 
 
 class _SyntheticRelay:

--- a/src/skulk/operator/tests/test_relay.py
+++ b/src/skulk/operator/tests/test_relay.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import io
 import json
 import socket
 import ssl
+import zlib
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from datetime import datetime, timezone
@@ -16,9 +18,11 @@ from uuid import UUID
 
 import aiohttp
 import pytest
+import qrcode
 from aiohttp import web
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from qrcode.constants import ERROR_CORRECT_L
 
 import skulk.operator.cli as operator_cli
 from skulk.operator.authority import EncryptedAuthorityStore
@@ -27,6 +31,8 @@ from skulk.operator.pairing import (
     OperatorPairingService,
     PairingChallengeRequest,
     PairingExchangeRequest,
+    PairingPackage,
+    PairingPackageTooLargeError,
     pairing_signature_message,
 )
 from skulk.operator.relay import (
@@ -108,7 +114,33 @@ def test_relay_configuration_is_encrypted_and_returned_once_with_pairing(
     assert str(package.exchange_url) == (
         f"https://{configuration.gateway_server_name}/"
     )
-    assert len(package.as_url()) < 8_192
+    assert len(package.as_url().encode("utf-8")) <= 1_170
+    code = qrcode.QRCode(
+        border=2,
+        error_correction=ERROR_CORRECT_L,
+    )
+    code.add_data(package.as_url())
+    code.make(fit=True)
+    terminal_output = io.StringIO()
+    code.print_ascii(out=terminal_output, invert=True)
+    assert max(map(len, terminal_output.getvalue().splitlines())) <= 120
+    encoded = package.as_url().split("?z=", maxsplit=1)[1]
+    decoded_payload = cast(
+        object,
+        json.loads(
+            zlib.decompress(
+                base64.urlsafe_b64decode(f"{encoded}{'=' * (-len(encoded) % 4)}")
+            )
+        ),
+    )
+    assert isinstance(decoded_payload, dict)
+    compact_payload = cast(dict[str, object], decoded_payload)
+    assert compact_payload["v"] == 2
+    assert compact_payload["i"] == str(package.cluster_id)
+    remote_payload_value = compact_payload["r"]
+    assert isinstance(remote_payload_value, dict)
+    remote_payload = cast(dict[str, object], remote_payload_value)
+    assert remote_payload["c"] == provisioning.app_carrier_credential
     assert provisioning.gateway_carrier_credential not in package.model_dump_json()
 
     direct_package = service.create_session(
@@ -151,6 +183,29 @@ def test_relay_configuration_is_encrypted_and_returned_once_with_pairing(
     assert provisioning.gateway_carrier_credential not in exchange.model_dump_json()
     with pytest.raises(OperatorRelayAlreadyConfiguredError):
         service.configure_relay(provisioning, operator_api_port=52416)
+
+
+def test_oversized_relay_package_is_rejected_before_session_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A terminal-hostile relay QR must not leave a live nonce behind."""
+
+    service, _ = _service(tmp_path)
+    service.configure_relay(_provisioning(), operator_api_port=52416)
+
+    def oversized_url(_package: PairingPackage) -> str:
+        return "x" * 1_171
+
+    monkeypatch.setattr(PairingPackage, "as_url", oversized_url)
+
+    def unexpected_append(*_arguments: object) -> None:
+        raise AssertionError("oversized pairing session was persisted")
+
+    monkeypatch.setattr(OperatorPairingService, "_append_session", unexpected_append)
+
+    with pytest.raises(PairingPackageTooLargeError, match="supported QR size"):
+        service.create_session()
 
 
 @pytest.mark.parametrize(
@@ -228,7 +283,7 @@ def test_pair_cli_uses_configured_relay_without_direct_url(
 
     assert operator_cli.main(["pair"]) == 0
     assert len(payloads) == 1
-    assert payloads[0].startswith("skulk://pair?payload=")
+    assert payloads[0].startswith("skulk://pair?z=")
 
 
 class _SyntheticRelay:

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -242,6 +242,11 @@ host-authorized pairing material and do not publish it. The app-role carrier
 credential only admits an opaque relay lane; the five-minute nonce and device
 proof still gate credential issuance at Skulk.
 
+Version-two packages use bounded compact JSON compressed with zlib and carried
+in the QR's single `z` query parameter. Skulk rejects a package before
+persisting its session if it would exceed the terminal-scannable budget.
+Version-one direct packages retain the uncompressed `payload` shape.
+
 `--exchange-url https://gateway.example.invalid` remains an optional direct
 LAN/Tailscale path and is required only before relay provisioning. Remote
 exchange URLs must use HTTPS; cleartext HTTP is accepted only for loopback

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -227,17 +227,26 @@ configuration so the designated gateway opens its bounded outbound lane pool.
 
 ```bash
 uv run skulk operator pair \
-  --exchange-url https://gateway.example.invalid \
   --cluster-name "Cluster"
 ```
 
 The command initializes the gateway's encrypted local authority store when
 needed, creates one high-entropy session that expires after five minutes, and
 prints a terminal QR code plus the exact `skulk://pair?...` fallback payload.
-The QR contains cluster identity, fingerprint, exchange URL, expiry, and the
-single-use nonce. It never contains an access or refresh credential. Remote
+When relay access is configured, the version-two QR uses it by default and
+contains cluster identity, fingerprint, the single-use nonce and expiry, plus
+the app-role outer carrier locator/credential and pinned inner-TLS material
+needed to reach these same pairing routes. It never contains a canonical access
+or refresh credential, or the gateway-role carrier credential. Treat the QR as
+host-authorized pairing material and do not publish it. The app-role carrier
+credential only admits an opaque relay lane; the five-minute nonce and device
+proof still gate credential issuance at Skulk.
+
+`--exchange-url https://gateway.example.invalid` remains an optional direct
+LAN/Tailscale path and is required only before relay provisioning. Remote
 exchange URLs must use HTTPS; cleartext HTTP is accepted only for loopback
-development URLs.
+development URLs. A relay-configured package includes both the protected inner
+origin and relay bootstrap material, and the app prefers the relay path.
 
 ### Create a device challenge
 

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -161,7 +161,9 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   initializes the encrypted store when needed, and emits one five-minute QR
   capability. A relay-configured gateway emits the version-two package with
   app-role carrier and pinned inner-TLS bootstrap material; `--exchange-url`
-  remains the direct-development fallback. Challenge binds a proposed Ed25519
+  remains the direct-development fallback. The relay package is bounded compact
+  JSON compressed with zlib under the QR's `z` parameter and is rejected before
+  session persistence if it exceeds the terminal-scannable budget. Challenge binds a proposed Ed25519
   device key; exchange verifies a domain-separated signature, consumes the
   session, and returns one access/refresh credential pair. The journal stores
   encrypted state and one-way token digests, not raw nonces or tokens. Refresh

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -157,16 +157,19 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   consensus. The topic and consensus service remain dormant. API nodes do
   construct the independent local pairing service, which never uses this
   network topic.
-- **V1 pairing:** `skulk operator pair --exchange-url ...` explicitly
-  designates the local host, initializes the encrypted store when needed, and
-  emits one five-minute QR capability. Challenge binds a proposed Ed25519
+- **V1 pairing:** `skulk operator pair` explicitly designates the local host,
+  initializes the encrypted store when needed, and emits one five-minute QR
+  capability. A relay-configured gateway emits the version-two package with
+  app-role carrier and pinned inner-TLS bootstrap material; `--exchange-url`
+  remains the direct-development fallback. Challenge binds a proposed Ed25519
   device key; exchange verifies a domain-separated signature, consumes the
   session, and returns one access/refresh credential pair. The journal stores
   encrypted state and one-way token digests, not raw nonces or tokens. Refresh
   rotates both tokens atomically; bearer validation enforces typed scopes; and
   device list/revoke routes expose no credential material. A relay-configured
   exchange also returns the app-role carrier credential, opaque locator, and
-  pinned inner-TLS trust once; the gateway role never leaves Skulk.
+  pinned inner-TLS trust once for durable local storage; the gateway role never
+  leaves Skulk. Neither QR version contains a canonical access or refresh token.
 - **V1 remote carrier:** `skulk operator configure-relay --provisioning-file`
   validates one generated paired-WebSocket route, encrypts locator and distinct
   app/gateway carrier credentials in the local journal, and creates a protected

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -963,6 +963,9 @@ the version-two package includes only the app-role outer carrier admission and
 pinned inner-TLS material needed to reach the same challenge/exchange routes;
 the gateway-role carrier credential and canonical access/refresh credentials
 never enter the QR. `--exchange-url` remains the direct-development fallback.
+The relay package uses bounded compact JSON compressed with zlib so the
+terminal QR remains camera-scannable; oversized packages are rejected before
+their session is persisted.
 The API exposes only challenge and exchange before authentication: a phone
 proposes an Ed25519 key, signs a domain-separated random challenge, and receives
 opaque access and refresh credentials once. Raw nonces and tokens are never stored in plaintext;

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -958,10 +958,14 @@ automatic gateway failover are later hardening, not prerequisites for pairing.
 If this gateway is down, remote operator access is down while local cluster and
 dashboard operation continue.
 
-The local command creates a five-minute QR capability. The API exposes only
-challenge and exchange before authentication: a phone proposes an Ed25519 key,
-signs a domain-separated random challenge, and receives opaque access and
-refresh credentials once. Raw nonces and tokens are never stored in plaintext;
+The local command creates a five-minute QR capability. After relay provisioning,
+the version-two package includes only the app-role outer carrier admission and
+pinned inner-TLS material needed to reach the same challenge/exchange routes;
+the gateway-role carrier credential and canonical access/refresh credentials
+never enter the QR. `--exchange-url` remains the direct-development fallback.
+The API exposes only challenge and exchange before authentication: a phone
+proposes an Ed25519 key, signs a domain-separated random challenge, and receives
+opaque access and refresh credentials once. Raw nonces and tokens are never stored in plaintext;
 the authority journal contains encrypted state and one-way token digests.
 Refresh rotates and invalidates the prior access/refresh pair atomically. The
 same service validates short-lived bearer access, exposes credential-free


### PR DESCRIPTION
## Summary\n- make relay-backed five-minute QR pairing the normal operator path\n- keep an explicit direct exchange URL as the LAN/Tailscale fallback\n- encode only app-role carrier admission and pinned inner-TLS bootstrap material in version-two QR packages\n- preserve the exact version-one direct QR shape and keep canonical access/refresh credentials out of both formats\n- document the pairing contract and architecture in the public operator/API references\n\n## App counterpart\n- Foxlight-Foundation/skulk-app#27 consumes the same relay carrier and canonical operator API contracts.\n\n## Validation\n- \n- 0 errors, 0 warnings, 0 notes\n- All checks passed!\n- 28 focused operator gateway, authentication, relay, and pairing tests passed\n- complete suite: 3,139 passed, 1 skipped; two unrelated model-store download tests were blocked because the development machine had less free disk than Skulk's intentional 10 GiB reserve\n- OpenAPI export was not required because no HTTP route changed; a local export attempt stopped only because this isolated worktree does not have dashboard dependencies installed