### PR TITLE
feat(operator): target node restart by stable identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,8 +110,11 @@ A single Skulk `Node` (src/skulk/main.py) runs multiple components:
   identities, deterministic Ed25519 quorum certification, two-phase
   crash-fault vote collection and recovery, a public consensus SQLite log, and
   an encrypted local compare-and-set journal under `src/skulk/operator/`. It
-  remains separate from event-sourced `State`, telemetry, diagnostics, and the
-  public event log. Restart recovery reverifies the complete certificate and
+  keeps keys, credentials, authority membership, and journal contents separate
+  from event-sourced `State`, telemetry, diagnostics, and the public event log.
+  The non-secret per-host `node_install_id` alone is published with existing
+  static node telemetry, projected through canonical `/state`, and resolved by
+  `/admin/restart` to the current live runtime node. Restart recovery reverifies the complete certificate and
   membership chain from immutable bootstrap anchors. The encrypted journal
   requires an injected external data-key provider. The v1 designated gateway
   uses a protected local-file provider and `skulk operator pair` to create a
@@ -329,7 +332,8 @@ The system uses event sourcing for state management:
   lifecycle, separate public consensus persistence, and encrypted authority
   persistence. Runtime libp2p `NodeId`
   remains unsuitable for mobile history, device membership, or authorization
-  subjects.
+  subjects; canonical node truth exposes the non-secret stable installation ID
+  for those references and for restart targeting.
 
 ### Rust Components
 Rust code in `rust/` provides:

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -56,7 +56,7 @@ from fastapi.staticfiles import StaticFiles
 from hypercorn.config import Config
 from hypercorn.typing import ASGIFramework
 from loguru import logger
-from pydantic import ValidationError
+from pydantic import UUID4, ValidationError
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
 import skulk.shared.types.tasks as task_types
@@ -2476,7 +2476,9 @@ class API:
             summary="Restart a node",
             description=(
                 "Restart the Skulk process on this or a remote node. "
-                "Pass node_id query param to target a specific node. "
+                "Pass node_install_id to resolve a stable installation identity "
+                "to its current live runtime node, or node_id for a legacy "
+                "session-scoped target. "
                 "Active inference is interrupted, and the process is replaced; "
                 "the node rejoins the cluster automatically on startup."
             ),
@@ -13103,13 +13105,56 @@ class API:
                     break
         return transcript_chunks
 
