### PR TITLE
Ground Steward answers in canonical operator truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,9 @@ platform gate bars them from `llama_server`. Repair builders re-stamp `system_ro
 exclusions). `TextGeneration.target_instance_id` pins generation to one
 instance (mirrors SpeechSynthesis). Harness = `src/skulk/api/steward.py`:
 bounded read-only tools (state/resources/telemetry/data-plane/versions/
-envelopes/doctor/catalog), 8 steps per turn, observe/advise only, rides the
+envelopes/doctor/catalog), with state normalized into exact heterogeneous
+node facts and non-overlapping placement/ready/terminal lifecycle buckets;
+8 steps per turn, observe/advise only, rides the
 normal chat dispatch path. Client surface = reserved virtual
 model `skulk/steward` on chat-completions (client tools 400; trace as
 reasoning_content; streaming via the ordinary adapters over

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -474,6 +474,11 @@ def _bounded(payload: object) -> str:
     return rendered
 
 
+def _compact_json(payload: object) -> str:
+    """Render one tool result as compact JSON without sacrificing validity."""
+    return json.dumps(payload, separators=(",", ":"), default=str)
+
+
 InstanceLifecycle = Literal[
     "placing", "loading", "warming", "ready", "running", "stopping", "failed"
 ]
@@ -581,6 +586,7 @@ def _node_summaries(state_payload: dict[str, object]) -> list[dict[str, object]]
         accelerator_vendor = accelerator.get("vendor")
         if isinstance(accelerator_vendor, str):
             capability_tokens.add(accelerator_vendor.lower())
+        has_capability_evidence = bool(resources or accelerator)
         total_bytes = _memory_bytes(memory.get("ramTotal"))
         available_bytes = _memory_bytes(memory.get("ramAvailable"))
         summaries.append(
@@ -615,19 +621,25 @@ def _node_summaries(state_payload: dict[str, object]) -> list[dict[str, object]]
                 "hardwareClasses": hardware_classes,
                 "participation": resources.get("participation"),
                 "supports": {
-                    "cuda": any(
+                    "cuda": None
+                    if not has_capability_evidence
+                    else any(
                         token == "nvidia"
                         or token.startswith("nvidia:")
                         or "cuda" in token
                         for token in capability_tokens
                     ),
-                    "rocm": any(
+                    "rocm": None
+                    if not has_capability_evidence
+                    else any(
                         token == "amd"
                         or token.startswith("amd:")
                         or "rocm" in token
                         for token in capability_tokens
                     ),
-                    "mlx": any(
+                    "mlx": None
+                    if not has_capability_evidence
+                    else any(
                         token == "apple"
                         or token.startswith(("apple:", "mlx"))
                         for token in capability_tokens
@@ -731,6 +743,132 @@ def steward_operator_summary(state_payload: dict[str, object]) -> dict[str, obje
         "downloads": _downloads_summary(state_payload),
         "nodeDisk": state_payload.get("nodeDisk", {}),
     }
+
+
+def _compact_node_summary(node: dict[str, object]) -> dict[str, object]:
+    """Keep the exact node facts most useful to operator questions."""
+    health = _as_object_dict(node.get("health"))
+    return {
+        key: node.get(key)
+        for key in ("nodeId", "name", "model", "chip")
+    } | {
+        "health": {"level": health.get("level")},
+        "memory": node.get("memory"),
+        "accelerator": node.get("accelerator"),
+        "backends": node.get("backends"),
+        "supports": node.get("supports"),
+    }
+
+
+def steward_operator_tool_result(state_payload: dict[str, object]) -> str:
+    """Render authoritative operator truth within the steward tool budget.
+
+    The complete compact record is preferred. If it is still too large, the
+    fallback reserves space for every lifecycle bucket before adding compact
+    node and download rows. Coverage counts make every omission explicit, and
+    the result always remains valid JSON rather than ending inside a record.
+
+    Args:
+        state_payload: JSON-compatible cluster state returned by the API.
+
+    Returns:
+        A valid JSON document no longer than :data:`MAX_TOOL_RESULT_CHARS`.
+    """
+    summary = steward_operator_summary(state_payload)
+    rendered = _compact_json(summary)
+    if len(rendered) <= MAX_TOOL_RESULT_CHARS:
+        return rendered
+
+    list_fields = (
+        "activePlacements",
+        "readyOrRunningInstances",
+        "stoppingOrFailedInstances",
+        "recentInstanceFailures",
+    )
+    nodes = [
+        _compact_node_summary(node)
+        for item in _as_object_list(summary.get("nodes"))
+        if (node := _as_object_dict(item))
+    ]
+    downloads = _as_object_dict(summary.get("downloads"))
+    node_disk = _as_object_dict(summary.get("nodeDisk"))
+    total_downloads = sum(
+        len(_as_object_list(rows)) for rows in downloads.values()
+    )
+    coverage: dict[str, object] = {
+        field: {
+            "included": 0,
+            "total": len(_as_object_list(summary.get(field))),
+        }
+        for field in list_fields
+    }
+    coverage["nodes"] = {"included": 0, "total": len(nodes)}
+    coverage["downloads"] = {
+        "included": 0,
+        "total": total_downloads,
+    }
+    coverage["nodeDisk"] = {"included": 0, "total": len(node_disk)}
+    compact: dict[str, object] = {
+        "nodeCount": summary.get("nodeCount"),
+        "detailState": "compacted",
+        "coverage": coverage,
+        **{field: [] for field in list_fields},
+        "nodes": [],
+        "downloads": {},
+        "nodeDisk": {},
+    }
+
+    def append_list_row(field: str, row: object) -> bool:
+        target = _as_object_list(compact[field])
+        compact[field] = target
+        field_coverage = _as_object_dict(coverage[field])
+        target.append(row)
+        field_coverage["included"] = len(target)
+        if len(_compact_json(compact)) <= MAX_TOOL_RESULT_CHARS:
+            return True
+        target.pop()
+        field_coverage["included"] = len(target)
+        return False
+
+    # Lifecycle truth answers the most important operator questions and must
+    # never disappear behind a large node table.
+    for field in list_fields:
+        for row in _as_object_list(summary.get(field)):
+            if not append_list_row(field, row):
+                break
+    for node in nodes:
+        if not append_list_row("nodes", node):
+            break
+
+    compact_downloads = cast("dict[str, object]", compact["downloads"])
+    download_coverage = _as_object_dict(coverage["downloads"])
+    included_downloads = 0
+    download_limit_reached = False
+    for node_id, rows in downloads.items():
+        compact_downloads[node_id] = []
+        target_rows = _as_object_list(compact_downloads[node_id])
+        compact_downloads[node_id] = target_rows
+        for row in _as_object_list(rows):
+            target_rows.append(row)
+            download_coverage["included"] = included_downloads + 1
+            if len(_compact_json(compact)) > MAX_TOOL_RESULT_CHARS:
+                target_rows.pop()
+                download_coverage["included"] = included_downloads
+                download_limit_reached = True
+                break
+            included_downloads += 1
+        if not target_rows:
+            del compact_downloads[node_id]
+        if download_limit_reached:
+            break
+
+    compact["nodeDisk"] = node_disk
+    node_disk_coverage = _as_object_dict(coverage["nodeDisk"])
+    node_disk_coverage["included"] = len(node_disk)
+    if len(_compact_json(compact)) > MAX_TOOL_RESULT_CHARS:
+        compact["nodeDisk"] = {}
+        node_disk_coverage["included"] = 0
+    return _compact_json(compact)
 
 
 _FUNCTION_BLOCK = re.compile(r"<function=([\w.-]+)>(.*?)</function>", re.DOTALL)
@@ -964,7 +1102,7 @@ class StewardHarness:
         api = self._api
         if name == "get_cluster_state":
             payload = await api.get_cluster_state()
-            return _bounded(steward_operator_summary(payload))
+            return steward_operator_tool_result(payload)
         if name == "get_node_resources":
             payload = await api.get_cluster_state()
             nodes = _as_object_dict(payload.get("nodeResources"))

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -145,6 +145,10 @@ Rules:
   search_docs is the primary source.
 - Call ONE tool at a time and read its result before deciding the next step.
 - Evidence means concrete observed values from tool results, not guesses.
+- Treat the tool's nodeCount, memory values, capability booleans, and lifecycle
+  buckets as authoritative. Copy them exactly; never infer a missing value.
+- "Placing" means only the entries in activePlacements. Ready or running
+  instances are already placed and must not be described as placing.
 - If everything is healthy, say so; do not invent problems.
 - In this interface you can only observe and advise. You cannot change your
   cluster; when
@@ -160,9 +164,10 @@ def steward_tool_definitions() -> list[dict[str, Any]]:
         (
             "get_cluster_state",
             "Fetch the cluster's authoritative state summary: nodes with "
-            "health reasons, model instances and their placement, recent "
-            "terminal instance failures, and download records. This is the "
-            "first thing to look at.",
+            "exact identity, memory, accelerator and backend facts; model "
+            "instances split into active placement versus ready/running "
+            "lifecycle buckets; recent terminal failures; and typed download "
+            "records. This is the first thing to look at.",
             no_args,
         ),
         (
@@ -469,8 +474,55 @@ def _bounded(payload: object) -> str:
     return rendered
 
 
+InstanceLifecycle = Literal[
+    "placing", "loading", "warming", "ready", "running", "stopping", "failed"
+]
+
+
+def _tagged_kind(value: object) -> str:
+    """Return the discriminant of one JSON-encoded ``TaggedModel`` value."""
+    return next(iter(_as_object_dict(value)), "")
+
+
+def _memory_bytes(value: object) -> int | None:
+    """Read a ``Memory`` JSON value without inventing zero for missing data."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    payload = _as_object_dict(value)
+    raw = payload.get("inBytes", payload.get("in_bytes"))
+    return raw if isinstance(raw, int) and not isinstance(raw, bool) else None
+
+
+def _instance_lifecycle(
+    instance: dict[str, object], state_payload: dict[str, object]
+) -> tuple[InstanceLifecycle, dict[str, str]]:
+    """Derive one instance lifecycle from its authoritative runner statuses."""
+    assignments = _as_object_dict(instance.get("shardAssignments"))
+    runners = _as_object_dict(state_payload.get("runners"))
+    runner_states: dict[str, str] = {}
+    for node_id, runner_id in _as_object_dict(
+        assignments.get("nodeToRunner")
+    ).items():
+        if isinstance(runner_id, str):
+            runner_states[node_id] = _tagged_kind(runners.get(runner_id)) or "Missing"
+    kinds = tuple(runner_states.values())
+    if any(kind == "RunnerFailed" for kind in kinds):
+        return "failed", runner_states
+    if any(kind in {"RunnerShuttingDown", "RunnerShutdown"} for kind in kinds):
+        return "stopping", runner_states
+    if any(kind in {"RunnerLoading", "RunnerLoaded"} for kind in kinds):
+        return "loading", runner_states
+    if any(kind == "RunnerWarmingUp" for kind in kinds):
+        return "warming", runner_states
+    if kinds and all(kind in {"RunnerReady", "RunnerRunning"} for kind in kinds):
+        return (
+            "running" if any(kind == "RunnerRunning" for kind in kinds) else "ready"
+        ), runner_states
+    return "placing", runner_states
+
+
 def _instances_summary(state_payload: dict[str, object]) -> list[dict[str, object]]:
-    """Compact instance listing for the steward's context window."""
+    """Compact instance listing with explicit, non-overlapping lifecycle truth."""
     summary: list[dict[str, object]] = []
     for instance_id, envelope in _as_object_dict(
         state_payload.get("instances")
@@ -478,6 +530,7 @@ def _instances_summary(state_payload: dict[str, object]) -> list[dict[str, objec
         for kind, body_obj in _as_object_dict(envelope).items():
             body = _as_object_dict(body_obj)
             assignments = _as_object_dict(body.get("shardAssignments"))
+            lifecycle, runner_states = _instance_lifecycle(body, state_payload)
             summary.append(
                 {
                     "instanceId": instance_id,
@@ -485,9 +538,104 @@ def _instances_summary(state_payload: dict[str, object]) -> list[dict[str, objec
                     "modelId": assignments.get("modelId"),
                     "nodes": sorted(_as_object_dict(assignments.get("nodeToRunner"))),
                     "systemRole": body.get("systemRole"),
+                    "lifecycle": lifecycle,
+                    "runnerStates": runner_states,
                 }
             )
     return summary
+
+
+def _node_summaries(state_payload: dict[str, object]) -> list[dict[str, object]]:
+    """Project exact heterogeneous-node facts into a compact operator table."""
+    topology = _as_object_dict(state_payload.get("topology"))
+    topology_nodes = [
+        node_id
+        for node_id in _as_object_list(topology.get("nodes"))
+        if isinstance(node_id, str)
+    ]
+    identities = _as_object_dict(state_payload.get("nodeIdentities"))
+    memory_by_node = _as_object_dict(state_payload.get("nodeMemory"))
+    system_by_node = _as_object_dict(state_payload.get("nodeSystem"))
+    resources_by_node = _as_object_dict(state_payload.get("nodeResources"))
+    health_by_node = _as_object_dict(state_payload.get("nodeHealth"))
+    summaries: list[dict[str, object]] = []
+    for node_id in topology_nodes:
+        identity = _as_object_dict(identities.get(node_id))
+        memory = _as_object_dict(memory_by_node.get(node_id))
+        system = _as_object_dict(system_by_node.get(node_id))
+        accelerator = _as_object_dict(system.get("accelerator"))
+        resources = _as_object_dict(resources_by_node.get(node_id))
+        backends = sorted(
+            item
+            for item in _as_object_list(resources.get("backends"))
+            if isinstance(item, str)
+        )
+        hardware_classes = sorted(
+            item
+            for item in _as_object_list(resources.get("hardwareClasses"))
+            if isinstance(item, str)
+        )
+        capability_tokens = {
+            item.lower() for item in (*backends, *hardware_classes)
+        }
+        accelerator_vendor = accelerator.get("vendor")
+        if isinstance(accelerator_vendor, str):
+            capability_tokens.add(accelerator_vendor.lower())
+        total_bytes = _memory_bytes(memory.get("ramTotal"))
+        available_bytes = _memory_bytes(memory.get("ramAvailable"))
+        summaries.append(
+            {
+                "nodeId": node_id,
+                "name": identity.get("friendlyName"),
+                "model": identity.get("modelId"),
+                "chip": identity.get("chipId"),
+                "operatingSystem": identity.get("osVersion"),
+                "health": _as_object_dict(health_by_node.get(node_id)),
+                "memory": {
+                    "ramTotalBytes": total_bytes,
+                    "ramTotalGiB": None
+                    if total_bytes is None
+                    else round(total_bytes / (1024**3), 1),
+                    "ramAvailableBytes": available_bytes,
+                    "ramAvailableGiB": None
+                    if available_bytes is None
+                    else round(available_bytes / (1024**3), 1),
+                },
+                "accelerator": {
+                    key: accelerator.get(key)
+                    for key in (
+                        "vendor",
+                        "name",
+                        "computeCapability",
+                        "nativeFp4",
+                        "nativeFp8",
+                    )
+                },
+                "backends": backends,
+                "hardwareClasses": hardware_classes,
+                "participation": resources.get("participation"),
+                "supports": {
+                    "cuda": any(
+                        token == "nvidia"
+                        or token.startswith("nvidia:")
+                        or "cuda" in token
+                        for token in capability_tokens
+                    ),
+                    "rocm": any(
+                        token == "amd"
+                        or token.startswith("amd:")
+                        or "rocm" in token
+                        for token in capability_tokens
+                    ),
+                    "mlx": any(
+                        token == "apple"
+                        or token.startswith(("apple:", "mlx"))
+                        for token in capability_tokens
+                    ),
+                },
+            }
+        )
+    return summaries
 
 
 def _instance_failures_summary(
@@ -516,14 +664,24 @@ def _instance_failures_summary(
 
 
 def _downloads_summary(state_payload: dict[str, object]) -> dict[str, object]:
-    """Compact download listing keeping error and progress essentials."""
+    """Compact downloads while explicitly separating live from terminal state."""
     summary: dict[str, object] = {}
     for node_id, entries in _as_object_dict(state_payload.get("downloads")).items():
         rows: list[dict[str, object]] = []
         for envelope in _as_object_list(entries):
             for kind, body_obj in _as_object_dict(envelope).items():
                 body = _as_object_dict(body_obj)
-                row: dict[str, object] = {"kind": kind}
+                lifecycle = {
+                    "DownloadPending": "pending",
+                    "DownloadOngoing": "downloading",
+                    "DownloadCompleted": "completed",
+                    "DownloadFailed": "failed",
+                }.get(kind, "unknown")
+                row: dict[str, object] = {
+                    "kind": kind,
+                    "lifecycle": lifecycle,
+                    "active": lifecycle in {"pending", "downloading"},
+                }
                 # The model id lives on the shard's card; without it a node
                 # staging several models gives the steward ambiguous rows.
                 shard_envelope = _as_object_dict(body.get("shardMetadata"))
@@ -545,6 +703,34 @@ def _downloads_summary(state_payload: dict[str, object]) -> dict[str, object]:
         if rows:
             summary[node_id] = rows
     return summary
+
+
+def steward_operator_summary(state_payload: dict[str, object]) -> dict[str, object]:
+    """Build the complete factual record supplied to the fabric resident."""
+    instances = _instances_summary(state_payload)
+    nodes = _node_summaries(state_payload)
+    return {
+        "nodeCount": len(nodes),
+        "nodes": nodes,
+        "activePlacements": [
+            instance
+            for instance in instances
+            if instance.get("lifecycle") in {"placing", "loading", "warming"}
+        ],
+        "readyOrRunningInstances": [
+            instance
+            for instance in instances
+            if instance.get("lifecycle") in {"ready", "running"}
+        ],
+        "stoppingOrFailedInstances": [
+            instance
+            for instance in instances
+            if instance.get("lifecycle") in {"stopping", "failed"}
+        ],
+        "recentInstanceFailures": _instance_failures_summary(state_payload),
+        "downloads": _downloads_summary(state_payload),
+        "nodeDisk": state_payload.get("nodeDisk", {}),
+    }
 
 
 _FUNCTION_BLOCK = re.compile(r"<function=([\w.-]+)>(.*?)</function>", re.DOTALL)
@@ -778,19 +964,7 @@ class StewardHarness:
         api = self._api
         if name == "get_cluster_state":
             payload = await api.get_cluster_state()
-            return _bounded(
-                {
-                    "nodeHealth": payload.get("nodeHealth", {}),
-                    "instances": _instances_summary(payload),
-                    "recentInstanceFailures": _instance_failures_summary(payload),
-                    "downloads": _downloads_summary(payload),
-                    "nodeIdentities": payload.get("nodeIdentities", {}),
-                    "nodeDisk": payload.get("nodeDisk", {}),
-                    "topologyNodes": _as_object_dict(payload.get("topology")).get(
-                        "nodes", []
-                    ),
-                }
-            )
+            return _bounded(steward_operator_summary(payload))
         if name == "get_node_resources":
             payload = await api.get_cluster_state()
             nodes = _as_object_dict(payload.get("nodeResources"))

--- a/src/skulk/api/tests/test_steward_operator_grounding.py
+++ b/src/skulk/api/tests/test_steward_operator_grounding.py
@@ -1,0 +1,182 @@
+"""Regression coverage for the fabric resident's factual operator projection."""
+
+from typing import cast
+
+from skulk.api.steward import steward_operator_summary
+
+
+def _instance(
+    *, model_id: str, node_to_runner: dict[str, str], system_role: str | None = None
+) -> dict[str, object]:
+    return {
+        "MlxRingInstance": {
+            "instanceId": f"instance-{model_id}",
+            "shardAssignments": {
+                "modelId": model_id,
+                "nodeToRunner": node_to_runner,
+                "runnerToShard": {},
+            },
+            "systemRole": system_role,
+        }
+    }
+
+
+def test_operator_summary_preserves_heterogeneous_node_truth() -> None:
+    payload: dict[str, object] = {
+        "topology": {"nodes": ["apple-node", "amd-node", "cuda-node"]},
+        "nodeIdentities": {
+            "apple-node": {
+                "friendlyName": "Apple",
+                "modelId": "Mac mini",
+                "chipId": "Apple M4",
+                "osVersion": "macOS",
+            },
+            "amd-node": {
+                "friendlyName": "AMD",
+                "modelId": "AI workstation",
+                "chipId": "AMD Ryzen AI MAX+ 395",
+                "osVersion": "Linux",
+            },
+            "cuda-node": {
+                "friendlyName": "CUDA",
+                "modelId": "GX10",
+                "chipId": "NVIDIA GB10",
+                "osVersion": "Linux",
+            },
+        },
+        "nodeMemory": {
+            "apple-node": {
+                "ramTotal": {"inBytes": 16 * 1024**3},
+                "ramAvailable": {"inBytes": 8 * 1024**3},
+            },
+            "amd-node": {
+                "ramTotal": {"inBytes": 128 * 1024**3},
+                "ramAvailable": {"inBytes": 96 * 1024**3},
+            },
+            "cuda-node": {
+                "ramTotal": {"inBytes": 128 * 1024**3},
+                "ramAvailable": {"inBytes": 112 * 1024**3},
+            },
+        },
+        "nodeSystem": {
+            "apple-node": {"accelerator": {"vendor": "apple", "name": "M4"}},
+            "amd-node": {"accelerator": {"vendor": "amd", "name": "Radeon 8060S"}},
+            "cuda-node": {
+                "accelerator": {
+                    "vendor": "nvidia",
+                    "name": "NVIDIA GB10",
+                    "computeCapability": "12.1",
+                    "nativeFp4": True,
+                    "nativeFp8": True,
+                }
+            },
+        },
+        "nodeResources": {
+            "apple-node": {
+                "backends": ["mlx"],
+                "hardwareClasses": ["apple", "apple:m4"],
+                "participation": "full",
+            },
+            "amd-node": {
+                "backends": ["llama_server-rocm"],
+                "hardwareClasses": ["amd", "amd:amd-gpu"],
+                "participation": "full",
+            },
+            "cuda-node": {
+                "backends": ["llama_server-cuda"],
+                "hardwareClasses": ["nvidia", "nvidia:nvidia-gb10", "nvidia:sm-12.1"],
+                "participation": "full",
+            },
+        },
+        "nodeHealth": {
+            "apple-node": {"level": "healthy"},
+            "amd-node": {"level": "healthy"},
+            "cuda-node": {"level": "healthy"},
+        },
+    }
+
+    summary = steward_operator_summary(payload)
+
+    assert summary["nodeCount"] == 3
+    nodes = cast("list[dict[str, object]]", summary["nodes"])
+    by_id = {cast(str, node["nodeId"]): node for node in nodes}
+    assert by_id["apple-node"]["chip"] == "Apple M4"
+    assert by_id["amd-node"]["chip"] == "AMD Ryzen AI MAX+ 395"
+    assert by_id["cuda-node"]["chip"] == "NVIDIA GB10"
+    assert cast("dict[str, object]", by_id["amd-node"]["memory"])["ramTotalGiB"] == 128.0
+    assert cast("dict[str, object]", by_id["cuda-node"]["supports"]) == {
+        "cuda": True,
+        "rocm": False,
+        "mlx": False,
+    }
+    assert cast("dict[str, object]", by_id["amd-node"]["supports"])["rocm"] is True
+    assert cast("dict[str, object]", by_id["apple-node"]["supports"])["mlx"] is True
+
+
+def test_operator_summary_separates_active_placement_from_ready_instances() -> None:
+    payload: dict[str, object] = {
+        "topology": {"nodes": ["node-a", "node-b"]},
+        "instances": {
+            "placing": _instance(
+                model_id="org/placing-model", node_to_runner={"node-a": "runner-loading"}
+            ),
+            "ready": _instance(
+                model_id="org/ready-model", node_to_runner={"node-b": "runner-ready"}
+            ),
+        },
+        "runners": {
+            "runner-loading": {"RunnerLoading": {"layersLoaded": 2, "totalLayers": 20}},
+            "runner-ready": {"RunnerReady": {}},
+        },
+    }
+
+    summary = steward_operator_summary(payload)
+
+    active = cast("list[dict[str, object]]", summary["activePlacements"])
+    ready = cast("list[dict[str, object]]", summary["readyOrRunningInstances"])
+    assert [(row["modelId"], row["lifecycle"]) for row in active] == [
+        ("org/placing-model", "loading")
+    ]
+    assert [(row["modelId"], row["lifecycle"]) for row in ready] == [
+        ("org/ready-model", "ready")
+    ]
+
+
+def test_operator_summary_marks_terminal_downloads_inactive() -> None:
+    payload: dict[str, object] = {
+        "topology": {"nodes": ["node-a"]},
+        "downloads": {
+            "node-a": [
+                {
+                    "DownloadCompleted": {
+                        "shardMetadata": {
+                            "MlxShardMetadata": {
+                                "modelCard": {"modelId": "org/already-downloaded"}
+                            }
+                        }
+                    }
+                },
+                {
+                    "DownloadOngoing": {
+                        "shardMetadata": {
+                            "MlxShardMetadata": {
+                                "modelCard": {"modelId": "org/downloading-now"}
+                            }
+                        },
+                        "downloadProgress": {
+                            "downloaded": {"inBytes": 5},
+                            "total": {"inBytes": 10},
+                            "etaMs": 1000,
+                        },
+                    }
+                },
+            ]
+        },
+    }
+
+    summary = steward_operator_summary(payload)
+    downloads = cast("dict[str, list[dict[str, object]]]", summary["downloads"])
+    assert [(row["modelId"], row["lifecycle"], row["active"]) for row in downloads["node-a"]] == [
+        ("org/already-downloaded", "completed", False),
+        ("org/downloading-now", "downloading", True),
+    ]

--- a/src/skulk/api/tests/test_steward_operator_grounding.py
+++ b/src/skulk/api/tests/test_steward_operator_grounding.py
@@ -1,8 +1,13 @@
 """Regression coverage for the fabric resident's factual operator projection."""
 
+import json
 from typing import cast
 
-from skulk.api.steward import steward_operator_summary
+from skulk.api.steward import (
+    MAX_TOOL_RESULT_CHARS,
+    steward_operator_summary,
+    steward_operator_tool_result,
+)
 
 
 def _instance(
@@ -113,6 +118,27 @@ def test_operator_summary_preserves_heterogeneous_node_truth() -> None:
     assert cast("dict[str, object]", by_id["apple-node"]["supports"])["mlx"] is True
 
 
+def test_operator_summary_does_not_invent_negative_capability_truth() -> None:
+    payload: dict[str, object] = {
+        "topology": {"nodes": ["joining-node"]},
+        "nodeIdentities": {
+            "joining-node": {
+                "friendlyName": "Joining",
+                "modelId": "Unknown workstation",
+            }
+        },
+    }
+
+    summary = steward_operator_summary(payload)
+
+    nodes = cast("list[dict[str, object]]", summary["nodes"])
+    assert cast("dict[str, object]", nodes[0]["supports"]) == {
+        "cuda": None,
+        "rocm": None,
+        "mlx": None,
+    }
+
+
 def test_operator_summary_separates_active_placement_from_ready_instances() -> None:
     payload: dict[str, object] = {
         "topology": {"nodes": ["node-a", "node-b"]},
@@ -180,3 +206,79 @@ def test_operator_summary_marks_terminal_downloads_inactive() -> None:
         ("org/already-downloaded", "completed", False),
         ("org/downloading-now", "downloading", True),
     ]
+
+
+def test_operator_tool_result_preserves_lifecycle_truth_when_nodes_are_large() -> None:
+    node_ids = [f"node-{index}" for index in range(12)]
+    payload: dict[str, object] = {
+        "topology": {"nodes": node_ids},
+        "nodeIdentities": {
+            node_id: {
+                "friendlyName": f"Detailed node {index} " + "x" * 180,
+                "modelId": "Workstation " + "y" * 180,
+                "chipId": "Heterogeneous accelerator " + "z" * 180,
+                "osVersion": "Linux distribution with extensive build metadata " + "v" * 180,
+            }
+            for index, node_id in enumerate(node_ids)
+        },
+        "nodeResources": {
+            node_id: {
+                "backends": ["llama_server-cuda", "llama_cpp-cpu"],
+                "hardwareClasses": ["nvidia", "nvidia:sm-12.1"],
+                "participation": "full",
+            }
+            for node_id in node_ids
+        },
+        "instances": {
+            "placing": _instance(
+                model_id="org/model-being-placed",
+                node_to_runner={"node-0": "runner-loading"},
+            ),
+            "ready": _instance(
+                model_id="org/model-ready",
+                node_to_runner={"node-1": "runner-ready"},
+            ),
+        },
+        "runners": {
+            "runner-loading": {"RunnerLoading": {}},
+            "runner-ready": {"RunnerReady": {}},
+        },
+    }
+
+    rendered = steward_operator_tool_result(payload)
+    result = cast("dict[str, object]", json.loads(rendered))
+
+    assert len(rendered) <= MAX_TOOL_RESULT_CHARS
+    assert result["detailState"] == "compacted"
+    assert result["nodeCount"] == 12
+    active = cast("list[dict[str, object]]", result["activePlacements"])
+    ready = cast("list[dict[str, object]]", result["readyOrRunningInstances"])
+    assert [(row["modelId"], row["lifecycle"]) for row in active] == [
+        ("org/model-being-placed", "loading")
+    ]
+    assert [(row["modelId"], row["lifecycle"]) for row in ready] == [
+        ("org/model-ready", "ready")
+    ]
+    coverage = cast("dict[str, dict[str, int]]", result["coverage"])
+    assert coverage["nodes"]["total"] == 12
+
+
+def test_operator_tool_result_keeps_downloads_from_multiple_nodes() -> None:
+    payload: dict[str, object] = {
+        "topology": {"nodes": ["node-a", "node-b"]},
+        "downloads": {
+            "node-a": [{"DownloadPending": {}}],
+            "node-b": [{"DownloadPending": {}}],
+        },
+        # Force the bounded representation without competing with the compact
+        # rows whose cross-node behavior this regression covers.
+        "nodeDisk": {"diagnostic": "x" * MAX_TOOL_RESULT_CHARS},
+    }
+
+    rendered = steward_operator_tool_result(payload)
+    result = cast("dict[str, object]", json.loads(rendered))
+
+    downloads = cast("dict[str, list[dict[str, object]]]", result["downloads"])
+    assert sorted(downloads) == ["node-a", "node-b"]
+    coverage = cast("dict[str, dict[str, int]]", result["coverage"])
+    assert coverage["downloads"] == {"included": 2, "total": 2}

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -124,7 +124,9 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 - Pinning: `TextGeneration.target_instance_id` (mirrors SpeechSynthesis);
   miss emits TaskFailed `instance_unavailable`.
 - Harness: `src/skulk/api/steward.py`. Read-only tools: cluster state
-  summary, node resources, telemetry diagnostics, data-plane diagnostics,
+  summary (exact node count; per-node identity, RAM, accelerator, backends,
+  and CUDA/ROCm/MLX support; separate active-placement, ready/running, and
+  stopping/failed lifecycle buckets), node resources, telemetry diagnostics, data-plane diagnostics,
   cluster versions, performance envelopes, local doctor registry, model
   catalog, and `search_docs` (steward_docs.py: dependency-free tf-idf
   section index over the checkout's own docs, anchored on

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -733,7 +733,10 @@ endpoint using the reserved virtual model id `skulk/steward`, streaming
 included, so any OpenAI-compatible client can talk to the cluster with no
 steward-specific integration. The reserved id selects the model plus the
 server-side harness: a bounded, strictly read-only tool surface (cluster
-state with health reasons, per-node resources and capability conflicts,
+state normalized into an exact node count, heterogeneous identity, RAM,
+accelerator, backend, and capability facts plus mutually exclusive active
+placement, ready/running, and stopping/failed instance lifecycle buckets;
+health reasons and capability conflicts;
 telemetry and data-plane diagnostics, per-node version status, performance
 envelopes, the local doctor check registry, the model catalog, and a
 search over Skulk's own bundled documentation so what-is and how-to
@@ -765,6 +768,9 @@ probe already shows up in the status as a degraded steward, well before the
 third one triggers the replacement. In this release
 the steward observes and advises only: no tool can change the cluster, and
 anything action-shaped is returned to the operator as a recommendation.
+The normalized operator record is deliberately deterministic: the resident
+copies counts and measurements rather than reconstructing them from prose, and
+"placing" never includes an already-ready or running instance.
 
 The role name remains internal plumbing (`system_role: "steward"`,
 `skulk/steward`, and `GET /v1/steward`). Product surfaces instead let an


### PR DESCRIPTION
## Summary

- project exact node count, hardware, memory, accelerator, backend, and participation truth for Steward tools
- derive explicit instance lifecycle and keep active placements separate from ready, running, stopping, and failed instances
- expose active versus terminal download lifecycle without asking the model to infer it
- document the operator-truth projection and add heterogeneous-cluster regression coverage

## Root cause

The Steward tool projection omitted canonical node memory and system details and collapsed runtime lifecycle into an underspecified instance list. The model therefore had to infer cluster facts that Skulk already knew, causing incorrect hardware, memory, capability, and placement answers.

## Validation

- uv run basedpyright
- uv run ruff check
- nix fmt
- git diff --check
- uv run pytest -q
- 3,566 passed, 2 skipped, 237 deselected