### PR TITLE
Build managed CUDA engine wheel for ARM64

### DIFF
--- a/.github/workflows/engine-wheel.yml
+++ b/.github/workflows/engine-wheel.yml
@@ -1,8 +1,8 @@
 # Builds the pip-installable llama-server engine wheels
 # (skulk-llama-server-cuda, skulk-llama-server-vulkan; packaging/) and
 # publishes them to PyPI via trusted publishing. Same principle as
-# cuda-image.yml: the compilers run on plain amd64 runners without a GPU,
-# inside pinned containers, so each wheel's glibc/toolkit lineage is known.
+# cuda-image.yml: the compilers run on plain amd64 or arm64 runners without a
+# GPU, inside pinned containers, so each wheel's glibc/toolkit lineage is known.
 # Building from the pinned upstream SOURCE (not upstream's binaries) is the
 # supply-chain posture: we trust llama.cpp's code at a tag, built by us.
 #
@@ -35,11 +35,9 @@ env:
   # Must match src/skulk/provisioning/manifest.py LLAMA_SERVER_PIN and both
   # packaging versions (0.<build>.<rev>); the guard step enforces all of them.
   LLAMA_CPP_PIN: b10434
-  CUDA_ARCHITECTURES: "80-real;86-real;89-real;90"
-
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       id-token: write
@@ -53,13 +51,29 @@ jobs:
       matrix:
         include:
           - variant: cuda
+            runner: ubuntu-22.04
             container: nvidia/cuda:12.4.1-devel-ubuntu22.04
+            cuda_architectures: "80-real;86-real;89-real;90"
             package: skulk-llama-server-cuda
             module: skulk_llama_server_cuda
+            artifact: skulk-llama-server-cuda-amd64-wheel
+          - variant: cuda
+            # Grace Blackwell / GB10 is an arm64 host with compute capability
+            # 12.1. CUDA 12.9 is the first toolkit lane we support for sm_121.
+            runner: ubuntu-22.04-arm
+            container: nvidia/cuda:12.9.1-devel-ubuntu22.04
+            cuda_architectures: "121-real"
+            package: skulk-llama-server-cuda
+            module: skulk_llama_server_cuda
+            artifact: skulk-llama-server-cuda-arm64-wheel
           - variant: vulkan
+            runner: ubuntu-22.04
             container: ubuntu:22.04
+            cuda_architectures: ""
             package: skulk-llama-server-vulkan
             module: skulk_llama_server_vulkan
+            # The PyPI mirror job intentionally downloads this exact name.
+            artifact: skulk-llama-server-vulkan-wheel
     container: ${{ matrix.container }}
     steps:
       - name: Install build prerequisites
@@ -109,7 +123,7 @@ jobs:
             # driver-API reference; llama-server commits its KV window up
             # front at a fixed -c, so the VMM pool allocator's benefit is
             # marginal for this serving shape.
-            BACKEND_FLAGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=$CUDA_ARCHITECTURES -DGGML_CUDA_NO_VMM=ON"
+            BACKEND_FLAGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=${{ matrix.cuda_architectures }} -DGGML_CUDA_NO_VMM=ON"
           else
             BACKEND_FLAGS="-DGGML_VULKAN=ON"
           fi