-    async def restart_node(self, node_id: NodeId | None = None) -> JSONResponse:
+    async def restart_node(
+        self,
+        node_id: Annotated[
+            NodeId | None,
+            Query(
+                description=(
+                    "Legacy session-scoped runtime node ID. Prefer node_install_id "
+                    "for operator actions."
+                )
+            ),
+        ] = None,
+        node_install_id: Annotated[
+            UUID4 | None,
+            Query(
+                description=(
+                    "Stable per-installation node identity resolved against current "
+                    "live cluster truth."
+                )
+            ),
+        ] = None,
+    ) -> JSONResponse:
         """Restart the Skulk process on this or a remote node.
 
-        If node_id is omitted or matches this node, replaces the current
-        process image via os.execv (in-place restart, same PID). Otherwise,
-        sends a RestartNode command via pub/sub to the target node."""
-        target = node_id or self.node_id
+        Args:
+            node_id: Legacy session-scoped runtime target. Omit for this API node.
+            node_install_id: Stable installation identity resolved to one live
+                runtime node before command dispatch.
+
+        Returns:
+            Accepted local or remote restart status and the resolved runtime node.
+
+        Raises:
+            HTTPException: Both target forms are supplied, or the stable target
+                is missing or ambiguous in current live cluster truth.
+        """
+        if node_id is not None and node_install_id is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="provide either node_id or node_install_id, not both",
+            )
+        target = (
+            self._runtime_node_for_installation(node_install_id)
+            if node_install_id is not None
+            else node_id or self.node_id
+        )
+        response_identity = (
+            {"node_install_id": str(node_install_id)}
+            if node_install_id is not None
+            else {}
+        )
 
         if target == self.node_id:
             from skulk.utils.restart import schedule_restart
@@ -13120,14 +13165,62 @@ class API:
             scheduled = schedule_restart()
             if not scheduled:
                 return JSONResponse(
-                    {"status": "restart_already_pending", "node_id": str(self.node_id)},
+                    {
+                        "status": "restart_already_pending",
+                        "node_id": str(self.node_id),
+                        **response_identity,
+                    },
                     status_code=409,
                 )
-            return JSONResponse({"status": "restarting", "node_id": str(self.node_id)})
+            return JSONResponse(
+                {
+                    "status": "restarting",
+                    "node_id": str(self.node_id),
+                    **response_identity,
+                }
+            )
 
         # Remote restart — send command via download commands channel
         from skulk.shared.types.commands import RestartNode
 
         logger.info(f"Remote node restart requested for {target}")
         await self._send_download(RestartNode(target_node_id=target))
-        return JSONResponse({"status": "restart_sent", "node_id": str(target)})
+        return JSONResponse(
+            {
+                "status": "restart_sent",
+                "node_id": str(target),
+                **response_identity,
+            }
+        )
+
+    def _runtime_node_for_installation(self, node_install_id: UUID4) -> NodeId:
+        """Resolve one stable installation identity to its live runtime node.
+
+        Args:
+            node_install_id: Persistent per-host identity reported in node telemetry.
+
+        Returns:
+            The current session-scoped runtime node ID.
+
+        Raises:
+            HTTPException: No live node or more than one live node reports the
+                requested installation identity.
+        """
+        live_nodes = self._live_node_timestamps()
+        matches = [
+            runtime_node_id
+            for runtime_node_id, identity in self._telemetry_view.node_identities.items()
+            if runtime_node_id in live_nodes
+            and identity.node_install_id == node_install_id
+        ]
+        if not matches:
+            raise HTTPException(
+                status_code=404,
+                detail="stable node identity is not present in current live cluster truth",
+            )
+        if len(matches) > 1:
+            raise HTTPException(
+                status_code=409,
+                detail="stable node identity is ambiguous in current live cluster truth",
+            )
+        return matches[0]

--- a/src/skulk/api/tests/test_admin_restart.py
+++ b/src/skulk/api/tests/test_admin_restart.py
@@ -2,6 +2,7 @@
 
 from typing import cast
 from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
 
 from fastapi.testclient import TestClient
 from httpx2 import Response
@@ -11,7 +12,9 @@ from skulk.shared.election import ElectionMessage
 from skulk.shared.types.commands import ForwarderCommand, ForwarderDownloadCommand
 from skulk.shared.types.common import NodeId
 from skulk.shared.types.events import IndexedEvent
+from skulk.shared.types.telemetry import NodeTelemetry
 from skulk.utils.channels import channel
+from skulk.utils.info_gatherer.info_gatherer import StaticNodeInformation
 
 
 def _json_object(response: Response) -> dict[str, object]:
@@ -34,6 +37,24 @@ def _build_api(node_id: str = "test-node") -> API:
         election_receiver=election_receiver,
         enable_event_log=False,
         mount_dashboard=False,
+    )
+
+
+def _report_stable_identity(api: API, node_id: str, node_install_id: UUID) -> None:
+    """Publish one live static-identity reading into the API telemetry view."""
+    api._telemetry_view.apply(  # pyright: ignore[reportPrivateUsage]
+        NodeTelemetry(
+            node_id=NodeId(node_id),
+            info=StaticNodeInformation(
+                node_install_id=node_install_id,
+                model="Test host",
+                chip="Test chip",
+                os_version="1",
+                os_build_version="1",
+                skulk_version="1",
+                skulk_commit="abc123",
+            ),
+        )
     )
 
 
@@ -99,3 +120,91 @@ def test_restart_remote_node() -> None:
     cmd = cast(object, mock_send.call_args[0][0])
     assert isinstance(cmd, RestartNode)
     assert cmd.target_node_id == NodeId("remote-node")
+
+
+def test_restart_resolves_stable_remote_node_identity() -> None:
+    """Stable installation identity resolves to the current live runtime node."""
+    api = _build_api("local-node")
+    node_install_id = uuid4()
+    _report_stable_identity(api, "remote-session", node_install_id)
+    client = TestClient(api.app)
+
+    with patch.object(api, "_send_download", new_callable=AsyncMock) as mock_send:
+        response = client.post(
+            "/admin/restart",
+            params={"node_install_id": str(node_install_id)},
+        )
+
+    assert response.status_code == 200
+    assert _json_object(response) == {
+        "status": "restart_sent",
+        "node_id": "remote-session",
+        "node_install_id": str(node_install_id),
+    }
+    from skulk.shared.types.commands import RestartNode
+
+    command = cast(object, mock_send.call_args[0][0])
+    assert isinstance(command, RestartNode)
+    assert command.target_node_id == NodeId("remote-session")
+
+
+def test_restart_resolves_stable_local_node_identity() -> None:
+    """A stable identity may safely target the API node itself."""
+    api = _build_api("local-session")
+    node_install_id = uuid4()
+    _report_stable_identity(api, "local-session", node_install_id)
+    client = TestClient(api.app)
+
+    with patch("skulk.utils.restart.schedule_restart", return_value=True) as mock:
+        response = client.post(
+            "/admin/restart",
+            params={"node_install_id": str(node_install_id)},
+        )
+
+    assert response.status_code == 200
+    assert _json_object(response) == {
+        "status": "restarting",
+        "node_id": "local-session",
+        "node_install_id": str(node_install_id),
+    }
+    mock.assert_called_once()
+
+
+def test_restart_rejects_missing_or_conflicting_stable_targets() -> None:
+    """Stable targeting fails closed when current live truth cannot resolve it."""
+    api = _build_api("local-node")
+    client = TestClient(api.app)
+    missing_identity = uuid4()
+
+    missing = client.post(
+        "/admin/restart",
+        params={"node_install_id": str(missing_identity)},
+    )
+    conflicting = client.post(
+        "/admin/restart",
+        params={"node_id": "local-node", "node_install_id": str(missing_identity)},
+    )
+    _report_stable_identity(api, "first-session", missing_identity)
+    _report_stable_identity(api, "second-session", missing_identity)
+    ambiguous = client.post(
+        "/admin/restart",
+        params={"node_install_id": str(missing_identity)},
+    )
+
+    assert missing.status_code == 404
+    assert conflicting.status_code == 400
+    assert ambiguous.status_code == 409
+
+
+def test_state_projects_stable_node_identity() -> None:
+    """Canonical cluster truth exposes the stable ID beside runtime node truth."""
+    api = _build_api("local-node")
+    node_install_id = uuid4()
+    _report_stable_identity(api, "remote-session", node_install_id)
+
+    response = TestClient(api.app).get("/state")
+
+    assert response.status_code == 200
+    node_identities = cast(dict[str, object], _json_object(response)["nodeIdentities"])
+    remote_identity = cast(dict[str, object], node_identities["remote-session"])
+    assert remote_identity["nodeInstallId"] == str(node_install_id)

--- a/src/skulk/shared/types/profiling.py
+++ b/src/skulk/shared/types/profiling.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal, Self, cast, final
 
 import psutil
-from pydantic import BaseModel, field_serializer, field_validator
+from pydantic import UUID4, BaseModel, Field, field_serializer, field_validator
 
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.node_facts import CapabilityConflict
@@ -263,6 +263,13 @@ class NetworkInterfaceInfo(CamelCaseModel):
 class NodeIdentity(CamelCaseModel):
     """Static and slow-changing node identification data."""
 
+    node_install_id: UUID4 | None = Field(
+        default=None,
+        description=(
+            "Stable per-installation operator identity, independent of the current "
+            "runtime libp2p node ID."
+        ),
+    )
     model_id: str = "Unknown"
     chip_id: str = "Unknown"
     friendly_name: str = "Unknown"

--- a/src/skulk/shared/types/telemetry.py
+++ b/src/skulk/shared/types/telemetry.py
@@ -338,6 +338,7 @@ class TelemetryView:
             current = self.node_identities.get(node_id, NodeIdentity())
             self.node_identities[node_id] = current.model_copy(
                 update={
+                    "node_install_id": info.node_install_id,
                     "model_id": info.model,
                     "chip_id": info.chip,
                     "os_version": info.os_version,

--- a/src/skulk/shared/types/tests/test_telemetry.py
+++ b/src/skulk/shared/types/tests/test_telemetry.py
@@ -7,6 +7,7 @@ an in-process-only test missed a strict round-trip failure.
 """
 
 from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 from skulk.routing.topics import TELEMETRY
 from skulk.shared.tests.conftest import get_pipeline_shard_metadata
