### PR TITLE
Add long-lived revocable pairing invitations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,11 @@ A single Skulk `Node` (src/skulk/main.py) runs multiple components:
   membership chain from immutable bootstrap anchors. The encrypted journal
   requires an injected external data-key provider. The v1 designated gateway
   uses a protected local-file provider and `skulk operator pair` to create a
-  five-minute QR capability. A relay-configured gateway includes app-role
+  legacy five-minute QR capability. Explicit duration or pairing-limit flags
+  create a reusable version-three invitation bounded to 90 days, twenty
+  successful pairings, ten live attempts, and one hundred total attempts. Each
+  scan receives an independent five-minute challenge record, and host-only
+  commands list or revoke invitations without exposing bearer material. A relay-configured gateway includes app-role
   carrier and pinned inner-TLS bootstrap material in the version-two QR while
   retaining `--exchange-url` as a direct fallback. Relay packages use bounded,
   zlib-compressed compact JSON so terminal QRs remain scannable; the API exposes only

--- a/src/skulk/api/operator_auth.py
+++ b/src/skulk/api/operator_auth.py
@@ -20,6 +20,7 @@ from skulk.operator.pairing import (
     PairingExchangeRequest,
     PairingExchangeResponse,
     PairingGatewayNotInitializedError,
+    PairingInvitationCapacityError,
     PairingProofError,
     PairingSessionExpiredError,
     PairingSessionNotFoundError,
@@ -83,11 +84,13 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
     @router.post(
         "/pairing-sessions/challenge",
         response_model=PairingChallengeResponse,
+        response_model_exclude_none=True,
         summary="Bind a device key to a local pairing session",
         description=(
             "Accept a candidate Ed25519 public key only when the nonce names an "
-            "unexpired host-created pairing session, then return one random "
-            "challenge for proof of possession."
+            "unexpired host-created pairing session or invitation, then return "
+            "one random challenge for proof of possession. Reusable invitations "
+            "return an independent five-minute attempt identity."
         ),
     )
     def create_pairing_challenge(
@@ -105,6 +108,12 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
             raise HTTPException(status_code=410, detail=str(exc)) from exc
         except PairingSessionStateError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except PairingInvitationCapacityError as exc:
+            raise HTTPException(
+                status_code=429,
+                detail=str(exc),
+                headers={"Retry-After": str(exc.retry_after_seconds)},
+            ) from exc
         except PairingProofError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -113,9 +122,9 @@ def create_operator_auth_router(service: OperatorPairingService) -> APIRouter:
         response_model=PairingExchangeResponse,
         summary="Exchange a device-key proof for operator credentials",
         description=(
-            "Verify the candidate device's Ed25519 signature, consume the "
-            "single-use session, and return short-lived access plus rotating "
-            "refresh credentials exactly once."
+            "Verify the candidate device's Ed25519 signature, consume its "
+            "single-use session or independent invitation attempt, and return "
+            "short-lived access plus rotating refresh credentials exactly once."
         ),
     )
     def exchange_pairing_proof(

--- a/src/skulk/api/tests/test_operator_auth.py
+++ b/src/skulk/api/tests/test_operator_auth.py
@@ -1,7 +1,7 @@
 """HTTP contract tests for host-authorized operator pairing."""
 
 import base64
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import cast
 from uuid import UUID
@@ -16,6 +16,7 @@ from skulk.operator.authority import EncryptedAuthorityStore
 from skulk.operator.key_provider import LocalFileAuthorityKeyProvider
 from skulk.operator.pairing import (
     OperatorPairingService,
+    pairing_invitation_signature_message,
     pairing_signature_message,
 )
 
@@ -118,6 +119,114 @@ def test_pairing_routes_issue_credentials_and_reject_reuse(tmp_path: Path) -> No
         json={"nonce": package.nonce, "signature": _base64url(signature)},
     )
     assert reused_response.status_code == 409
+
+
+def test_reusable_invitation_routes_return_and_require_attempt_identity(
+    tmp_path: Path,
+) -> None:
+    """Version-three exchanges bind credentials to one independent HTTP attempt."""
+
+    now = datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "key.bin")
+    service = OperatorPairingService(
+        EncryptedAuthorityStore(provider, tmp_path / "authority.sqlite3"),
+        provider,
+        now=lambda: now,
+    )
+    package = service.create_invitation(
+        lifetime=timedelta(days=90),
+        exchange_url="https://example.invalid",
+    )
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    app = FastAPI()
+    app.include_router(create_operator_auth_router(service))
+    client = TestClient(app)
+
+    challenged = client.post(
+        "/v1/auth/pairing-sessions/challenge",
+        json={
+            "nonce": package.nonce,
+            "invitationId": str(package.invitation_id),
+            "deviceName": "Review phone",
+            "devicePublicKey": _base64url(public_key),
+        },
+    )
+    assert challenged.status_code == 200, challenged.text
+    challenge_body = cast(dict[str, object], challenged.json())
+    attempt_id = UUID(str(challenge_body["attemptId"]))
+    signature = private_key.sign(
+        pairing_invitation_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            invitation_id=package.invitation_id,
+            nonce=package.nonce,
+            attempt_id=attempt_id,
+            challenge=str(challenge_body["challenge"]),
+        )
+    )
+    exchanged = client.post(
+        "/v1/auth/pairing-sessions/exchange",
+        json={
+            "nonce": package.nonce,
+            "invitationId": str(package.invitation_id),
+            "attemptId": str(attempt_id),
+            "signature": _base64url(signature),
+        },
+    )
+    assert exchanged.status_code == 200, exchanged.text
+    assert client.post(
+        "/v1/auth/pairing-sessions/exchange",
+        json={
+            "nonce": package.nonce,
+            "invitationId": str(package.invitation_id),
+            "attemptId": str(attempt_id),
+            "signature": _base64url(signature),
+        },
+    ).status_code == 409
+
+
+def test_reusable_invitation_active_attempt_capacity_returns_retry_after(
+    tmp_path: Path,
+) -> None:
+    """The public challenge route exposes temporary capacity as HTTP 429."""
+
+    now = datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)
+    provider = LocalFileAuthorityKeyProvider(tmp_path / "key.bin")
+    service = OperatorPairingService(
+        EncryptedAuthorityStore(provider, tmp_path / "authority.sqlite3"),
+        provider,
+        now=lambda: now,
+    )
+    package = service.create_invitation(
+        lifetime=timedelta(days=1),
+        exchange_url="https://example.invalid",
+    )
+    app = FastAPI()
+    app.include_router(create_operator_auth_router(service))
+    client = TestClient(app)
+    for index in range(11):
+        private_key = Ed25519PrivateKey.generate()
+        public_key = private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        response = client.post(
+            "/v1/auth/pairing-sessions/challenge",
+            json={
+                "nonce": package.nonce,
+                "invitationId": str(package.invitation_id),
+                "deviceName": f"Review phone {index}",
+                "devicePublicKey": _base64url(public_key),
+            },
+        )
+        if index < 10:
+            assert response.status_code == 200
+        else:
+            assert response.status_code == 429
+            assert response.headers["retry-after"] == "300"
 
 
 def test_pairing_routes_are_present_in_openapi(tmp_path: Path) -> None:

--- a/src/skulk/operator/cli.py
+++ b/src/skulk/operator/cli.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import argparse
+import os
+import re
 import sys
 from collections.abc import Sequence
+from datetime import timedelta
 from pathlib import Path
 from typing import Literal, cast
+from uuid import UUID
 
 from skulk.operator.pairing import (
     OperatorPairingService,
+    PairingInvitationPackage,
     PairingPackageTooLargeError,
 )
 from skulk.operator.relay import OperatorRelayProvisioning
@@ -24,6 +29,9 @@ class _PairArguments(FrozenModel):
     command: Literal["pair"]
     exchange_url: str | None
     cluster_name: str
+    valid_for: timedelta | None
+    max_pairings: int | None
+    qr_output: Path | None
 
 
 class _ConfigureRelayArguments(FrozenModel):
@@ -33,6 +41,42 @@ class _ConfigureRelayArguments(FrozenModel):
     provisioning_file: Path
     operator_api_port: int
     cluster_name: str
+
+
+class _InvitationListArguments(FrozenModel):
+    """Strictly validated invitation-list arguments."""
+
+    command: Literal["invitations"]
+    invitation_command: Literal["list"]
+
+
+class _InvitationRevokeArguments(FrozenModel):
+    """Strictly validated invitation-revocation arguments."""
+
+    command: Literal["invitations"]
+    invitation_command: Literal["revoke"]
+    invitation_id: UUID
+
+
+_DURATION_PATTERN = re.compile(r"^([1-9][0-9]*)([mhd])$")
+
+
+def _parse_invitation_duration(value: str) -> timedelta:
+    """Parse a bounded integer minute, hour, or day duration."""
+
+    match = _DURATION_PATTERN.fullmatch(value)
+    if match is None:
+        raise argparse.ArgumentTypeError("duration must be a positive integer plus m, h, or d")
+    amount = int(match.group(1))
+    unit = match.group(2)
+    duration = {
+        "m": timedelta(minutes=amount),
+        "h": timedelta(hours=amount),
+        "d": timedelta(days=amount),
+    }[unit]
+    if duration > timedelta(days=90):
+        raise argparse.ArgumentTypeError("duration must not exceed 90 days")
+    return duration
 
 
 def _print_pairing_qr(payload: str) -> None:
@@ -51,6 +95,28 @@ def _print_pairing_qr(payload: str) -> None:
     print(payload)
 
 
