### PR TITLE
fix(operator): interoperate with the native relay carrier

### DIFF
--- a/src/skulk/operator/relay.py
+++ b/src/skulk/operator/relay.py
@@ -521,7 +521,10 @@ def _generate_tls_identity(server_name: str) -> tuple[bytes, bytes]:
             x509.SubjectAlternativeName([x509.DNSName(server_name)]),
             critical=False,
         )
-        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        # The phone pins this exact leaf certificate as its trust anchor. Marking
+        # the served leaf as a CA works with OpenSSL but Rustls correctly rejects
+        # it as `CaUsedAsEndEntity`, so the gateway must remain a server leaf.
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
         .add_extension(
             x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
             critical=False,

--- a/src/skulk/operator/relay.py
+++ b/src/skulk/operator/relay.py
@@ -46,6 +46,12 @@ _TLS_CLOCK_SKEW: Final = timedelta(minutes=5)
 _ROUTE_HEADER: Final = "x-skulk-relay-route"
 
 
+def _aiohttp_receive_limit_bytes(inclusive_frame_bytes: int) -> int:
+    """Translate the inclusive carrier frame bound to aiohttp's exclusive limit."""
+
+    return inclusive_frame_bytes + 1
+
+
 class OperatorRelayError(RuntimeError):
     """Base class for safe designated-gateway relay failures."""
 
@@ -387,7 +393,7 @@ class OperatorGatewayConnector:
             heartbeat=20.0,
             autoping=True,
             autoclose=True,
-            max_msg_size=self._frame_bytes,
+            max_msg_size=_aiohttp_receive_limit_bytes(self._frame_bytes),
         ) as websocket:
             reader, writer = await asyncio.open_connection(
                 "127.0.0.1",

--- a/src/skulk/operator/relay.py
+++ b/src/skulk/operator/relay.py
@@ -34,7 +34,11 @@ _RELAY_RECORD_TYPE: Final = "operator_relay_configuration"
 _RELAY_RECORD_ID: Final = "designated_gateway_v1"
 _CARRIER_VALUE_BYTES: Final = 32
 _ENCODED_CARRIER_VALUE_LENGTH: Final = 43
-_DEFAULT_FRAME_BYTES: Final = 1024 * 1024
+# The native Rust carrier accepts one opaque ingress frame into a bounded
+# 64 KiB session buffer. Larger HTTP responses remain streaming-safe because
+# the gateway splits the TLS byte stream before the relay forwards it.
+_DEFAULT_FRAME_BYTES: Final = 64 * 1024
+_MAXIMUM_FRAME_BYTES: Final = 1024 * 1024
 _MINIMUM_RECONNECT_SECONDS: Final = 0.25
 _MAXIMUM_RECONNECT_SECONDS: Final = 5.0
 _TLS_VALIDITY: Final = timedelta(days=3650)
@@ -332,7 +336,7 @@ class OperatorGatewayConnector:
     ) -> None:
         """Create one connector for a persisted designated-gateway route."""
 
-        if not 1 <= frame_bytes <= _DEFAULT_FRAME_BYTES:
+        if not 1 <= frame_bytes <= _MAXIMUM_FRAME_BYTES:
             raise ValueError("frame_bytes must be between 1 and 1048576")
         self._configuration = configuration
         self._frame_bytes = frame_bytes
@@ -394,7 +398,7 @@ class OperatorGatewayConnector:
                     self._websocket_to_tls(websocket, writer)
                 )
                 tls_to_websocket = asyncio.create_task(
-                    self._tls_to_websocket(reader, websocket)
+                    self.forward_tls_to_websocket(reader, websocket)
                 )
                 tasks = (websocket_to_tls, tls_to_websocket)
                 _, pending = await asyncio.wait(
@@ -439,12 +443,12 @@ class OperatorGatewayConnector:
             if message.type is aiohttp.WSMsgType.TEXT:
                 raise OperatorRelayError("operator relay sent a non-binary frame")
 
-    async def _tls_to_websocket(
+    async def forward_tls_to_websocket(
         self,
         reader: asyncio.StreamReader,
         websocket: aiohttp.ClientWebSocketResponse,
     ) -> None:
-        """Copy inner TLS records into bounded binary WebSocket messages."""
+        """Copy inner TLS bytes into native-client-sized WebSocket messages."""
 
         while payload := await reader.read(self._frame_bytes):
             await websocket.send_bytes(payload)

--- a/src/skulk/operator/tests/test_relay.py
+++ b/src/skulk/operator/tests/test_relay.py
@@ -20,8 +20,10 @@ import aiohttp
 import pytest
 import qrcode
 from aiohttp import web
+from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.x509.oid import ExtendedKeyUsageOID
 from qrcode.constants import ERROR_CORRECT_L
 
 import skulk.operator.cli as operator_cli
@@ -180,6 +182,15 @@ def test_relay_configuration_is_encrypted_and_returned_once_with_pairing(
     )
     assert exchange.remote_access.routing_locator == provisioning.routing_locator
     assert "BEGIN CERTIFICATE" in exchange.remote_access.gateway_ca_certificate_pem
+    certificate = x509.load_pem_x509_certificate(
+        exchange.remote_access.gateway_ca_certificate_pem.encode("ascii")
+    )
+    assert not certificate.extensions.get_extension_for_class(
+        x509.BasicConstraints
+    ).value.ca
+    assert certificate.extensions.get_extension_for_class(
+        x509.ExtendedKeyUsage
+    ).value == x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH])
     assert provisioning.gateway_carrier_credential not in exchange.model_dump_json()
     with pytest.raises(OperatorRelayAlreadyConfiguredError):
         service.configure_relay(provisioning, operator_api_port=52416)

