### PR TITLE
Fix Grace Blackwell chip identity

### DIFF
--- a/src/skulk/utils/info_gatherer/nvidia_gpu.py
+++ b/src/skulk/utils/info_gatherer/nvidia_gpu.py
@@ -113,6 +113,29 @@ def _name_of(nvml: NvmlLike, handle: object) -> str:
     return raw.decode() if isinstance(raw, bytes) else raw
 
 
+def read_nvidia_device_name(nvml: NvmlLike) -> str | None:
+    """Return the normalized name of NVML device 0 when it is available.
+
+    This intentionally queries only the device handle and name. Static Linux
+    identity collection uses it as a fallback on ARM systems whose
+    ``/proc/cpuinfo`` omits the x86-style ``model name`` field, and should not
+    pay for or depend on live utilization, memory, power, or thermal metrics.
+
+    Args:
+        nvml: Initialized NVML-compatible collector surface.
+
+    Returns:
+        A non-empty device name, or ``None`` when NVML cannot identify a device.
+    """
+    try:
+        handle = nvml.nvmlDeviceGetHandleByIndex(0)
+        name = _name_of(nvml, handle).strip()
+    except Exception as exc:  # noqa: BLE001 - identity degrades independently
+        logger.debug(f"NVML device-name query failed: {exc}")
+        return None
+    return name if name and name.casefold() != "unknown" else None
+
+
 @final
 class _MemoryInfoLike:
     total: int

--- a/src/skulk/utils/info_gatherer/system_info.py
+++ b/src/skulk/utils/info_gatherer/system_info.py
@@ -8,6 +8,10 @@ import psutil
 from anyio import run_process
 
 from skulk.shared.types.profiling import InterfaceType, NetworkInterfaceInfo
+from skulk.utils.info_gatherer.nvidia_gpu import (
+    load_nvml,
+    read_nvidia_device_name,
+)
 
 # DMI fields are frequently populated with OEM placeholder junk; treat these
 # (case-insensitively) as "not set" so a node reports a real name or nothing.
@@ -264,14 +268,16 @@ async def get_network_interfaces() -> list[NetworkInterfaceInfo]:
 
 
 def _linux_model_and_chip() -> tuple[str, str]:
-    """Derive (model, chip) for a Linux node from sysfs/procfs (no subprocess).
+    """Derive (model, chip) for a Linux node without launching subprocesses.
 
     Model comes from DMI (``/sys/class/dmi/id``): the product name, falling back
     to the board name, prefixed with the vendor when it adds information (e.g.
     ``"Nimo Direct Inc. MME3L"``). Chip is the CPU brand string from
     ``/proc/cpuinfo`` (``"AMD RYZEN AI MAX+ 395 w/ Radeon 8060S"``), which on an
