### PR TITLE
docs: make "work from dev" an explicit mandatory rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ These rules apply to every change. No exceptions.
 
 ### Work from `dev`, always
 
-`dev` is the baseline for every change. Cut branches from it, open pull
+`dev` is the baseline for day-to-day work. Cut branches from it, open pull
 requests against it, and read it whenever you need current truth:
 
 ```bash
@@ -260,6 +260,11 @@ research never saw.
 
 So: when a claim about this codebase matters, verify it on `dev`, and say which
 branch you checked.
+
+The one exception is the release cut itself: promotion pull requests from `dev`
+to `main` are opened by maintainers. This rule restates, for agents, the
+branching model already documented in
+[`CONTRIBUTING.md`](CONTRIBUTING.md) - keep the two in step if either changes.
 
 ### Experimental code stays out of dev
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,27 @@ Centralized logging uses a three-layer stack:
 
 These rules apply to every change. No exceptions.
 
+### Work from `dev`, always
+
+`dev` is the baseline for every change. Cut branches from it, open pull
+requests against it, and read it whenever you need current truth:
+
+```bash
+git fetch origin dev && git checkout -b <branch> origin/dev
+```
+
+`main` is the release branch and trails `dev` by an entire release cycle -
+routinely hundreds of commits. Anything read from `main` may therefore be
+stale: file paths and line anchors, where a function lives, which subsystems
+exist at all, and whether an architectural claim still holds. This is a
+recorded failure mode, not a theoretical one - a planning pass was once
+researched entirely against `main` and had to be redone when `dev` turned out
+to be 305 commits and a minor version ahead, with a whole subsystem the
+research never saw.
+
+So: when a claim about this codebase matters, verify it on `dev`, and say which
+branch you checked.
+
 ### Experimental code stays out of dev
 
 Unproven, demo-bound, or design-in-motion work never merges to dev. It lives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -587,6 +587,27 @@ peer APIs rather than through a central authoritative trace store.
 
 These rules apply to every change. No exceptions.
 
+### Work from `dev`, always
+
+`dev` is the baseline for every change. Cut branches from it, open pull
+requests against it, and read it whenever you need current truth:
+
+```bash
+git fetch origin dev && git checkout -b <branch> origin/dev
+```
+
+`main` is the release branch and trails `dev` by an entire release cycle -
+routinely hundreds of commits. Anything read from `main` may therefore be
+stale: file paths and line anchors, where a function lives, which subsystems
+exist at all, and whether an architectural claim still holds. This is a
+recorded failure mode, not a theoretical one - a planning pass was once
+researched entirely against `main` and had to be redone when `dev` turned out
+to be 305 commits and a minor version ahead, with a whole subsystem the
+research never saw.
+
+So: when a claim about this codebase matters, verify it on `dev`, and say which
+branch you checked.
+
 ### Experimental code stays out of dev
 
 Unproven, demo-bound, or design-in-motion work never merges to dev. It lives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,7 +589,7 @@ These rules apply to every change. No exceptions.
 
 ### Work from `dev`, always
 
-`dev` is the baseline for every change. Cut branches from it, open pull
+`dev` is the baseline for day-to-day work. Cut branches from it, open pull
 requests against it, and read it whenever you need current truth:
 
 ```bash
@@ -607,6 +607,11 @@ research never saw.
 
 So: when a claim about this codebase matters, verify it on `dev`, and say which
 branch you checked.
+
+The one exception is the release cut itself: promotion pull requests from `dev`
+to `main` are opened by maintainers. This rule restates, for agents, the
+branching model already documented in
+[`CONTRIBUTING.md`](CONTRIBUTING.md) - keep the two in step if either changes.
 
 ### Experimental code stays out of dev
 


### PR DESCRIPTION
## Why

Both instruction files reference `dev` in passing — experimental code stays out of it, it carries the next version after a promotion, docs deploy from it — but **neither ever says to start from it**. An agent can read all of `CLAUDE.md`, come away knowing `dev` exists and matters, and still baseline its work on `main`.

That's not hypothetical. During the media-initiative planning pass (speech / music / video, now in `foxlight-docs`), every file anchor and architectural claim was researched against `main` 1.5.0. `dev` turned out to be **305 commits and a minor version ahead**, carrying an entire model-registry subsystem the research never saw. Findings had to be re-verified and five documents re-baselined.

Worth being blunt about the near-miss: it was luck, not judgment, that `speech/`, `backends.py` and `realtime.py` happened to be byte-identical between the branches. Had they moved, the conclusions would have been wrong rather than merely stale-anchored.

## The rule already existed — just not where agents read

Review verification turned up something better than the fix it prompted. `CONTRIBUTING.md`'s Branching Model already says:

> Day-to-day work branches from `dev` and merges back to `dev` via pull request… Open pull requests against `dev` (the repository default); release promotion PRs from `dev` to `main` are opened by the maintainers.

So this convention was documented all along, in a file agents don't read. That reframes the change: it **propagates an existing rule** into `CLAUDE.md` and `AGENTS.md` rather than inventing one — and it explains how a whole planning pass could baseline on `main` without ever contradicting anything it had been told.

## What changes

A rule as the **first** entry under `## Mandatory Workflow Rules` in both files — ahead of "Experimental code stays out of dev", since it's the precondition for it:

- cut branches from `dev`, open PRs against `dev`, read `dev` for current truth
- the `git fetch origin dev` / `git checkout -b BRANCH origin/dev` mechanic, so there's no ambiguity
- what specifically goes stale when read from `main`: file paths and line anchors, where a function lives, which subsystems exist at all, whether an architectural claim still holds
- the concrete failure above, so the rule carries its own justification rather than reading as ceremony
- say which branch you checked when a claim matters
- scoped to day-to-day work, with the release-promotion exception named, and `CONTRIBUTING.md` linked as the origin with a note to keep the two in step

Docs only — 52 lines across two files, no code paths touched.

## Review

Four threads, all resolved:

- **Copilot ×2** — `<branch>` isn't paste-safe in a shell block. Severity 1, declined: `<placeholder>` is this repo's established convention inside shell blocks (`git push origin <branch>` twice, `gh pr comment <PR_NUMBER>`, `initiative/<name>`), so changing one line would leave the file internally inconsistent.
- **Codex** — the rule conflicted with the documented release-promotion workflow. Scored severity 2, **fixed anyway** in `390495c`: it's a contradiction inside a "No exceptions" block rather than a style preference, and the fix was one clause.
- **Codex** — claimed this change is landing on `main`. Declined as factually incorrect: `origin/main` (`a71a3346`) is not an ancestor of this branch, `origin/dev` (`6721aa45`) is, and the PR's own `base.ref` is `dev`. Evidence in the thread.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KByyiUEiVSY3eDvrWbqDDi)_