+def _write_pairing_qr(payload: str, output_path: Path) -> None:
+    """Write a permission-restricted QR PNG without replacing an existing file."""
+
+    import qrcode
+    from qrcode.constants import ERROR_CORRECT_L
+
+    code = qrcode.QRCode(border=2, error_correction=ERROR_CORRECT_L)
+    code.add_data(payload)
+    code.make(fit=True)
+    descriptor = os.open(
+        output_path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        0o600,
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as output:
+            code.make_image().save(output)
+    except BaseException:
+        output_path.unlink(missing_ok=True)
+        raise
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the local `skulk operator` command group.
 
@@ -65,7 +131,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
     pair_parser = subparsers.add_parser(
         "pair",
-        help="Create a five-minute host-authorized phone pairing QR code.",
+        help="Create a host-authorized phone pairing QR code or invitation.",
     )
     pair_parser.add_argument(
         "--exchange-url",
@@ -78,6 +144,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--cluster-name",
         default="Cluster",
         help="Initial cluster name when designating a gateway for the first time.",
+    )
+    pair_parser.add_argument(
+        "--valid-for",
+        type=_parse_invitation_duration,
+        help="Create a reusable v3 invitation lasting 1m through 90d.",
+    )
+    pair_parser.add_argument(
+        "--max-pairings",
+        type=int,
+        choices=range(1, 21),
+        metavar="1-20",
+        help="Create a reusable v3 invitation with this successful-pairing limit.",
+    )
+    pair_parser.add_argument(
+        "--qr-output",
+        type=Path,
+        help="Also write a permission-restricted QR PNG without overwriting a file.",
     )
     relay_parser = subparsers.add_parser(
         "configure-relay",
@@ -103,9 +186,50 @@ def main(argv: Sequence[str] | None = None) -> int:
         default="Cluster",
         help="Initial cluster name when designating a gateway for the first time.",
     )
+    invitations_parser = subparsers.add_parser(
+        "invitations",
+        help="List or revoke reusable pairing invitations.",
+    )
+    invitation_subparsers = invitations_parser.add_subparsers(
+        dest="invitation_command",
+        required=True,
+    )
+    invitation_subparsers.add_parser(
+        "list",
+        help="List safe invitation status without bearer capabilities.",
+    )
+    revoke_parser = invitation_subparsers.add_parser(
+        "revoke",
+        help="Revoke an invitation without disconnecting paired devices.",
+    )
+    revoke_parser.add_argument("invitation_id", type=UUID)
     parsed = parser.parse_args(list(argv) if argv is not None else None)
     parsed_values = cast(dict[str, object], vars(parsed))
     service = OperatorPairingService.from_default_paths()
+    if parsed_values.get("command") == "invitations":
+        if parsed_values.get("invitation_command") == "list":
+            _InvitationListArguments.model_validate(parsed_values)
+            invitations = service.invitations()
+            if not invitations:
+                print("No reusable pairing invitations.")
+                return 0
+            print(
+                "INVITATION ID                         CREATED                   "
+                "EXPIRES                   USE  ACTIVE  STATE"
+            )
+            for invitation in invitations:
+                print(
+                    f"{invitation.invitation_id}  "
+                    f"{invitation.created_at.isoformat()}  "
+                    f"{invitation.expires_at.isoformat()}  "
+                    f"{invitation.successful_pairings}/{invitation.max_pairings}  "
+                    f"{invitation.active_attempts}       {invitation.state}"
+                )
+            return 0
+        invitation_arguments = _InvitationRevokeArguments.model_validate(parsed_values)
+        service.revoke_invitation(invitation_arguments.invitation_id)
+        print(f"Revoked pairing invitation {invitation_arguments.invitation_id}.")
+        return 0
     if parsed_values.get("command") == "configure-relay":
         arguments = _ConfigureRelayArguments.model_validate(parsed_values)
         try:
@@ -129,9 +253,21 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     arguments = _PairArguments.model_validate(parsed_values)
     try:
-        package = service.create_session(
-            exchange_url=arguments.exchange_url,
-            cluster_name=arguments.cluster_name,
+        invitation_mode = (
+            arguments.valid_for is not None or arguments.max_pairings is not None
+        )
+        package = (
+            service.create_invitation(
+                lifetime=arguments.valid_for or timedelta(minutes=5),
+                max_pairings=arguments.max_pairings or 10,
+                exchange_url=arguments.exchange_url,
+                cluster_name=arguments.cluster_name,
+            )
+            if invitation_mode
+            else service.create_session(
+                exchange_url=arguments.exchange_url,
+                cluster_name=arguments.cluster_name,
+            )
         )
     except PairingPackageTooLargeError:
         parser.error("relay pairing package is too large for a reliable QR code")
@@ -144,7 +280,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"{package.expires_at.isoformat()}."
     )
     print(f"Cluster fingerprint: {package.cluster_fingerprint}")
-    _print_pairing_qr(package.as_url())
+    payload = package.as_url()
+    if isinstance(package, PairingInvitationPackage):
+        print(
+            "This reusable QR is a secret bearer invitation. "
+            f"It permits up to {package.max_pairings} successful pairings."
+        )
+    print(
+        "Treat the terminal QR, fallback payload, and any saved image as secrets."
+    )
+    _print_pairing_qr(payload)
+    if arguments.qr_output is not None:
+        try:
+            _write_pairing_qr(payload, arguments.qr_output)
+        except FileExistsError:
+            parser.error("--qr-output refuses to overwrite an existing file")
+        except OSError:
+            parser.error("--qr-output could not be written")
+        print(f"Wrote protected QR image to {arguments.qr_output}.")
     return 0
 
 

--- a/src/skulk/operator/pairing.py
+++ b/src/skulk/operator/pairing.py
@@ -1,4 +1,4 @@
-"""Single-use host-authorized pairing for one designated Skulk gateway."""
+"""Host-authorized pairing for one designated Skulk gateway."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from uuid import UUID, uuid4
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-from pydantic import AnyHttpUrl, Field, field_validator, model_validator
+from pydantic import AnyHttpUrl, Field, ValidationInfo, field_validator, model_validator
 
 from skulk.operator.authority import (
     AuthorityCommitConflictError,
@@ -34,10 +34,19 @@ from skulk.operator.relay import (
 from skulk.utils.pydantic_ext import FrozenModel
 
 _PAIRING_RECORD_TYPE = "operator_pairing_session"
+_PAIRING_INVITATION_RECORD_TYPE = "operator_pairing_invitation"
+_PAIRING_ATTEMPT_RECORD_TYPE = "operator_pairing_attempt"
 _PAIRING_LIFETIME = timedelta(minutes=5)
+_MAXIMUM_INVITATION_LIFETIME = timedelta(days=90)
+_DEFAULT_INVITATION_PAIRINGS = 10
+_MAXIMUM_INVITATION_PAIRINGS = 20
+_MAXIMUM_ACTIVE_INVITATION_ATTEMPTS = 10
+_MAXIMUM_TOTAL_INVITATION_ATTEMPTS = 100
+_AUTHORITY_RETRY_LIMIT = 3
 _ACCESS_TOKEN_LIFETIME = timedelta(minutes=15)
 _REFRESH_TOKEN_LIFETIME = timedelta(days=30)
 _PAIRING_SIGNATURE_CONTEXT = b"skulk-device-pairing-v1\x00"
+_PAIRING_INVITATION_SIGNATURE_CONTEXT = b"skulk-device-pairing-v2\x00"
 _MAXIMUM_RELAY_PAIRING_URL_BYTES = 1_170
 
 type OperatorScope = Literal[
@@ -71,6 +80,16 @@ class PairingSessionExpiredError(PairingError):
 
 class PairingSessionStateError(PairingError):
     """Raised when a pairing transition is repeated or out of order."""
+
+
+class PairingInvitationCapacityError(PairingError):
+    """Raised when an invitation cannot issue another bounded attempt."""
+
+    def __init__(self, message: str, *, retry_after_seconds: int) -> None:
+        """Create a safe capacity failure with a bounded retry hint."""
+
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
 
 
 class PairingProofError(PairingError):
@@ -196,13 +215,109 @@ class PairingPackage(FrozenModel):
         return f"skulk://pair?payload={encoded}"
 
 
+class PairingInvitationPackage(FrozenModel):
+    """Reusable public invitation encoded in a Skulk pairing QR code."""
+
+    version: Literal[3] = Field(
+        default=3,
+        description="Pairing invitation format version.",
+    )
+    cluster_id: UUID = Field(description="Stable identity of the target cluster.")
+    cluster_name: str = Field(description="Operator-visible cluster name.")
+    cluster_fingerprint: str = Field(
+        description="Display fingerprint of the cluster identity key."
+    )
+    exchange_url: AnyHttpUrl = Field(
+        description="Direct or relayed URL serving the pairing exchange."
+    )
+    invitation_id: UUID = Field(description="Public identifier used to manage the invitation.")
+    issued_at: datetime = Field(description="UTC creation time of the invitation.")
+    expires_at: datetime = Field(description="UTC expiry of the invitation.")
+    max_pairings: int = Field(
+        ge=1,
+        le=_MAXIMUM_INVITATION_PAIRINGS,
+        description="Maximum successful device pairings allowed by the invitation.",
+    )
+    nonce: str = Field(
+        min_length=32,
+        max_length=128,
+        description="High-entropy bearer capability for the invitation.",
+    )
+    remote_access: OperatorRemoteAccessMaterial | None = Field(
+        default=None,
+        description="Optional relay and pinned inner-TLS connection material.",
+    )
+
+    @field_validator("issued_at", "expires_at")
+    @classmethod
+    def _timestamps_are_timezone_aware(cls, value: datetime) -> datetime:
+        """Reject ambiguous invitation timestamps."""
+
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("pairing invitation timestamps must include a timezone")
+        return value
+
+    @field_validator("exchange_url")
+    @classmethod
+    def _exchange_url_protects_remote_credentials(
+        cls,
+        value: AnyHttpUrl,
+    ) -> AnyHttpUrl:
+        """Require HTTPS except for explicitly local development URLs."""
+
+        return _validate_exchange_url(value)
+
+    @model_validator(mode="after")
+    def _lifetime_is_bounded(self) -> "PairingInvitationPackage":
+        """Keep invitation duration positive and bounded by product policy."""
+
+        lifetime = self.expires_at - self.issued_at
+        if lifetime < timedelta(minutes=1) or lifetime > _MAXIMUM_INVITATION_LIFETIME:
+            raise ValueError("pairing invitation lifetime must be from one minute to 90 days")
+        return self
+
+    def as_url(self) -> str:
+        """Return the invitation as one compact custom-scheme QR payload."""
+
+        compact_payload: dict[str, object] = {
+            "v": self.version,
+            "i": str(self.cluster_id),
+            "n": self.cluster_name,
+            "f": self.cluster_fingerprint,
+            "u": str(self.exchange_url),
+            "d": str(self.invitation_id),
+            "a": self.issued_at.isoformat(),
+            "e": self.expires_at.isoformat(),
+            "m": self.max_pairings,
+            "o": self.nonce,
+        }
+        if self.remote_access is not None:
+            compact_payload["r"] = {
+                "t": self.remote_access.transport,
+                "w": self.remote_access.app_websocket_url,
+                "l": self.remote_access.routing_locator,
+                "c": self.remote_access.app_carrier_credential,
+                "s": self.remote_access.gateway_server_name,
+                "p": self.remote_access.gateway_ca_certificate_pem,
+            }
+        compressed = zlib.compress(
+            json.dumps(
+                compact_payload,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8"),
+            level=9,
+        )
+        return f"skulk://pair?z={_base64url_encode(compressed)}"
+
+
 class PairingChallengeRequest(FrozenModel):
     """Candidate device identity submitted before credential exchange."""
 
     nonce: str = Field(
         min_length=32,
         max_length=128,
-        description="High-entropy single-use capability from the pairing QR.",
+        description="High-entropy bearer capability from the pairing QR.",
     )
     device_name: str = Field(
         min_length=1,
@@ -213,6 +328,10 @@ class PairingChallengeRequest(FrozenModel):
         min_length=40,
         max_length=64,
         description="Unpadded URL-safe base64 Ed25519 device public key.",
+    )
+    invitation_id: UUID | None = Field(
+        default=None,
+        description="Reusable invitation identity, absent for legacy single-use pairing.",
     )
 
     @field_validator("device_name")
@@ -225,6 +344,13 @@ class PairingChallengeRequest(FrozenModel):
             raise ValueError("device_name must not be blank")
         return normalized
 
+    @field_validator("invitation_id", mode="before")
+    @classmethod
+    def _parse_wire_invitation_id(cls, value: object) -> object:
+        """Convert the optional JSON invitation UUID before strict validation."""
+
+        return _parse_optional_wire_uuid(value, "invitation_id")
+
 
 class PairingChallengeResponse(FrozenModel):
     """Cluster challenge that the candidate device must sign."""
@@ -232,7 +358,11 @@ class PairingChallengeResponse(FrozenModel):
     challenge: str = Field(
         description="Unpadded URL-safe base64 random challenge."
     )
-    expires_at: datetime = Field(description="UTC expiry inherited from the session.")
+    expires_at: datetime = Field(description="UTC expiry of this pairing attempt.")
+    attempt_id: UUID | None = Field(
+        default=None,
+        description="Independent reusable-invitation attempt, absent for legacy pairing.",
+    )
 
 
 class PairingExchangeRequest(FrozenModel):
@@ -241,13 +371,40 @@ class PairingExchangeRequest(FrozenModel):
     nonce: str = Field(
         min_length=32,
         max_length=128,
-        description="High-entropy single-use capability from the pairing QR.",
+        description="High-entropy bearer capability from the pairing QR.",
     )
     signature: str = Field(
         min_length=80,
         max_length=100,
         description="Ed25519 signature over the domain-separated pairing challenge.",
     )
+    invitation_id: UUID | None = Field(
+        default=None,
+        description="Reusable invitation identity, absent for legacy pairing.",
+    )
+    attempt_id: UUID | None = Field(
+        default=None,
+        description="Challenge attempt identity, absent for legacy pairing.",
+    )
+
+    @model_validator(mode="after")
+    def _invitation_fields_are_complete(self) -> "PairingExchangeRequest":
+        """Reject partially specified invitation exchanges."""
+
+        if (self.invitation_id is None) != (self.attempt_id is None):
+            raise ValueError("invitation_id and attempt_id must be supplied together")
+        return self
+
+
+    @field_validator("invitation_id", "attempt_id", mode="before")
+    @classmethod
+    def _parse_wire_ids(cls, value: object, info: ValidationInfo) -> object:
+        """Convert optional JSON UUIDs before strict validation."""
+
+        return _parse_optional_wire_uuid(
+            value,
+            info.field_name or "pairing identifier",
+        )
 
 
 class PairingExchangeResponse(FrozenModel):
@@ -374,6 +531,75 @@ class _StoredPairingSession(FrozenModel):
     scopes: tuple[OperatorScope, ...] = ()
 
 
+class _StoredPairingInvitation(FrozenModel):
+    """Encrypted durable state for one reusable host invitation."""
+
+    state: Literal["active", "revoked"]
+    invitation_id: UUID
+    nonce_hash: str
+    created_at: datetime
+    expires_at: datetime
+    exchange_url: str
+    max_pairings: int = Field(ge=1, le=_MAXIMUM_INVITATION_PAIRINGS)
+
+
+class _StoredPairingAttempt(FrozenModel):
+    """Encrypted durable state for one invitation challenge and device."""
+
+    state: Literal["challenged", "consumed", "revoked"]
+    invitation_id: UUID
+    attempt_id: UUID
+    created_at: datetime
+    expires_at: datetime
+    device_name: str
+    device_public_key: str
+    challenge: str
+    device_id: UUID | None = None
+    access_token_hash: str | None = None
+    access_token_expires_at: datetime | None = None
+    refresh_token_hash: str | None = None
+    refresh_token_expires_at: datetime | None = None
+    scopes: tuple[OperatorScope, ...] = ()
+
+
+type _StoredDeviceCredential = _StoredPairingSession | _StoredPairingAttempt
+
+
+type PairingInvitationState = Literal[
+    "active",
+    "expired",
+    "exhausted",
+    "attempt-limit",
+    "revoked",
+]
+
+
+class PairingInvitationSummary(FrozenModel):
+    """Safe host-visible status for one reusable pairing invitation."""
+
+    invitation_id: UUID = Field(description="Public invitation identifier.")
+    created_at: datetime = Field(description="UTC invitation creation time.")
+    expires_at: datetime = Field(description="UTC invitation expiry.")
+    successful_pairings: int = Field(
+        ge=0,
+        description="Number of devices that received credentials.",
+    )
+    max_pairings: int = Field(
+        ge=1,
+        le=_MAXIMUM_INVITATION_PAIRINGS,
+        description="Maximum successful pairings allowed.",
+    )
+    active_attempts: int = Field(
+        ge=0,
+        description="Unexpired attempts currently awaiting proof.",
+    )
+    total_attempts: int = Field(
+        ge=0,
+        description="All attempts issued during the invitation lifetime.",
+    )
+    state: PairingInvitationState = Field(description="Current invitation state.")
+
+
 def _utc_now() -> datetime:
     """Return the current timezone-aware UTC time."""
 
@@ -401,6 +627,19 @@ def _opaque_digest(value: str) -> str:
     """Return a non-reversible identifier for a bearer value."""
 
     return _base64url_encode(hashlib.sha256(value.encode("utf-8")).digest())
+
+
+def _parse_optional_wire_uuid(value: object, field_name: str) -> object:
+    """Convert one optional JSON UUID representation for strict models."""
+
+    if value is None or isinstance(value, UUID):
+        return value
+    if not isinstance(value, str):
+        return value
+    try:
+        return UUID(value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be a UUID") from exc
 
 
 def _validate_exchange_url(value: str | AnyHttpUrl) -> AnyHttpUrl:
@@ -444,6 +683,41 @@ def pairing_signature_message(
         + str(cluster_id).encode("ascii")
         + b"\x00"
         + nonce.encode("ascii")
+        + b"\x00"
+        + challenge.encode("ascii")
+    )
+
+
+def pairing_invitation_signature_message(
+    *,
+    cluster_id: UUID,
+    invitation_id: UUID,
+    nonce: str,
+    attempt_id: UUID,
+    challenge: str,
+) -> bytes:
+    """Build the proof message for one reusable-invitation attempt.
+
+    Args:
+        cluster_id: Target cluster identity from the invitation.
+        invitation_id: Public identity of the reusable invitation.
+        nonce: Bearer capability from the invitation QR.
+        attempt_id: Independent attempt returned with the challenge.
+        challenge: Random challenge returned by the gateway.
+
+    Returns:
+        Domain-separated bytes binding the proof to the exact attempt.
+    """
+
+    return (
+        _PAIRING_INVITATION_SIGNATURE_CONTEXT
+        + str(cluster_id).encode("ascii")
+        + b"\x00"
+        + str(invitation_id).encode("ascii")
+        + b"\x00"
+        + nonce.encode("ascii")
+        + b"\x00"
+        + str(attempt_id).encode("ascii")
         + b"\x00"
         + challenge.encode("ascii")
     )
@@ -602,6 +876,87 @@ class OperatorPairingService:
         self._append_session(nonce_hash, session)
         return package
 
+    def create_invitation(
+        self,
+        *,
+        lifetime: timedelta,
+        max_pairings: int = _DEFAULT_INVITATION_PAIRINGS,
+        exchange_url: str | None = None,
+        cluster_name: str = "Cluster",
+    ) -> PairingInvitationPackage:
+        """Create one reusable, revocable host pairing invitation.
+
+        Args:
+            lifetime: Positive invitation lifetime no longer than 90 days.
+            max_pairings: Successful device-pairing limit from one through 20.
+            exchange_url: Optional direct HTTPS base URL. When omitted, a
+                configured relay supplies the inner gateway origin.
+            cluster_name: Name used only when initializing a new gateway.
+
+        Returns:
+            Version-three invitation safe to render as a QR code.
+
+        Raises:
+            ValueError: Policy bounds or protected reachability are invalid.
+            PairingPackageTooLargeError: The resulting QR would be unreliable.
+        """
+
+        if lifetime < timedelta(minutes=1) or lifetime > _MAXIMUM_INVITATION_LIFETIME:
+            raise ValueError("pairing invitation lifetime must be from one minute to 90 days")
+        if not 1 <= max_pairings <= _MAXIMUM_INVITATION_PAIRINGS:
+            raise ValueError("pairing invitation max_pairings must be from one through 20")
+
+        relay_configuration = self._relay_repository.load()
+        use_relay = exchange_url is None
+        if exchange_url is None:
+            if relay_configuration is None:
+                raise ValueError(
+                    "exchange_url is required until operator relay is configured"
+                )
+            exchange_url = f"https://{relay_configuration.gateway_server_name}"
+        validated_exchange_url = _validate_exchange_url(exchange_url)
+        identity = self.initialize_gateway(cluster_name)
+        remote_access = (
+            relay_configuration.device_material()
+            if use_relay and relay_configuration is not None
+            else None
+        )
+
+        now = self._now()
+        invitation_id = uuid4()
+        nonce = secrets.token_urlsafe(32)
+        package = PairingInvitationPackage(
+            cluster_id=UUID(str(identity.cluster_id)),
+            cluster_name=identity.name,
+            cluster_fingerprint=identity.fingerprint,
+            exchange_url=validated_exchange_url,
+            invitation_id=invitation_id,
+            issued_at=now,
+            expires_at=now + lifetime,
+            max_pairings=max_pairings,
+            nonce=nonce,
+            remote_access=remote_access,
+        )
+        if len(package.as_url().encode("utf-8")) > _MAXIMUM_RELAY_PAIRING_URL_BYTES:
+            raise PairingPackageTooLargeError(
+                "pairing invitation package exceeds the supported QR size"
+            )
+        invitation = _StoredPairingInvitation(
+            state="active",
+            invitation_id=invitation_id,
+            nonce_hash=_opaque_digest(nonce),
+            created_at=now,
+            expires_at=package.expires_at,
+            exchange_url=str(package.exchange_url),
+            max_pairings=max_pairings,
+        )
+        self._append_authority_record(
+            record_type=_PAIRING_INVITATION_RECORD_TYPE,
+            record_id=str(invitation_id),
+            payload=invitation,
+        )
+        return package
+
     def create_challenge(
         self,
         request: PairingChallengeRequest,
@@ -621,6 +976,8 @@ class OperatorPairingService:
             PairingProofError: The proposed public key is malformed.
         """
 
+        if request.invitation_id is not None:
+            return self._create_invitation_challenge(request)
         self._decode_device_public_key(request.device_public_key)
         nonce_hash = _opaque_digest(request.nonce)
         session, session_commit_index = self._load_session(nonce_hash)
@@ -662,6 +1019,8 @@ class OperatorPairingService:
             PairingSessionExpiredError: The session expired.
         """
 
+        if request.invitation_id is not None and request.attempt_id is not None:
+            return self._exchange_invitation_proof(request)
         nonce_hash = _opaque_digest(request.nonce)
         session, session_commit_index = self._load_session(nonce_hash)
         self._require_unexpired(session)
@@ -728,6 +1087,204 @@ class OperatorPairingService:
             remote_access=remote_access,
         )
 
+    def _create_invitation_challenge(
+        self,
+        request: PairingChallengeRequest,
+    ) -> PairingChallengeResponse:
+        """Create an independent five-minute attempt under an invitation."""
+
+        self._decode_device_public_key(request.device_public_key)
+        invitation_id = request.invitation_id
+        if invitation_id is None:
+            raise PairingSessionStateError("pairing invitation identity is required")
+        for _ in range(_AUTHORITY_RETRY_LIMIT):
+            invitation, _, attempts, expected_commit_index = self._invitation_snapshot(
+                invitation_id
+            )
+            self._require_invitation_available(
+                invitation,
+                nonce=request.nonce,
+                attempts=attempts,
+                creating_attempt=True,
+            )
+            now = self._now()
+            active_attempts = tuple(
+                attempt
+                for _, attempt, _ in attempts
+                if attempt.state == "challenged" and now < attempt.expires_at
+            )
+            if len(active_attempts) >= _MAXIMUM_ACTIVE_INVITATION_ATTEMPTS:
+                retry_at = min(attempt.expires_at for attempt in active_attempts)
+                retry_seconds = max(1, int((retry_at - now).total_seconds()))
+                raise PairingInvitationCapacityError(
+                    "pairing invitation has too many active attempts",
+                    retry_after_seconds=retry_seconds,
+                )
+
+            attempt_id = uuid4()
+            challenge = _base64url_encode(secrets.token_bytes(32))
+            expires_at = min(now + _PAIRING_LIFETIME, invitation.expires_at)
+            attempt = _StoredPairingAttempt(
+                state="challenged",
+                invitation_id=invitation_id,
+                attempt_id=attempt_id,
+                created_at=now,
+                expires_at=expires_at,
+                device_name=request.device_name,
+                device_public_key=request.device_public_key,
+                challenge=challenge,
+            )
+            try:
+                self._append_authority_record(
+                    record_type=_PAIRING_ATTEMPT_RECORD_TYPE,
+                    record_id=str(attempt_id),
+                    payload=attempt,
+                    expected_commit_index=expected_commit_index,
+                )
+            except AuthorityCommitConflictError:
+                continue
+            return PairingChallengeResponse(
+                challenge=challenge,
+                expires_at=expires_at,
+                attempt_id=attempt_id,
+            )
+        raise PairingSessionStateError(
+            "pairing state changed concurrently; restart pairing"
+        )
+
+    def _exchange_invitation_proof(
+        self,
+        request: PairingExchangeRequest,
+    ) -> PairingExchangeResponse:
+        """Verify and atomically consume one invitation attempt."""
+
+        invitation_id = request.invitation_id
+        attempt_id = request.attempt_id
+        if invitation_id is None or attempt_id is None:
+            raise PairingSessionStateError("pairing invitation attempt is required")
+        for _ in range(_AUTHORITY_RETRY_LIMIT):
+            invitation, _, attempts, expected_commit_index = self._invitation_snapshot(
+                invitation_id
+            )
+            self._require_invitation_available(
+                invitation,
+                nonce=request.nonce,
+                attempts=attempts,
+                creating_attempt=False,
+            )
+            matched = next(
+                (
+                    (record_id, attempt, commit_index)
+                    for record_id, attempt, commit_index in attempts
+                    if attempt.attempt_id == attempt_id
+                ),
+                None,
+            )
+            if matched is None:
+                raise PairingSessionNotFoundError("pairing attempt was not found")
+            record_id, attempt, attempt_commit_index = matched
+            if self._now() >= attempt.expires_at:
+                raise PairingSessionExpiredError("pairing attempt expired")
+            if attempt.state != "challenged":
+                raise PairingSessionStateError("pairing attempt was already used")
+
+            public_key = self._decode_device_public_key(attempt.device_public_key)
+            try:
+                signature = _base64url_decode(request.signature)
+                public_key.verify(
+                    signature,
+                    pairing_invitation_signature_message(
+                        cluster_id=UUID(
+                            str(self._store.cluster_identity().cluster_id)
+                        ),
+                        invitation_id=invitation_id,
+                        nonce=request.nonce,
+                        attempt_id=attempt_id,
+                        challenge=attempt.challenge,
+                    ),
+                )
+            except (InvalidSignature, ValueError, UnicodeError) as exc:
+                raise PairingProofError("device pairing proof is invalid") from exc
+
+            now = self._now()
+            device_id = uuid4()
+            access_token = secrets.token_urlsafe(32)
+            refresh_token = secrets.token_urlsafe(48)
+            access_expires_at = now + _ACCESS_TOKEN_LIFETIME
+            refresh_expires_at = now + _REFRESH_TOKEN_LIFETIME
+            consumed = attempt.model_copy(
+                update={
+                    "state": "consumed",
+                    "device_id": device_id,
+                    "access_token_hash": _opaque_digest(access_token),
+                    "access_token_expires_at": access_expires_at,
+                    "refresh_token_hash": _opaque_digest(refresh_token),
+                    "refresh_token_expires_at": refresh_expires_at,
+                    "scopes": _DEFAULT_SCOPES,
+                }
+            )
+            try:
+                self._append_authority_record(
+                    record_type=_PAIRING_ATTEMPT_RECORD_TYPE,
+                    record_id=record_id,
+                    payload=consumed,
+                    expected_commit_index=expected_commit_index,
+                    expected_record_commit_index=attempt_commit_index,
+                )
+            except AuthorityCommitConflictError:
+                continue
+
+            relay_configuration = self._relay_repository.load()
+            return PairingExchangeResponse(
+                device_id=device_id,
+                cluster=self._store.cluster_identity(),
+                access_token=access_token,
+                access_token_expires_at=access_expires_at,
+                refresh_token=refresh_token,
+                refresh_token_expires_at=refresh_expires_at,
+                scopes=_DEFAULT_SCOPES,
+                remote_access=(
+                    relay_configuration.device_material()
+                    if relay_configuration is not None
+                    else None
+                ),
+            )
+        raise PairingSessionStateError(
+            "pairing state changed concurrently; restart pairing"
+        )
+
+    def invitations(self) -> tuple[PairingInvitationSummary, ...]:
+        """Return safe status for every reusable host invitation."""
+
+        summaries: list[PairingInvitationSummary] = []
+        for invitation_id in self._invitation_ids():
+            invitation, _, attempts, _ = self._invitation_snapshot(invitation_id)
+            summaries.append(self._invitation_summary(invitation, attempts))
+        summaries.sort(key=lambda item: (item.created_at, str(item.invitation_id)))
+        return tuple(summaries)
+
+    def revoke_invitation(self, invitation_id: UUID) -> None:
+        """Revoke an invitation without revoking its already paired devices."""
+
+        invitation, invitation_commit_index, _, expected_commit_index = (
+            self._invitation_snapshot(invitation_id)
+        )
+        if invitation.state == "revoked":
+            return
+        revoked = invitation.model_copy(update={"state": "revoked"})
+        try:
+            self._append_authority_record(
+                record_type=_PAIRING_INVITATION_RECORD_TYPE,
+                record_id=str(invitation_id),
+                payload=revoked,
+                expected_commit_index=expected_commit_index,
+                expected_record_commit_index=invitation_commit_index,
+            )
+        except AuthorityCommitConflictError as exc:
+            raise PairingSessionStateError(
+                "pairing state changed concurrently; retry revocation"
+            ) from exc
+
     def refresh(self, request: OperatorTokenRequest) -> OperatorTokenResponse:
         """Rotate one valid refresh credential and its access token.
 
@@ -744,8 +1301,8 @@ class OperatorPairingService:
             PairingSessionStateError: Concurrent authority state changed.
         """
 
-        record_id, session, session_commit_index = self._load_device_session(
-            request.device_id
+        record_type, record_id, session, session_commit_index = (
+            self._load_device_session(request.device_id)
         )
         self._require_active_device(session)
         if (
@@ -775,9 +1332,10 @@ class OperatorPairingService:
                 "refresh_token_expires_at": refresh_expires_at,
             }
         )
-        self._append_session(
-            record_id,
-            updated,
+        self._append_device_credential(
+            record_type=record_type,
+            record_id=record_id,
+            credential=updated,
             expected_record_commit_index=session_commit_index,
         )
         return OperatorTokenResponse(
@@ -810,8 +1368,8 @@ class OperatorPairingService:
         """
 
         token_hash = _opaque_digest(token)
-        matched_session: _StoredPairingSession | None = None
-        for _, session, _ in self._latest_device_sessions():
+        matched_session: _StoredDeviceCredential | None = None
+        for _, _, session, _ in self._latest_device_sessions():
             if session.access_token_hash is not None and compare_digest(
                 session.access_token_hash,
                 token_hash,
@@ -850,7 +1408,7 @@ class OperatorPairingService:
             required_scopes=("devices:manage",),
         )
         devices: list[OperatorDevice] = []
-        for _, session, _ in self._latest_device_sessions():
+        for _, _, session, _ in self._latest_device_sessions():
             if session.device_id is None or session.device_name is None:
                 continue
             devices.append(
@@ -883,7 +1441,9 @@ class OperatorPairingService:
             access_token,
             required_scopes=("devices:manage",),
         )
-        record_id, session, session_commit_index = self._load_device_session(device_id)
+        record_type, record_id, session, session_commit_index = (
+            self._load_device_session(device_id)
+        )
         if session.state == "revoked":
             return
         revoked = session.model_copy(
@@ -895,19 +1455,20 @@ class OperatorPairingService:
                 "refresh_token_expires_at": None,
             }
         )
