### PR TITLE
fix(dashboard): stabilize custom speech voices

### DIFF
--- a/dashboard-react/src/audio/speechSynthesisRequest.test.ts
+++ b/dashboard-react/src/audio/speechSynthesisRequest.test.ts
@@ -4,6 +4,7 @@ import {
   batchSpeechMaxTokens,
   buildSpeechSynthesisRequest,
   DASHBOARD_SPEECH_SEED,
+  DASHBOARD_SPEECH_SAMPLING,
   MAX_REFERENCE_AUDIO_BYTES,
   speechLanguageForDashboardLocale,
 } from './speechSynthesisRequest';
@@ -32,6 +33,10 @@ describe('buildSpeechSynthesisRequest', () => {
       lang_code: 'English',
       response_format: 'mp3',
       seed: DASHBOARD_SPEECH_SEED,
+      temperature: DASHBOARD_SPEECH_SAMPLING.temperature,
+      top_p: DASHBOARD_SPEECH_SAMPLING.topP,
+      top_k: DASHBOARD_SPEECH_SAMPLING.topK,
+      repetition_penalty: DASHBOARD_SPEECH_SAMPLING.repetitionPenalty,
       max_tokens: 8192,
       voice: 'ryan',
     });
@@ -64,6 +69,12 @@ describe('buildSpeechSynthesisRequest', () => {
     expect(body.get('lang_code')).toBe('English');
     expect(body.get('response_format')).toBe('pcm');
     expect(body.get('seed')).toBe(String(DASHBOARD_SPEECH_SEED));
+    expect(body.get('temperature')).toBe(String(DASHBOARD_SPEECH_SAMPLING.temperature));
+    expect(body.get('top_p')).toBe(String(DASHBOARD_SPEECH_SAMPLING.topP));
+    expect(body.get('top_k')).toBe(String(DASHBOARD_SPEECH_SAMPLING.topK));
+    expect(body.get('repetition_penalty')).toBe(
+      String(DASHBOARD_SPEECH_SAMPLING.repetitionPenalty),
+    );
     expect(body.get('stream')).toBe('true');
     expect(body.has('voice')).toBe(false);
     const uploadedReference = body.get('reference_audio');

--- a/dashboard-react/src/audio/speechSynthesisRequest.ts
+++ b/dashboard-react/src/audio/speechSynthesisRequest.ts
@@ -6,6 +6,20 @@ export const MAX_REFERENCE_AUDIO_BYTES = 25 * 1024 * 1024;
 /** Stable seed used for every dashboard sentence and replay generation. */
 export const DASHBOARD_SPEECH_SEED = 42;
 
+/**
+ * Lower-variance sampling used for interactive dashboard speech.
+ *
+ * These values mirror mlx-audio's speech-serving preset. Sending them on every
+ * request keeps a model package's defaults from changing the selected voice's
+ * character between sentences or releases.
+ */
+export const DASHBOARD_SPEECH_SAMPLING = {
+  temperature: 0.7,
+  topP: 0.95,
+  topK: 40,
+  repetitionPenalty: 1,
+} as const;
+
 /** Default omitted server budget and bounded ceiling for dashboard batch playback. */
 const DEFAULT_BATCH_SPEECH_MAX_TOKENS = 4096;
 const MAX_BATCH_SPEECH_MAX_TOKENS = 131_072;
@@ -94,6 +108,13 @@ export function buildSpeechSynthesisRequest(
     formData.set('lang_code', language);
     formData.set('response_format', responseFormat);
     formData.set('seed', String(seed));
+    formData.set('temperature', String(DASHBOARD_SPEECH_SAMPLING.temperature));
+    formData.set('top_p', String(DASHBOARD_SPEECH_SAMPLING.topP));
+    formData.set('top_k', String(DASHBOARD_SPEECH_SAMPLING.topK));
+    formData.set(
+      'repetition_penalty',
+      String(DASHBOARD_SPEECH_SAMPLING.repetitionPenalty),
+    );
     if (maxTokens !== null) formData.set('max_tokens', String(maxTokens));
     if (stream) formData.set('stream', 'true');
     // The uploaded clip is the voice condition for this request. Sending the
@@ -118,6 +139,10 @@ export function buildSpeechSynthesisRequest(
       lang_code: language,
       response_format: responseFormat,
       seed,
+      temperature: DASHBOARD_SPEECH_SAMPLING.temperature,
+      top_p: DASHBOARD_SPEECH_SAMPLING.topP,
+      top_k: DASHBOARD_SPEECH_SAMPLING.topK,
+      repetition_penalty: DASHBOARD_SPEECH_SAMPLING.repetitionPenalty,
       ...(maxTokens !== null ? { max_tokens: maxTokens } : {}),
       ...(stream ? { stream: true } : {}),
       ...(voice ? { voice } : {}),


### PR DESCRIPTION
## Summary

- send an explicit lower-variance synthesis preset from the dashboard
- retain one stable seed and the selected voice across sentence requests
- apply the same contract to JSON and multipart reference-audio speech

## Root cause

The dashboard already supplied the selected custom voice on each request, but it inherited the mounted model's comparatively high-variance sampling defaults. A generative TTS model could therefore drift away from its reference voice even though voice selection remained intact.

## User impact

Long spoken answers should retain a more consistent voice between sentences and across assistant turns. This narrows stochastic variation; it does not claim that generative speech is bit-identical.

## Validation

- `npm run test` (134 tests)
- `npm run build`
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt` (no changes)
- `uv run pytest` (3,376 passed, 2 skipped)