@@ -168,7 +182,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.package }}-wheel
+          name: ${{ matrix.artifact }}
           path: packaging/${{ matrix.package }}/dist/*.whl
           if-no-files-found: error
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ This project records release notes here and mirrors public-facing notes in
   use served CUDA, while its independently versioned in-process CUDA backend
   remains excluded.
 
+- The managed CUDA llama-server wheel now ships for Linux aarch64 as well as
+  x86_64. The aarch64 lane is built natively with CUDA 12.9 for compute
+  capability 12.1, allowing Grace Blackwell and GB10 nodes to use the CUDA
+  served engine instead of falling back to Vulkan.
+
 - Intelligent Fabric now speaks and identifies as Skulk rather than presenting
   a separate Steward character. The dashboard streams answer prose through a
   ready TTS model only when its voice catalog contains the signature `skulk`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,15 +167,17 @@ upstream llama-server build on demand (Vulkan for visible GPUs, CPU
 otherwise; no upstream Linux CUDA prebuilt exists; the CUDA lane is the
 Foxlight wheel, auto-installed on demand for NVIDIA nodes, #661);
 `SKULK_LLAMA_SERVER_BIN` overrides, `SKULK_NO_ENGINE_AUTOPROVISION=1` opts
-out. The CUDA engine also ships as the pip wheel `skulk-llama-server-cuda`
-(packaging/, built by `.github/workflows/engine-wheel.yml`), which outranks
+out. The CUDA engine also ships as x86_64 and aarch64 variants of the pip wheel
+`skulk-llama-server-cuda` (packaging/, built by
+`.github/workflows/engine-wheel.yml`), which outranks
 tarball provisioning on NVIDIA nodes. Engine wheels publish to the Foxlight
 PEP 503 index on Cloudflare R2 (`wheels.foxlight.ai`, source of
 truth; `scripts/publish_wheel_index.py`; CUDA wheel exceeds PyPI's size
 limit) with the Vulkan wheel mirrored to PyPI. The CUDA wheel builds with
 `GGML_CUDA_NO_VMM=ON`: GPU-less CI cannot satisfy the driver API's transitive
 libcuda.so.1 link (stubs ship only libcuda.so), so never reintroduce
-driver-API-dependent flags to that build. ADVANCING THE ENGINE PIN IS A
+driver-API-dependent flags to that build. The aarch64 lane uses CUDA 12.9 and
+targets compute capability 12.1 for Grace Blackwell/GB10. ADVANCING THE ENGINE PIN IS A
 CHECKLIST (architecture-reference.md "Engine pin advancement"): bump pin +
 re-record checksums + bump wheel version + republish + fresh-box gauntlet;
 never advance casually. `install.sh` is the one-command fresh-box installer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,8 @@ limit) with the Vulkan wheel mirrored to PyPI. The CUDA wheel builds with
 `GGML_CUDA_NO_VMM=ON`: GPU-less CI cannot satisfy the driver API's transitive
 libcuda.so.1 link (stubs ship only libcuda.so), so never reintroduce
 driver-API-dependent flags to that build. The aarch64 lane uses CUDA 12.9 and
-targets compute capability 12.1 for Grace Blackwell/GB10. ADVANCING THE ENGINE PIN IS A
+targets compute capability 12.1 for Grace Blackwell/GB10; provisioning admits
+that first ARM64 payload only on exact `sm_121` hardware. ADVANCING THE ENGINE PIN IS A
 CHECKLIST (architecture-reference.md "Engine pin advancement"): bump pin +
 re-record checksums + bump wheel version + republish + fresh-box gauntlet;
 never advance casually. `install.sh` is the one-command fresh-box installer

--- a/packaging/skulk-llama-server-cuda/README.md
+++ b/packaging/skulk-llama-server-cuda/README.md
@@ -1,6 +1,6 @@
 # skulk-llama-server-cuda
 
-The pip-installable CUDA `llama-server` build for [Skulk](https://github.com/Foxlight-Foundation/Skulk)'s served GGUF engine (Linux x86_64).
+The pip-installable CUDA `llama-server` build for [Skulk](https://github.com/Foxlight-Foundation/Skulk)'s served GGUF engine on Linux x86_64 and aarch64.
 
 The wheel carries the Foxlight-built `llama-server` and `ggml-rpc-server` binaries, compiled from the pinned upstream [llama.cpp](https://github.com/ggml-org/llama.cpp) release with CUDA enabled (upstream publishes no Linux CUDA prebuilt). The CUDA runtime is not rehosted here: it resolves from NVIDIA's official PyPI wheels (`nvidia-cuda-runtime-cu12`, `nvidia-cublas-cu12`), which install as ordinary dependencies. The `llama-server-cuda` entry point puts those libraries on the loader path and execs the real binary, forwarding all arguments.
 
@@ -10,6 +10,8 @@ llama-server-cuda --list-devices
 ```
 
 Skulk's engine provisioning discovers the installed wheel automatically and wires it as the node's served engine; no configuration is needed. A machine additionally needs the NVIDIA driver (anything where `nvidia-smi` works), which only NVIDIA can ship.
+
+The x86_64 wheel carries kernels for the established Ampere-through-Hopper fleet. The aarch64 wheel targets compute capability 12.1 with CUDA 12.9 for Grace Blackwell systems such as GB10. The platform-specific filenames share one package version so ordinary Python package resolution selects the correct payload.
 
 Version scheme: `0.<llama.cpp build>.<packaging revision>`; `0.10068.0` is the first packaging of upstream `b10068`. Built and published by the `engine-wheel` workflow to Foxlight's package index with build-provenance attestations.
 

--- a/packaging/skulk-llama-server-cuda/hatch_build.py
+++ b/packaging/skulk-llama-server-cuda/hatch_build.py
@@ -1,15 +1,40 @@
 """Hatch build hook: tag the wheel as a platform binary.
 
 The Python shim is pure, but the payload under ``bin/`` is a compiled Linux
-x86_64 binary linked against glibc 2.35 (the ubuntu-22.04 build runner), so
-the wheel must carry a platform tag rather than ``any``.
+x86_64 or aarch64 binary linked against glibc 2.35 (the Ubuntu 22.04 build
+runner), so the wheel must carry a platform tag rather than ``any``.
 """
 
 from __future__ import annotations
 
+import platform
 from typing import Any
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+_MANYLINUX_TAG_BY_MACHINE = {
+    "aarch64": "py3-none-manylinux_2_35_aarch64",
+    "arm64": "py3-none-manylinux_2_35_aarch64",
+    "x86_64": "py3-none-manylinux_2_35_x86_64",
+}
+
+
+def wheel_tag(machine: str) -> str:
+    """Return the binary wheel tag for a supported Linux build machine.
+
+    Args:
+        machine: Architecture reported by :func:`platform.machine`.
+
+    Returns:
+        A Python 3, ABI-independent manylinux tag for the compiled payload.
+
+    Raises:
+        ValueError: The workflow ran on an architecture Skulk does not publish.
+    """
+    try:
+        return _MANYLINUX_TAG_BY_MACHINE[machine]
+    except KeyError as error:
+        raise ValueError(f"unsupported CUDA wheel architecture: {machine}") from error
 
 
 class CustomBuildHook(BuildHookInterface):
@@ -18,4 +43,4 @@ class CustomBuildHook(BuildHookInterface):
     def initialize(self, version: str, build_data: dict[str, Any]) -> None:
         """Mark the wheel non-pure with the manylinux tag of the payload."""
         build_data["pure_python"] = False
-        build_data["tag"] = "py3-none-manylinux_2_35_x86_64"
+        build_data["tag"] = wheel_tag(platform.machine())

--- a/packaging/skulk-llama-server-cuda/pyproject.toml
+++ b/packaging/skulk-llama-server-cuda/pyproject.toml
@@ -19,15 +19,19 @@
 [project]
 name = "skulk-llama-server-cuda"
 version = "0.10434.0"
-description = "Pinned CUDA llama-server build for Skulk's served GGUF engine (Linux x86_64)"
+description = "Pinned CUDA llama-server build for Skulk's served GGUF engine (Linux x86_64 and aarch64)"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 dependencies = [
   # NVIDIA's official CUDA runtime wheels; the shim puts their lib dirs on
   # LD_LIBRARY_PATH before exec'ing llama-server.
-  "nvidia-cuda-runtime-cu12>=12.4",
-  "nvidia-cublas-cu12>=12.4",
+  "nvidia-cuda-runtime-cu12>=12.4; platform_machine == 'x86_64'",
+  "nvidia-cublas-cu12>=12.4; platform_machine == 'x86_64'",
+  # The aarch64 wheel targets Grace Blackwell sm_121 and is compiled with
+  # CUDA 12.9, so its user-space runtime must be at least that new.
+  "nvidia-cuda-runtime-cu12>=12.9; platform_machine == 'aarch64'",
+  "nvidia-cublas-cu12>=12.9; platform_machine == 'aarch64'",
 ]
 
 [project.scripts]
@@ -45,6 +49,6 @@ packages = ["src/skulk_llama_server_cuda"]
 artifacts = ["src/skulk_llama_server_cuda/bin/**", "src/skulk_llama_server_cuda/licenses/**"]
 
 [tool.hatch.build.targets.wheel.hooks.custom]
-# Marks the wheel platform-specific (linux x86_64) even though the Python
-# shim itself is pure: the payload under bin/ is compiled.
+# Marks the wheel platform-specific (Linux x86_64 or aarch64) even though the
+# Python shim itself is pure: the payload under bin/ is compiled.
 path = "hatch_build.py"

--- a/src/skulk/provisioning/llama_server.py
+++ b/src/skulk/provisioning/llama_server.py
@@ -57,6 +57,12 @@ _DOWNLOAD_TIMEOUT_SECONDS = 300.0
 # degrading to the Vulkan/tarball chain.
 _WHEEL_INSTALL_TIMEOUT_SECONDS = 900.0
 
+# The first native arm64 CUDA wheel is deliberately GB10-specific: unlike the
+# x86_64 wheel, its CI build carries only an sm_121 real-code image. Do not let
+# package-tag compatibility masquerade as GPU-kernel compatibility on GH200 or
+# another arm64 NVIDIA system; those nodes retain the verified Vulkan fallback.
+_ARM64_CUDA_WHEEL_COMPUTE_CAPABILITIES = frozenset({(12, 1)})
+
 # Mirrors install.sh's ENGINE_INDEX_FLAGS: the Foxlight PEP 503 index is the
 # source of truth for engine wheels (the CUDA wheel exceeds PyPI's size
 # limit), with the default index pinned explicitly so a host exporting
@@ -162,12 +168,16 @@ def _wheel_version_matches_pin(distribution: str, *, quiet: bool = False) -> boo
 
 
 def _cuda_capability_ok(facts: NodeFacts) -> bool:
-    """Whether an observed NVIDIA GPU meets the CUDA wheel's compiled SM floor.
+    """Whether an observed NVIDIA GPU matches this host wheel's compiled SMs.
 
     An unknown capability (NVML degraded) is treated as not-ok: preferring a
     wheel that may have no kernels for the silicon would fail at model load,
     while the Vulkan fallback fails loudly at probe time if it fails at all.
+    The x86_64 wheel retains its established Ampere-or-newer policy. The first
+    aarch64 wheel is narrower and accepts only the GB10 ``sm_121`` target it
+    actually carries.
     """
+    machine = platform_module.machine().lower()
     for gpu in facts.gpus_of("nvidia"):
         if gpu.compute_capability is None:
             continue
@@ -175,7 +185,14 @@ def _cuda_capability_ok(facts: NodeFacts) -> bool:
             major, minor = (int(part) for part in gpu.compute_capability.split("."))
         except ValueError:
             continue
-        if (major, minor) >= CUDA_WHEEL_MIN_COMPUTE_CAPABILITY:
+        capability = (major, minor)
+        if machine in {"aarch64", "arm64"}:
+            if capability in _ARM64_CUDA_WHEEL_COMPUTE_CAPABILITIES:
+                return True
+            continue
+        if machine in {"x86_64", "amd64"} and (
+            capability >= CUDA_WHEEL_MIN_COMPUTE_CAPABILITY
+        ):
             return True
     return False
 

--- a/src/skulk/provisioning/tests/test_llama_server.py
+++ b/src/skulk/provisioning/tests/test_llama_server.py
@@ -121,6 +121,9 @@ def _never_install_wheels(  # pyright: ignore[reportUnusedFunction] - autouse
     def _no_install(installed_facts: object) -> bool:
         return False
 
+    # Existing synthetic NVIDIA facts model the established x86_64 wheel lane.
+    # Tests for the narrower arm64 kernel contract override this explicitly.
+    monkeypatch.setattr(provisioning.platform_module, "machine", lambda: "x86_64")
     monkeypatch.setattr(provisioning, "try_install_cuda_wheel", _no_install)
 
 
@@ -469,6 +472,30 @@ def test_cuda_capability_gate() -> None:
         provisioning._cuda_capability_ok(make_facts(gpus=(NVIDIA_PRESENCE_ONLY,)))
         is False
     )
+
+
+def test_cuda_capability_gate_on_arm64(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The arm64 package tag must not admit a GPU without a compiled kernel."""
+    from skulk.shared.types.node_facts import GpuDeviceFact
+
+    monkeypatch.setattr(provisioning.platform_module, "machine", lambda: "aarch64")
+    gb10 = GpuDeviceFact(
+        vendor="nvidia",
+        name="NVIDIA GB10",
+        detection_source="nvml",
+        vram_total_bytes=128 * 2**30,
+        compute_capability="12.1",
+    )
+    gh200 = GpuDeviceFact(
+        vendor="nvidia",
+        name="NVIDIA GH200",
+        detection_source="nvml",
+        vram_total_bytes=96 * 2**30,
+        compute_capability="9.0",
+    )
+
+    assert provisioning._cuda_capability_ok(make_facts(gpus=(gb10,))) is True
+    assert provisioning._cuda_capability_ok(make_facts(gpus=(gh200,))) is False
 
 
 def test_cuda_wheel_install_gates_on_capability_and_uv(

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -1006,7 +1006,8 @@ change ships:
    (scheme `0.<build>.<rev>`) and the engine workflow pin; the `engine-wheel`
    guard fails if either package, the workflow, the manifest, or the installer's
    derived-version wiring disagrees.
-3. Rebuild both wheels and publish them together (`engine-wheel` workflow,
+3. Rebuild the Vulkan wheel and both CUDA platform wheels (x86_64 and aarch64)
+   and publish them together (`engine-wheel` workflow,
    dispatch with `publish=true`). When the CUDA pod image pin also changes,
    rebuild it from the same source tag so its server and RPC donor cannot drift.
 4. Diagnose the new pin on a clean ephemeral NVIDIA target, then run the full

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -832,6 +832,9 @@ Vulkan loader bundled; the driver's ICD remains the one OS prerequisite).
 The aarch64 CUDA wheel is built natively with CUDA 12.9 for compute capability
 12.1, covering Grace Blackwell systems such as GB10; Python wheel tags keep it
 distinct from the x86_64 payload while both share the pinned engine version.
+Provisioning also checks that exact compute capability before adopting the
+ARM64 wheel, so another ARM64 NVIDIA system without an included kernel retains
+the verified Vulkan fallback instead of failing later during model load.
 An installed wheel is wired automatically, including its bundled
 `ggml-rpc-server` donor binary for multi-node GGUF. On an NVIDIA node with
 no usable CUDA wheel installed (a bare checkout or a GPU-cloud container

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -825,9 +825,13 @@ nodes the preferred managed source is a pip-installable engine wheel,
 built from the pinned upstream source in Skulk's own CI, published on
 Foxlight's own package index at `wheels.foxlight.ai`, and installed
 through the same standard tooling as every other dependency:
-`skulk-llama-server-cuda` on NVIDIA (CUDA runtime resolved from NVIDIA's
-official PyPI packages) and `skulk-llama-server-vulkan` on AMD (Khronos
+`skulk-llama-server-cuda` on NVIDIA (Linux x86_64 and aarch64 wheels; CUDA
+runtime resolved from NVIDIA's official PyPI packages) and
+`skulk-llama-server-vulkan` on AMD (Khronos
 Vulkan loader bundled; the driver's ICD remains the one OS prerequisite).
+The aarch64 CUDA wheel is built natively with CUDA 12.9 for compute capability
+12.1, covering Grace Blackwell systems such as GB10; Python wheel tags keep it
+distinct from the x86_64 payload while both share the pinned engine version.
 An installed wheel is wired automatically, including its bundled
 `ggml-rpc-server` donor binary for multi-node GGUF. On an NVIDIA node with
 no usable CUDA wheel installed (a bare checkout or a GPU-cloud container

--- a/website/docs/release-notes/next.md
+++ b/website/docs/release-notes/next.md
@@ -4,6 +4,13 @@ title: Next release
 sidebar_position: 0
 ---
 
+## Native CUDA serving on Linux ARM64
+
+The managed CUDA llama-server wheel now ships for Linux aarch64 as well as
+x86_64. The ARM64 lane is built natively with CUDA 12.9 for compute capability
+12.1, allowing Grace Blackwell and GB10 nodes to use the CUDA served engine
+instead of falling back to Vulkan.
+
 ## Skulk fabric identity and spoken answers
 
 Intelligent Fabric now appears as Skulk itself rather than as a separate


### PR DESCRIPTION
## Summary

- publish a native Linux ARM64 variant of the managed CUDA llama-server wheel
- target CUDA 12.9 and compute capability 12.1 for Grace Blackwell systems
- select architecture-specific wheel tags and NVIDIA runtime dependencies
- keep wheel publishing artifacts distinct across CUDA platforms
- document the expanded managed-engine platform contract

## Why

The managed CUDA package previously emitted only an x86_64 wheel. Linux ARM64 NVIDIA systems therefore could not use Skulk's preferred CUDA served-engine path and fell back to another backend despite having compatible CUDA hardware.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt` (0 changes)
- `uv run pytest` (3,505 passed, 2 skipped, 237 deselected)
- `uv run pytest src/skulk/provisioning/tests/test_llama_server.py` (32 passed)
- architecture tag contract exercised for x86_64, aarch64, arm64, and an unsupported target
- workflow YAML parsed locally

Provisioning admits the first ARM64 payload only on the exact `sm_121`
hardware it contains; other ARM64 NVIDIA systems retain the verified fallback.

The CI engine-wheel job is the authoritative compile, smoke-test, and provenance-attestation gate for the new ARM64 binary payload.