-        self._append_session(
-            record_id,
-            revoked,
+        self._append_device_credential(
+            record_type=record_type,
+            record_id=record_id,
+            credential=revoked,
             expected_record_commit_index=session_commit_index,
         )
 
     def _latest_device_sessions(
         self,
-    ) -> tuple[tuple[str, _StoredPairingSession, int], ...]:
-        """Return the newest durable session record for every paired device."""
+    ) -> tuple[tuple[str, str, _StoredDeviceCredential, int], ...]:
+        """Return legacy and invitation-backed paired-device records."""
 
-        latest_record_ids: list[str] = []
-        seen: set[str] = set()
+        latest_records: list[tuple[str, str]] = []
+        seen: set[tuple[str, str]] = set()
         try:
             records = self._store.records()
         except AuthorityNotInitializedError as exc:
@@ -915,30 +1476,37 @@ class OperatorPairingService:
                 "operator gateway is not initialized"
             ) from exc
         for record in reversed(records):
-            if record.record_type != _PAIRING_RECORD_TYPE or record.record_id in seen:
+            identity = (record.record_type, record.record_id)
+            if record.record_type not in {
+                _PAIRING_RECORD_TYPE,
+                _PAIRING_ATTEMPT_RECORD_TYPE,
+            } or identity in seen:
                 continue
