### PR TITLE
Separate steward current and historical runtime truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,7 +327,9 @@ exclusions). `TextGeneration.target_instance_id` pins generation to one
 instance (mirrors SpeechSynthesis). Harness = `src/skulk/api/steward.py`:
 bounded read-only tools (state/resources/telemetry/data-plane/versions/
 envelopes/doctor/catalog), with state normalized into exact heterogeneous
-node facts and non-overlapping placement/ready/terminal lifecycle buckets;
+node facts, non-overlapping operator placement/ready/terminal lifecycle
+buckets, a separate internal-service bucket, and explicitly historical
+terminal failures;
 8 steps per turn, observe/advise only, rides the
 normal chat dispatch path. Client surface = reserved virtual
 model `skulk/steward` on chat-completions (client tools 400; trace as

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -147,8 +147,17 @@ Rules:
 - Evidence means concrete observed values from tool results, not guesses.
 - Treat the tool's nodeCount, memory values, capability booleans, and lifecycle
   buckets as authoritative. Copy them exactly; never infer a missing value.
-- "Placing" means only the entries in activePlacements. Ready or running
-  instances are already placed and must not be described as placing.
+- The latest tool result supersedes model memory and earlier conversation
+  claims about cluster state.
+- Current operator-managed model instances exist ONLY in the three fields whose
+  names begin with "operator". An empty operator field means there are none.
+- "Placing" means only the entries in operatorActivePlacements. Ready or
+  running instances are already placed and must not be described as placing.
+- fabricSystemInstances are internal services, not operator-placed models. Do
+  not count them as active operator models unless explicitly asked about
+  internal fabric services.
+- historicalTerminalFailures are retained past events, never current instances.
+  Do not report a model from this field as placed, running, or active.
 - If everything is healthy, say so; do not invent problems.
 - In this interface you can only observe and advise. You cannot change your
   cluster; when
@@ -165,9 +174,10 @@ def steward_tool_definitions() -> list[dict[str, Any]]:
             "get_cluster_state",
             "Fetch the cluster's authoritative state summary: nodes with "
             "exact identity, memory, accelerator and backend facts; model "
-            "instances split into active placement versus ready/running "
-            "lifecycle buckets; recent terminal failures; and typed download "
-            "records. This is the first thing to look at.",
+            "instances split into current operator lifecycle buckets versus "
+            "internal fabric services; explicitly historical terminal "
+            "failures; and typed download records. This is the first thing "
+            "to look at, and it supersedes earlier conversation claims.",
             no_args,
         ),
         (
@@ -653,23 +663,27 @@ def _node_summaries(state_payload: dict[str, object]) -> list[dict[str, object]]
 def _instance_failures_summary(
     state_payload: dict[str, object],
 ) -> list[dict[str, object]]:
-    """Compact retained failure truth so vanished placements remain explainable."""
+    """Compact retained failures while marking them as non-current history."""
     summary: list[dict[str, object]] = []
     for item in _as_object_list(state_payload.get("instanceFailures")):
         failure = _as_object_dict(item)
         summary.append(
             {
-                key: failure.get(key)
-                for key in (
-                    "instanceId",
-                    "modelId",
-                    "systemRole",
-                    "errorCode",
-                    "errorMessage",
-                    "affectedNodeIds",
-                    "recordedAt",
-                )
-                if failure.get(key) is not None
+                "historical": True,
+                "currentInstance": False,
+                **{
+                    key: failure.get(key)
+                    for key in (
+                        "instanceId",
+                        "modelId",
+                        "systemRole",
+                        "errorCode",
+                        "errorMessage",
+                        "affectedNodeIds",
+                        "recordedAt",
+                    )
+                    if failure.get(key) is not None
+                },
             }
         )
     return summary
@@ -718,28 +732,35 @@ def _downloads_summary(state_payload: dict[str, object]) -> dict[str, object]:
 
 
 def steward_operator_summary(state_payload: dict[str, object]) -> dict[str, object]:
-    """Build the complete factual record supplied to the fabric resident."""
+    """Build current operator truth separately from internal and past state."""
     instances = _instances_summary(state_payload)
     nodes = _node_summaries(state_payload)
+    operator_instances = [
+        instance for instance in instances if not instance.get("systemRole")
+    ]
+    fabric_system_instances = [
+        instance for instance in instances if instance.get("systemRole")
+    ]
     return {
         "nodeCount": len(nodes),
         "nodes": nodes,
-        "activePlacements": [
+        "operatorActivePlacements": [
             instance
-            for instance in instances
+            for instance in operator_instances
             if instance.get("lifecycle") in {"placing", "loading", "warming"}
         ],
-        "readyOrRunningInstances": [
+        "operatorReadyOrRunningInstances": [
             instance
-            for instance in instances
+            for instance in operator_instances
             if instance.get("lifecycle") in {"ready", "running"}
         ],
-        "stoppingOrFailedInstances": [
+        "operatorStoppingOrFailedInstances": [
             instance
-            for instance in instances
+            for instance in operator_instances
             if instance.get("lifecycle") in {"stopping", "failed"}
         ],
-        "recentInstanceFailures": _instance_failures_summary(state_payload),
+        "fabricSystemInstances": fabric_system_instances,
+        "historicalTerminalFailures": _instance_failures_summary(state_payload),
         "downloads": _downloads_summary(state_payload),
         "nodeDisk": state_payload.get("nodeDisk", {}),
     }
@@ -780,10 +801,11 @@ def steward_operator_tool_result(state_payload: dict[str, object]) -> str:
         return rendered
 
     list_fields = (
-        "activePlacements",
-        "readyOrRunningInstances",
-        "stoppingOrFailedInstances",
-        "recentInstanceFailures",
+        "operatorActivePlacements",
+        "operatorReadyOrRunningInstances",
+        "operatorStoppingOrFailedInstances",
+        "fabricSystemInstances",
+        "historicalTerminalFailures",
     )
     nodes = [
         _compact_node_summary(node)

--- a/src/skulk/api/steward.py
+++ b/src/skulk/api/steward.py
@@ -157,7 +157,9 @@ Rules:
   not count them as active operator models unless explicitly asked about
   internal fabric services.
 - historicalTerminalFailures are retained past events, never current instances.
-  Do not report a model from this field as placed, running, or active.
+  Never report the failed instanceId or historical event as current. A newer
+  live instance may legitimately use the same modelId; in that case the
+  authoritative operator lifecycle bucket wins for the new instance.
 - If everything is healthy, say so; do not invent problems.
 - In this interface you can only observe and advise. You cannot change your
   cluster; when

--- a/src/skulk/api/tests/test_steward_failure_truth.py
+++ b/src/skulk/api/tests/test_steward_failure_truth.py
@@ -19,6 +19,8 @@ def test_steward_receives_recent_instance_failure_truth() -> None:
 
     assert _instance_failures_summary(payload) == [
         {
+            "historical": True,
+            "currentInstance": False,
             "instanceId": "instance-a",
             "modelId": "org/model",
             "errorCode": "runner_crashed",

--- a/src/skulk/api/tests/test_steward_identity.py
+++ b/src/skulk/api/tests/test_steward_identity.py
@@ -10,3 +10,5 @@ def test_intelligent_fabric_prompt_identifies_as_skulk_itself() -> None:
     assert "speak in the first person" in prompt
     assert "not a separate assistant, steward, or" in prompt
     assert "intelligent distributed AI fabric" in prompt
+    assert "failed instanceId or historical event" in prompt
+    assert "newer live instance may legitimately use the same modelId" in prompt

--- a/src/skulk/api/tests/test_steward_operator_grounding.py
+++ b/src/skulk/api/tests/test_steward_operator_grounding.py
@@ -228,6 +228,44 @@ def test_operator_summary_separates_internal_services_and_historical_failures() 
     ]
 
 
+def test_operator_summary_keeps_replacement_instance_current_with_same_model_id() -> None:
+    payload: dict[str, object] = {
+        "topology": {"nodes": ["node-a"]},
+        "instances": {
+            "replacement-instance": _instance(
+                model_id="org/recovered-model",
+                node_to_runner={"node-a": "replacement-runner"},
+            )
+        },
+        "runners": {"replacement-runner": {"RunnerReady": {}}},
+        "instanceFailures": [
+            {
+                "instanceId": "failed-instance",
+                "modelId": "org/recovered-model",
+                "errorCode": "runner_crashed",
+                "errorMessage": "Earlier runner exited.",
+                "affectedNodeIds": ["node-a"],
+                "recordedAt": "2026-08-17T12:00:00Z",
+            }
+        ],
+    }
+
+    summary = steward_operator_summary(payload)
+
+    ready = cast(
+        "list[dict[str, object]]", summary["operatorReadyOrRunningInstances"]
+    )
+    failures = cast(
+        "list[dict[str, object]]", summary["historicalTerminalFailures"]
+    )
+    assert [(row["modelId"], row["lifecycle"]) for row in ready] == [
+        ("org/recovered-model", "ready")
+    ]
+    assert [(row["instanceId"], row["modelId"]) for row in failures] == [
+        ("failed-instance", "org/recovered-model")
+    ]
+
+
 def test_operator_summary_marks_terminal_downloads_inactive() -> None:
     payload: dict[str, object] = {
         "topology": {"nodes": ["node-a"]},

--- a/src/skulk/api/tests/test_steward_operator_grounding.py
+++ b/src/skulk/api/tests/test_steward_operator_grounding.py
@@ -158,13 +158,73 @@ def test_operator_summary_separates_active_placement_from_ready_instances() -> N
 
     summary = steward_operator_summary(payload)
 
-    active = cast("list[dict[str, object]]", summary["activePlacements"])
-    ready = cast("list[dict[str, object]]", summary["readyOrRunningInstances"])
+    active = cast("list[dict[str, object]]", summary["operatorActivePlacements"])
+    ready = cast(
+        "list[dict[str, object]]", summary["operatorReadyOrRunningInstances"]
+    )
     assert [(row["modelId"], row["lifecycle"]) for row in active] == [
         ("org/placing-model", "loading")
     ]
     assert [(row["modelId"], row["lifecycle"]) for row in ready] == [
         ("org/ready-model", "ready")
+    ]
+
+
+def test_operator_summary_separates_internal_services_and_historical_failures() -> None:
+    payload: dict[str, object] = {
+        "topology": {"nodes": ["node-a", "node-b"]},
+        "instances": {
+            "operator-ready": _instance(
+                model_id="org/operator-model",
+                node_to_runner={"node-a": "runner-operator"},
+            ),
+            "fabric-ready": _instance(
+                model_id="org/steward-brain",
+                node_to_runner={"node-b": "runner-steward"},
+                system_role="steward",
+            ),
+        },
+        "runners": {
+            "runner-operator": {"RunnerReady": {}},
+            "runner-steward": {"RunnerReady": {}},
+        },
+        "instanceFailures": [
+            {
+                "instanceId": "vanished-instance",
+                "modelId": "org/old-model",
+                "errorCode": "runner_crashed",
+                "errorMessage": "Runner exited.",
+                "affectedNodeIds": ["node-a"],
+                "recordedAt": "2026-08-17T12:00:00Z",
+            }
+        ],
+    }
+
+    summary = steward_operator_summary(payload)
+
+    operator_ready = cast(
+        "list[dict[str, object]]", summary["operatorReadyOrRunningInstances"]
+    )
+    system_instances = cast(
+        "list[dict[str, object]]", summary["fabricSystemInstances"]
+    )
+    failures = cast(
+        "list[dict[str, object]]", summary["historicalTerminalFailures"]
+    )
+    assert [row["modelId"] for row in operator_ready] == ["org/operator-model"]
+    assert [row["modelId"] for row in system_instances] == ["org/steward-brain"]
+    assert system_instances[0]["systemRole"] == "steward"
+    assert failures == [
+        {
+            "historical": True,
+            "currentInstance": False,
+            "instanceId": "vanished-instance",
+            "modelId": "org/old-model",
+            "errorCode": "runner_crashed",
+            "errorMessage": "Runner exited.",
+            "affectedNodeIds": ["node-a"],
+            "recordedAt": "2026-08-17T12:00:00Z",
+        }
     ]
 
 
@@ -251,8 +311,10 @@ def test_operator_tool_result_preserves_lifecycle_truth_when_nodes_are_large() -
     assert len(rendered) <= MAX_TOOL_RESULT_CHARS
     assert result["detailState"] == "compacted"
     assert result["nodeCount"] == 12
-    active = cast("list[dict[str, object]]", result["activePlacements"])
-    ready = cast("list[dict[str, object]]", result["readyOrRunningInstances"])
+    active = cast("list[dict[str, object]]", result["operatorActivePlacements"])
+    ready = cast(
+        "list[dict[str, object]]", result["operatorReadyOrRunningInstances"]
+    )
     assert [(row["modelId"], row["lifecycle"]) for row in active] == [
         ("org/model-being-placed", "loading")
     ]

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -125,8 +125,10 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
   miss emits TaskFailed `instance_unavailable`.
 - Harness: `src/skulk/api/steward.py`. Read-only tools: cluster state
   summary (exact node count; per-node identity, RAM, accelerator, backends,
-  and CUDA/ROCm/MLX support; separate active-placement, ready/running, and
-  stopping/failed lifecycle buckets), node resources, telemetry diagnostics, data-plane diagnostics,
+  and CUDA/ROCm/MLX support; separate operator active-placement,
+  ready/running, and stopping/failed lifecycle buckets; internal system-role
+  services isolated from operator models; retained terminal failures marked
+  historical and non-current), node resources, telemetry diagnostics, data-plane diagnostics,
   cluster versions, performance envelopes, local doctor registry, model
   catalog, and `search_docs` (steward_docs.py: dependency-free tf-idf
   section index over the checkout's own docs, anchored on

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -734,8 +734,10 @@ included, so any OpenAI-compatible client can talk to the cluster with no
 steward-specific integration. The reserved id selects the model plus the
 server-side harness: a bounded, strictly read-only tool surface (cluster
 state normalized into an exact node count, heterogeneous identity, RAM,
-accelerator, backend, and capability facts plus mutually exclusive active
-placement, ready/running, and stopping/failed instance lifecycle buckets;
+accelerator, backend, and capability facts plus mutually exclusive operator
+active-placement, ready/running, and stopping/failed lifecycle buckets;
+internal system-role services in a separate bucket; retained terminal failures
+explicitly marked as historical and non-current;
 health reasons and capability conflicts;
 telemetry and data-plane diagnostics, per-node version status, performance
 envelopes, the local doctor check registry, the model catalog, and a
@@ -770,7 +772,10 @@ the steward observes and advises only: no tool can change the cluster, and
 anything action-shaped is returned to the operator as a recommendation.
 The normalized operator record is deliberately deterministic: the resident
 copies counts and measurements rather than reconstructing them from prose, and
-"placing" never includes an already-ready or running instance.
+"placing" never includes an already-ready or running instance. Current
+operator instances, internal fabric services, and retained failure history are
+separate top-level records, so a vanished failed placement cannot be reported
+as active and the resident brain is never counted as an operator-placed model.
 
 The role name remains internal plumbing (`system_role: "steward"`,
 `skulk/steward`, and `GET /v1/steward`). Product surfaces instead let an


### PR DESCRIPTION
## What changed

- separate current operator lifecycle buckets from internal fabric services
- mark retained terminal failures explicitly historical and non-current
- make the latest cluster tool result supersede earlier conversation claims
- update compact-result preservation, regression coverage, and architecture documentation

## Why

Retained failure history and the resident system instance previously sat beside current model lifecycle data with insufficient semantic separation. A small steward model could therefore report vanished models as active or count its own internal brain as an operator placement.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features 'nix-command flakes' fmt`
- `uv run pytest` (3,570 passed, 2 skipped)