@@ -504,22 +505,27 @@ def test_view_merges_identity_from_two_readings() -> None:
     # accumulation), regardless of arrival order.
     view = TelemetryView()
     node = NodeId("node-a")
+    node_install_id = uuid4()
     view.apply(NodeTelemetry(node_id=node, info=MiscData(friendly_name="Kite 2")))
-    view.apply(
-        NodeTelemetry(
-            node_id=node,
-            info=StaticNodeInformation(
-                model="Mac mini",
-                chip="M4",
-                os_version="26.4",
-                os_build_version="X",
-                skulk_version="1.2.0",
-                skulk_commit="abc123",
-            ),
-        )
+    static_reading = NodeTelemetry(
+        node_id=node,
+        info=StaticNodeInformation(
+            node_install_id=node_install_id,
+            model="Mac mini",
+            chip="M4",
+            os_version="26.4",
+            os_build_version="X",
+            skulk_version="1.2.0",
+            skulk_commit="abc123",
+        ),
     )
+    restored = TELEMETRY.deserialize(TELEMETRY.serialize(static_reading))
+    assert isinstance(restored.info, StaticNodeInformation)
+    assert restored.info.node_install_id == node_install_id
+    view.apply(restored)
     identity = view.node_identities[node]
     assert identity.friendly_name == "Kite 2"  # preserved across the static merge
+    assert identity.node_install_id == node_install_id
     assert identity.chip_id == "M4"
     assert identity.skulk_version == "1.2.0"
     # a later friendly-name update keeps the static fields

--- a/src/skulk/utils/info_gatherer/info_gatherer.py
+++ b/src/skulk/utils/info_gatherer/info_gatherer.py
@@ -16,8 +16,9 @@ from anyio import (
 )
 from anyio.streams.buffered import BufferedByteReceiveStream
 from loguru import logger
-from pydantic import ValidationError, field_serializer, field_validator
+from pydantic import UUID4, Field, ValidationError, field_serializer, field_validator
 
+from skulk.operator.identity import OperatorIdentityRepository
 from skulk.routing.zenoh_status import ZenohPeerSampler
 from skulk.shared.constants import SKULK_CONFIG_FILE, SKULK_MODELS_DIR
 from skulk.shared.types.memory import Memory
@@ -281,6 +282,13 @@ async def _is_service_enabled(service_name: str) -> bool | None:
 class StaticNodeInformation(TaggedModel):
     """Node information that should NEVER change, to be gathered once at startup"""
 
+    node_install_id: UUID4 | None = Field(
+        default=None,
+        description=(
+            "Stable per-installation operator identity, independent of the current "
+            "runtime libp2p node ID."
+        )
+    )
     model: str
     chip: str
     os_version: str
@@ -291,7 +299,9 @@ class StaticNodeInformation(TaggedModel):
     @classmethod
     async def gather(cls) -> Self:
         model, chip = await get_model_and_chip()
+        node_identity = OperatorIdentityRepository().load_or_create_node_identity()
         return cls(
+            node_install_id=node_identity.node_install_id,
             model=model,
             chip=chip,
             os_version=get_os_version(),

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -1645,15 +1645,29 @@ Node IDs are per-session and change when the process restarts.
 
 ### Restart a node
 
-**POST** `/admin/restart?node_id=<optional node id>`
+**POST** `/admin/restart?node_install_id=<stable id>`
 
-Gracefully restart the Skulk process on this or a remote node. When `node_id` is omitted or matches the local node, replaces the current process image in-place via `os.execv` (same PID). When `node_id` targets a remote node, sends a `RestartNode` command via pub/sub.
+Gracefully restart the Skulk process on this or a remote node. Operator clients
+should pass the stable UUIDv4 `node_install_id` published under
+`GET /state` → `nodeIdentities[*].nodeInstallId`. Skulk resolves that identity
+against current live telemetry immediately before dispatch, so a process restart
+cannot leave the client targeting an expired libp2p session. A missing stable
+target returns HTTP 404; an ambiguous target returns HTTP 409.
+
+Legacy local clients may continue to pass the session-scoped
+`node_id=<runtime id>`. Supplying both target forms returns HTTP 400. Omitting
+both restarts the API node itself. A local target replaces the current process
+image in-place via `os.execv` (same PID); a remote target sends the existing
+`RestartNode` command via pub/sub.
 
 - GPU/Metal memory is released when the process image is replaced
 - the node rejoins the cluster automatically on startup
 - active inference is interrupted
 
-Returns `{"status": "restarting", "node_id": "..."}` for local restarts, or `{"status": "restart_sent", "node_id": "..."}` for remote restarts.
+Returns `{"status": "restarting", "node_id": "...", "node_install_id": "..."}`
+for stable local targets, or the corresponding `"restart_sent"` status for
+stable remote targets. Legacy session-targeted responses retain their existing
+shape without `node_install_id`.
 If a local restart is already scheduled, returns HTTP 409 with `{"status": "restart_already_pending"}`.
 
 ### Onboarding status
@@ -2474,13 +2488,15 @@ The operator panel at `/operator` is designed for mobile access and can also be 
 
 | Endpoint | Description |
 | --- | --- |
-| `POST /admin/restart?node_id=<id>` | Send a restart command to any node in the cluster |
+| `POST /admin/restart?node_install_id=<id>` | Resolve a stable installation identity and send a restart command to its current live node |
 
 ### Typical operator app workflow
 
 1. Call `GET /v1/connectivity/remote-access` on the initially discovered node to get the `preferredUrl`, then use that as the base URL for subsequent calls.
-2. Poll `GET /state` every 5 seconds for node health (memory, GPU, temperature).
-3. Show per-node cards with restart buttons that call `POST /admin/restart?node_id=<id>`.
+2. Poll `GET /state` every 5 seconds for node health (memory, GPU, temperature)
+   and stable `nodeIdentities[*].nodeInstallId` values.
+3. Show restart only when the selected live node reports a stable installation
+   identity, then call `POST /admin/restart?node_install_id=<id>`.
 4. On first launch or settings screen, show the `operatorUrl` as a QR code so users can hand it off to another device.
 
 ## Helpful Next Docs

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -109,6 +109,12 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 - **Stable node identity:** `NodeInstallationIdentity.node_install_id` is a
   persisted UUIDv4 under the protected operator configuration directory. It is
   intentionally independent of the currently ephemeral libp2p `NodeId`.
+  `StaticNodeInformation` publishes only this non-secret ID on the existing
+  last-write-wins telemetry plane, so `GET /state` projects it as
+  `nodeIdentities[*].nodeInstallId`. The authority journal, keys, credentials,
+  and membership records remain excluded. Stable `POST /admin/restart`
+  targeting resolves the ID to exactly one live runtime node before dispatch;
+  missing or ambiguous mappings fail closed.
 - **Cluster identity:** `ClusterPublicIdentity` carries the UUIDv4 cluster ID,
   normalized operator-visible name, raw Ed25519 public key, bound SHA-256
   fingerprint, and creation timestamp. The private key may be handed only to
@@ -504,7 +510,7 @@ Lives in `src/skulk/api/main.py` (route registration in `API.__init__`).
 | `/store/models/{model_id}/download` | POST | Request store download |
 | `/store/models/{model_id}/download` | DELETE | Cancel a pending or active store download while preserving resumable partial files |
 | `/store/models/{model_id}` | DELETE | Delete store model |
-| `/admin/restart` | POST | Request node restart. Optional `node_id` query param targets a specific peer; without it, restarts the local node. |
+| `/admin/restart` | POST | Request node restart. Prefer `node_install_id` for a stable host target resolved against live telemetry; legacy `node_id` remains session-scoped, and omitting both restarts the local node. |
 
 ### Bench
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -888,6 +888,14 @@ cluster's Ed25519 public identity. A libp2p peer ID may change after a process
 restart; a mobile history reference, device membership record, or future deep
 link must therefore never use it as a durable subject.
 
+The non-secret `node_install_id` is included in the node's existing
+`StaticNodeInformation` telemetry reading and appears under
+`GET /state` → `nodeIdentities`. This is an identity projection, not authority
+state: keys, credentials, membership records, and encrypted journal contents
+never enter telemetry or event-sourced `State`. `POST /admin/restart` can resolve
+that stable identity to the currently live libp2p node immediately before it
+dispatches the existing `RestartNode` command.
+
 `src/skulk/operator/authority.py` is the encrypted local projection for
 replicated operator authority. Secret-bearing JSON records use
 AES-256-GCM with authenticated metadata binding the cluster ID, authority term,


### PR DESCRIPTION
## Summary
- publish each host's persistent installation identity in canonical `/state` telemetry
- let the existing `/admin/restart` route resolve that stable identity to one current live runtime node
- retain the legacy session-scoped target for direct dashboard clients
- document and test stable, missing, conflicting, and ambiguous targets

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix fmt`
- `uv run pytest` (3,157 passed, 2 skipped)
- focused restart and telemetry tests (30 passed)
- OpenAPI export