-            seen.add(record.record_id)
-            latest_record_ids.append(record.record_id)
-        sessions: list[tuple[str, _StoredPairingSession, int]] = []
-        for record_id in reversed(latest_record_ids):
-            session, commit_index = self._load_session(record_id)
-            if session.device_id is not None:
-                sessions.append((record_id, session, commit_index))
+            seen.add(identity)
+            latest_records.append(identity)
+        sessions: list[tuple[str, str, _StoredDeviceCredential, int]] = []
+        for record_type, record_id in reversed(latest_records):
+            if record_type == _PAIRING_RECORD_TYPE:
+                credential, commit_index = self._load_session(record_id)
+            else:
+                credential, commit_index = self._load_attempt(record_id)
+            if credential.device_id is not None:
+                sessions.append((record_type, record_id, credential, commit_index))
         return tuple(sessions)
 
     def _load_device_session(
         self,
         device_id: UUID,
-    ) -> tuple[str, _StoredPairingSession, int]:
+    ) -> tuple[str, str, _StoredDeviceCredential, int]:
         """Load the newest credential state for one stable device identity."""
 
-        for record_id, session, commit_index in self._latest_device_sessions():
+        for record_type, record_id, session, commit_index in self._latest_device_sessions():
             if session.device_id == device_id:
