### PR TITLE
ci: cancel superseded PR runs instead of running them to completion

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,12 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# A new push to a PR obsoletes the in-flight review (it reviews stale code and
+# spends real Claude usage), so superseded review runs are cancelled.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,13 @@ on:
       - main
       - dev
 
+# A new push to a PR obsoletes the in-flight validation build, so superseded
+# PR runs are cancelled. Pushes to main/dev keep unique groups (keyed by sha)
+# so deploys are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,6 +12,14 @@ on:
       - main
       - dev
 
+# A new push to a PR obsoletes the in-flight run's verdict, so superseded PR
+# runs are cancelled instead of running to completion. Pushes to long-lived
+# branches keep unique groups (keyed by sha) so every merge commit still gets
+# its full run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   wire-compat-guard:
     # Any PR touching the networking crate's wire surfaces must either bump


### PR DESCRIPTION
## Why

The enterprise Actions usage review (August) showed ci-pipeline ran 89 times this month, and multi-round review cycles trigger the full pipeline on every push, including the macOS test job, which meters at 10x the Linux rate. Runs made obsolete by a newer push to the same PR still ran to completion. The Claude Code Review workflow also re-reviewed superseded commits, spending real Claude usage on stale code.

## What

Adds a `concurrency` group to ci-pipeline, docs, and Claude Code Review:

- Pull request runs group by PR number with `cancel-in-progress`, so a new push cancels the now-obsolete in-flight run.
- Pushes to long-lived branches (dev/main/staging) group by commit sha, which is unique per run: no queueing, no cancellation, every merge commit gets its full run and docs deploys are never cancelled mid-flight.

No job content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)