### PR TITLE
fix(store): serialize installed card timestamps

### DIFF
--- a/src/skulk/store/installed_cards.py
+++ b/src/skulk/store/installed_cards.py
@@ -614,12 +614,12 @@ def associate_installed_card(
     directory_name = model_directory.name
     matches: list[tuple[ModelCard, InstalledArtifactRole, str, str | None]] = []
     for card in cards:
-        base_names = {
-            card.model_id.normalize(),
-            card.artifact_repository.normalize(),
-        }
+        base_matches = any(
+            _artifact_directory_matches(directory_name, repository, card.source_revision)
+            for repository in (card.model_id, card.artifact_repository)
+        )
         if (
-            directory_name in base_names
+            base_matches
             and _legacy_base_artifact_is_complete(model_directory)
             and _legacy_revision_marker_matches(
                 model_directory,
@@ -657,7 +657,9 @@ def associate_installed_card(
                 ]
             )
         for repository, revision in companion_candidates:
-            if repository is None or ModelId(repository).normalize() != directory_name:
+            if repository is None or not _artifact_directory_matches(
+                directory_name, ModelId(repository), revision
+            ):
                 continue
             role = companion_artifact_role(card, repository)
             if not _legacy_revision_marker_matches(model_directory, revision) or not (
@@ -690,6 +692,20 @@ def associate_installed_card(
         owner_card_id=(None if role == "base" else card.registry_card_id),
         artifact_repository=repository,
         artifact_revision=revision,
+    )
+
+
+def _artifact_directory_matches(
+    directory_name: str,
+    repository: ModelId,
+    source_revision: str | None,
+) -> bool:
+    """Match mutable and canonical revision-qualified artifact directories."""
+
+    normalized = repository.normalize()
+    return directory_name == normalized or (
+        source_revision is not None
+        and directory_name == f"{normalized}--revision-{source_revision}"
     )
 
 

--- a/src/skulk/store/model_store_server.py
+++ b/src/skulk/store/model_store_server.py
@@ -383,7 +383,7 @@ class ModelStoreServer:
         if _request.query.get("recover_installed_cards") == "true":
             await self._store.recover_installed_cards_serialized()
         models = self._store.list_models()
-        return web.json_response([m.model_dump() for m in models])
+        return web.json_response([m.model_dump(mode="json") for m in models])
 
     async def _handle_models(self, _request: web.Request) -> web.Response:
         """``GET /models`` — list of model IDs in the store."""

--- a/src/skulk/store/tests/test_installed_cards.py
+++ b/src/skulk/store/tests/test_installed_cards.py
@@ -80,6 +80,26 @@ def test_unmarked_registry_bytes_remain_local_legacy(tmp_path: Path) -> None:
     assert record.model_card.registry_card_id is not None
 
 
+def test_revision_qualified_base_directory_associates_signed_card(
+    tmp_path: Path,
+) -> None:
+    """Canonical pinned generations retain their signed registry identity."""
+
+    card = _card()
+    assert card.source_revision is not None
+    artifact = tmp_path / f"org--model--revision-{card.source_revision}"
+    artifact.mkdir()
+    (artifact / "config.json").write_text("{}")
+    (artifact / "model.safetensors").write_bytes(b"weights")
+    (artifact / ".skulk-source-revision").write_text(f"{card.source_revision}\n")
+
+    record = associate_installed_card(artifact, [card])
+
+    assert record is not None
+    assert record.verification == "registry_verified"
+    assert record.installed_identity == card.registry_card_id
+
+
 def test_custom_card_keeps_custom_verification(tmp_path: Path) -> None:
     artifact = _artifact(tmp_path)
     record = build_installed_card_record(
@@ -153,6 +173,29 @@ def test_companion_association_retains_owning_full_card(tmp_path: Path) -> None:
     assert record.owner_card_id == owner.registry_card_id
     assert record.model_card == owner
     assert record.artifact_file is None
+
+
+def test_revision_qualified_companion_associates_owning_card(tmp_path: Path) -> None:
+    """Pinned companion generations recognize the canonical directory layout."""
+
+    payload = _card().model_dump(mode="json")
+    revision = "b" * 40
+    payload["runtime"] = {
+        "mtp_sidecar_repo": "org/model-mtp",
+        "mtp_sidecar_revision": revision,
+    }
+    owner = ModelCard.model_validate(payload)
+    companion = tmp_path / f"org--model-mtp--revision-{revision}"
+    companion.mkdir()
+    (companion / "weights.safetensors").write_bytes(b"mtp")
+    (companion / ".skulk-source-revision").write_text(f"{revision}\n")
+
+    record = associate_installed_card(companion, [owner])
+
+    assert record is not None
+    assert record.artifact_role == "mtp_sidecar"
+    assert record.verification == "registry_verified"
+    assert record.owner_card_id == owner.registry_card_id
 
 
 def test_served_draft_record_selects_its_own_gguf(tmp_path: Path) -> None:

--- a/src/skulk/store/tests/test_model_store_server.py
+++ b/src/skulk/store/tests/test_model_store_server.py
@@ -1,0 +1,55 @@
+# pyright: reportPrivateUsage=false
+"""HTTP serialization contracts for the authoritative model-store server."""
+
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+from skulk.shared.models.model_cards import ModelCard, ModelTask
+from skulk.shared.types.common import ModelId
+from skulk.shared.types.memory import Memory
+from skulk.store.installed_cards import build_installed_card_record
+from skulk.store.model_store import ModelStore
+from skulk.store.model_store_server import ModelStoreServer
+
+
+@pytest.mark.anyio
+async def test_registry_serializes_installed_card_timestamp(tmp_path: Path) -> None:
+    """Installed-card datetimes remain valid JSON after reconciliation."""
+
+    store_root = tmp_path / "store"
+    artifact = store_root / "org--model"
+    artifact.mkdir(parents=True)
+    (artifact / "model.safetensors").write_bytes(b"weights")
+    card = ModelCard(
+        model_id=ModelId("org/model"),
+        storage_size=Memory.from_bytes(7),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+    )
+    installed_card = build_installed_card_record(artifact, card)
+    store = ModelStore(store_root)
+    store.register_model(
+        "org/model",
+        artifact,
+        ["model.safetensors"],
+        7,
+        installed_card=installed_card,
+    )
+    server = ModelStoreServer(store, host="127.0.0.1", port=0)
+
+    response = await server._handle_registry(make_mocked_request("GET", "/registry"))
+    assert response.text is not None
+    payload = cast("list[dict[str, object]]", json.loads(response.text))
+    installed_card_payload = cast(
+        "dict[str, object]", payload[0]["installed_card"]
+    )
+    captured_at = installed_card_payload["captured_at"]
+
+    assert isinstance(captured_at, str)
+    assert captured_at.endswith("Z")

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -1529,6 +1529,16 @@ The dashboard combines registry results with `GET /v1/models` metadata so it can
 display derived tags such as `vision`, `thinking`, `embedding`, `tensor`, and
 `optiq` in the Store list.
 
+**GET** `/registry` (internal model-store transport port)
+
+Returns the authoritative store index consumed by Skulk nodes. The optional
+`recover_installed_cards=true` query first rebuilds installed-card associations
+from complete local sidecars and trusted catalog cards. Every entry is emitted
+with JSON-native values; in particular, the nested installed card's
+`captured_at` value is an ISO 8601 UTC string rather than a native datetime.
+This endpoint is cluster-internal transport; operators and dashboards should
+use the enriched public `GET /store/registry` endpoint above.
+
 ### Store downloads
 
 **GET** `/store/downloads`


### PR DESCRIPTION
## Summary

- serialize internal model-store registry responses using Pydantic JSON mode
- preserve installed-card timestamps as ISO 8601 strings after reconciliation
- add a regression test for the reconciled registry response

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (3327 passed, 2 skipped, 231 deselected)