--- a/src/skulk/operator/tests/test_relay.py
+++ b/src/skulk/operator/tests/test_relay.py
@@ -13,7 +13,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import cast
+from typing import cast, final
 from uuid import UUID
 
 import aiohttp
@@ -86,6 +86,42 @@ def _service(
         ),
         repository,
     )
+
+
+@final
+class _RecordingWebSocket:
+    """Record gateway-to-app binary frames without opening a relay socket."""
+
+    def __init__(self) -> None:
+        self.frames: list[bytes] = []
+
+    async def send_bytes(self, payload: bytes) -> None:
+        """Retain one exact outbound binary frame."""
+
+        self.frames.append(payload)
+
+
+@pytest.mark.asyncio
+async def test_gateway_default_frames_fit_native_client_buffer(tmp_path: Path) -> None:
+    """Large TLS responses are split before reaching the 64 KiB native pump."""
+
+    service, _ = _service(tmp_path)
+    configuration = service.configure_relay(
+        _provisioning(),
+        operator_api_port=52416,
+    )
+    connector = OperatorGatewayConnector(configuration)
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"x" * ((64 * 1024) + 1))
+    reader.feed_eof()
+    websocket = _RecordingWebSocket()
+
+    await connector.forward_tls_to_websocket(
+        reader,
+        cast(aiohttp.ClientWebSocketResponse, cast(object, websocket)),
+    )
+
+    assert list(map(len, websocket.frames)) == [64 * 1024, 1]
 
 
 def test_relay_configuration_is_encrypted_and_returned_once_with_pairing(

--- a/src/skulk/operator/tests/test_relay.py
+++ b/src/skulk/operator/tests/test_relay.py
@@ -27,6 +27,7 @@ from cryptography.x509.oid import ExtendedKeyUsageOID
 from qrcode.constants import ERROR_CORRECT_L
 
 import skulk.operator.cli as operator_cli
+import skulk.operator.relay as relay_module
 from skulk.operator.authority import EncryptedAuthorityStore
 from skulk.operator.key_provider import LocalFileAuthorityKeyProvider
 from skulk.operator.pairing import (
@@ -122,6 +123,12 @@ async def test_gateway_default_frames_fit_native_client_buffer(tmp_path: Path) -
     )
 
     assert list(map(len, websocket.frames)) == [64 * 1024, 1]
+
+
+def test_gateway_aiohttp_receive_limit_is_above_inclusive_frame_bound() -> None:
+    """The aiohttp exclusive receive limit must admit an exact 64 KiB frame."""
+
+    assert relay_module._aiohttp_receive_limit_bytes(64 * 1024) == (64 * 1024) + 1  # pyright: ignore[reportPrivateUsage]
 
 
 def test_relay_configuration_is_encrypted_and_returned_once_with_pairing(


### PR DESCRIPTION
## Summary

- issue the pinned operator gateway certificate as a TLS server leaf rather than a CA
- split gateway-to-app TLS bytes into the native carrier's bounded 64 KiB ingress frames
- preserve the existing server-auth EKU and one-request relay semantics
- add focused certificate and frame-boundary regressions

## Why

The native Rustls carrier rejects a CA certificate when it is presented as the gateway server end entity. The phone pins the exact generated certificate, so it should be a normal self-signed leaf. Large canonical API responses also need to be segmented before entering the native carrier's bounded frame pump.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (3,144 passed, 2 skipped, 231 deselected)