### PR TITLE
fix(operator): support current Tailscale whois schema

### DIFF
--- a/src/skulk/connectivity/tailscale.py
+++ b/src/skulk/connectivity/tailscale.py
@@ -268,7 +268,11 @@ async def is_tailscale_peer(peer_host: str) -> bool:
     if not isinstance(node_object, dict):
         return False
     node = cast(dict[object, object], node_object)
-    if node.get("MachineAuthorized") is not True:
+    # Current Tailscale `whois --json` responses omit MachineAuthorized for
+    # valid peers. A successful local-daemon whois plus an exact address match
+    # is the membership proof; when the optional field is present, still fail
+    # closed unless it explicitly confirms authorization.
+    if "MachineAuthorized" in node and node.get("MachineAuthorized") is not True:
         return False
     addresses_object = node.get("Addresses")
     if not isinstance(addresses_object, list):

--- a/src/skulk/connectivity/tests/test_tailscale.py
+++ b/src/skulk/connectivity/tests/test_tailscale.py
@@ -175,15 +175,36 @@ async def test_tailscale_peer_rejects_cgnat_address_not_owned_by_whois_node(
     assert await tailscale_module.is_tailscale_peer("100.64.0.9") is False
 
 
-async def test_tailscale_peer_requires_explicit_machine_authorization(
+async def test_tailscale_peer_accepts_whois_schema_without_machine_authorization(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Missing authorization state fails closed despite an address match."""
+    """Current whois schemas omit MachineAuthorized for valid peers."""
 
     async def fake_exec(*_args: object, **_kwargs: object) -> _CompletedProcess:
         return _CompletedProcess(
             {
                 "Node": {
+                    "Addresses": ["100.101.102.103/32"],
+                }
+            }
+        )
+
+    monkeypatch.setattr(tailscale_module, "_resolve_tailscale_binary", lambda: "/usr/bin/tailscale")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    assert await tailscale_module.is_tailscale_peer("100.101.102.103") is True
+
+
+async def test_tailscale_peer_rejects_explicitly_unauthorized_machine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit negative authorization result always fails closed."""
+
+    async def fake_exec(*_args: object, **_kwargs: object) -> _CompletedProcess:
+        return _CompletedProcess(
+            {
+                "Node": {
+                    "MachineAuthorized": False,
                     "Addresses": ["100.101.102.103/32"],
                 }
             }


### PR DESCRIPTION
## Summary

- accept a successful local Tailscale whois result when the current schema omits the optional machine-authorization field
- continue to reject an explicit unauthorized result
- retain exact socket-address ownership as the required peer binding
- add regression coverage for both schema shapes

## Root cause

Current Tailscale whois responses can omit the optional authorization field for valid peers. Requiring it to be explicitly true caused every otherwise-valid dashboard pairing request to fail closed.

## Validation

- basedpyright
- ruff check
- nix fmt
- full pytest suite: 3386 passed, 2 skipped, 231 deselected
- focused pairing and Tailscale tests: 21 passed