### PR TITLE
Steward brain upgrade: Qwen3.6-35B-A3B, thinking off, and a legible not-ready state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,10 +265,15 @@ Optional resident operator assistant, config-gated (`intelligent_fabric` in
 skulk.yaml, default off). Identity = `BaseInstance.system_role` flagged
 placement (additive schema field); the master's `_maintain_steward_placement`
 planning-tick invariant keeps exactly one steward placed from the
-`steward_models` preference list (Qwen3.5-4B MLX/GGUF cards, then the
-Qwen3.5-0.8B GGUF universal floor so CPU-only fleets place one), tears down
-duplicates, and inherits failover from election since the invariant re-runs
-on every tick. Repair builders re-stamp `system_role` (same pattern as #658
+`steward_models` preference list (Qwen3.6-35B-A3B GGUF then MLX = the
+benched v1 brain, then the Qwen3.5-4B MLX/GGUF cards, then the Qwen3.5-0.8B
+GGUF universal floor so CPU-only fleets place one), tears down duplicates,
+and inherits failover from election since the invariant re-runs on every
+tick. Every steward generation runs with thinking OFF
+(`STEWARD_THINKING_ENABLED`): bench-measured, thinking degraded the
+finalists' trust behavior, and it is the harness's request shape rather
+than a card claim. GGUF steward cards must stay text-only or the vision
+platform gate bars them from `llama_server`. Repair builders re-stamp `system_role` (same pattern as #658
 exclusions). `TextGeneration.target_instance_id` pins generation to one
 instance (mirrors SpeechSynthesis). Harness = `src/skulk/api/steward.py`:
 bounded read-only tools (state/resources/telemetry/data-plane/versions/
@@ -276,13 +281,18 @@ envelopes/doctor/catalog), 8 steps per turn, observe/advise only, rides the
 normal chat dispatch path. Client surface = reserved virtual
 model `skulk/steward` on chat-completions (client tools 400; trace as
 reasoning_content; streaming via the ordinary adapters over
-`run_turn_chunks`); `GET /v1/steward` = presence; flagged entry in
-/v1/models (`system_role`). Ordinary deletion of the steward is refused
-while the mode is on; the dashboard hides `systemRole` instances. Canary:
-the hosting node's API probes the steward every 300s when idle-Ready
-(minimal pinned generation, code-checked); 3 consecutive failures tear it
-down and the invariant re-places (degraded-but-alive coverage; busy-wedge
-stays with the worker wedge detector).
+`run_turn_chunks`); `GET /v1/steward` = presence plus a derived `state`
+(`disabled|downloading|starting|ready|degraded`); flagged entry in
+/v1/models (`system_role`). The reserved id refuses with 503 (status
+payload + Retry-After) before streaming when no steward is ready, keeping
+the in-stream ErrorChunk for the post-preflight race. Ordinary deletion of
+the steward is refused while the mode is on; the dashboard hides
+`systemRole` instances. Canary: the hosting node's API probes the steward
+every 300s when idle-Ready (minimal pinned generation, code-checked); the
+failure run lives in `StewardCanaryState` so one failure already reads as
+`degraded`, and 3 consecutive failures tear it down and the invariant
+re-places (degraded-but-alive coverage; busy-wedge stays with the worker
+wedge detector).
 
 ### Message Flow
 Components communicate via typed pub/sub topics (src/skulk/routing/topics.py):

--- a/dashboard-react/src/components/pages/StewardChatView.test.tsx
+++ b/dashboard-react/src/components/pages/StewardChatView.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { store } from '../../store';
 import { apiSlice } from '../../store/api';
+import type { StewardState } from '../../store/endpoints/steward';
 import { darkTheme } from '../../theme/theme';
 import { StewardChatView } from './StewardChatView';
 