-                return record_id, session, commit_index
+                return record_type, record_id, session, commit_index
         raise OperatorDeviceNotFoundError("paired device was not found")
 
     @staticmethod
-    def _require_active_device(session: _StoredPairingSession) -> None:
+    def _require_active_device(session: _StoredDeviceCredential) -> None:
         """Reject a revoked or structurally incomplete device record."""
 
         if session.state != "consumed":
@@ -968,6 +1536,227 @@ class OperatorPairingService:
             raise PairingError("stored pairing session is invalid") from exc
         return session, record.commit_index
 
+    def _load_attempt(self, record_id: str) -> tuple[_StoredPairingAttempt, int]:
+        """Load and validate one encrypted invitation attempt."""
+
+        try:
+            record, payload = self._store.read_latest_record_payload(
+                _PAIRING_ATTEMPT_RECORD_TYPE,
+                record_id,
+            )
+        except AuthorityNotInitializedError as exc:
+            raise PairingSessionNotFoundError("pairing attempt was not found") from exc
+        try:
+            attempt = _StoredPairingAttempt.model_validate_json(
+                json.dumps(payload, separators=(",", ":"), allow_nan=False)
+            )
+        except ValueError as exc:
+            raise PairingError("stored pairing attempt is invalid") from exc
+        return attempt, record.commit_index
+
+    def _invitation_ids(self) -> tuple[UUID, ...]:
+        """Return every reusable invitation identity from public journal metadata."""
+
+        try:
+            records = self._store.records()
+        except AuthorityNotInitializedError as exc:
+            raise PairingGatewayNotInitializedError(
+                "operator gateway is not initialized"
+            ) from exc
+        identities: list[UUID] = []
+        seen: set[str] = set()
+        for record in records:
+            if (
+                record.record_type != _PAIRING_INVITATION_RECORD_TYPE
+                or record.record_id in seen
+            ):
+                continue
+            seen.add(record.record_id)
+            try:
+                identities.append(UUID(record.record_id))
+            except ValueError as exc:
+                raise PairingError("stored pairing invitation identity is invalid") from exc
+        return tuple(identities)
+
+    def _invitation_snapshot(
+        self,
+        invitation_id: UUID,
+    ) -> tuple[
+        _StoredPairingInvitation,
+        int,
+        tuple[tuple[str, _StoredPairingAttempt, int], ...],
+        int,
+    ]:
+        """Read invitation usage against one globally fenced journal snapshot."""
+
+        try:
+            records = self._store.records()
+        except AuthorityNotInitializedError as exc:
+            raise PairingGatewayNotInitializedError(
+                "operator gateway is not initialized"
+            ) from exc
+        if not records:
+            raise PairingSessionNotFoundError("pairing invitation was not found")
+        expected_commit_index = records[-1].commit_index
+        invitation_record = next(
+            (
+                record
+                for record in reversed(records)
+                if record.record_type == _PAIRING_INVITATION_RECORD_TYPE
+                and record.record_id == str(invitation_id)
+            ),
+            None,
+        )
+        if invitation_record is None:
+            raise PairingSessionNotFoundError("pairing invitation was not found")
+        try:
+            _, invitation_payload = self._store.read_latest_record_payload(
+                _PAIRING_INVITATION_RECORD_TYPE,
+                str(invitation_id),
+            )
+            invitation = _StoredPairingInvitation.model_validate_json(
+                json.dumps(invitation_payload, separators=(",", ":"), allow_nan=False)
+            )
+        except (AuthorityNotInitializedError, ValueError) as exc:
+            raise PairingError("stored pairing invitation is invalid") from exc
+
+        attempt_record_ids: list[str] = []
+        seen: set[str] = set()
+        for record in reversed(records):
+            if record.record_type != _PAIRING_ATTEMPT_RECORD_TYPE:
+                continue
+            if record.record_id in seen:
+                continue
+            seen.add(record.record_id)
+            attempt_record_ids.append(record.record_id)
+        attempts: list[tuple[str, _StoredPairingAttempt, int]] = []
+        for record_id in reversed(attempt_record_ids):
+            attempt, commit_index = self._load_attempt(record_id)
+            if attempt.invitation_id == invitation_id:
+                attempts.append((record_id, attempt, commit_index))
+        return (
+            invitation,
+            invitation_record.commit_index,
+            tuple(attempts),
+            expected_commit_index,
+        )
+
+    def _require_invitation_available(
+        self,
+        invitation: _StoredPairingInvitation,
+        *,
+        nonce: str,
+        attempts: tuple[tuple[str, _StoredPairingAttempt, int], ...],
+        creating_attempt: bool,
+    ) -> None:
+        """Reject unknown bearer material and unavailable invitation transitions."""
+
+        if not compare_digest(invitation.nonce_hash, _opaque_digest(nonce)):
+            raise PairingSessionNotFoundError("pairing invitation was not found")
+        now = self._now()
+        if invitation.state == "revoked":
+            raise PairingSessionExpiredError("pairing invitation is revoked")
+        if now >= invitation.expires_at:
+            raise PairingSessionExpiredError("pairing invitation is expired")
+        successful_pairings = sum(
+            attempt.state in {"consumed", "revoked"}
+            for _, attempt, _ in attempts
+        )
+        if successful_pairings >= invitation.max_pairings:
+            raise PairingSessionExpiredError("pairing invitation is exhausted")
+        if creating_attempt and len(attempts) >= _MAXIMUM_TOTAL_INVITATION_ATTEMPTS:
+            raise PairingSessionExpiredError("pairing invitation reached its attempt limit")
+
+    def _invitation_summary(
+        self,
+        invitation: _StoredPairingInvitation,
+        attempts: tuple[tuple[str, _StoredPairingAttempt, int], ...],
+    ) -> PairingInvitationSummary:
+        """Derive safe status from invitation and attempt truth."""
+
+        now = self._now()
+        successful_pairings = sum(
+            attempt.state in {"consumed", "revoked"}
+            for _, attempt, _ in attempts
+        )
+        active_attempts = sum(
+            attempt.state == "challenged" and now < attempt.expires_at
+            for _, attempt, _ in attempts
+        )
+        state: PairingInvitationState
+        if invitation.state == "revoked":
+            state = "revoked"
+        elif now >= invitation.expires_at:
+            state = "expired"
+        elif successful_pairings >= invitation.max_pairings:
+            state = "exhausted"
+        elif (
+            len(attempts) >= _MAXIMUM_TOTAL_INVITATION_ATTEMPTS
+            or active_attempts >= _MAXIMUM_ACTIVE_INVITATION_ATTEMPTS
+        ):
+            state = "attempt-limit"
+        else:
+            state = "active"
+        return PairingInvitationSummary(
+            invitation_id=invitation.invitation_id,
+            created_at=invitation.created_at,
+            expires_at=invitation.expires_at,
+            successful_pairings=successful_pairings,
+            max_pairings=invitation.max_pairings,
+            active_attempts=active_attempts,
+            total_attempts=len(attempts),
+            state=state,
+        )
+
+    def _append_authority_record(
+        self,
+        *,
+        record_type: str,
+        record_id: str,
+        payload: FrozenModel,
+        expected_commit_index: int | None = None,
+        expected_record_commit_index: int = 0,
+    ) -> None:
+        """Append one typed encrypted authority record with optional global fencing."""
+
+        if expected_commit_index is None:
+            records = self._store.records()
+            expected_commit_index = records[-1].commit_index if records else 1
+        serialized = cast(
+            Mapping[str, object],
+            payload.model_dump(mode="json", by_alias=True),
+        )
+        self._store.append(
+            expected_commit_index=expected_commit_index,
+            expected_record_commit_index=expected_record_commit_index,
+            authority_term=1,
+            record_type=record_type,
+            record_id=record_id,
+            payload=serialized,
+        )
+
+    def _append_device_credential(
+        self,
+        *,
+        record_type: str,
+        record_id: str,
+        credential: _StoredDeviceCredential,
+        expected_record_commit_index: int,
+    ) -> None:
+        """Append a legacy or invitation-backed credential transition."""
+
+        try:
+            self._append_authority_record(
+                record_type=record_type,
+                record_id=record_id,
+                payload=credential,
+                expected_record_commit_index=expected_record_commit_index,
+            )
+        except AuthorityCommitConflictError as exc:
+            raise PairingSessionStateError(
+                "pairing state changed concurrently; restart pairing"
+            ) from exc
+
     def _append_session(
         self,
         nonce_hash: str,
@@ -977,20 +1766,12 @@ class OperatorPairingService:
     ) -> None:
         """Append one encrypted session transition with local CAS."""
 
