### PR TITLE
Fix Voxtral staging, node diagnostics, and popover overflow

### DIFF
--- a/dashboard-react/src/components/common/InfoTooltip.test.tsx
+++ b/dashboard-react/src/components/common/InfoTooltip.test.tsx
@@ -1,0 +1,55 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ThemeProvider } from 'styled-components';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { darkTheme } from '../../theme/theme';
+import { InfoTooltip } from './InfoTooltip';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe('InfoTooltip containment', () => {
+  it('wraps long immutable identifiers within the viewport', async () => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    const identity = `local_${'abcdefghijklmnopqrstuvwxyz234567'.repeat(4)}`;
+
+    await act(async () => {
+      root?.render(
+        <ThemeProvider theme={darkTheme}>
+          <InfoTooltip content={<span>{identity}</span>} delay={0} />
+        </ThemeProvider>,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLElement>('[tabindex="0"]');
+    expect(trigger).not.toBeNull();
+    await act(async () => trigger?.focus());
+
+    const tooltip = document.querySelector<HTMLElement>('[role="tooltip"]');
+    expect(tooltip).not.toBeNull();
+    const style = getComputedStyle(tooltip!);
+    const content = tooltip!.querySelector<HTMLElement>('div');
+    expect(content).not.toBeNull();
+    const contentStyle = getComputedStyle(content!);
+    expect(style.boxSizing).toBe('border-box');
+    expect(style.overflowWrap).toBe('anywhere');
+    expect(contentStyle.overflowX).toBe('hidden');
+    expect(contentStyle.overflowY).toBe('auto');
+    expect(tooltip!.getBoundingClientRect().right).toBeLessThanOrEqual(
+      window.innerWidth,
+    );
+    expect(content!.scrollWidth).toBeLessThanOrEqual(content!.clientWidth);
+  });
+});

--- a/dashboard-react/src/components/common/InfoTooltip.tsx
+++ b/dashboard-react/src/components/common/InfoTooltip.tsx
@@ -47,7 +47,9 @@ const Trigger = styled.span`
 `;
 
 const TooltipBox = styled.div`
-  max-width: 360px;
+  box-sizing: border-box;
+  max-width: min(360px, calc(100vw - 16px));
+  overflow-wrap: anywhere;
   padding: 10px 14px;
   background: ${({ theme }) => theme.colors.surface};
   border: 1px solid ${({ theme }) => theme.colors.goldDim};
@@ -59,6 +61,12 @@ const TooltipBox = styled.div`
   line-height: 1.5;
   white-space: pre-line;
   z-index: 9999;
+`;
+
+const TooltipContent = styled.div`
+  max-height: calc(100vh - 36px);
+  overflow-x: hidden;
+  overflow-y: auto;
 `;
 
 const ARROW_SIZE = 8;
@@ -144,7 +152,7 @@ export function InfoTooltip({
               stroke={theme.colors.goldDim}
               strokeWidth={1}
             />
-            {content}
+            <TooltipContent>{content}</TooltipContent>
           </TooltipBox>
         </FloatingPortal>
       )}

--- a/dashboard-react/src/components/layout/StoreRegistryTable.stories.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.stories.tsx
@@ -59,3 +59,49 @@ export const Empty: Story = {
     onDelete: () => {},
   },
 };
+
+export const LongMetadata: Story = {
+  args: {
+    entries: [{
+      model_id: 'mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit',
+      total_bytes: 2.9 * GB,
+      files: [
+        '.gitattributes',
+        'README.md',
+        'config.json',
+        'model.safetensors',
+        'model.safetensors.index.json',
+        'tekken.json',
+      ],
+      downloaded_at: new Date(Date.now() - 86400000).toISOString(),
+      installed_card: {
+        installed_identity: 'local_t4s6oy3ch5u2r6kxst7e5igon2z2yvep35e4x5avqwb6j2dtuxwa',
+        verification: 'local_legacy',
+        artifact_role: 'base',
+      },
+      cached_on_nodes: [{
+        node_id: '12D3KooWFEguSgoQNiqpVKK418huqbmpom24Rf2wFe6Eff2crhWH',
+        complete: true,
+        installed_identity: 'local_t4s6oy3ch5u2r6kxst7e5igon2z2yvep35e4x5avqwb6j2dtuxwa',
+        bytes: 2.9 * GB,
+        last_use_epoch_seconds: Date.now() / 1000,
+        in_use: false,
+      }],
+    }],
+    modelCards: {
+      'mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit': {
+        family: 'voxtral_realtime',
+        quantization: '4bit',
+        baseModel: 'mistralai/Voxtral-Mini-4B-Realtime-2602',
+        capabilities: ['stt'],
+        resolvedCapabilities: {
+          supportsAudioInput: true,
+          supportsTranscription: true,
+          supportsRealtimeAudio: true,
+        },
+      },
+    },
+    onRefresh: () => {},
+    onDelete: () => {},
+  },
+};

--- a/dashboard-react/src/components/layout/StoreRegistryTable.tsx
+++ b/dashboard-react/src/components/layout/StoreRegistryTable.tsx
@@ -583,6 +583,36 @@ const ActionsCell = styled.div<{ $area?: MobileGridArea }>`
 
 const LinkIcon = () => <FiExternalLink size={14} style={{ flexShrink: 0 }} />;
 
+const ModelInfo = styled.div`
+  min-width: min(240px, calc(100vw - 44px));
+  max-width: 100%;
+`;
+
+const ModelInfoTitle = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  min-width: 0;
+  margin-bottom: 6px;
+
+  > span {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+`;
+
+const ModelInfoGrid = styled.div`
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 4px 12px;
+  min-width: 0;
+
+  > * {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+`;
+
 function ModelInfoContent({ entry, card }: { entry: StoreRegistryEntry; card?: ModelCardInfo }) {
   const { t } = useSkulkTranslation();
   const theme = useTheme() as Theme;
@@ -592,8 +622,8 @@ function ModelInfoContent({ entry, card }: { entry: StoreRegistryEntry; card?: M
   const resolved = card?.resolvedCapabilities;
 
   return (
-    <div style={{ minWidth: 240 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+    <ModelInfo>
+      <ModelInfoTitle>
         <span style={{ color: theme.colors.gold, fontWeight: 600 }}>
           {entry.model_id}
         </span>
@@ -610,14 +640,14 @@ function ModelInfoContent({ entry, card }: { entry: StoreRegistryEntry; card?: M
             <LinkIcon />
           </a>
         )}
-      </div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '4px 12px' }}>
+      </ModelInfoTitle>
+      <ModelInfoGrid>
         <span style={{ color: theme.colors.textMuted }}>{t('common.size', 'Size')}</span>
         <span>{formatBytes(entry.total_bytes)}</span>
         {entry.installed_card && (
           <>
             <span style={{ color: theme.colors.textMuted }}>{t('storeRegistry.installedIdentity', 'Installed identity')}</span>
-            <span style={{ overflowWrap: 'anywhere' }}>{entry.installed_card.installed_identity}</span>
+            <span>{entry.installed_card.installed_identity}</span>
             <span style={{ color: theme.colors.textMuted }}>{t('storeRegistry.verification', 'Verification')}</span>
             <span>{entry.installed_card.verification}</span>
           </>
@@ -684,7 +714,7 @@ function ModelInfoContent({ entry, card }: { entry: StoreRegistryEntry; card?: M
         <span>{entry.files.length}</span>
         <span style={{ color: theme.colors.textMuted }}>{t('storeRegistry.downloaded', 'Downloaded')}</span>
         <span>{new Date(entry.downloaded_at).toLocaleString()}</span>
-      </div>
+      </ModelInfoGrid>
       {entry.files.length > 0 && (
         <div style={{ marginTop: 8, borderTop: `1px solid ${theme.colors.borderLight}`, paddingTop: 6 }}>
           <div style={{ color: theme.colors.textMuted, textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4 }}>
@@ -697,7 +727,7 @@ function ModelInfoContent({ entry, card }: { entry: StoreRegistryEntry; card?: M
           </div>
         </div>
       )}
-    </div>
+    </ModelInfo>
   );
 }
 

--- a/src/skulk/api/diagnostics_compatibility.py
+++ b/src/skulk/api/diagnostics_compatibility.py
@@ -1,5 +1,6 @@
 """Compatibility helpers for cross-node operational diagnostics."""
 
+import json
 from collections.abc import Sequence
 
 from skulk.api.build_identity import (
@@ -29,7 +30,14 @@ def parse_peer_node_diagnostics(payload: object) -> NodeDiagnostics:
         The known portion of the peer's diagnostics bundle.
     """
 
-    return NodeDiagnostics.model_validate(payload, extra="ignore")
+    # Peer responses have already crossed a JSON boundary. Re-validating the
+    # decoded Python mapping in strict mode rejects valid JSON representations
+    # such as UUID and datetime strings. JSON-mode validation preserves strict
+    # field typing while applying only the coercions defined by the wire format.
+    return NodeDiagnostics.model_validate_json(
+        json.dumps(payload),
+        extra="ignore",
+    )
 
 
 def compare_diagnostics_builds(

--- a/src/skulk/api/tests/test_diagnostics_api.py
+++ b/src/skulk/api/tests/test_diagnostics_api.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timezone
 from typing import cast
+from uuid import uuid4
 
 import httpx
 import httpx2
@@ -527,6 +528,11 @@ def test_cluster_diagnostics_returns_local_and_peer_results(
     )
 
     peer_payload = peer_diagnostics.model_dump(mode="json", by_alias=True)
+    peer_install_id = uuid4()
+    peer_payload["identity"] = NodeIdentity(
+        node_install_id=peer_install_id,
+        friendly_name="Peer node",
+    ).model_dump(mode="json", by_alias=True)
     peer_payload["futureNodeCounter"] = 7
     data_plane = _json_mapping(cast(object, peer_payload["dataPlane"]))
     data_plane["futureLifecycleCounter"] = 11
@@ -578,6 +584,8 @@ def test_cluster_diagnostics_returns_local_and_peer_results(
     peer = next(node for node in nodes if node["nodeId"] == "peer-node")
     parsed = _json_mapping(peer["diagnostics"])
     assert "futureNodeCounter" not in parsed
+    identity = _json_mapping(parsed["identity"])
+    assert identity["nodeInstallId"] == str(peer_install_id)
     parsed_data_plane = _json_mapping(parsed["dataPlane"])
     assert "futureLifecycleCounter" not in parsed_data_plane
     parsed_egress = _json_mapping(parsed_data_plane["egress"])

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -105,6 +105,7 @@ from skulk.store.installed_cards import (
     installed_card_matches,
     installed_companion_matches,
     read_installed_card_with_fallback,
+    require_registry_installed_artifact,
     write_installed_card_with_fallback,
 )
 from skulk.store.staging_eviction import touch_last_used
@@ -179,6 +180,15 @@ def _staged_generation_matches(
                 owner_card=owner_card,
                 artifact_role=artifact_role,
             )
+        if requested_card.registry_card_id is not None:
+            try:
+                require_registry_installed_artifact(
+                    model_directory,
+                    requested_card,
+                )
+            except PermissionError:
+                return False
+            return True
         return installed_card_matches(model_directory, requested_card)
     return _staged_source_revision_matches(
         model_directory, requested_card.source_revision

--- a/src/skulk/store/tests/test_installed_cards.py
+++ b/src/skulk/store/tests/test_installed_cards.py
@@ -759,3 +759,42 @@ async def test_completed_download_refreshes_card_without_rehashing_bytes(
     assert refreshed is not None and refreshed.installed_card is not None
     assert refreshed.installed_card.model_card == new_card
     assert refreshed.installed_card.files == old_record.files
+
+
+async def test_completed_legacy_import_with_matching_revision_becomes_verified(
+    tmp_path: Path,
+) -> None:
+    """A trusted card request upgrades exact marked bytes without downloading."""
+
+    store = ModelStore(tmp_path / "store")
+    artifact = tmp_path / "store" / "org--model"
+    artifact.mkdir(parents=True)
+    (artifact / "config.json").write_text("{}")
+    (artifact / "model.safetensors").write_bytes(b"weights")
+    card = _card()
+    legacy = build_installed_card_record(artifact, card)
+    write_installed_card(artifact, legacy)
+    (artifact / ".skulk-source-revision").write_text(f"{card.source_revision}\n")
+    store.register_model(
+        "org/model",
+        artifact,
+        [entry.path for entry in legacy.files],
+        sum(entry.size_bytes for entry in legacy.files),
+        source_revision=card.source_revision,
+        source_repository=str(card.artifact_repository),
+        installed_card=legacy,
+    )
+
+    status = await store.request_download(
+        "org/model",
+        source_revision=card.source_revision,
+        source_repository=str(card.artifact_repository),
+        model_card=card,
+    )
+
+    refreshed = store.get_entry("org/model")
+    assert status.status == "complete"
+    assert refreshed is not None and refreshed.installed_card is not None
+    assert refreshed.installed_card.verification == "registry_verified"
+    assert refreshed.installed_card.installed_identity == card.registry_card_id
+    assert refreshed.installed_card.manifest_sha256 == legacy.manifest_sha256

--- a/src/skulk/store/tests/test_model_store_cancellation.py
+++ b/src/skulk/store/tests/test_model_store_cancellation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import skulk.store.model_store as model_store_module
 from skulk.download import download_utils
 from skulk.download.download_utils import FileListEntry
 from skulk.shared.models.model_cards import ModelId
@@ -35,6 +36,10 @@ async def test_cancel_store_download_is_idempotent_and_resumable(
 
     monkeypatch.setattr(download_utils, "fetch_file_list_with_cache", file_list)
     monkeypatch.setattr(download_utils, "download_file_with_retry", blocked_download)
+    # Cancellation behavior must not depend on the development host having the
+    # production store's 10 GiB operating reserve available. Capacity admission
+    # has dedicated tests; this fixture needs to reach its mocked transfer.
+    monkeypatch.setattr(model_store_module, "MINIMUM_STAGING_FREE_DISK_BYTES", 0)
     store = ModelStore(tmp_path)
 
     first_status = await store.request_download("org/model")

--- a/src/skulk/store/tests/test_peer_reconciliation.py
+++ b/src/skulk/store/tests/test_peer_reconciliation.py
@@ -8,6 +8,7 @@ from typing import cast
 import pytest
 from aiohttp import web
 
+import skulk.store.model_store as model_store_module
 from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
 from skulk.shared.types.memory import Memory
 from skulk.store.installed_cards import (
@@ -37,7 +38,11 @@ def _card() -> ModelCard:
     )
 
 
-async def test_peer_import_resumes_and_verifies_before_publish(tmp_path: Path) -> None:
+async def test_peer_import_resumes_and_verifies_before_publish(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(model_store_module, "MINIMUM_STAGING_FREE_DISK_BYTES", 0)
     source = tmp_path / "source" / "org--model"
     source.mkdir(parents=True)
     payload = b"verified-model-weights"
@@ -229,9 +234,12 @@ async def test_peer_import_promotes_complete_partial_without_network(
 
 
 async def test_peer_import_repairs_corrupt_matching_canonical_generation(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Identity equality cannot short-circuit manifest corruption recovery."""
+
+    monkeypatch.setattr(model_store_module, "MINIMUM_STAGING_FREE_DISK_BYTES", 0)
 
     source = tmp_path / "source" / "org--model"
     source.mkdir(parents=True)
@@ -321,8 +329,10 @@ async def test_deleted_alias_tombstone_blocks_stale_peer_import(
 
 
 async def test_failed_peer_replacement_preserves_old_generation(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(model_store_module, "MINIMUM_STAGING_FREE_DISK_BYTES", 0)
     source = tmp_path / "source" / "org--model"
     source.mkdir(parents=True)
     (source / "model.safetensors").write_bytes(b"new-generation")

--- a/src/skulk/store/tests/test_source_revision.py
+++ b/src/skulk/store/tests/test_source_revision.py
@@ -41,6 +41,7 @@ async def test_store_alias_download_reads_from_artifact_repository(
     tmp_path: Path,
 ) -> None:
     """The canonical store key must not become the Hugging Face origin."""
+    monkeypatch.setattr(model_store_module, "MINIMUM_STAGING_FREE_DISK_BYTES", 0)
     store = ModelStore(tmp_path)
     alias = "org/multi@q4-k-m"
     repository = ModelId("org/multi")
@@ -295,6 +296,7 @@ async def test_pinned_store_download_writes_revision_marker_and_offloads_hashing
 ) -> None:
     """A qualified store entry must remain discoverable by generic runners."""
 
+    monkeypatch.setattr(model_store_module, "MINIMUM_STAGING_FREE_DISK_BYTES", 0)
     store = ModelStore(tmp_path)
     model_id = "org/model"
     store._active_downloads[model_id] = StoreDownloadStatus(
@@ -562,6 +564,7 @@ async def test_mutable_main_download_clears_old_pinned_staging_residue(
 ) -> None:
     """An upgrade must not reuse pinned bytes left in mutable-main's path."""
 
+    monkeypatch.setattr(model_store_module, "MINIMUM_STAGING_FREE_DISK_BYTES", 0)
     store = ModelStore(tmp_path)
     model_id = "org/model"
     target_dir = tmp_path / "org--model"

--- a/src/skulk/store/tests/test_staged_pinned_gguf.py
+++ b/src/skulk/store/tests/test_staged_pinned_gguf.py
@@ -32,6 +32,41 @@ from skulk.store.model_store_client import (
 _MODEL_ID = "org/multi-quant-GGUF"
 
 
+def test_signed_staged_fast_path_rejects_local_legacy_sidecar(
+    tmp_path: Path,
+) -> None:
+    """Signed loads must refresh legacy evidence before reusing staged bytes."""
+
+    card = ModelCard(
+        model_id=ModelId("org/model"),
+        storage_size=Memory.from_mb(1),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        source_revision="a" * 40,
+        registry_card_id=f"card_{'a' * 52}",
+        registry_snapshot_id="snapshot_1_test",
+        registry_provenance="foxlight",
+    )
+    artifact = tmp_path / "org--model"
+    artifact.mkdir()
+    (artifact / "config.json").write_text("{}")
+    (artifact / "model.safetensors").write_bytes(b"weights")
+    legacy = build_installed_card_record(artifact, card)
+    write_installed_card(artifact, legacy)
+    (artifact / ".skulk-source-revision").write_text(f"{card.source_revision}\n")
+
+    assert legacy.verification == "local_legacy"
+    assert not _staged_generation_matches(
+        artifact,
+        artifact_model_id=str(card.model_id),
+        requested_card=card,
+        owner_card=None,
+        artifact_role="base",
+    )
+
+
 def test_published_generation_ignores_shared_parent_cleanup_failure(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- validate peer diagnostics in JSON mode so UUID and datetime wire values survive strict cross-node parsing
- require the staged signed-card fast path to satisfy the same exact installed-artifact proof as the runner boundary
- contain long Model Store metadata inside scrollable, viewport-bounded information popovers
- isolate transfer-focused tests from the production disk-reserve threshold

## Root cause

Peer diagnostics were decoded to Python objects and then revalidated in strict Python mode, which rejected valid UUID strings and returned a plain-text 500. Separately, staged-card reuse compared only the retained registry card ID, allowing a legacy sidecar to bypass the store metadata refresh before the stricter runner trust check. The popover grid did not allow long immutable identifiers to shrink and wrap.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` (3376 passed, 2 skipped)
- `npm run test` (134 passed)
- `npm run build`
- rendered Chromium validation of long installed/card/node identities with viewport containment, vertical scrolling, preserved arrow chrome, and no console warnings or errors
