### PR TITLE
Distinguish cluster fit from recommendation

### DIFF
--- a/dashboard-react/src/components/models/ModelBrowser.test.tsx
+++ b/dashboard-react/src/components/models/ModelBrowser.test.tsx
@@ -62,6 +62,8 @@ async function renderBrowser(
   onSelect = vi.fn(),
   getBurstInfo?: (variantId: string) => BurstInfo | null,
   mode: PickerMode = 'store-download',
+  models: ModelInfo[] = MODELS,
+  getModelFitStatus: () => 'fits_now' | 'fits_cluster_capacity' = () => 'fits_now',
 ): Promise<ReturnType<typeof vi.fn>> {
   container = document.createElement('div');
   document.body.append(container);
@@ -70,11 +72,11 @@ async function renderBrowser(
     root?.render(
       <ThemeProvider theme={darkTheme}>
         <ModelBrowser
-          models={MODELS}
+          models={models}
           selectedModelId={null}
           favorites={new Set()}
           canModelFit={() => true}
-          getModelFitStatus={() => 'fits_now'}
+          getModelFitStatus={getModelFitStatus}
           onSelect={onSelect}
           onToggleFavorite={vi.fn()}
           hfTrendingModels={HUB_MODELS}
@@ -182,6 +184,40 @@ describe('ModelBrowser store discovery taxonomy', () => {
 
     expect(container?.textContent).toContain('Fits this cluster');
     expect(container?.textContent).not.toContain('Recommended');
+  });
+
+  it('includes models that fit total cluster capacity under the fit heading', async () => {
+    await renderBrowser(
+      vi.fn(),
+      undefined,
+      'launch',
+      MODELS,
+      () => 'fits_cluster_capacity',
+    );
+
+    expect(container?.textContent).toContain('Fits this cluster');
+    expect(container?.textContent).not.toContain('Other');
+  });
+
+  it('does not apply registry provenance to an unprovenanced grouped variant', async () => {
+    const mixedModels = [
+      MODELS[0],
+      {
+        ...MODELS[0],
+        id: 'local/Qwen3-4B-8bit',
+        name: 'Qwen3-4B-8bit',
+        quantization: '8bit',
+        catalog_source: 'bundled' as const,
+        registry_provenance: null,
+      },
+    ];
+    await renderBrowser(vi.fn(), undefined, 'launch', mixedModels);
+
+    expect(container?.textContent).not.toContain('Foxlight');
+    const rowTitle = Array.from(container?.querySelectorAll('span') ?? [])
+      .find((element) => element.textContent === 'Qwen3 4B');
+    await act(async () => rowTitle?.click());
+    expect(container?.textContent).toContain('Foxlight');
   });
 
   it('partitions burst models after placeable ones and keeps them interactive', async () => {

--- a/dashboard-react/src/components/models/ModelBrowser.test.tsx
+++ b/dashboard-react/src/components/models/ModelBrowser.test.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from 'styled-components';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { darkTheme } from '../../theme/theme';
-import type { HuggingFaceModel, ModelInfo } from '../../types/models';
+import type { HuggingFaceModel, ModelInfo, PickerMode } from '../../types/models';
 import { ModelBrowser } from './ModelBrowser';
 import type { BurstInfo } from './burst';
 
@@ -27,6 +27,8 @@ const MODELS: ModelInfo[] = [
     family: 'qwen',
     quantization: '4bit',
     storage_size_megabytes: 2100,
+    catalog_source: 'registry',
+    registry_provenance: 'foxlight',
   },
   {
     id: 'mlx-community/LongCat-AudioDiT-1B-4bit',
@@ -59,6 +61,7 @@ let container: HTMLDivElement | null = null;
 async function renderBrowser(
   onSelect = vi.fn(),
   getBurstInfo?: (variantId: string) => BurstInfo | null,
+  mode: PickerMode = 'store-download',
 ): Promise<ReturnType<typeof vi.fn>> {
   container = document.createElement('div');
   document.body.append(container);
@@ -75,7 +78,7 @@ async function renderBrowser(
           onSelect={onSelect}
           onToggleFavorite={vi.fn()}
           hfTrendingModels={HUB_MODELS}
-          mode="store-download"
+          mode={mode}
           getBurstInfo={getBurstInfo}
           fleetMemoryBytes={64 * 2 ** 30}
         />
@@ -156,6 +159,7 @@ describe('ModelBrowser store discovery taxonomy', () => {
     // and artifact format (the fixture id is an mlx-community repo).
     expect(container?.textContent).toContain('4bit');
     expect(container?.textContent).toContain('MLX');
+    expect(container?.textContent).toContain('Foxlight');
 
     // Clicking the row body of a single-variant group must NOT start a download.
     const rowTitle = Array.from(container?.querySelectorAll('span') ?? [])
@@ -171,6 +175,13 @@ describe('ModelBrowser store discovery taxonomy', () => {
     expect(downloadButton).not.toBeNull();
     await act(async () => downloadButton?.click());
     expect(onSelect).toHaveBeenCalledWith('mlx-community/Qwen3-4B-4bit');
+  });
+
+  it('describes current fit without claiming a recommendation', async () => {
+    await renderBrowser(vi.fn(), undefined, 'launch');
+
+    expect(container?.textContent).toContain('Fits this cluster');
+    expect(container?.textContent).not.toContain('Recommended');
   });
 
   it('partitions burst models after placeable ones and keeps them interactive', async () => {

--- a/dashboard-react/src/components/models/ModelBrowser.tsx
+++ b/dashboard-react/src/components/models/ModelBrowser.tsx
@@ -612,7 +612,7 @@ export function ModelBrowser({
               )}
               {mode !== 'store-download' && picker.recommendedGroups.length > 0 && (
                 <>
-                  <SectionHeader>{t('modelBrowser.recommended', 'Recommended')}</SectionHeader>
+                  <SectionHeader>{t('modelBrowser.recommended', 'Fits this cluster')}</SectionHeader>
                   <ListCard>
                     {picker.recommendedGroups.map(renderGroup)}
                   </ListCard>

--- a/dashboard-react/src/components/models/ModelPickerGroup.tsx
+++ b/dashboard-react/src/components/models/ModelPickerGroup.tsx
@@ -416,10 +416,10 @@ export function ModelPickerGroup({
   const chips = group.capabilities.filter((c) => CHIP_CAPABILITIES.has(c));
   const contextLength = group.smallestVariant.context_length;
   const provenanceValues = new Set(
-    variants.map((variant) => variant.registry_provenance).filter(Boolean),
+    variants.map((variant) => variant.registry_provenance),
   );
   const uniformProvenance = provenanceValues.size === 1
-    ? variants.find((variant) => variant.registry_provenance)?.registry_provenance ?? null
+    ? variants[0]?.registry_provenance ?? null
     : null;
   const provenanceLabel = (value: NonNullable<ModelInfo['registry_provenance']>) => ({
     foxlight: t('modelInfo.provenanceFoxlight', 'Foxlight'),

--- a/dashboard-react/src/components/models/ModelPickerGroup.tsx
+++ b/dashboard-react/src/components/models/ModelPickerGroup.tsx
@@ -190,6 +190,10 @@ const RegistryChip = styled.span`
   padding: 1px 6px;
 `;
 
+const ProvenanceChip = styled(RegistryChip)`
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
 const StatusDot = styled.span<{ $class: string }>`
   width: 7px;
   height: 7px;
@@ -411,6 +415,17 @@ export function ModelPickerGroup({
 
   const chips = group.capabilities.filter((c) => CHIP_CAPABILITIES.has(c));
   const contextLength = group.smallestVariant.context_length;
+  const provenanceValues = new Set(
+    variants.map((variant) => variant.registry_provenance).filter(Boolean),
+  );
+  const uniformProvenance = provenanceValues.size === 1
+    ? variants.find((variant) => variant.registry_provenance)?.registry_provenance ?? null
+    : null;
+  const provenanceLabel = (value: NonNullable<ModelInfo['registry_provenance']>) => ({
+    foxlight: t('modelInfo.provenanceFoxlight', 'Foxlight'),
+    agent: t('modelInfo.provenanceAgent', 'Agent'),
+    community: t('modelInfo.provenanceCommunity', 'Community'),
+  })[value];
 
   // Artifact format (GGUF, MLX) is placement-relevant truth. Show it on the
   // group row when every variant shares one format; otherwise it appears per
@@ -483,6 +498,11 @@ export function ModelPickerGroup({
             )}
             {variants.every((variant) => variant.catalog_source === 'registry') && (
               <RegistryChip>{t('modelInfo.signedRegistry', 'Signed registry')}</RegistryChip>
+            )}
+            {uniformProvenance && (
+              <ProvenanceChip title={t('modelInfo.provenance', 'Provenance')}>
+                {provenanceLabel(uniformProvenance)}
+              </ProvenanceChip>
             )}
             <MetaText>
               {[
@@ -587,6 +607,11 @@ export function ModelPickerGroup({
                   <QuantBadge>{deriveFormatLabel(v.id)}</QuantBadge>
                 )}
                 <QuantBadge>{v.quantization ?? '—'}</QuantBadge>
+                {!uniformProvenance && v.registry_provenance && (
+                  <ProvenanceChip title={t('modelInfo.provenance', 'Provenance')}>
+                    {provenanceLabel(v.registry_provenance)}
+                  </ProvenanceChip>
+                )}
                 {groupBurst === null && (() => {
                   const b = getBurstInfo?.(v.id) ?? null;
                   return b ? <BurstChip info={b} fleetMemoryBytes={fleetMemoryBytes} /> : null;

--- a/dashboard-react/src/hooks/useModelPicker.ts
+++ b/dashboard-react/src/hooks/useModelPicker.ts
@@ -181,7 +181,10 @@ export function useModelPicker({
     const rec: ModelGroup[] = [];
     const other: ModelGroup[] = [];
     for (const g of filteredGroups) {
-      const fits = g.variants.some((v) => getModelFitStatus(v.id) === 'fits_now');
+      const fits = g.variants.some((variant) => {
+        const status = getModelFitStatus(variant.id);
+        return status === 'fits_now' || status === 'fits_cluster_capacity';
+      });
       if (fits) rec.push(g);
       else other.push(g);
     }

--- a/dashboard-react/src/i18n/en/skulk.json
+++ b/dashboard-react/src/i18n/en/skulk.json
@@ -337,7 +337,7 @@
   "modelBrowser.noModelsMatch": "No models match your search",
   "modelBrowser.noResultsFound": "No results found",
   "modelBrowser.other": "Other",
-  "modelBrowser.recommended": "Recommended",
+  "modelBrowser.recommended": "Fits this cluster",
   "modelBrowser.searchAriaLabel": "Search models",
   "modelBrowser.searchHuggingFace": "Search all of Hugging Face...",
   "modelBrowser.searching": "Searching...",

--- a/website/docs/model-store.md
+++ b/website/docs/model-store.md
@@ -43,6 +43,10 @@ model card, immutable registry identity and provenance when available, exact
 artifact selection, base or companion role, owning base card, and a canonical
 SHA-256 file manifest. The sidecar is durable truth; `registry.json` is a
 rebuildable index.
+The dashboard labels the immediately placeable group **Fits this cluster**. This
+is a live capacity statement, not a recommendation or qualification claim.
+Registry-backed rows also show the signed origin as Foxlight, Agent, or
+Community; provenance describes authorship, not runtime confidence.
 When a model root is mounted read-only, Skulk stores the same strict record
 under its data directory, keyed by the resolved artifact path and manifest
 digest. This fallback changes only metadata placement; the model bytes remain


### PR DESCRIPTION
## Summary

- label structural placement compatibility as `Fits this cluster` rather than `Recommended`
- show Foxlight, agent, or community provenance in the model picker
- document that fit, authorship, and recommendation confidence are separate concepts

## Why

Registry-discovered cards remain user-loadable, but structural compatibility must not be presented as a recommendation or qualification claim.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` (3,330 passed, 2 skipped)
- dashboard tests (131 passed)
- dashboard production build