@@ -45,6 +46,7 @@ interface StewardStatusFixture {
   ready: boolean;
   steward_model: string | null;
   instance_id: string | null;
+  state: StewardState;
 }
 
 function sseBody(events: string[]): ReadableStream<Uint8Array> {
@@ -133,11 +135,14 @@ const READY: StewardStatusFixture = {
   ready: true,
   steward_model: 'org/steward-4b',
   instance_id: 'inst-1',
+  state: 'ready',
 };
 
 describe('StewardChatView', () => {
   it('shows the disabled state when intelligent fabric is off', async () => {
-    stubFetch({ status: { ...READY, enabled: false, present: false, ready: false } });
+    stubFetch({
+      status: { ...READY, enabled: false, present: false, ready: false, state: 'disabled' },
+    });
     await renderPage();
     await waitFor(
       () => container?.textContent?.includes('Intelligent Fabric is off') ?? false,
@@ -146,12 +151,15 @@ describe('StewardChatView', () => {
   });
 
   it('holds the placing state until the steward is ready, not merely present', async () => {
-    stubFetch({ status: { ...READY, ready: false } });
+    stubFetch({ status: { ...READY, ready: false, state: 'downloading' } });
     await renderPage();
     await waitFor(
       () => container?.textContent?.includes('Steward is being placed') ?? false,
       'placing state never rendered',
     );
+    // The lifecycle word distinguishes "still staging weights" from "placing",
+    // which is the difference between a minutes-long and a seconds-long wait.
+    expect(container?.textContent?.includes('Status: downloading')).toBe(true);
     expect(container?.querySelector('textarea')).toBeNull();
   });
 

--- a/dashboard-react/src/components/pages/StewardChatView.tsx
+++ b/dashboard-react/src/components/pages/StewardChatView.tsx
@@ -169,7 +169,15 @@ export function StewardChatView() {
           try {
             const body: unknown = await res.json();
             const parsed = (body as { detail?: unknown }).detail;
-            if (typeof parsed === 'string') detail = parsed;
+            if (typeof parsed === 'string') {
+              detail = parsed;
+            } else if (typeof parsed === 'object' && parsed !== null) {
+              // The not-ready 503 answers with the steward status object
+              // plus a human message; surface the message rather than
+              // falling back to the generic failure text.
+              const message = (parsed as { message?: unknown }).message;
+              if (typeof message === 'string') detail = message;
+            }
           } catch {
             /* keep fallback */
           }
@@ -275,6 +283,9 @@ export function StewardChatView() {
             'stewardChat.placing.body',
             'The fabric is placing the steward and preparing its model. This page will become available automatically; the first start may take a few minutes while the model downloads.',
           )}
+        </CenterBody>
+        <CenterBody>
+          {t('stewardChat.placing.state', 'Status: {state}', { state: status.state })}
         </CenterBody>
       </CenterState>
     );

--- a/dashboard-react/src/i18n/en/skulk.json
+++ b/dashboard-react/src/i18n/en/skulk.json
@@ -666,6 +666,7 @@
   "stewardChat.loading.title": "Checking steward status",
   "stewardChat.placeholder": "Ask about the cluster...",
   "stewardChat.placing.body": "The fabric is placing the steward and preparing its model. This page will become available automatically; the first start may take a few minutes while the model downloads.",
+  "stewardChat.placing.state": "Status: {state}",
   "stewardChat.placing.title": "Steward is being placed",
   "stewardChat.servedBy": "steward: {model}",
   "storeRegistry.chatWithModel": "Chat with model",

--- a/dashboard-react/src/store/endpoints/steward.ts
+++ b/dashboard-react/src/store/endpoints/steward.ts
@@ -1,5 +1,18 @@
 import { apiSlice } from '../api';
 
+/**
+ * One-word lifecycle summary of the steward, derived server-side from the
+ * boolean fields plus liveness-canary history:
+ *
+ * - `disabled`: intelligent-fabric mode is off.
+ * - `downloading`: placed, weights still staging (the long first wait).
+ * - `starting`: being placed, or placed and loading.
+ * - `ready`: serving, with a clean canary history.
+ * - `degraded`: serving, but a liveness probe has failed and the fabric may
+ *   repair the placement.
+ */
+export type StewardState = 'disabled' | 'downloading' | 'starting' | 'ready' | 'degraded';
+
 /** Steward availability as reported by `GET /v1/steward`. */
 export interface StewardStatus {
   /** Whether intelligent-fabric mode is enabled in Settings. */
@@ -12,6 +25,11 @@ export interface StewardStatus {
   steward_model: string | null;
   /** The steward instance id when present. */
   instance_id: string | null;
+  /**
+   * Renderable lifecycle word. The booleans above stay authoritative; this
+   * saves every client from re-deriving the same precedence rules.
+   */
+  state: StewardState;
 }
 
 /**

--- a/resources/inference_model_cards/mlx-community--Qwen3.6-35B-A3B-4bit.toml
+++ b/resources/inference_model_cards/mlx-community--Qwen3.6-35B-A3B-4bit.toml
@@ -1,0 +1,62 @@
+# Qwen3.6 35B A3B, 4-bit MLX. The Apple Silicon lane of the intelligent-fabric
+# steward's brain: same weights class the steward bench picked on the GPU lane,
+# so a Mac-only fleet with enough unified memory gets the same resident
+# intelligence instead of falling through to a smaller model. Also a general
+# large-MoE chat model for MLX nodes. Architecture from the repo's config.json
+# text_config (arch qwen3_5_moe: 40 layers, hidden 2048, 2 KV heads,
+# 262144 ctx), matching the Qwen3.5-35B-A3B sibling exactly.
+model_id = "mlx-community/Qwen3.6-35B-A3B-4bit"
+n_layers = 40
+hidden_size = 2048
+num_key_value_heads = 2
+supports_tensor = true
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "4bit"
+base_model = "Qwen3.6 35B A3B"
+capabilities = ["text", "thinking", "thinking_toggle", "vision"]
+context_length = 262144
+# Pinned to the repository state the steward bench ran against, so an
+# upstream requantization cannot silently change the brain.
+source_revision = "38740b847e4cb78f352aba30aa41c76e08e6eb46"
+trust_remote_code = false
+
+[reasoning]
+supports_toggle = true
+format = "token_delimited"
+default_effort = "medium"
+disabled_effort = "none"
+
+# Qwen3.6 emits the Qwen3 XML function dialect
+#   <tool_call>\n<function=NAME>\n<parameter=KEY>\nVALUE\n</parameter>\n</function>\n</tool_call>
+# (verified against this repo's chat_template.jinja, which is the same
+# tool-call block the GGUF sibling embeds). Declaring the generic format is
+# load-bearing on this card: a natively multimodal repo loads through the
+# mlx-vlm vision path, which does not inherit mlx-lm's inferred tool parser,
+# and the generic declaration is what wires the shared XML/Hermes text parser
+# through the runner's marker mechanism (#728).
+[tooling]
+supports_tool_calling = true
+tool_call_format = "generic"
+
+# Qwen3.6 is a natively multimodal (early-fusion) VLM: config.json ships a
+# vision_config and the repo is tagged image-text-to-text. The MLX vision path
+# splices image embeddings at image_token_id (248056, from config.json) and
+# the tower weights ship in this same repo. The steward never sends images;
+# this is the model's own capability, declared because the card states model
+# truth rather than the steward's usage.
+[modalities]
+supports_native_multimodal = true
+
+[vision]
+image_token_id = 248056
+model_type = "qwen3_5_moe"
+
+# NO MTP section, by measurement on the immediate predecessor rather than by
+# omission: the Qwen3.5-35B-A3B sidecar drafted at 85% acceptance yet measured
+# 0.63x end to end, because a fast MoE routes every verify token to its own
+# experts and a low per-step baseline magnifies fixed per-round overhead. Do
+# not add a sidecar here without re-measuring on this checkpoint.
+
+[storage_size]
+in_bytes = 20429169263

--- a/resources/inference_model_cards/unsloth--Qwen3.6-35B-A3B-GGUF.toml
+++ b/resources/inference_model_cards/unsloth--Qwen3.6-35B-A3B-GGUF.toml
@@ -1,0 +1,71 @@
+# Qwen3.6 35B A3B GGUF (unsloth UD-Q4_K_M), the intelligent-fabric steward's
+# GPU-lane brain. Chosen by the steward bench matrix: it led the trust axes
+# among the large candidates, was the only large model with zero forbidden
+# actions, and decoded at ~48 tok/s on a Vulkan GGUF node. A 3B-active MoE, so
+# it buys 35B-class judgement at small-model decode cost.
+#
+# Text-only through Skulk, deliberately: the base model is natively
+# multimodal, but the served llama_server runner does not load the mmproj
+# projector, and a vision-declaring card is gated off the served lanes by
+# platform truth (platform_compatible_backends in shared/backends.py). The
+# steward never sends images, so omitting vision here costs nothing and keeps
+# the card placeable on exactly the nodes it is meant for. Same reasoning as
+# the Qwen3.5-4B GGUF steward card.
+#
+# Architecture facts from the base repo config's text_config (arch
+# qwen3_5_moe: 40 layers, hidden 2048, 2 KV heads, 262144 ctx). storage_size
+# is the pinned quant file, the only weight file this card downloads.
+# supports_tensor = false: single-node on either GGUF engine.
+#
+# NO speculative-decoding section: the checkpoint ships MTP prediction heads
+# (mtp_num_hidden_layers = 1) and llama-server can drive them with
+# --spec-type draft-mtp, but that pairing is unmeasured on this quant, and
+# the sibling Qwen3.5-35B-A3B measured MTP NET NEGATIVE on MLX because fast
+# MoE decode magnifies per-round overhead. Add served_spec_type only with a
+# measurement behind it.
+model_id = "unsloth/Qwen3.6-35B-A3B-GGUF"
+n_layers = 40
+hidden_size = 2048
+num_key_value_heads = 2
+supports_tensor = false
+tasks = ["TextGeneration"]
+family = "qwen"
+quantization = "UD-Q4_K_M"
+base_model = "Qwen3.6 35B A3B"
+capabilities = ["text", "thinking", "thinking_toggle"]
+context_length = 262144
+gguf_file = "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+# Pinned to the repository state the steward bench ran against, so an
+# upstream requant cannot silently change the brain.
+source_revision = "a483e9e6cbd595906af30beda3187c2663a1118c"
+trust_remote_code = false
+
+[reasoning]
+supports_toggle = true
+format = "token_delimited"
+default_effort = "medium"
+disabled_effort = "none"
+
+# Verified against this repo's chat template (the GGUF's embedded template and
+# the MLX sibling's chat_template.jinja emit the identical block): Qwen3.6
+# writes tool calls as
+#   <tool_call>\n<function=NAME>\n<parameter=KEY>\nVALUE\n</parameter>\n</function>\n</tool_call>
+# which is exactly the Qwen3 XML dialect the shared generic text parser
+# recognizes (tool_text_parser._TOOLCALL_BLOCK_RE / _FUNCTION_RE /
+# _PARAMETER_RE), and the same dialect the steward harness re-parses if an
+# engine passes the markup through as content.
+[tooling]
+supports_tool_calling = true
+tool_call_format = "generic"
+
+[placement]
+# Every GGUF lane, matching the steward floor card: a node with
+# llama-cpp-python but no llama-server binary advertises only
+# llama_cpp-<compute>, and this card should be servable wherever the weights
+# fit. CPU lanes are listed for completeness but rank last; a 22 GB quant on
+# CPU is a fallback, not a plan.
+compatible_backends = ["llama_server-vulkan", "llama_server-rocm", "llama_server-cuda", "llama_server-cpu", "llama_cpp-vulkan", "llama_cpp-cuda", "llama_cpp-rocm", "llama_cpp-cpu"]
+backend_preference = ["llama_server-cuda", "llama_server-vulkan", "llama_server-rocm", "llama_cpp-cuda", "llama_cpp-vulkan", "llama_cpp-rocm", "llama_server-cpu", "llama_cpp-cpu"]
+
+[storage_size]
+in_bytes = 22134528992

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -116,10 +116,14 @@ from skulk.api.realtime import (
     RealtimeTranscriptionBridge,
 )
 from skulk.api.steward import (
+    STEWARD_NOT_READY_MESSAGES,
+    STEWARD_RETRY_AFTER_SECONDS,
     STEWARD_VIRTUAL_MODEL_ID,
+    StewardCanaryState,
     StewardChatMessage,
     StewardHarness,
     StewardStatusResponse,
+    derive_steward_state,
 )
 from skulk.api.types import (
     AddCustomModelParams,
@@ -402,7 +406,7 @@ from skulk.shared.types.telemetry import (
     record_membership_from_event,
 )
 from skulk.shared.types.text_generation import TextGenerationTaskParams
-from skulk.shared.types.worker.downloads import DownloadCompleted
+from skulk.shared.types.worker.downloads import DownloadCompleted, LiveDownloadProgress
 from skulk.shared.types.worker.instances import (
     Instance,
     InstanceId,
@@ -1339,6 +1343,11 @@ class API:
             for descriptor in self._extensions.capability_descriptors:
                 self._telemetry_view.local_advertised_capabilities.add(descriptor.id)
             self._extensions.run_startup_hooks(self._extension_context)
+        # Steward liveness history, shared between the canary loop that writes
+        # it and the status endpoint that reads it (both event-loop tasks on
+        # this node), so an outstanding failed probe surfaces as `degraded`
+        # instead of hiding until the third failure tears the steward down.
+        self._steward_canary = StewardCanaryState()
         self._event_log = DiskEventLog(_API_EVENT_LOG_DIR) if enable_event_log else None
         self._event_log_appends_since_retention_check = 0
         self._system_id = SystemId()
@@ -1809,7 +1818,10 @@ class API:
             description=(
                 "Generate text with an OpenAI Chat Completions-compatible payload. The requested "
                 "model must already be placed, running, and declare TextGeneration; speech-only "
-                "models are rejected before command dispatch."
+                "models are rejected before command dispatch. The reserved model id "
+                "'skulk/steward' selects the intelligent-fabric steward and answers 404 when "
+                "that mode is disabled, or 503 with the steward status payload while the "
+                "steward is still being placed, staged, or loaded."
             ),
         )(self.chat_completions)
         self.app.post(
@@ -2228,8 +2240,11 @@ class API:
             description=(
                 "Report whether intelligent-fabric mode is enabled and whether "
                 "a steward placement currently exists, with its model and "
-                "instance id when present. The steward is the fabric-maintained "
-                "resident assistant; see the steward chat endpoint."
+                "instance id when present, plus a one-word lifecycle 'state' "
+                "(disabled, downloading, starting, ready, degraded) derived "
+                "from those fields and the liveness canary's history. The "
+                "steward is the fabric-maintained resident assistant; see the "
+                "steward chat endpoint."
             ),
         )(self.get_steward_status)
         self.app.post(
@@ -2941,6 +2956,23 @@ class API:
                     "steward to answer"
                 ),
             )
+        status = self._steward_status()
+        if not status.ready:
+            # Readiness preflight: a steward that is still placing, staging
+            # weights, or loading cannot answer, and saying so as a 503 with
+            # the status payload is a contract a client can act on (retry,
+            # show progress). Reporting it as a 200 SSE error chunk instead
+            # made "the fabric is still setting up" indistinguishable from
+            # "the model failed mid-answer" to every OpenAI-compatible
+            # client. The in-stream error path stays for the race where the
+            # placement disappears between this check and dispatch.
+            detail: dict[str, object] = status.model_dump(mode="json")
+            detail["message"] = STEWARD_NOT_READY_MESSAGES[status.state]
+            raise HTTPException(
+                status_code=503,
+                detail=detail,
+                headers={"Retry-After": str(STEWARD_RETRY_AFTER_SECONDS)},
+            )
         harness = StewardHarness(self)
         command_id = CommandId()
         chunk_stream = harness.run_turn_chunks(history)
@@ -2983,13 +3015,12 @@ class API:
             canary_probe_target,
         )
 
-        failures = 0
-        last_instance: InstanceId | None = None
+        canary = self._steward_canary
         while True:
             await anyio.sleep(CANARY_INTERVAL_SECONDS)
             try:
                 if not self._intelligent_fabric_enabled():
-                    failures = 0
+                    canary.clear_failures()
                     continue
                 target = canary_probe_target(
                     self.state.instances,
@@ -3003,23 +3034,20 @@ class API:
                     # count so "3 consecutive failures" means three failed
                     # probes with no intervening success. Reset only when
                     # the steward instance itself is gone.
-                    if last_instance is not None and last_instance not in (
-                        self.state.instances
-                    ):
-                        failures = 0
-                        last_instance = None
+                    tracked = canary.instance_id
+                    if tracked is not None and tracked not in self.state.instances:
+                        canary.reset()
                     continue
-                if target != last_instance:
-                    failures = 0
-                    last_instance = target
+                if target != canary.instance_id:
+                    canary.track(target)
                 harness = StewardHarness(self)
                 located = harness.steward_instance()
                 if located is None or located[0] != target:
                     continue
                 if await harness.canary_probe(target, located[1]):
-                    failures = 0
+                    canary.clear_failures()
                     continue
-                failures += 1
+                failures = canary.record_failure()
                 logger.warning(
                     f"Steward canary probe failed ({failures}/"
                     f"{CANARY_FAILURE_THRESHOLD}) for instance {target}"
@@ -3031,7 +3059,7 @@ class API:
                         "probes; tearing it down for re-placement"
                     )
                     await self._send(DeleteInstance(instance_id=target))
-                    failures = 0
+                    canary.clear_failures()
             except Exception:
                 # The canary must never take the API down; a broken probe
                 # pass just waits for the next interval.
@@ -3039,10 +3067,38 @@ class API:
 
     async def get_steward_status(self) -> "StewardStatusResponse":
         """Report intelligent-fabric mode and the current steward placement."""
-        from skulk.api.steward import StewardHarness, StewardStatusResponse
+        return self._steward_status()
 
+    def _steward_model_is_downloading(self, model_id: str) -> bool:
+        """Whether any node holds a live download record for ``model_id``.
+
+        Live means Pending or Ongoing in the effective view (telemetry's
+        non-terminal records merged over the terminal ones in state), which
+        is exactly the window in which the steward exists as a placement but
+        its weights are not on disk yet.
+        """
+        for records in self._telemetry_view.effective_downloads(
+            self.state.downloads
+        ).values():
+            for record in records:
+                if not isinstance(record, LiveDownloadProgress):
+                    continue
+                if str(record.shard_metadata.model_card.model_id) == model_id:
+                    return True
+        return False
+
+    def _steward_status(self) -> "StewardStatusResponse":
+        """Build the steward status snapshot.
+
+        Shared by ``GET /v1/steward`` and the chat-completions readiness
+        preflight so a client polling the status endpoint and a client
+        posting a turn can never disagree about whether the steward is
+        servable.
+        """
         located = StewardHarness(self).steward_instance()
         ready = False
+        downloading = False
+        canary_failures = 0
         if located is not None:
             instance = self.state.instances.get(located[0])
             if instance is not None:
@@ -3056,12 +3112,25 @@ class API:
                     )
                     for runner_id in runner_ids
                 )
+            if not ready:
+                downloading = self._steward_model_is_downloading(located[1])
+            canary_failures = self._steward_canary.consecutive_failures_for(
+                located[0]
+            )
+        enabled = self._intelligent_fabric_enabled()
         return StewardStatusResponse(
-            enabled=self._intelligent_fabric_enabled(),
+            enabled=enabled,
             present=located is not None,
             ready=ready,
             steward_model=located[1] if located is not None else None,
             instance_id=str(located[0]) if located is not None else None,
+            state=derive_steward_state(
+                enabled=enabled,
+                present=located is not None,
+                ready=ready,
+                downloading=downloading,
+                canary_failures=canary_failures,
+            ),
         )
 
     def _intelligent_fabric_enabled(self) -> bool:

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -2907,6 +2907,18 @@ class API:
         assistant turns; multimodal content parts are flattened to their
         text. Both streaming and non-streaming ride the ordinary adapters
         over the harness's chunk stream.
+
+        Refusals happen before the response begins, in this order: 400 for
+        client tool definitions, 404 when intelligent-fabric mode is off,
+        400 for a conversation with no question to answer, then 503 with the
+        steward status payload while no steward is ready to answer.
+
+        Raises:
+            HTTPException: 400, 404, or 503 per the order above.
+
+        Returns:
+            The streaming (SSE) or collected (JSON) chat-completions
+            response for one steward turn.
         """
         if payload.tools:
             raise HTTPException(

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -76,6 +76,20 @@ CANARY_FAILURE_THRESHOLD = 3
 re-placement. One failure is a blip; three spaced five minutes apart is a
 wedge."""
 
+STEWARD_THINKING_ENABLED = False
+"""Whether steward turns ask the brain to think before answering.
+
+Off, by measurement. The steward bench ranked every candidate with thinking
+disabled and then ran a thinking-on tiebreaker over the two finalists: both
+scored WORSE on the trust axes with thinking on (the winner's trust score
+fell and it began proposing forbidden actions it had never proposed before)
+and neither gained on the established task tier. The steward workload is
+short tool-driven investigation, not open-ended reasoning, so the harness
+pins thinking off for every brain rather than encoding the verdict on one
+card. Reasoning stays available on the same cards for ordinary chat: this is
+the harness's own request shape, not a claim about the model.
+"""
+
 STEWARD_SYSTEM_PROMPT = """\
 You are the steward: the resident operator intelligence of this Skulk
 cluster. Skulk is a distributed AI inference fabric that runs models across
@@ -530,8 +544,8 @@ class StewardHarness:
             # A thinking-default model would spend the whole bounded budget
             # reasoning and emit no non-thinking text, failing every probe
             # and tearing down a healthy steward. The probe is a liveness
-            # check, not a benchmark: thinking off.
-            enable_thinking=False,
+            # check, not a benchmark: thinking off, same as a real turn.
+            enable_thinking=STEWARD_THINKING_ENABLED,
         )
         model_card = await api.running_model_card(request.model)
         task_params = await chat_request_to_text_generation(
@@ -935,6 +949,11 @@ class StewardHarness:
             temperature=0.1,
             max_tokens=1024,
             stream=False,
+            # Thinking off for every steward brain, by bench measurement
+            # (see STEWARD_THINKING_ENABLED). Non-toggleable models ignore
+            # this at the capability boundary, so it is safe to send
+            # unconditionally.
+            enable_thinking=STEWARD_THINKING_ENABLED,
         )
         model_card = await api.running_model_card(request.model)
         task_params = await chat_request_to_text_generation(

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -20,7 +20,7 @@ import contextlib
 import json
 import re
 from collections.abc import AsyncGenerator, Mapping
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast, final
 
 import anyio
 from pydantic import BaseModel, ConfigDict, Field
@@ -75,6 +75,43 @@ CANARY_FAILURE_THRESHOLD = 3
 """Consecutive probe failures before the steward is torn down for
 re-placement. One failure is a blip; three spaced five minutes apart is a
 wedge."""
+
+STEWARD_RETRY_AFTER_SECONDS = 15
+"""``Retry-After`` hint sent with the not-ready 503 on the chat surface.
+
+Short on purpose: the states behind that 503 resolve on the master's ten
+second planning tick or on a download, so a client that backs off for a
+quarter of a minute and retries tracks the fabric closely without polling
+it hard.
+"""
+
+StewardState = Literal["disabled", "downloading", "starting", "ready", "degraded"]
+"""One-word lifecycle summary of the steward, derived from the other status
+fields plus canary history. See :func:`derive_steward_state`."""
+
+STEWARD_NOT_READY_MESSAGES: dict[StewardState, str] = {
+    "disabled": (
+        "Intelligent-fabric mode is disabled; enable it in Settings to use "
+        "the steward."
+    ),
+    "downloading": (
+        "The steward is staging its model weights and cannot answer yet."
+    ),
+    "starting": (
+        "The fabric is establishing the steward placement; it cannot answer "
+        "yet."
+    ),
+    "degraded": (
+        "The steward is not answering right now; the fabric is repairing it."
+    ),
+    "ready": "The steward is not available right now.",
+}
+"""Human-readable reason accompanying the not-ready 503, keyed by state.
+
+``ready`` and ``disabled`` are unreachable through that path (a ready
+steward is dispatched and a disabled one is already a 404), but the mapping
+stays total so a future state cannot silently produce a message-less error.
+"""
 
 STEWARD_THINKING_ENABLED = False
 """Whether steward turns ask the brain to think before answering.
@@ -221,6 +258,100 @@ class StewardChatMessage(BaseModel):
     content: str = Field(description="The message text.")
 
 
+def derive_steward_state(
+    *,
+    enabled: bool,
+    present: bool,
+    ready: bool,
+    downloading: bool,
+    canary_failures: int,
+) -> StewardState:
+    """Collapse the steward's status signals into one lifecycle word.
+
+    The individual booleans stay on the response (nothing is removed), but a
+    client that only wants to render one line should not have to re-derive
+    the precedence rules. They are:
+
+    - ``disabled``: intelligent-fabric mode is off, so no other signal means
+      anything.
+    - ``degraded``: serving, but the hosting node's canary has at least one
+      consecutive failed probe outstanding. The steward still answers; this
+      is the early warning before the third failure tears it down.
+    - ``ready``: serving with a clean canary history.
+    - ``downloading``: a placement exists and its weights are still being
+      staged, which is the long wait a client should explain to the operator.
+    - ``starting``: everything else while the mode is on, which covers both
+      "the master has not placed it yet" and "placed, staged, still loading".
+
+    Args:
+        enabled: whether intelligent-fabric mode is enabled.
+        present: whether a steward placement exists in state.
+        ready: whether every runner of that placement is Ready or Running.
+        downloading: whether the steward model has a live download record.
+        canary_failures: consecutive canary probe failures currently
+            outstanding for this steward instance.
+
+    Returns:
+        The lifecycle word for this combination of signals.
+    """
+    if not enabled:
+        return "disabled"
+    if ready:
+        return "degraded" if canary_failures >= 1 else "ready"
+    if present and downloading:
+        return "downloading"
+    return "starting"
+
+
+@final
+class StewardCanaryState:
+    """Consecutive canary-probe failures for the current steward instance.
+
+    Lifted out of ``_steward_canary_loop``'s local variables so the status
+    endpoint can report ``degraded`` before the third failure tears the
+    steward down. Both the loop that writes it and the status handler that
+    reads it run as tasks on the API's single event loop, and every mutation
+    here is a whole method with no ``await`` inside, so no reader can observe
+    a half-applied update and no lock is needed.
+    """
+
+    def __init__(self) -> None:
+        self._instance_id: InstanceId | None = None
+        self._failures: int = 0
+
+    @property
+    def instance_id(self) -> InstanceId | None:
+        """The steward instance the current failure count belongs to."""
+        return self._instance_id
+
+    def consecutive_failures_for(self, instance_id: InstanceId) -> int:
+        """Outstanding consecutive failures for ``instance_id``.
+
+        Zero for any other instance: a count earned by a torn-down steward
+        says nothing about its replacement.
+        """
+        return self._failures if self._instance_id == instance_id else 0
+
+    def track(self, instance_id: InstanceId) -> None:
+        """Start counting for a newly observed steward instance."""
+        self._instance_id = instance_id
+        self._failures = 0
+
+    def record_failure(self) -> int:
+        """Count one failed probe and return the new consecutive total."""
+        self._failures += 1
+        return self._failures
+
+    def clear_failures(self) -> None:
+        """Forget the failure run (a probe succeeded, or one was acted on)."""
+        self._failures = 0
+
+    def reset(self) -> None:
+        """Forget the tracked instance entirely (the steward is gone)."""
+        self._instance_id = None
+        self._failures = 0
+
+
 class StewardStatusResponse(BaseModel):
     """Whether the steward exists and what serves it right now."""
 
@@ -247,6 +378,17 @@ class StewardStatusResponse(BaseModel):
     instance_id: str | None = Field(
         default=None,
         description="The steward instance id, when present.",
+    )
+    state: StewardState = Field(
+        default="disabled",
+        description=(
+            "One-word lifecycle summary derived from the other fields plus "
+            "canary history: 'disabled' (mode off), 'downloading' (placed, "
+            "weights still staging), 'starting' (placing or loading), "
+            "'ready' (serving, clean canary), 'degraded' (serving, but the "
+            "liveness canary has an outstanding failed probe). The boolean "
+            "fields remain authoritative; this is the renderable summary."
+        ),
     )
 
 

--- a/src/skulk/api/tests/test_steward_status_state.py
+++ b/src/skulk/api/tests/test_steward_status_state.py
@@ -15,8 +15,13 @@ from skulk.api.steward import (
     derive_steward_state,
 )
 from skulk.api.types.api import ChatCompletionMessage, ChatCompletionRequest
-from skulk.shared.models.model_cards import ModelId
+from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from skulk.shared.types.common import NodeId
+from skulk.shared.types.memory import Memory
+from skulk.shared.types.telemetry import TelemetryView
+from skulk.shared.types.worker.downloads import DownloadOngoing, DownloadProgressData
 from skulk.shared.types.worker.instances import InstanceId
+from skulk.shared.types.worker.shards import PipelineShardMetadata
 
 if TYPE_CHECKING:
     from skulk.api.steward import StewardState
@@ -208,3 +213,76 @@ async def test_malformed_conversation_is_still_a_400_before_the_503() -> None:
             _stub_api(_status("starting")), payload
         )
     assert raised.value.status_code == 400
+
+
+def _download_record(model_id: str, node_id: NodeId) -> DownloadOngoing:
+    card = ModelCard(
+        model_id=ModelId(model_id),
+        storage_size=Memory.from_gb(20),
+        n_layers=40,
+        hidden_size=2048,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+    )
+    return DownloadOngoing(
+        node_id=node_id,
+        shard_metadata=PipelineShardMetadata(
+            model_card=card,
+            device_rank=0,
+            world_size=1,
+            start_layer=0,
+            end_layer=40,
+            n_layers=40,
+        ),
+        download_progress=DownloadProgressData(
+            total=Memory.from_gb(20),
+            downloaded=Memory.from_gb(4),
+            downloaded_this_session=Memory.from_gb(4),
+            completed_files=1,
+            total_files=3,
+            speed=1.0,
+            eta_ms=1000,
+            files={},
+        ),
+    )
+
+
+def _downloads_api(records: list[DownloadOngoing]) -> API:
+    """An API stand-in exposing only the download lookup's collaborators."""
+    node_id = NodeId()
+    return cast(
+        "API",
+        cast(
+            object,
+            SimpleNamespace(
+                _telemetry_view=TelemetryView(),
+                state=SimpleNamespace(downloads={node_id: records}),
+            ),
+        ),
+    )
+
+
+def test_live_download_for_the_steward_model_is_detected() -> None:
+    """The downloading state hinges on this lookup matching by model id."""
+    api = _downloads_api([_download_record("org/steward-brain", NodeId())])
+    assert (
+        API._steward_model_is_downloading(  # pyright: ignore[reportPrivateUsage]
+            api, "org/steward-brain"
+        )
+        is True
+    )
+    assert (
+        API._steward_model_is_downloading(  # pyright: ignore[reportPrivateUsage]
+            api, "org/some-other-model"
+        )
+        is False
+    )
+
+
+def test_no_download_records_is_not_downloading() -> None:
+    assert (
+        API._steward_model_is_downloading(  # pyright: ignore[reportPrivateUsage]
+            _downloads_api([]), "org/steward-brain"
+        )
+        is False
+    )

--- a/src/skulk/api/tests/test_steward_status_state.py
+++ b/src/skulk/api/tests/test_steward_status_state.py
@@ -1,0 +1,210 @@
+"""Steward lifecycle state: derivation, canary history, and the 503 preflight."""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from fastapi import HTTPException
+
+from skulk.api.main import API
+from skulk.api.steward import (
+    STEWARD_NOT_READY_MESSAGES,
+    STEWARD_RETRY_AFTER_SECONDS,
+    StewardCanaryState,
+    StewardStatusResponse,
+    derive_steward_state,
+)
+from skulk.api.types.api import ChatCompletionMessage, ChatCompletionRequest
+from skulk.shared.models.model_cards import ModelId
+from skulk.shared.types.worker.instances import InstanceId
+
+if TYPE_CHECKING:
+    from skulk.api.steward import StewardState
+
+
+def test_disabled_mode_wins_over_every_other_signal() -> None:
+    assert (
+        derive_steward_state(
+            enabled=False,
+            present=True,
+            ready=True,
+            downloading=True,
+            canary_failures=2,
+        )
+        == "disabled"
+    )
+
+
+def test_ready_with_a_clean_canary_is_ready() -> None:
+    assert (
+        derive_steward_state(
+            enabled=True,
+            present=True,
+            ready=True,
+            downloading=False,
+            canary_failures=0,
+        )
+        == "ready"
+    )
+
+
+def test_one_outstanding_canary_failure_is_degraded() -> None:
+    """Degraded is the early warning, not the teardown: one failure shows."""
+    assert (
+        derive_steward_state(
+            enabled=True,
+            present=True,
+            ready=True,
+            downloading=False,
+            canary_failures=1,
+        )
+        == "degraded"
+    )
+
+
+def test_live_download_on_a_placed_steward_is_downloading() -> None:
+    assert (
+        derive_steward_state(
+            enabled=True,
+            present=True,
+            ready=False,
+            downloading=True,
+            canary_failures=0,
+        )
+        == "downloading"
+    )
+
+
+def test_placed_but_loading_is_starting() -> None:
+    assert (
+        derive_steward_state(
+            enabled=True,
+            present=True,
+            ready=False,
+            downloading=False,
+            canary_failures=0,
+        )
+        == "starting"
+    )
+
+
+def test_no_placement_yet_is_starting() -> None:
+    """Enabled with nothing placed: the invariant is still establishing it."""
+    assert (
+        derive_steward_state(
+            enabled=True,
+            present=False,
+            ready=False,
+            downloading=False,
+            canary_failures=0,
+        )
+        == "starting"
+    )
+
+
+def test_canary_state_counts_consecutive_failures_per_instance() -> None:
+    canary = StewardCanaryState()
+    first = InstanceId()
+    canary.track(first)
+    assert canary.consecutive_failures_for(first) == 0
+    assert canary.record_failure() == 1
+    assert canary.record_failure() == 2
+    assert canary.consecutive_failures_for(first) == 2
+
+    # A count earned by one steward says nothing about another instance.
+    assert canary.consecutive_failures_for(InstanceId()) == 0
+
+    canary.clear_failures()
+    assert canary.consecutive_failures_for(first) == 0
+    assert canary.instance_id == first
+
+    canary.reset()
+    assert canary.instance_id is None
+
+
+def test_tracking_a_new_instance_drops_the_previous_failure_run() -> None:
+    canary = StewardCanaryState()
+    first = InstanceId()
+    canary.track(first)
+    _ = canary.record_failure()
+    second = InstanceId()
+    canary.track(second)
+    assert canary.consecutive_failures_for(second) == 0
+
+
+def _request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model=ModelId("skulk/steward"),
+        messages=[ChatCompletionMessage(role="user", content="is the fleet ok?")],
+        stream=True,
+    )
+
+
+def _stub_api(status: StewardStatusResponse) -> API:
+    """An API stand-in exposing only what the preflight path touches."""
+    return cast(
+        "API",
+        cast(
+            object,
+            SimpleNamespace(
+                _intelligent_fabric_enabled=lambda: status.enabled,
+                _steward_status=lambda: status,
+            ),
+        ),
+    )
+
+
+def _status(state: "StewardState", *, enabled: bool = True) -> StewardStatusResponse:
+    return StewardStatusResponse(
+        enabled=enabled,
+        present=state in ("downloading", "ready", "degraded"),
+        ready=state in ("ready", "degraded"),
+        steward_model="org/steward-brain" if state != "disabled" else None,
+        instance_id="inst-1" if state != "disabled" else None,
+        state=state,
+    )
+
+
+@pytest.mark.parametrize("state", ["starting", "downloading"])
+async def test_not_ready_steward_answers_503_with_the_status_payload(
+    state: "StewardState",
+) -> None:
+    """A steward that cannot answer is a 503 contract, not a 200 error chunk."""
+    status = _status(state)
+    with pytest.raises(HTTPException) as raised:
+        await API._steward_chat_completions(  # pyright: ignore[reportPrivateUsage]
+            _stub_api(status), _request()
+        )
+    error = raised.value
+    assert error.status_code == 503
+    assert isinstance(error.detail, dict)
+    detail = cast("dict[str, object]", error.detail)
+    assert detail["state"] == state
+    assert detail["ready"] is False
+    assert detail["steward_model"] == "org/steward-brain"
+    assert detail["message"] == STEWARD_NOT_READY_MESSAGES[state]
+    assert error.headers is not None
+    assert error.headers["Retry-After"] == str(STEWARD_RETRY_AFTER_SECONDS)
+
+
+async def test_disabled_mode_still_answers_404_not_503() -> None:
+    """The disabled contract predates this preflight and does not change."""
+    with pytest.raises(HTTPException) as raised:
+        await API._steward_chat_completions(  # pyright: ignore[reportPrivateUsage]
+            _stub_api(_status("disabled", enabled=False)), _request()
+        )
+    assert raised.value.status_code == 404
+
+
+async def test_malformed_conversation_is_still_a_400_before_the_503() -> None:
+    """A client error stays a client error even while the steward is starting."""
+    payload = ChatCompletionRequest(
+        model=ModelId("skulk/steward"),
+        messages=[ChatCompletionMessage(role="assistant", content="unprompted")],
+        stream=True,
+    )
+    with pytest.raises(HTTPException) as raised:
+        await API._steward_chat_completions(  # pyright: ignore[reportPrivateUsage]
+            _stub_api(_status("starting")), payload
+        )
+    assert raised.value.status_code == 400

--- a/src/skulk/api/tests/test_steward_text_tool_calls.py
+++ b/src/skulk/api/tests/test_steward_text_tool_calls.py
@@ -3,6 +3,27 @@
 import json
 
 from skulk.api.steward import parse_text_tool_calls, strip_tool_markup
+from skulk.worker.runner.llm_inference.tool_text_parser import (
+    parse_tool_calls_from_text,
+)
+
+# Verbatim shape of the block Qwen3.6's chat template emits and instructs the
+# model to produce: `<tool_call>\n<function=NAME>\n<parameter=KEY>\nVALUE\n
+# </parameter>\n</function>\n</tool_call>`, with each value on its own lines
+# and free to span several of them. The steward brain card
+# (unsloth/Qwen3.6-35B-A3B-GGUF and its MLX sibling) declares
+# tool_call_format = "generic" on the strength of these two parsers handling
+# exactly this, so the shape is pinned here rather than paraphrased.
+_QWEN36_MULTILINE_CALL = (
+    "I will check the node first.\n"
+    "<tool_call>\n"
+    "<function=get_node_resources>\n"
+    "<parameter=node_id>\n"
+    "den-node-1\n"
+    "</parameter>\n"
+    "</function>\n"
+    "</tool_call>"
+)
 
 
 def test_parses_qwen_xml_function_format() -> None:
@@ -39,3 +60,46 @@ def test_bare_function_block_without_wrapper() -> None:
 
 def test_plain_text_yields_no_calls() -> None:
     assert parse_text_tool_calls("The cluster is healthy.") == []
+
+
+def test_qwen36_template_shape_parses_in_the_harness_recovery_parser() -> None:
+    calls = parse_text_tool_calls(_QWEN36_MULTILINE_CALL)
+    assert len(calls) == 1
+    assert calls[0].function.name == "get_node_resources"
+    assert json.loads(calls[0].function.arguments) == {"node_id": "den-node-1"}
+    assert strip_tool_markup(_QWEN36_MULTILINE_CALL) == "I will check the node first."
+
+
+def test_qwen36_template_shape_parses_in_the_shared_engine_parser() -> None:
+    """The engine-side generic parser must agree with the harness fallback.
+
+    Both are in play for a Qwen3.6 steward: the served and llama_cpp engines
+    reparse the model's text with this one, and the MLX vision loader wires
+    the same function through its marker mechanism, while the harness parser
+    is the last net if an engine passes markup through as content. A steward
+    whose tool calls parse on one lane and not the other is the failure this
+    guards.
+    """
+    items = parse_tool_calls_from_text(_QWEN36_MULTILINE_CALL)
+    assert items is not None
+    assert len(items) == 1
+    assert items[0].name == "get_node_resources"
+    assert json.loads(items[0].arguments) == {"node_id": "den-node-1"}
+
+
+def test_qwen36_multiline_parameter_value_survives_both_parsers() -> None:
+    """The template explicitly allows a value spanning several lines."""
+    text = (
+        "<tool_call>\n"
+        "<function=search_docs>\n"
+        "<parameter=query>\n"
+        "zenoh transport\nmodel store staging\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+    expected = {"query": "zenoh transport\nmodel store staging"}
+    assert json.loads(parse_text_tool_calls(text)[0].function.arguments) == expected
+    items = parse_tool_calls_from_text(text)
+    assert items is not None
+    assert json.loads(items[0].arguments) == expected

--- a/src/skulk/api/tests/test_steward_thinking_off.py
+++ b/src/skulk/api/tests/test_steward_thinking_off.py
@@ -1,0 +1,121 @@
+"""The steward pins thinking off on every generation it dispatches.
+
+Bench measurement, not taste: ranking every candidate brain with thinking
+disabled and then re-running the two finalists with it enabled made both
+WORSE on the trust axes and better on nothing. The harness therefore sends
+``enable_thinking=False`` on both the investigation turns and the liveness
+canary, and these tests assert it survives the capability boundary as a real
+disabled-thinking task rather than being dropped on the way to the runner.
+"""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+from skulk.api.steward import (
+    STEWARD_THINKING_ENABLED,
+    StewardChatMessage,
+    StewardHarness,
+)
+from skulk.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    ModelTask,
+    ReasoningCardConfig,
+)
+from skulk.shared.types.chunks import TokenChunk
+from skulk.shared.types.common import CommandId
+from skulk.shared.types.memory import Memory
+from skulk.shared.types.text_generation import TextGenerationTaskParams
+from skulk.shared.types.worker.instances import InstanceId
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from skulk.api.main import API
+
+_STEWARD_MODEL = "org/steward-brain"
+
+
+def _thinking_toggle_card() -> ModelCard:
+    """A card shaped like the steward brains: thinking present, toggleable."""
+    return ModelCard(
+        model_id=ModelId(_STEWARD_MODEL),
+        storage_size=Memory.from_gb(20),
+        n_layers=40,
+        hidden_size=2048,
+        num_key_value_heads=2,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family="qwen",
+        capabilities=["text", "thinking", "thinking_toggle"],
+        reasoning=ReasoningCardConfig(
+            supports_toggle=True,
+            default_effort="medium",
+            disabled_effort="none",
+        ),
+    )
+
+
+class _CapturingApi:
+    """Records the task params the harness dispatches."""
+
+    def __init__(self) -> None:
+        self.dispatched: list[TextGenerationTaskParams] = []
+
+    async def running_model_card(self, model_id: ModelId) -> ModelCard:
+        assert str(model_id) == _STEWARD_MODEL
+        return _thinking_toggle_card()
+
+    async def dispatch_text_generation(
+        self,
+        task_params: TextGenerationTaskParams,
+        target_instance_id: InstanceId | None = None,
+    ) -> object:
+        self.dispatched.append(task_params)
+        return SimpleNamespace(command_id=CommandId())
+
+    def text_generation_chunk_stream(
+        self, command: object, task_params: TextGenerationTaskParams
+    ) -> "AsyncGenerator[TokenChunk, None]":
+        async def _stream() -> "AsyncGenerator[TokenChunk, None]":
+            yield TokenChunk(
+                model=ModelId(_STEWARD_MODEL),
+                text="All healthy.",
+                token_id=-1,
+                usage=None,
+                finish_reason="stop",
+            )
+
+        return _stream()
+
+
+async def test_investigation_turns_dispatch_with_thinking_disabled() -> None:
+    api = _CapturingApi()
+    harness = StewardHarness(cast("API", cast(object, api)))
+    harness.steward_instance = lambda: (InstanceId(), _STEWARD_MODEL)
+
+    async for _chunk in harness.run_turn_chunks(
+        [StewardChatMessage(role="user", content="is the fleet ok?")]
+    ):
+        pass
+
+    assert api.dispatched, "the harness dispatched no generation"
+    for task_params in api.dispatched:
+        assert task_params.enable_thinking is False
+        # The capability boundary must also normalize the effort, or a
+        # served engine would still be handed a thinking budget.
+        assert task_params.reasoning_effort == "none"
+
+
+async def test_canary_probe_dispatches_with_thinking_disabled() -> None:
+    api = _CapturingApi()
+    harness = StewardHarness(cast("API", cast(object, api)))
+
+    assert await harness.canary_probe(InstanceId(), _STEWARD_MODEL) is True
+    assert len(api.dispatched) == 1
+    assert api.dispatched[0].enable_thinking is False
+
+
+def test_thinking_stays_off_until_a_measurement_says_otherwise() -> None:
+    """Pin the verdict: flipping this constant must be a deliberate change."""
+    assert STEWARD_THINKING_ENABLED is False

--- a/src/skulk/master/tests/test_steward_placement.py
+++ b/src/skulk/master/tests/test_steward_placement.py
@@ -7,9 +7,15 @@ from skulk.master.placement import (
     replacement_command_for_refused_instance,
 )
 from skulk.master.tests.test_placement import fully_connected_three_nodes
-from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from skulk.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    ModelTask,
+    PlacementCardConfig,
+)
 from skulk.shared.types.commands import PlaceInstance
 from skulk.shared.types.memory import Memory
+from skulk.shared.types.profiling import NodeResources
 from skulk.shared.types.worker.instances import InstanceMeta, MlxRingInstance
 from skulk.shared.types.worker.shards import Sharding
 
@@ -99,3 +105,64 @@ def test_repair_commands_keep_none_for_ordinary_instances() -> None:
     placed = place_instance(command, topology, {}, node_memory, node_network)
     instance = next(iter(placed.values()))
     assert replacement_command_for_refused_instance(instance).system_role is None
+
+
+def _gguf_steward_card() -> ModelCard:
+    """A card shaped like the GGUF steward brains: served lanes, no mlx."""
+    return ModelCard(
+        model_id=ModelId("org/steward-brain-GGUF"),
+        storage_size=Memory.from_gb(3),
+        n_layers=12,
+        hidden_size=30,
+        num_key_value_heads=2,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        family="qwen",
+        quantization="Q4_K_M",
+        gguf_file="steward-brain-Q4_K_M.gguf",
+        context_length=262144,
+        placement=PlacementCardConfig(
+            compatible_backends=frozenset(
+                {"llama_server-cuda", "llama_cpp-cuda"}
+            ),
+            backend_preference=("llama_server-cuda", "llama_cpp-cuda"),
+        ),
+    )
+
+
+def test_mlx_ring_meta_is_benign_for_a_single_node_gguf_steward() -> None:
+    """The invariant's hardcoded InstanceMeta.MlxRing must not break GGUF.
+
+    ``_maintain_steward_placement`` always asks for ``InstanceMeta.MlxRing``,
+    which is the same default every dashboard placement sends. For a
+    single-node cycle the planner rewrites the request to Pipeline/Ring
+    regardless of engine, and a multi-node GGUF cycle resolves to the RPC
+    shape on its own, so the meta never has to describe the engine. This
+    test pins that so a future planner change cannot make the invariant
+    place the GGUF brain wrongly (or refuse to place it) unnoticed.
+    """
+    topology, node_memory, node_network, node_ids = fully_connected_three_nodes(
+        (10.0, 10.0, 10.0)
+    )
+    command = PlaceInstance(
+        model_card=_gguf_steward_card(),
+        sharding=Sharding.Pipeline,
+        instance_meta=InstanceMeta.MlxRing,
+        min_nodes=1,
+        system_role="steward",
+    )
+    placed = place_instance(
+        command,
+        topology,
+        {},
+        node_memory,
+        node_network,
+        node_resources={
+            node_id: NodeResources(backends=frozenset({"llama_server-cuda"}))
+            for node_id in node_ids
+        },
+    )
+    instance = next(iter(placed.values()))
+    assert isinstance(instance, MlxRingInstance)
+    assert instance.system_role == "steward"
+    assert len(instance.shard_assignments.node_to_runner) == 1

--- a/src/skulk/shared/tests/test_bundled_model_cards.py
+++ b/src/skulk/shared/tests/test_bundled_model_cards.py
@@ -233,3 +233,70 @@ def test_qwen_custom_voice_card_exposes_upstream_speaker_inventory() -> None:
     assert tuple(voice.id for voice in card.audio.voice_catalog) == card.audio.voices
     assert card.audio.voice_catalog[3].name == "Ryan"
     assert card.audio.voice_catalog[3].preferred_languages == ("en",)
+
+
+def test_default_steward_models_are_bundled_tool_calling_text_cards() -> None:
+    """Every default steward brain must exist, place, and call tools.
+
+    The master walks ``steward_models`` in order and places the first card
+    the cluster can serve, so an entry naming a card that is not bundled is
+    a silent skip that costs a fleet its best brain, and an entry whose card
+    cannot call tools would place a steward that can never investigate.
+    """
+    from skulk.shared.backends import platform_compatible_backends
+    from skulk.store.config import IntelligentFabricConfig
+
+    bundled = {
+        str(_load(path).model_id): path
+        for kind, path in _CARD_FILES
+        if kind == "inference"
+    }
+    for model_ref in IntelligentFabricConfig().steward_models:
+        assert model_ref in bundled, f"steward model {model_ref} has no bundled card"
+        card = _load(bundled[model_ref])
+        profile = resolve_model_capability_profile(card.model_id, model_card=card)
+        assert profile.supports_tool_calling, (
+            f"steward model {model_ref} cannot call tools"
+        )
+        # The platform filter is what placement actually applies; a card that
+        # loses every backend to it is unplaceable no matter what it declares.
+        assert platform_compatible_backends(
+            card.placement.compatible_backends,
+            card_serves_vision=card.vision is not None,
+            card_serves_speech=False,
+        ), f"steward model {model_ref} has no platform-servable backend"
+
+
+def test_steward_gguf_brains_stay_eligible_for_the_served_lanes() -> None:
+    """A vision declaration would gate the GGUF brains off llama_server.
+
+    The served runner cannot load an mmproj projector, so ``[vision]`` on a
+    GGUF card removes every ``llama_server-*`` tag at placement time. Both
+    Qwen3.6 and Qwen3.5 GGUF steward cards are deliberately text-only for
+    this reason, and the base models being natively multimodal makes that an
+    easy thing to "fix" back into a break.
+    """
+    from skulk.shared.backends import engine_of, platform_compatible_backends
+    from skulk.store.config import IntelligentFabricConfig
+
+    bundled = {
+        str(_load(path).model_id): path
+        for kind, path in _CARD_FILES
+        if kind == "inference"
+    }
+    gguf_refs = [
+        ref for ref in IntelligentFabricConfig().steward_models if "GGUF" in ref
+    ]
+    assert gguf_refs, "the steward preference list lost its GGUF entries"
+    for model_ref in gguf_refs:
+        card = _load(bundled[model_ref])
+        assert card.vision is None, f"{model_ref} declares vision"
+        assert "vision" not in card.capabilities, f"{model_ref} declares vision"
+        servable = platform_compatible_backends(
+            card.placement.compatible_backends,
+            card_serves_vision=False,
+            card_serves_speech=False,
+        )
+        assert "llama_server" in {
+            engine for tag in servable if (engine := engine_of(tag))
+        }, f"{model_ref} lost the served lane"

--- a/src/skulk/store/config.py
+++ b/src/skulk/store/config.py
@@ -396,20 +396,32 @@ class IntelligentFabricConfig(FrozenModel):
             while the feature hardens; flipping it on makes the master
             establish the steward placement within one planning cycle.
         steward_models: Ordered model-card preference list for the steward
-            brain. The master places the first card the cluster can serve.
-            The defaults are the benched steward class: Qwen3.5-4B in MLX
-            and GGUF form, then the Qwen3.5-0.8B GGUF as the universal
-            floor so every fleet, including CPU-only nodes, can place a
-            steward. Operators may override with any bundled or custom
-            text model that supports tool calling.
+            brain. The master places the first card the cluster can serve,
+            so the list descends from the best brain to the universal
+            floor and a fleet simply falls through to the largest model it
+            can host. Qwen3.6-35B-A3B (GGUF first, then MLX) is the benched
+            v1 brain; Qwen3.5-4B in GGUF and MLX form is the small-fleet
+            tier; the Qwen3.5-0.8B GGUF is the floor that lets a CPU-only
+            fleet place a steward at all. Operators may override with any
+            bundled or custom text model that supports tool calling.
     """
 
     enabled: bool = False
     # list (not tuple): strict validation rejects YAML sequences for tuple
     # fields, which would make the documented override unloadable; matches
     # the convention of other config lists (e.g. bootstrap_peers).
+    #
+    # The 35B brain leads with its GGUF card because that card is text-only
+    # and therefore eligible for the served lanes as well as the in-process
+    # ones, so it is placeable on strictly more node classes than its MLX
+    # sibling; an Apple-only fleet has no GGUF engine at all and falls
+    # through to the MLX entry on the next line. The 4B and 0.8B tiers keep
+    # the order they already shipped with, so a fleet that cannot host the
+    # 35B brain behaves exactly as it did before.
     steward_models: list[str] = Field(
         default_factory=lambda: [
+            "unsloth/Qwen3.6-35B-A3B-GGUF",
+            "mlx-community/Qwen3.6-35B-A3B-4bit",
             "mlx-community/Qwen3.5-4B-MLX-4bit",
             "unsloth/Qwen3.5-4B-GGUF",
             "unsloth/Qwen3.5-0.8B-GGUF",

--- a/src/skulk/store/tests/test_config.py
+++ b/src/skulk/store/tests/test_config.py
@@ -170,6 +170,8 @@ def test_intelligent_fabric_config_defaults() -> None:
     assert parsed.intelligent_fabric is not None
     assert parsed.intelligent_fabric.enabled
     assert parsed.intelligent_fabric.steward_models == [
+        "unsloth/Qwen3.6-35B-A3B-GGUF",
+        "mlx-community/Qwen3.6-35B-A3B-4bit",
         "mlx-community/Qwen3.5-4B-MLX-4bit",
         "unsloth/Qwen3.5-4B-GGUF",
         "unsloth/Qwen3.5-0.8B-GGUF",

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -1216,13 +1216,26 @@ Semantics of the reserved id:
 - Client `system` messages are ignored in favor of the steward's own system
   prompt; `user` and `assistant` turns form the conversation history, which
   the client owns and resends each turn (the server is stateless).
+- The steward always runs with thinking disabled, regardless of what the
+  brain model supports. Requests to the reserved id cannot turn it back on;
+  addressing the underlying card directly still gives you the model's normal
+  reasoning behavior.
 - Requests to the id while intelligent-fabric mode is disabled return `404`
-  with an explanatory message. If the mode is enabled but the placement is
-  not currently available (first placement, repair in flight), the response
-  is an error chunk in the normal chat-completions error shape.
-- The underlying model card id (for example the bundled Qwen3.5-4B) remains
-  addressable as an ordinary model and answers WITHOUT tools or cluster
-  access: only the reserved id selects model-plus-harness.
+  with an explanatory message.
+- If the mode is enabled but the steward is not ready to answer (still being
+  placed, still downloading its weights, still loading), the request is
+  refused with `503` before any streaming begins, carrying a `Retry-After`
+  header and a JSON body whose `detail` is the `GET /v1/steward` payload
+  (`enabled`, `present`, `ready`, `steward_model`, `instance_id`, `state`)
+  plus a human-readable `message`. Clients should back off and retry, or
+  poll `GET /v1/steward` and show the `state` while they wait.
+- A steward that disappears in the window between that check and dispatch
+  (a repair starting at exactly the wrong moment) still surfaces as an error
+  chunk in the normal chat-completions error shape, because the response has
+  already begun by then.
+- The underlying model card id (for example the bundled Qwen3.6-35B-A3B)
+  remains addressable as an ordinary model and answers WITHOUT tools or
+  cluster access: only the reserved id selects model-plus-harness.
 
 The steward appears in `GET /v1/models` as an entry flagged with
 `system_role: "steward"` while the mode is enabled, so model pickers can
@@ -1242,6 +1255,19 @@ Response fields:
   should keep showing a preparing state and hold chat until ready.
 - `steward_model`: model card id of the steward brain when present, else null.
 - `instance_id`: the steward instance id when present, else null.
+- `state`: a one-word lifecycle summary derived from the fields above plus
+  the liveness canary's history, for clients that want to render a single
+  line instead of re-deriving the precedence rules. The booleans remain
+  authoritative. Values:
+  - `disabled`: intelligent-fabric mode is off.
+  - `downloading`: a placement exists and the brain's weights are still
+    being staged. This is the long first-run wait.
+  - `starting`: the fabric is placing the steward, or it is placed and
+    loading.
+  - `ready`: serving, with no outstanding liveness failure.
+  - `degraded`: serving, but the hosting node's liveness canary has at least
+    one failed probe outstanding. The steward may still answer; three
+    consecutive failures make the fabric replace the placement.
 
 Note: deleting the steward instance through `DELETE /instance/{instance_id}`
 is refused with `409` while intelligent-fabric mode is enabled; disable the

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -83,9 +83,18 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 ### Steward (intelligent fabric)
 
 - Config: `intelligent_fabric` in `skulk.yaml` (`enabled`, default false;
-  `steward_models` preference list, default Qwen3.5-4B MLX, then the 4B
-  GGUF, then the Qwen3.5-0.8B GGUF universal floor so CPU-only fleets
-  still place a steward).
+  `steward_models` preference list, default Qwen3.6-35B-A3B GGUF then MLX
+  (the benched v1 brain), then Qwen3.5-4B MLX, then the 4B GGUF, then the
+  Qwen3.5-0.8B GGUF universal floor so CPU-only fleets still place a
+  steward). The master places the first entry the cluster can serve, so a
+  fleet falls through to the largest brain it can host.
+- Thinking: OFF for every steward generation
+  (`STEWARD_THINKING_ENABLED = False`, sent as `enable_thinking` on both
+  investigation turns and canary probes). Bench measurement, not a card
+  field: the candidate matrix ranked thinking-off, and the thinking-on
+  tiebreaker made both finalists worse on the trust axes. Model cards keep
+  declaring their real reasoning support; this is the harness's request
+  shape.
 - Identity: `BaseInstance.system_role = "steward" | None` (additive field;
   None on replayed old logs). Stamped from `PlaceInstance.system_role` at
   mint; all three repair builders re-stamp it from the instance.
@@ -94,7 +103,10 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   task; busy-wedge belongs to the worker wedge detector). Probe = minimal
   pinned no-tools generation, code-checked non-empty text within 120s; 3
   consecutive failures send DeleteInstance and the invariant re-places.
-  Pure target selection = `canary_probe_target` (steward.py). Limitation:
+  Pure target selection = `canary_probe_target` (steward.py). The failure
+  run lives in `StewardCanaryState` on the API (not a loop local), so the
+  status endpoint can report `degraded` from the FIRST failure instead of
+  hiding the problem until teardown; single event loop, no lock. Limitation:
   requires the hosting node to run an API; split API/worker shapes = #734.
 - Invariant: `Master._maintain_steward_placement` runs each planning tick
   behind the topology-settle grace: places first servable card from the
@@ -122,14 +134,27 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   hold-back gate (`splittable_prefix`): prose emits as it arrives, a
   suspicious tail holds until disambiguated, and tool markup is never
   emitted as content. `GET /v1/models` carries a flagged entry
-  (`system_role: "steward"`) while enabled. `GET /v1/steward` = presence.
-  The earlier bespoke `POST /v1/steward/chat` was removed before any
-  release. Ordinary `DELETE /instance/{id}` of the steward is refused 409
-  while the mode is enabled.
+  (`system_role: "steward"`) while enabled. `GET /v1/steward` = presence
+  plus `state` (`disabled | downloading | starting | ready | degraded`,
+  pure `derive_steward_state`; the booleans stay authoritative). The
+  earlier bespoke `POST /v1/steward/chat` was removed before any release.
+  Ordinary `DELETE /instance/{id}` of the steward is refused 409 while the
+  mode is enabled.
+- Readiness preflight: the reserved id answers 404 when the mode is off and
+  503 (status payload + `message` + `Retry-After`) when the mode is on but
+  no steward is ready, checked BEFORE the response begins. The in-stream
+  ErrorChunk path remains only for the placement-vanishes-after-preflight
+  race, so "the fabric is still setting up" is no longer indistinguishable
+  from "the model failed mid-answer".
 - Dashboard: instances with `systemRole` set are hidden from all instance
   surfaces (filter in App.tsx instanceCards).
-- Cards: `mlx-community/Qwen3.5-4B-MLX-4bit` (vision, MLX) and
-  `unsloth/Qwen3.5-4B-GGUF` (text-only so served lanes stay eligible).
+- Cards: `unsloth/Qwen3.6-35B-A3B-GGUF` (text-only so served lanes stay
+  eligible) and `mlx-community/Qwen3.6-35B-A3B-4bit` (vision, MLX) are the
+  v1 brain, both revision-pinned; `mlx-community/Qwen3.5-4B-MLX-4bit` /
+  `unsloth/Qwen3.5-4B-GGUF` are the small-fleet tier and
+  `unsloth/Qwen3.5-0.8B-GGUF` the floor. GGUF steward cards must stay
+  text-only: a `[vision]` section gates them off `llama_server`, whose
+  runner cannot load an mmproj projector.
 
 ### Dashboard
 

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -661,12 +661,25 @@ the answer; client-supplied tool definitions are rejected, and client system
 prompts are ignored in favor of the steward's own. Generation itself rides
 the normal text-generation dispatch path, pinned to the steward instance,
 and the underlying model card id remains addressable as an ordinary model
-without tools or cluster access. A small status endpoint reports presence
-and readiness so clients know whether to offer the surface. The node
+without tools or cluster access. Steward turns always run with the brain's
+thinking disabled: the model candidates were compared with and without it,
+and thinking made the finalists measurably less trustworthy on this
+workload while gaining nothing, so the harness pins it off rather than
+leaving the choice to whichever model is placed.
+
+A small status endpoint reports presence and readiness so clients know
+whether to offer the surface, along with a single lifecycle word covering
+the whole progression from disabled through downloading, starting, and
+ready to degraded. Because a steward that has not finished being placed
+cannot answer, the reserved model id refuses those requests up front with a
+service-unavailable response carrying that same status, so a client can tell
+"the fabric is still setting up" from "the answer failed halfway". The node
 hosting the steward also runs a slow deterministic canary: a minimal
 pinned generation whose answer is shape-checked by code, so a steward
 that is alive in state but wedged in generation is torn down and
-re-placed by the same invariant that handles node loss. In this release
+re-placed by the same invariant that handles node loss. The first failed
+probe already shows up in the status as a degraded steward, well before the
+third one triggers the replacement. In this release
 the steward observes and advises only: no tool can change the cluster, and
 anything action-shaped is returned to the operator as a recommendation.
 


### PR DESCRIPTION
## What this is

The intelligent-fabric steward is the resident model Skulk keeps placed as a
hidden system instance so operators can ask the cluster about itself. Three
bounded changes here: it gets a real brain, that brain runs the way the
bench says it should, and a steward that is not ready to answer now says so
instead of looking broken.

## 1. A benched brain, and a preference list that falls through

Until now the steward preference list topped out at a 4B model, so a fleet
with a GPU-rich node ran the same brain as a laptop. A candidate matrix of
nine models across a GPU (Vulkan GGUF) lane and an Apple Silicon (MLX) lane,
scored on an established task tier plus six trust axes, picked
**Qwen3.6-35B-A3B**: trust-axis lead among the large candidates, the only
large model that never proposed a forbidden action, and roughly 48 tokens
per second because it is a mixture-of-experts model with about 3B active
parameters. The analysis and raw per-model numbers live in the private
foxlight-docs hub at
`initiatives/skulk-intelligent-fabric/research/bench-v3-final-analysis.md`.

Two new bundled cards, both pinned to an immutable Hugging Face commit so an
upstream requantization cannot silently change the brain:

| card | lane | quant | pinned artifact |
|---|---|---|---|
| `unsloth/Qwen3.6-35B-A3B-GGUF` | llama_server / llama_cpp | UD-Q4_K_M | `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`, 22.1 GB |
| `mlx-community/Qwen3.6-35B-A3B-4bit` | mlx | 4bit | 20.4 GB |

They go at the head of `IntelligentFabricConfig.steward_models`, ahead of
the existing 4B and 0.8B entries, which are untouched. The master places the
first entry the cluster can serve, so a big fleet gets the brain and a small
one behaves exactly as it did before. The GGUF card leads the pair because
it is text-only and therefore eligible for the served lanes as well as the
in-process ones; an Apple-only fleet has no GGUF engine and falls straight
through to the MLX entry.

**Text-only GGUF card, on purpose.** The base model is natively multimodal,
but the served `llama_server` runner cannot load an mmproj projector, so a
vision-declaring GGUF card is filtered off every served lane by
`platform_compatible_backends` and becomes placeable on far fewer nodes. The
MLX card does declare vision, because the MLX lane serves it and the card
states model truth. A test pins both halves so the multimodal base model
cannot tempt a later "fix" into breaking placement.

**Tool format: verified, not assumed.** Both cards set
`tooling.tool_call_format = "generic"`. Qwen3.6's chat template both
instructs the model to emit and itself renders:

```
<tool_call>
<function=NAME>
<parameter=KEY>
VALUE
</parameter>
</function>
</tool_call>
```

That is exactly the Qwen3 XML dialect the shared engine-side parser handles
(`tool_text_parser`: `_TOOLCALL_BLOCK_RE` / `_FUNCTION_RE` /
`_PARAMETER_RE`) and the same dialect the steward harness re-parses if an
engine passes markup through as content (`steward.parse_text_tool_calls`,
which also handles a bare `<function=...>` block). The GGUF repo's embedded
template and the MLX repo's `chat_template.jinja` emit an identical
tool-call block, so both lanes speak the same dialect. New tests drive that
verbatim shape, including a parameter value spanning several lines, through
both parsers and assert they agree.

No speculative-decoding section on either card. The checkpoint does ship MTP
prediction heads, but that pairing is unmeasured on these quants, and the
immediate predecessor measured MTP net negative on MLX (85% draft acceptance
yet 0.63x end to end, because a fast mixture-of-experts routes every verify
token to its own experts). Both cards say so in a comment.

## 2. Thinking off for every steward generation

The bench ranked all candidates with thinking disabled, then re-ran the two
finalists with it enabled. Thinking made both worse: the winner's trust
score fell from 0.583 to 0.500 and it began proposing forbidden actions it
had never proposed before (0.000 to 0.083); the runner-up degraded on both
measures; neither gained on the established task tier.

The harness now sends `enable_thinking=False` on investigation turns as well
as on the liveness canary, which already did it for a different reason (a
thinking-default model spends its whole probe budget reasoning and emits no
answer text, failing every probe). Tests assert this survives the capability
boundary as a genuinely disabled-thinking task, not a flag dropped on the
way to the runner.

This lives in the harness rather than on a card. It is a property of the
steward workload, not of any model: the same cards serve ordinary chat where
their reasoning is worth having.

## 3. A lifecycle state, and a 503 instead of a broken-looking stream

`GET /v1/steward` returned three booleans and left each client to re-derive
the same rules, with no way to express two real conditions: weights still
downloading (a wait measured in minutes) and a serving steward that has
already failed a liveness probe. The response now also carries a one-word
`state`: `disabled | downloading | starting | ready | degraded`, derived by
a pure function from those booleans plus download records and canary
history. The booleans are unchanged and remain authoritative.

`degraded` needs the canary's failure count, which lived in a local variable
inside the canary loop. It now lives in a small `StewardCanaryState` on the
API, so the **first** failed probe is visible instead of the problem hiding
until the third one tears the placement down. Both the writing loop and the
reading handler are tasks on the node's single event loop and every mutation
is a whole method with no `await` inside, so no lock is needed; the counting
semantics are unchanged.

Separately, posting to `skulk/steward` while the steward was still being
placed returned HTTP 200 followed by an error chunk inside the SSE stream,
which to an OpenAI-compatible client is indistinguishable from a generation
that failed halfway. The reserved id now runs a readiness preflight before
any response begins and refuses with **503**, carrying `Retry-After` and a
body whose `detail` is the status payload plus a human message. The
disabled-mode 404 and the malformed-conversation 400 still take precedence,
and the in-stream error path remains for the narrow race where the placement
disappears between preflight and dispatch.

The dashboard gets the field on its status type, shows the state word while
it waits, and reads the 503's message instead of its generic failure text.

## Judgment calls

- **No new card field for thinking.** The task asked me to find the
  card/runtime field that defaults thinking off. There is none:
  `reasoning.default_effort` is only consulted when a request explicitly
  enables thinking, and `resolve_reasoning_params` returns "no opinion" when
  a request specifies neither control, so the model's own template default
  (thinking on, for Qwen3.6) wins. Adding such a field would also apply the
  steward's verdict to ordinary chat with the same cards, which the bench
  does not support. The harness constant is the honest home, and it matches
  the bench methodology, which ran every candidate thinking-off.
- **The invariant's hardcoded `InstanceMeta.MlxRing` is benign, so it is
  unchanged.** It is the same default every dashboard placement sends; the
  planner rewrites a single-node cycle to Pipeline/Ring regardless of engine
  and resolves a multi-node GGUF cycle to the RPC shape on its own. A new
  test places a GGUF-shaped steward card through that exact request on
  `llama_server`-only nodes and pins the result, so a future planner change
  cannot break the invariant unnoticed.
- **`state` is additive.** No existing field was removed or repurposed, and
  the dashboard change is a type plus one status line, not a redesign.

## Testing

- `uv run basedpyright`: 0 errors, 0 warnings.
- `uv run ruff check`: clean.
- `nix fmt`: 0 files changed.
- `uv run pytest`: 3061 passed, 1 skipped.
- `dashboard-react`: `npm run test` 69 passed across 13 files; `npm run
  build` succeeds.
- `uv run python scripts/export_openapi.py` regenerates cleanly.

New coverage: the Qwen3.6 tool-call shape through both parsers, the
lifecycle-state derivation matrix, `StewardCanaryState` semantics, the 503
preflight (including that 404 and 400 still win), thinking-off on both the
investigation and canary paths, steward preference-list entries resolving to
bundled tool-calling cards with a platform-servable backend, the GGUF cards
staying off the vision gate, and the GGUF placement shape under the
invariant's request.

Not validated on hardware: nothing here places or serves the 35B brain on a
live fleet. The pre-ship checks the bench itself lists (quant-sensitivity
spot check on the pick, AMD-lane smoke) remain outstanding and are not
blockers for this change.