-    APU usefully also names the integrated GPU. Either falls back to the Mac-style
-    ``"Unknown Model"`` / ``"Unknown Chip"`` so callers stay uniform.
+    APU usefully also names the integrated GPU. ARM systems commonly omit that
+    x86-style field, so an available NVIDIA device name from the existing NVML
+    collector provides the chip identity instead. Either falls back to the
+    Mac-style ``"Unknown Model"`` / ``"Unknown Chip"`` so callers stay uniform.
     """
     dmi = "/sys/class/dmi/id"
     product = _clean_dmi(_read_text(f"{dmi}/product_name")) or _clean_dmi(
@@ -288,6 +294,10 @@ def _linux_model_and_chip() -> tuple[str, str]:
         if line.lower().startswith("model name"):
             chip = line.split(":", 1)[1].strip() or "Unknown Chip"
             break
+    if chip == "Unknown Chip":
+        nvml = load_nvml()
+        if nvml is not None:
+            chip = read_nvidia_device_name(nvml) or chip
     return (model, chip)
 
 

--- a/src/skulk/utils/info_gatherer/tests/test_linux_identity.py
+++ b/src/skulk/utils/info_gatherer/tests/test_linux_identity.py
@@ -29,7 +29,14 @@ def fake_files(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(system_info, "_read_text", fake_read_text)
 
 
-def test_linux_model_and_chip(fake_files: None) -> None:
+def test_linux_model_and_chip(
+    fake_files: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_nvml_is_loaded() -> None:
+        raise AssertionError("x86 CPU identity must take precedence over NVML")
+
+    monkeypatch.setattr(system_info, "load_nvml", fail_if_nvml_is_loaded)
     model, chip = system_info._linux_model_and_chip()
     assert model == "Nimo Direct Inc. MME3L"  # vendor prefixed onto product
     assert chip == "AMD RYZEN AI MAX+ 395 w/ Radeon 8060S"  # from /proc/cpuinfo
@@ -59,6 +66,42 @@ def test_linux_model_falls_back_to_board_then_unknown(
         return files.get(path, "")
 
     monkeypatch.setattr(system_info, "_read_text", fake_read_text)
+    monkeypatch.setattr(system_info, "load_nvml", lambda: None)
     model, chip = system_info._linux_model_and_chip()
     assert model == "NIMO Mini PC"  # vendor was junk, product junk -> board name
     assert chip == "Unknown Chip"
+
+
+def test_linux_arm_identity_falls_back_to_nvml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files = {
+        "/sys/class/dmi/id/product_name": "GX10",
+        "/sys/class/dmi/id/board_name": "GX10",
+        "/sys/class/dmi/id/sys_vendor": "ASUSTeK COMPUTER INC.",
+        "/proc/cpuinfo": (
+            "processor\t: 0\n"
+            "CPU implementer\t: 0x41\n"
+            "CPU part\t: 0xd85\n"
+        ),
+    }
+    nvml = object()
+
+    def fake_read_text(path: str) -> str:
+        return files.get(path, "")
+
+    def fake_nvidia_device_name(loaded_nvml: object) -> str | None:
+        return "NVIDIA GB10" if loaded_nvml is nvml else None
+
+    monkeypatch.setattr(system_info, "_read_text", fake_read_text)
+    monkeypatch.setattr(system_info, "load_nvml", lambda: nvml)
+    monkeypatch.setattr(
+        system_info,
+        "read_nvidia_device_name",
+        fake_nvidia_device_name,
+    )
+
+    model, chip = system_info._linux_model_and_chip()
+
+    assert model == "ASUSTeK COMPUTER INC. GX10"
+    assert chip == "NVIDIA GB10"

--- a/src/skulk/utils/info_gatherer/tests/test_nvidia_gpu.py
+++ b/src/skulk/utils/info_gatherer/tests/test_nvidia_gpu.py
@@ -9,6 +9,7 @@ import pytest
 from skulk.utils.info_gatherer.nvidia_gpu import (
     has_nvidia_gpu,
     read_accelerator_metrics,
+    read_nvidia_device_name,
     read_system_profile,
 )
 
@@ -131,6 +132,34 @@ def test_compute_capability_degrades_to_none() -> None:
 def test_bytes_name_decodes() -> None:
     metrics = read_accelerator_metrics(_FakeNvml(name=b"NVIDIA A5000"))
     assert metrics.name == "NVIDIA A5000"
+
+
+def test_device_name_reads_only_static_nvml_identity() -> None:
+    nvml = _FakeNvml(
+        broken={
+            "utilization",
+            "memory",
+            "power",
+            "temperature",
+            "clock",
+            "compute_capability",
+        },
+        name=b"NVIDIA GB10",
+    )
+
+    assert read_nvidia_device_name(nvml) == "NVIDIA GB10"
+
+
+@pytest.mark.parametrize("broken", [{"handle"}, {"name"}])
+def test_device_name_degrades_when_nvml_identity_is_unavailable(
+    broken: set[str],
+) -> None:
+    assert read_nvidia_device_name(_FakeNvml(broken=broken)) is None
+
+
+@pytest.mark.parametrize("name", ["", "  ", "Unknown", b"unknown"])
+def test_device_name_rejects_empty_or_unknown_values(name: str | bytes) -> None:
+    assert read_nvidia_device_name(_FakeNvml(name=name)) is None
 
 
 def test_per_field_degradation_never_blanks_the_rest() -> None:


### PR DESCRIPTION
## Summary
- use the existing NVML collector as a static chip-name fallback when ARM Linux omits `/proc/cpuinfo` `model name`
- preserve CPU identity precedence on conventional x86 Linux hosts
- degrade cleanly to `Unknown Chip` when NVML cannot identify a device

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (3563 passed, 2 skipped, 237 deselected)

## Documentation
No API or architecture contract changes; this corrects an existing static identity field.