-        records = self._store.records()
-        expected_index = records[-1].commit_index if records else 1
-        payload = cast(
-            Mapping[str, object],
-            session.model_dump(mode="json", by_alias=True),
-        )
         try:
-            self._store.append(
-                expected_commit_index=expected_index,
-                expected_record_commit_index=expected_record_commit_index,
-                authority_term=1,
+            self._append_authority_record(
                 record_type=_PAIRING_RECORD_TYPE,
                 record_id=nonce_hash,
-                payload=payload,
+                payload=session,
+                expected_record_commit_index=expected_record_commit_index,
             )
         except AuthorityCommitConflictError as exc:
             raise PairingSessionStateError(

--- a/src/skulk/operator/tests/test_pairing.py
+++ b/src/skulk/operator/tests/test_pairing.py
@@ -1,6 +1,7 @@
 """Tests for host-authorized single-gateway pairing."""
 
 import base64
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from uuid import UUID
@@ -21,12 +22,16 @@ from skulk.operator.pairing import (
     OperatorPairingService,
     OperatorTokenRequest,
     PairingChallengeRequest,
+    PairingChallengeResponse,
     PairingExchangeRequest,
     PairingExchangeResponse,
     PairingGatewayNotInitializedError,
+    PairingInvitationCapacityError,
+    PairingInvitationPackage,
     PairingProofError,
     PairingSessionExpiredError,
     PairingSessionStateError,
+    pairing_invitation_signature_message,
     pairing_signature_message,
 )
 
@@ -85,6 +90,43 @@ def _complete_pairing(
     return service.exchange(
         PairingExchangeRequest(
             nonce=package.nonce,
+            signature=_base64url(signature),
+        )
+    )
+
+
+def _complete_invitation_pairing(
+    service: OperatorPairingService,
+    package: PairingInvitationPackage,
+    *,
+    device_name: str = "Review phone",
+) -> PairingExchangeResponse:
+    """Complete one independent attempt under a reusable invitation."""
+
+    private_key, public_key = _device_key()
+    challenge = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            device_name=device_name,
+            device_public_key=public_key,
+        )
+    )
+    assert challenge.attempt_id is not None
+    signature = private_key.sign(
+        pairing_invitation_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            invitation_id=package.invitation_id,
+            nonce=package.nonce,
+            attempt_id=challenge.attempt_id,
+            challenge=challenge.challenge,
+        )
+    )
+    return service.exchange(
+        PairingExchangeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            attempt_id=challenge.attempt_id,
             signature=_base64url(signature),
         )
     )
@@ -193,6 +235,469 @@ def test_pairing_expires_after_five_minutes(tmp_path: Path) -> None:
                 device_name="Phone",
                 device_public_key=public_key,
             ),
+        )
+
+
+def test_reusable_invitation_issues_independent_attempts(tmp_path: Path) -> None:
+    """Simultaneous scans receive distinct challenges and both can pair."""
+
+    clock = [datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    package = service.create_invitation(
+        lifetime=timedelta(days=90),
+        max_pairings=10,
+        exchange_url="https://example.invalid/operator",
+        cluster_name="Review Fabric",
+    )
+    first_private, first_public = _device_key()
+    second_private, second_public = _device_key()
+    first_challenge = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            device_name="First reviewer",
+            device_public_key=first_public,
+        )
+    )
+    second_challenge = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            device_name="Second reviewer",
+            device_public_key=second_public,
+        )
+    )
+    assert first_challenge.attempt_id is not None
+    assert second_challenge.attempt_id is not None
+    assert first_challenge.attempt_id != second_challenge.attempt_id
+    assert first_challenge.expires_at == clock[0] + timedelta(minutes=5)
+
+    first = service.exchange(
+        PairingExchangeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            attempt_id=first_challenge.attempt_id,
+            signature=_base64url(
+                first_private.sign(
+                    pairing_invitation_signature_message(
+                        cluster_id=UUID(str(package.cluster_id)),
+                        invitation_id=package.invitation_id,
+                        nonce=package.nonce,
+                        attempt_id=first_challenge.attempt_id,
+                        challenge=first_challenge.challenge,
+                    )
+                )
+            ),
+        )
+    )
+    second = service.exchange(
+        PairingExchangeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            attempt_id=second_challenge.attempt_id,
+            signature=_base64url(
+                second_private.sign(
+                    pairing_invitation_signature_message(
+                        cluster_id=UUID(str(package.cluster_id)),
+                        invitation_id=package.invitation_id,
+                        nonce=package.nonce,
+                        attempt_id=second_challenge.attempt_id,
+                        challenge=second_challenge.challenge,
+                    )
+                )
+            ),
+        )
+    )
+
+    assert first.device_id != second.device_id
+    summary = service.invitations()[0]
+    assert summary.successful_pairings == 2
+    assert summary.active_attempts == 0
+    assert summary.total_attempts == 2
+    assert summary.state == "active"
+    assert package.nonce.encode("ascii") not in (
+        tmp_path / "authority.sqlite3"
+    ).read_bytes()
+
+
+def test_invitation_exhaustion_and_revocation_are_separate_from_devices(
+    tmp_path: Path,
+) -> None:
+    """Invitation limits block new scans while issued device credentials remain valid."""
+
+    clock = [datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    exhausted = service.create_invitation(
+        lifetime=timedelta(days=1),
+        max_pairings=1,
+        exchange_url="https://example.invalid",
+    )
+    paired = _complete_invitation_pairing(service, exhausted)
+    _, public_key = _device_key()
+    with pytest.raises(PairingSessionExpiredError, match="exhausted"):
+        service.create_challenge(
+            PairingChallengeRequest(
+                nonce=exhausted.nonce,
+                invitation_id=exhausted.invitation_id,
+                device_name="Another phone",
+                device_public_key=public_key,
+            )
+        )
+    assert service.validate_access_token(paired.access_token).device_id == paired.device_id
+
+    revoked = service.create_invitation(
+        lifetime=timedelta(days=1),
+        max_pairings=2,
+        exchange_url="https://example.invalid",
+    )
+    existing_device = _complete_invitation_pairing(service, revoked)
+    unfinished_private_key, unfinished_public_key = _device_key()
+    unfinished = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=revoked.nonce,
+            invitation_id=revoked.invitation_id,
+            device_name="Unfinished phone",
+            device_public_key=unfinished_public_key,
+        )
+    )
+    assert unfinished.attempt_id is not None
+    service.revoke_invitation(revoked.invitation_id)
+    with pytest.raises(PairingSessionExpiredError, match="revoked"):
+        service.create_challenge(
+            PairingChallengeRequest(
+                nonce=revoked.nonce,
+                invitation_id=revoked.invitation_id,
+                device_name="Blocked phone",
+                device_public_key=public_key,
+            )
+        )
+    unfinished_signature = unfinished_private_key.sign(
+        pairing_invitation_signature_message(
+            cluster_id=UUID(str(revoked.cluster_id)),
+            invitation_id=revoked.invitation_id,
+            nonce=revoked.nonce,
+            attempt_id=unfinished.attempt_id,
+            challenge=unfinished.challenge,
+        )
+    )
+    with pytest.raises(PairingSessionExpiredError, match="revoked"):
+        service.exchange(
+            PairingExchangeRequest(
+                nonce=revoked.nonce,
+                invitation_id=revoked.invitation_id,
+                attempt_id=unfinished.attempt_id,
+                signature=_base64url(unfinished_signature),
+            )
+        )
+    assert (
+        service.validate_access_token(existing_device.access_token).device_id
+        == existing_device.device_id
+    )
+    listed = service.devices(existing_device.access_token)
+    assert {device.device_id for device in listed.devices} == {
+        paired.device_id,
+        existing_device.device_id,
+    }
+    summaries = {summary.invitation_id: summary for summary in service.invitations()}
+    assert summaries[exhausted.invitation_id].state == "exhausted"
+    assert summaries[revoked.invitation_id].state == "revoked"
+    assert summaries[revoked.invitation_id].successful_pairings == 1
+    assert summaries[revoked.invitation_id].active_attempts == 1
+
+
+def test_invitation_and_pending_attempt_survive_service_restart(tmp_path: Path) -> None:
+    """Durable authority records preserve reusable pairing across a restart."""
+
+    clock = [datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)]
+    before_restart = _service(tmp_path, clock)
+    package = before_restart.create_invitation(
+        lifetime=timedelta(days=90),
+        exchange_url="https://example.invalid/operator",
+    )
+    private_key, public_key = _device_key()
+    challenge = before_restart.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            device_name="Restarted phone",
+            device_public_key=public_key,
+        )
+    )
+    assert challenge.attempt_id is not None
+
+    after_restart = _service(tmp_path, clock)
+    signature = private_key.sign(
+        pairing_invitation_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            invitation_id=package.invitation_id,
+            nonce=package.nonce,
+            attempt_id=challenge.attempt_id,
+            challenge=challenge.challenge,
+        )
+    )
+    paired = after_restart.exchange(
+        PairingExchangeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            attempt_id=challenge.attempt_id,
+            signature=_base64url(signature),
+        )
+    )
+
+    assert after_restart.validate_access_token(paired.access_token).device_id == paired.device_id
+    summary = after_restart.invitations()[0]
+    assert summary.successful_pairings == 1
+    assert summary.total_attempts == 1
+
+
+def test_invitation_attempts_expire_and_active_capacity_is_bounded(
+    tmp_path: Path,
+) -> None:
+    """Unfinished scans do not consume pairing slots and cannot grow without bound."""
+
+    clock = [datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    package = service.create_invitation(
+        lifetime=timedelta(days=1),
+        exchange_url="https://example.invalid",
+    )
+    for index in range(10):
+        _, public_key = _device_key()
+        service.create_challenge(
+            PairingChallengeRequest(
+                nonce=package.nonce,
+                invitation_id=package.invitation_id,
+                device_name=f"Phone {index}",
+                device_public_key=public_key,
+            )
+        )
+    _, overflow_public_key = _device_key()
+    with pytest.raises(PairingInvitationCapacityError) as raised:
+        service.create_challenge(
+            PairingChallengeRequest(
+                nonce=package.nonce,
+                invitation_id=package.invitation_id,
+                device_name="Overflow phone",
+                device_public_key=overflow_public_key,
+            )
+        )
+    assert raised.value.retry_after_seconds == 300
+    assert service.invitations()[0].state == "attempt-limit"
+
+    clock[0] += timedelta(minutes=5)
+    replacement = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            device_name="Replacement phone",
+            device_public_key=overflow_public_key,
+        )
+    )
+    assert replacement.attempt_id is not None
+    summary = service.invitations()[0]
+    assert summary.successful_pairings == 0
+    assert summary.active_attempts == 1
+    assert summary.total_attempts == 11
+
+
+def test_invitation_total_attempts_are_bounded(tmp_path: Path) -> None:
+    """The journal stops growing while its final live attempt can still finish."""
+
+    clock = [datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    package = service.create_invitation(
+        lifetime=timedelta(days=90),
+        exchange_url="https://example.invalid",
+    )
+    final_private_key: Ed25519PrivateKey | None = None
+    final_challenge: PairingChallengeResponse | None = None
+    for index in range(100):
+        private_key, public_key = _device_key()
+        challenge = service.create_challenge(
+            PairingChallengeRequest(
+                nonce=package.nonce,
+                invitation_id=package.invitation_id,
+                device_name=f"Attempt {index}",
+                device_public_key=public_key,
+            )
+        )
+        if index == 99:
+            final_private_key = private_key
+            final_challenge = challenge
+        else:
+            clock[0] += timedelta(minutes=5)
+
+    _, overflow_public_key = _device_key()
+    with pytest.raises(PairingSessionExpiredError, match="attempt limit"):
+        service.create_challenge(
+            PairingChallengeRequest(
+                nonce=package.nonce,
+                invitation_id=package.invitation_id,
+                device_name="Attempt 101",
+                device_public_key=overflow_public_key,
+            )
+        )
+    summary = service.invitations()[0]
+    assert summary.total_attempts == 100
+    assert summary.successful_pairings == 0
+    assert summary.state == "attempt-limit"
+
+    assert final_private_key is not None
+    assert final_challenge is not None
+    assert final_challenge.attempt_id is not None
+    signature = final_private_key.sign(
+        pairing_invitation_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            invitation_id=package.invitation_id,
+            nonce=package.nonce,
+            attempt_id=final_challenge.attempt_id,
+            challenge=final_challenge.challenge,
+        )
+    )
+    paired = service.exchange(
+        PairingExchangeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            attempt_id=final_challenge.attempt_id,
+            signature=_base64url(signature),
+        )
+    )
+    assert service.validate_access_token(paired.access_token).device_id == paired.device_id
+    assert service.invitations()[0].successful_pairings == 1
+
+
+def test_invitation_proof_is_bound_to_its_attempt(tmp_path: Path) -> None:
+    """A valid signature for one attempt cannot complete another attempt."""
+
+    clock = [datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    package = service.create_invitation(
+        lifetime=timedelta(days=1),
+        exchange_url="https://example.invalid",
+    )
+    private_key, public_key = _device_key()
+    first = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            device_name="Phone",
+            device_public_key=public_key,
+        )
+    )
+    second = service.create_challenge(
+        PairingChallengeRequest(
+            nonce=package.nonce,
+            invitation_id=package.invitation_id,
+            device_name="Phone",
+            device_public_key=public_key,
+        )
+    )
+    assert first.attempt_id is not None
+    assert second.attempt_id is not None
+    signature = private_key.sign(
+        pairing_invitation_signature_message(
+            cluster_id=UUID(str(package.cluster_id)),
+            invitation_id=package.invitation_id,
+            nonce=package.nonce,
+            attempt_id=first.attempt_id,
+            challenge=first.challenge,
+        )
+    )
+    with pytest.raises(PairingProofError, match="invalid"):
+        service.exchange(
+            PairingExchangeRequest(
+                nonce=package.nonce,
+                invitation_id=package.invitation_id,
+                attempt_id=second.attempt_id,
+                signature=_base64url(signature),
+            )
+        )
+
+
+def test_concurrent_invitation_exchanges_cannot_exceed_success_limit(
+    tmp_path: Path,
+) -> None:
+    """Global authority fencing admits only one racing final pairing slot."""
+
+    clock = [datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    package = service.create_invitation(
+        lifetime=timedelta(days=1),
+        max_pairings=1,
+        exchange_url="https://example.invalid",
+    )
+    exchanges: list[PairingExchangeRequest] = []
+    for name in ("First", "Second"):
+        private_key, public_key = _device_key()
+        challenge = service.create_challenge(
+            PairingChallengeRequest(
+                nonce=package.nonce,
+                invitation_id=package.invitation_id,
+                device_name=name,
+                device_public_key=public_key,
+            )
+        )
+        assert challenge.attempt_id is not None
+        exchanges.append(
+            PairingExchangeRequest(
+                nonce=package.nonce,
+                invitation_id=package.invitation_id,
+                attempt_id=challenge.attempt_id,
+                signature=_base64url(
+                    private_key.sign(
+                        pairing_invitation_signature_message(
+                            cluster_id=UUID(str(package.cluster_id)),
+                            invitation_id=package.invitation_id,
+                            nonce=package.nonce,
+                            attempt_id=challenge.attempt_id,
+                            challenge=challenge.challenge,
+                        )
+                    )
+                ),
+            )
+        )
+
+    def exchange(request: PairingExchangeRequest) -> str:
+        """Return the safe result category from one racing exchange."""
+
+        try:
+            service.exchange(request)
+        except PairingSessionExpiredError:
+            return "unavailable"
+        return "paired"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = tuple(executor.map(exchange, exchanges))
+
+    assert sorted(results) == ["paired", "unavailable"]
+    summary = service.invitations()[0]
+    assert summary.successful_pairings == 1
+    assert summary.state == "exhausted"
+
+
+@pytest.mark.parametrize(
+    "lifetime,max_pairings",
+    [
+        (timedelta(seconds=59), 10),
+        (timedelta(days=90, seconds=1), 10),
+        (timedelta(days=1), 0),
+        (timedelta(days=1), 21),
+    ],
+)
+def test_invitation_policy_bounds_are_enforced(
+    tmp_path: Path,
+    lifetime: timedelta,
+    max_pairings: int,
+) -> None:
+    """Hosts cannot create unbounded reusable bearer invitations."""
+
+    clock = [datetime(2026, 8, 12, 12, 0, tzinfo=timezone.utc)]
+    service = _service(tmp_path, clock)
+    with pytest.raises(ValueError):
+        service.create_invitation(
+            lifetime=lifetime,
+            max_pairings=max_pairings,
+            exchange_url="https://example.invalid",
         )
 
 

--- a/src/skulk/operator/tests/test_relay.py
+++ b/src/skulk/operator/tests/test_relay.py
@@ -11,7 +11,7 @@ import ssl
 import zlib
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import cast, final
 from uuid import UUID
@@ -34,6 +34,7 @@ from skulk.operator.pairing import (
     OperatorPairingService,
     PairingChallengeRequest,
     PairingExchangeRequest,
+    PairingInvitationPackage,
     PairingPackage,
     PairingPackageTooLargeError,
     pairing_signature_message,
@@ -262,6 +263,33 @@ def test_oversized_relay_package_is_rejected_before_session_persistence(
         service.create_session()
 
 
+def test_oversized_invitation_is_rejected_before_invitation_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A terminal-hostile reusable QR never creates invitation authority."""
+
+    service, _ = _service(tmp_path)
+    service.configure_relay(_provisioning(), operator_api_port=52416)
+
+    def oversized_url(_package: PairingInvitationPackage) -> str:
+        return "x" * 1_171
+
+    monkeypatch.setattr(PairingInvitationPackage, "as_url", oversized_url)
+
+    def unexpected_append(*_arguments: object, **_keywords: object) -> None:
+        raise AssertionError("oversized pairing invitation was persisted")
+
+    monkeypatch.setattr(
+        OperatorPairingService,
+        "_append_authority_record",
+        unexpected_append,
+    )
+
+    with pytest.raises(PairingPackageTooLargeError, match="supported QR size"):
+        service.create_invitation(lifetime=timedelta(days=90))
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     (
@@ -373,6 +401,99 @@ def test_pair_cli_uses_configured_relay_without_direct_url(
     assert operator_cli.main(["pair"]) == 0
     assert len(payloads) == 1
     assert payloads[0].startswith("skulk://pair?z=")
+
+
+def test_pair_cli_creates_protected_reusable_invitation_png(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Explicit invitation flags preserve defaults and write a protected QR."""
+
+    service, _ = _service(tmp_path)
+    service.configure_relay(_provisioning(), operator_api_port=52416)
+    payloads: list[str] = []
+
+    def service_from_default_paths(
+        _service_type: type[OperatorPairingService],
+    ) -> OperatorPairingService:
+        """Return the isolated configured service for this CLI invocation."""
+
+        return service
+
+    monkeypatch.setattr(
+        OperatorPairingService,
+        "from_default_paths",
+        classmethod(service_from_default_paths),
+    )
+    monkeypatch.setattr(operator_cli, "_print_pairing_qr", payloads.append)
+    qr_path = tmp_path / "review.png"
+
+    assert (
+        operator_cli.main(
+            ["pair", "--valid-for", "90d", "--qr-output", str(qr_path)]
+        )
+        == 0
+    )
+    assert payloads[0].startswith("skulk://pair?z=")
+    assert qr_path.read_bytes().startswith(b"\x89PNG")
+    assert qr_path.stat().st_mode & 0o777 == 0o600
+    invitation = service.invitations()[0]
+    assert invitation.max_pairings == 10
+    assert invitation.state == "active"
+    output = capsys.readouterr().out
+    assert "Treat the terminal QR" in output
+    assert "secret bearer invitation" in output
+
+    with pytest.raises(SystemExit):
+        operator_cli.main(
+            ["pair", "--valid-for", "90d", "--qr-output", str(qr_path)]
+        )
+
+
+def test_invitation_cli_lists_and_revokes_without_printing_nonce(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Host management exposes safe invitation status but never its capability."""
+
+    service, _ = _service(tmp_path)
+    package = service.create_invitation(
+        lifetime=timedelta(days=1),
+        exchange_url="https://example.invalid",
+    )
+
+    def service_from_default_paths(
+        _service_type: type[OperatorPairingService],
+    ) -> OperatorPairingService:
+        """Return the isolated service for CLI management."""
+
+        return service
+
+    monkeypatch.setattr(
+        OperatorPairingService,
+        "from_default_paths",
+        classmethod(service_from_default_paths),
+    )
+
+    assert operator_cli.main(["invitations", "list"]) == 0
+    listed = capsys.readouterr().out
+    assert str(package.invitation_id) in listed
+    assert package.issued_at.isoformat() in listed
+    assert package.expires_at.isoformat() in listed
+    assert package.nonce not in listed
+    assert "active" in listed
+
+    assert (
+        operator_cli.main(
+            ["invitations", "revoke", str(package.invitation_id)]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert operator_cli.main(["invitations", "list"]) == 0
+    assert "revoked" in capsys.readouterr().out
 
 
 class _SyntheticRelay:

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -323,10 +323,34 @@ Behavior:
   returns `410` only when requesting another attempt, while already-issued
   attempts may still finish before their own expiry.
 
-The device signs the domain-separated message defined by
-`pairing_signature_message` in `src/skulk/operator/pairing.py`. Clients should
-consume the generated contract rather than reconstructing the message from
-this prose.
+Legacy version-one and version-two packages sign the domain-separated message
+defined by `pairing_signature_message` in `src/skulk/operator/pairing.py`:
+
+```text
+"skulk-device-pairing-v1\\0"
+  || ASCII(clusterId) || "\\0"
+  || ASCII(nonce) || "\\0"
+  || ASCII(challenge)
+```
+
+Version-three invitations instead sign the distinct message defined by
+`pairing_invitation_signature_message`:
+
+```text
+"skulk-device-pairing-v2\\0"
+  || ASCII(clusterId) || "\\0"
+  || ASCII(invitationId) || "\\0"
+  || ASCII(nonce) || "\\0"
+  || ASCII(attemptId) || "\\0"
+  || ASCII(challenge)
+```
+
+Here `||` means byte concatenation, each quoted `\\0` is one NUL byte, and
+UUIDs use their canonical lowercase hyphenated representation. The v3 domain
+and both returned identifiers are mandatory: signing the legacy transcript for
+an invitation fails proof verification. Clients should use the corresponding
+shared helper when available rather than maintaining another copy of these
+bytes.
 
 ### Exchange device proof
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -250,6 +250,42 @@ in the QR's single `z` query parameter. Skulk rejects a package before
 persisting its session if it would exceed the terminal-scannable budget.
 Version-one direct packages retain the uncompressed `payload` shape.
 
+The legacy command remains five-minute and single-use for compatibility. For a
+reusable, revocable version-three invitation, opt in with bounded host flags:
+
+```bash
+uv run skulk operator pair \
+  --valid-for 90d \
+  --max-pairings 10 \
+  --qr-output review.png
+```
+
+`--valid-for` accepts a positive integer followed by `m`, `h`, or `d`, from one
+minute through 90 days. Invitation mode permits ten successful pairings by
+default and accepts an explicit limit from one through twenty. It creates a
+separate five-minute attempt for every scan, so concurrent devices do not share
+or replace challenges. At most ten attempts may be live and one hundred may be
+issued over an invitation's lifetime. Only successful credential issuance
+counts against the pairing limit.
+
+The compressed version-three package adds a public invitation ID, issue time,
+expiry, and pairing limit. It may carry the same app-role relay admission and
+pinned inner-TLS material as version two, but never a canonical Skulk access or
+refresh credential. Treat the QR and optional owner-only PNG as bearer secrets.
+The PNG writer uses owner-only permissions and refuses to overwrite a path.
+
+Invitation management remains local to the designated host:
+
+```bash
+uv run skulk operator invitations list
+uv run skulk operator invitations revoke <invitation-id>
+```
+
+Listing exposes only ID, creation and expiry times, usage, active-attempt
+count, and safe state; it never prints the nonce. Revocation blocks new and
+unfinished attempts but does not disconnect devices that already paired.
+Revoke those devices through the authenticated device-management API.
+
 `--exchange-url https://gateway.example.invalid` remains an optional direct
 LAN/Tailscale path and is required only before relay provisioning. Remote
 exchange URLs must use HTTPS; cleartext HTTP is accepted only for loopback
@@ -269,15 +305,23 @@ Parameters:
   characters after whitespace normalization.
 - JSON body `devicePublicKey` (required): unpadded URL-safe base64 containing
   one raw 32-byte Ed25519 public key.
+- JSON body `invitationId` (optional): version-three invitation UUID. Omit it
+  for legacy single-use packages.
 
 Behavior:
 
-- accepts only a host-created, unused, unexpired session;
-- binds the proposed device key to the session;
-- returns a random base64url `challenge` and the session `expiresAt`;
+- accepts only a host-created, available session or invitation;
+- binds the proposed device key to a legacy session or a new independent
+  five-minute invitation attempt;
+- returns a random base64url `challenge`, attempt `expiresAt`, and an
+  `attemptId` only for version-three invitations;
 - returns `404` for an unknown nonce, `410` after expiry, `409` after another
-  transition already used the session, `422` for an invalid public key, and
-  `503` on an API node that has not been initialized as a gateway.
+  transition already used the session, `422` for an invalid public key, `429`
+  with `Retry-After` when ten invitation attempts are already live, and `503`
+  on an API node that has not been initialized as a gateway. Revoked,
+  exhausted or expired invitations return `410`; the lifetime attempt ceiling
+  returns `410` only when requesting another attempt, while already-issued
+  attempts may still finish before their own expiry.
 
 The device signs the domain-separated message defined by
 `pairing_signature_message` in `src/skulk/operator/pairing.py`. Clients should
@@ -294,11 +338,13 @@ Parameters:
   excluded from the URL so normal request-path logs cannot retain it.
 - JSON body `signature` (required): unpadded URL-safe base64 Ed25519 signature
   produced by the challenged device key.
+- JSON body `invitationId` and `attemptId` (optional as a pair): required for a
+  version-three invitation and omitted together for legacy packages.
 
 Behavior:
 
 - verifies possession of the exact device key bound during the challenge;
-- atomically consumes the session;
+- atomically consumes the legacy session or exact invitation attempt;
 - returns a stable `deviceId`, the validated cluster identity, a 15-minute
   opaque access token, a 30-day rotating refresh token, their expiries, and the
   granted canonical API scopes;
@@ -308,8 +354,9 @@ Behavior:
   certificate. The gateway-role carrier credential is never returned;
 - stores only encrypted session/device state and one-way token digests;
 - never returns either credential again;
-- returns `401` for an invalid proof, `409` for reuse or an out-of-order
-  exchange, `410` after expiry, and `503` on a non-designated node.
+- returns `401` for an invalid proof, `404` for an unknown invitation or
+  attempt, `409` for reuse or an out-of-order exchange, `410` when the session,
+  attempt, or invitation is unavailable, and `503` on a non-designated node.
 
 Together with refresh rotation, these are the complete pre-access-token HTTP
 surface on the relay-only listener. That listener serves the existing canonical

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -163,7 +163,7 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   consensus. The topic and consensus service remain dormant. API nodes do
   construct the independent local pairing service, which never uses this
   network topic.
-- **V1 pairing:** `skulk operator pair` explicitly designates the local host,
+- **Operator pairing:** `skulk operator pair` explicitly designates the local host,
   initializes the encrypted store when needed, and emits one five-minute QR
   capability. A relay-configured gateway emits the version-two package with
   app-role carrier and pinned inner-TLS bootstrap material; `--exchange-url`
@@ -177,7 +177,15 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   device list/revoke routes expose no credential material. A relay-configured
   exchange also returns the app-role carrier credential, opaque locator, and
   pinned inner-TLS trust once for durable local storage; the gateway role never
-  leaves Skulk. Neither QR version contains a canonical access or refresh token.
+  leaves Skulk. No QR package contains a canonical access or refresh token.
+  Explicit duration or pairing-limit flags emit a compressed version-three
+  reusable invitation lasting at most 90 days and permitting at most twenty
+  successful pairings. Every scan receives a separate five-minute attempt.
+  Invitations and attempts are distinct encrypted journal records; ten live
+  and one hundred total attempts are admitted. Global compare-and-set fencing
+  prevents concurrent exchanges from oversubscribing the success limit.
+  Host-only list/revoke commands reveal no nonce. Revocation blocks new and
+  unfinished attempts without revoking credentials already issued to devices.
 - **V1 remote carrier:** `skulk operator configure-relay --provisioning-file`
   validates one generated paired-WebSocket route, encrypts locator and distinct
   app/gateway carrier credentials in the local journal, and creates a protected

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -970,7 +970,7 @@ automatic gateway failover are later hardening, not prerequisites for pairing.
 If this gateway is down, remote operator access is down while local cluster and
 dashboard operation continue.
 
-The local command creates a five-minute QR capability. After relay provisioning,
+The default local command creates a legacy five-minute QR capability. After relay provisioning,
 the version-two package includes only the app-role outer carrier admission and
 pinned inner-TLS material needed to reach the same challenge/exchange routes;
 the gateway-role carrier credential and canonical access/refresh credentials
@@ -978,9 +978,18 @@ never enter the QR. `--exchange-url` remains the direct-development fallback.
 The relay package uses bounded compact JSON compressed with zlib so the
 terminal QR remains camera-scannable; oversized packages are rejected before
 their session is persisted.
+An explicit `--valid-for` or `--max-pairings` creates a version-three reusable
+invitation instead, bounded to 90 days and twenty successful pairings. The
+encrypted journal separates the invitation from its independent five-minute
+attempt records. Global compare-and-set fencing and bounded retries prevent
+concurrent exchanges from exceeding the success limit; ten live and one
+hundred total attempts bound abuse and journal growth. Host-only list and
+revoke commands expose no bearer material. Invitation revocation blocks new and
+unfinished attempts without changing credentials already issued to devices.
 The API exposes only challenge and exchange before authentication: a phone
 proposes an Ed25519 key, signs a domain-separated random challenge, and receives
-opaque access and refresh credentials once. Raw nonces and tokens are never stored in plaintext;
+opaque access and refresh credentials once. Version three binds its proof to
+the cluster, invitation, nonce, attempt, and challenge. Raw nonces and tokens are never stored in plaintext;
 the authority journal contains encrypted state and one-way token digests.
 Refresh rotates and invalidates the prior access/refresh pair atomically. The
 same service validates short-lived bearer access, exposes credential-free


### PR DESCRIPTION
## Summary

- preserve the existing five-minute, single-use pairing package as the default
- add opt-in v3 invitations with bounded lifetime, successful-use, active-attempt, and total-attempt limits
- give each scan an independent five-minute challenge and credential exchange
- add host-only invitation list/revoke commands and owner-only PNG output
- extend the existing operator API additively while keeping the relay unchanged
- document the CLI, wire contract, API behavior, and authority-journal architecture

## Validation

- 45 focused operator pairing, relay, and HTTP tests
- full Skulk suite: 3,362 passed, 2 skipped
- basedpyright
- ruff
- nix formatting
- OpenAPI export

## Delivery order

Deploy this backward-compatible Skulk change before distributing the dependent native-app update. Default legacy QR generation remains compatible with installed app builds.