### PR TITLE
Recover corrupt staged vision projectors

### DIFF
--- a/src/skulk/store/installed_cards.py
+++ b/src/skulk/store/installed_cards.py
@@ -290,6 +290,49 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def unlink_relative_artifact_path_without_following(
+    model_directory: Path,
+    relative_path: str,
+) -> bool:
+    """Unlink one invalid artifact entry without following staged symlinks.
+
+    The path must use the installed-manifest canonical relative POSIX form. If
+    an intermediate component is a symlink, that in-root symlink is removed so
+    the normal staging path can recreate the directory tree. A final symlink is
+    likewise unlinked as an entry rather than resolving and deleting its target.
+
+    Args:
+        model_directory: Root of the canonical or staged artifact generation.
+        relative_path: Canonical repository-relative path selected by the card.
+
+    Returns:
+        ``True`` when an invalid file or symlink entry was removed.
+    """
+
+    path = PurePosixPath(relative_path)
+    if (
+        path.is_absolute()
+        or relative_path != path.as_posix()
+        or "\\" in relative_path
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        return False
+    current = model_directory.resolve()
+    for part in path.parts[:-1]:
+        component = current / part
+        if component.is_symlink():
+            component.unlink()
+            return True
+        if not component.is_dir():
+            return False
+        current = component
+    candidate = current / path.name
+    if candidate.is_symlink() or candidate.is_file():
+        candidate.unlink()
+        return True
+    return False
+
+
 def build_file_manifest(
     model_directory: Path,
 ) -> tuple[InstalledFileManifestEntry, ...]:

--- a/src/skulk/store/installed_cards.py
+++ b/src/skulk/store/installed_cards.py
@@ -226,9 +226,10 @@ class VerifiedDetachedInstalledCardCache:
     """Process-local cache for expensive detached installed-card verification.
 
     Detached records receive full hash verification before admission. Later
-    operator-inventory scans may reuse that result only while every manifest
-    file retains the same path, device, inode, size, modification time, and
-    change time. Transfer and reconciliation callers do not use this cache.
+    operator-inventory scans and local launch/cache checks may reuse that result
+    only while every manifest file retains the same path, device, inode, size,
+    modification time, and change time. Transfer and reconciliation callers do
+    not use this cache.
     """
 
     def __init__(self) -> None:
@@ -623,8 +624,8 @@ def read_installed_card_with_fallback(
         model_directory: Artifact directory whose installed identity is needed.
         fallback_root: Process-level directory containing detached records.
         verified_detached_cache: Optional process-local cache used only by
-            lossy operator inventory. A detached record is admitted only after
-            a full hash pass and is invalidated by file-stat changes.
+            inventory or launch/cache checks. A detached record is admitted
+            only after a full hash pass and is invalidated by file-stat changes.
 
     Returns:
         The trusted installed-card record, or ``None`` when no complete record
@@ -689,11 +690,23 @@ def read_installed_card_with_fallback(
 def installed_card_matches(
     model_directory: Path,
     model_card: ModelCard,
+    *,
+    verified_detached_cache: VerifiedDetachedInstalledCardCache | None = None,
 ) -> bool:
-    """Return whether a complete sidecar identifies the requested card generation."""
+    """Return whether a complete sidecar identifies the requested card generation.
+
+    Args:
+        model_directory: Artifact root containing or owning installed metadata.
+        model_card: Exact effective card requested for the generation.
+        verified_detached_cache: Optional cache for an already authenticated
+            detached record on a read-only artifact root.
+    """
 
     try:
-        record = read_installed_card_with_fallback(model_directory)
+        record = read_installed_card_with_fallback(
+            model_directory,
+            verified_detached_cache=verified_detached_cache,
+        )
     except (OSError, ValueError):
         return False
     if record is None:
@@ -713,6 +726,8 @@ def installed_card_matches(
 def require_registry_installed_artifact(
     model_directory: Path,
     model_card: ModelCard,
+    *,
+    verified_detached_cache: VerifiedDetachedInstalledCardCache | None = None,
 ) -> None:
     """Require a staged artifact to match an immutable signed card exactly.
 
@@ -726,6 +741,8 @@ def require_registry_installed_artifact(
     Args:
         model_directory: Complete staged or canonical artifact directory.
         model_card: Signed card selected for this runner generation.
+        verified_detached_cache: Optional cache for an already authenticated
+            detached record on a read-only artifact root.
 
     Raises:
         PermissionError: If signed identity cannot be proven from local state.
@@ -734,7 +751,10 @@ def require_registry_installed_artifact(
     if card_id is None:
         return
     try:
-        record = read_installed_card_with_fallback(model_directory)
+        record = read_installed_card_with_fallback(
+            model_directory,
+            verified_detached_cache=verified_detached_cache,
+        )
     except (OSError, ValueError) as error:
         raise PermissionError(
             f"{MODEL_TRUST_FAILURE_MARKER}: installed artifact identity is "
@@ -767,11 +787,24 @@ def installed_companion_matches(
     artifact_model_id: str,
     owner_card: ModelCard,
     artifact_role: InstalledArtifactRole,
+    verified_detached_cache: VerifiedDetachedInstalledCardCache | None = None,
 ) -> bool:
-    """Return whether a complete local artifact belongs to an owning card."""
+    """Return whether a complete local artifact belongs to an owning card.
+
+    Args:
+        model_directory: Complete companion artifact directory.
+        artifact_model_id: Store identity of the companion repository.
+        owner_card: Complete effective card that owns the companion.
+        artifact_role: Declared role of the companion artifact.
+        verified_detached_cache: Optional cache for an already authenticated
+            detached record on a read-only artifact root.
+    """
 
     try:
-        record = read_installed_card_with_fallback(model_directory)
+        record = read_installed_card_with_fallback(
+            model_directory,
+            verified_detached_cache=verified_detached_cache,
+        )
     except (OSError, ValueError):
         return False
     if record is None:

--- a/src/skulk/store/model_store.py
+++ b/src/skulk/store/model_store.py
@@ -89,6 +89,7 @@ from skulk.store.installed_cards import (
     build_installed_card_record,
     manifest_sha256,
     read_installed_card,
+    unlink_relative_artifact_path_without_following,
     verify_installed_card,
     verify_installed_file,
     write_installed_card,
@@ -1121,9 +1122,10 @@ class ModelStore:
         registered_path = _resolve_store_child_path(self._store_path, entry.store_path)
         if registered_path is None or registered_path.resolve() != target_dir.resolve():
             return
-        candidate = (registered_path / required_file).resolve()
-        if candidate.is_relative_to(registered_path.resolve()) and candidate.is_file():
-            candidate.unlink()
+        if unlink_relative_artifact_path_without_following(
+            registered_path,
+            required_file,
+        ):
             logger.warning(
                 f"ModelStore: removed invalid pinned file {required_file!r} from "
                 f"{model_id} before immutable recovery download"

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -535,6 +535,19 @@ def _remove_invalid_staged_projector(
         )
 
 
+async def _staged_vision_projector_missing_async(
+    shard: ShardMetadata,
+    directory: Path,
+) -> bool:
+    """Authenticate a staged projector without hashing it on the event loop."""
+
+    return await asyncio.to_thread(
+        _staged_vision_projector_missing,
+        shard,
+        directory,
+    )
+
+
 def _staged_pinned_gguf_missing(shard: ShardMetadata, directory: Path) -> bool:
     """Return whether a staged directory lacks the card-selected GGUF group.
 
@@ -2088,7 +2101,10 @@ class ModelStoreDownloader(ShardDownloader):
                     direct_path is not None
                     and _staged_directory_looks_complete(direct_path)
                     and not _staged_pinned_gguf_missing(shard, direct_path)
-                    and not _staged_vision_projector_missing(shard, direct_path)
+                    and not await _staged_vision_projector_missing_async(
+                        shard,
+                        direct_path,
+                    )
                     and not _staged_same_repo_draft_missing(shard, direct_path)
                 ):
                     if not _staged_generation_matches(
@@ -2125,7 +2141,7 @@ class ModelStoreDownloader(ShardDownloader):
                             replacement_path is None
                             or not _staged_directory_looks_complete(replacement_path)
                             or _staged_pinned_gguf_missing(shard, replacement_path)
-                            or _staged_vision_projector_missing(
+                            or await _staged_vision_projector_missing_async(
                                 shard,
                                 replacement_path,
                             )
@@ -2175,7 +2191,7 @@ class ModelStoreDownloader(ShardDownloader):
             dest_path.exists()
             and _staged_directory_looks_complete(dest_path)
             and not _staged_pinned_gguf_missing(shard, dest_path)
-            and not _staged_vision_projector_missing(shard, dest_path)
+            and not await _staged_vision_projector_missing_async(shard, dest_path)
             and not _staged_same_repo_draft_missing(shard, dest_path)
             and _staged_generation_matches(
                 dest_path,

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -106,6 +106,7 @@ from skulk.store.installed_cards import (
     installed_companion_matches,
     read_installed_card_with_fallback,
     require_registry_installed_artifact,
+    unlink_relative_artifact_path_without_following,
     verify_installed_file,
     write_installed_card_with_fallback,
 )
@@ -525,10 +526,10 @@ def _remove_invalid_staged_projector(
         or not _staged_vision_projector_missing(shard, directory)
     ):
         return
-    root = directory.resolve()
-    projector = (root / vision.projector_file).resolve()
-    if projector.is_relative_to(root) and projector.is_file():
-        projector.unlink()
+    if unlink_relative_artifact_path_without_following(
+        directory,
+        vision.projector_file,
+    ):
         logger.warning(
             f"ModelStoreDownloader: removed invalid staged projector "
             f"{vision.projector_file!r} for {card.model_id} before recovery"

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -100,6 +100,7 @@ from skulk.store.installed_cards import (
     INSTALLED_CARD_RELATIVE_PATH,
     InstalledArtifactRole,
     InstalledCardRecord,
+    VerifiedDetachedInstalledCardCache,
     build_installed_card_record,
     companion_artifact_role,
     installed_card_matches,
@@ -162,6 +163,7 @@ def _staged_generation_matches(
     requested_card: ModelCard,
     owner_card: ModelCard | None,
     artifact_role: InstalledArtifactRole,
+    verified_detached_cache: VerifiedDetachedInstalledCardCache | None = None,
 ) -> bool:
     """Return whether local bytes carry the requested durable generation.
 
@@ -171,7 +173,10 @@ def _staged_generation_matches(
     """
 
     try:
-        installed = read_installed_card_with_fallback(model_directory)
+        installed = read_installed_card_with_fallback(
+            model_directory,
+            verified_detached_cache=verified_detached_cache,
+        )
     except (OSError, ValueError):
         return False
     if installed is not None:
@@ -181,17 +186,23 @@ def _staged_generation_matches(
                 artifact_model_id=artifact_model_id,
                 owner_card=owner_card,
                 artifact_role=artifact_role,
+                verified_detached_cache=verified_detached_cache,
             )
         if requested_card.registry_card_id is not None:
             try:
                 require_registry_installed_artifact(
                     model_directory,
                     requested_card,
+                    verified_detached_cache=verified_detached_cache,
                 )
             except PermissionError:
                 return False
             return True
-        return installed_card_matches(model_directory, requested_card)
+        return installed_card_matches(
+            model_directory,
+            requested_card,
+            verified_detached_cache=verified_detached_cache,
+        )
     return _staged_source_revision_matches(
         model_directory, requested_card.source_revision
     )
@@ -204,11 +215,15 @@ def _completed_staged_generation_differs(
     requested_card: ModelCard,
     owner_card: ModelCard | None,
     artifact_role: InstalledArtifactRole,
+    verified_detached_cache: VerifiedDetachedInstalledCardCache | None = None,
 ) -> bool:
     """Return whether a completed local generation must be transactionally replaced."""
 
     try:
-        installed = read_installed_card_with_fallback(model_directory)
+        installed = read_installed_card_with_fallback(
+            model_directory,
+            verified_detached_cache=verified_detached_cache,
+        )
     except (OSError, ValueError):
         return True
     if installed is not None:
@@ -218,6 +233,7 @@ def _completed_staged_generation_differs(
             requested_card=requested_card,
             owner_card=owner_card,
             artifact_role=artifact_role,
+            verified_detached_cache=verified_detached_cache,
         )
     # An in-progress directory has no final marker and remains resumable. A
     # completed legacy generation with a different revision must retain its
@@ -475,7 +491,11 @@ def _staged_directory_looks_complete(directory: Path) -> bool:
     return (directory / "mtp.safetensors").is_file()
 
 
-def _staged_vision_projector_missing(shard: ShardMetadata, directory: Path) -> bool:
+def _staged_vision_projector_missing(
+    shard: ShardMetadata,
+    directory: Path,
+    verified_detached_cache: VerifiedDetachedInstalledCardCache | None = None,
+) -> bool:
     """True when a GGUF vision model's staged dir lacks its authenticated ``mmproj``.
 
     The generic completeness probe (``_staged_directory_looks_complete``)
@@ -496,7 +516,10 @@ def _staged_vision_projector_missing(shard: ShardMetadata, directory: Path) -> b
     if card.vision.projector_file is not None:
         assert card.vision.projector_size is not None
         try:
-            record = read_installed_card_with_fallback(directory)
+            record = read_installed_card_with_fallback(
+                directory,
+                verified_detached_cache=verified_detached_cache,
+            )
         except (OSError, ValueError):
             return True
         return record is None or not verify_installed_file(
@@ -515,6 +538,7 @@ def _staged_vision_projector_missing(shard: ShardMetadata, directory: Path) -> b
 def _remove_invalid_staged_projector(
     shard: ShardMetadata,
     directory: Path,
+    verified_detached_cache: VerifiedDetachedInstalledCardCache | None = None,
 ) -> None:
     """Remove only a corrupt pinned projector so normal staging replaces it."""
 
@@ -523,7 +547,11 @@ def _remove_invalid_staged_projector(
     if (
         vision is None
         or vision.projector_file is None
-        or not _staged_vision_projector_missing(shard, directory)
+        or not _staged_vision_projector_missing(
+            shard,
+            directory,
+            verified_detached_cache,
+        )
     ):
         return
     if unlink_relative_artifact_path_without_following(
@@ -539,6 +567,7 @@ def _remove_invalid_staged_projector(
 async def _staged_vision_projector_missing_async(
     shard: ShardMetadata,
     directory: Path,
+    verified_detached_cache: VerifiedDetachedInstalledCardCache | None = None,
 ) -> bool:
     """Authenticate a staged projector without hashing it on the event loop."""
 
@@ -546,6 +575,7 @@ async def _staged_vision_projector_missing_async(
         _staged_vision_projector_missing,
         shard,
         directory,
+        verified_detached_cache,
     )
 
 
@@ -1794,6 +1824,9 @@ class ModelStoreDownloader(ShardDownloader):
         self._staging_config = staging_config
         self._allow_hf_fallback = allow_hf_fallback
         self._installed_card_callback = installed_card_callback
+        self._verified_detached_installed_card_cache = (
+            VerifiedDetachedInstalledCardCache()
+        )
         self._staging_transfer_lock = asyncio.Lock()
         self._staging_capacity_callback: StagingCapacityCallback | None = None
         self._active_staging_model_ids: dict[str, int] = {}
@@ -1856,6 +1889,7 @@ class ModelStoreDownloader(ShardDownloader):
                     _remove_invalid_staged_projector,
                     shard,
                     destination,
+                    self._verified_detached_installed_card_cache,
                 )
             staged_path = await self._store_client.stage_shard(
                 model_id,
@@ -2108,6 +2142,7 @@ class ModelStoreDownloader(ShardDownloader):
                         await _staged_vision_projector_missing_async(
                             shard,
                             direct_path,
+                            self._verified_detached_installed_card_cache,
                         )
                     )
                     generation_requires_recovery = not _staged_generation_matches(
@@ -2116,6 +2151,9 @@ class ModelStoreDownloader(ShardDownloader):
                         requested_card=shard.model_card,
                         owner_card=installed_owner_card,
                         artifact_role=installed_artifact_role,
+                        verified_detached_cache=(
+                            self._verified_detached_installed_card_cache
+                        ),
                     )
                     if projector_requires_recovery or generation_requires_recovery:
                         await self._store_client.request_and_wait_for_download(
@@ -2148,6 +2186,7 @@ class ModelStoreDownloader(ShardDownloader):
                             or await _staged_vision_projector_missing_async(
                                 shard,
                                 replacement_path,
+                                self._verified_detached_installed_card_cache,
                             )
                             or _staged_same_repo_draft_missing(
                                 shard,
@@ -2159,6 +2198,9 @@ class ModelStoreDownloader(ShardDownloader):
                                 requested_card=shard.model_card,
                                 owner_card=installed_owner_card,
                                 artifact_role=installed_artifact_role,
+                                verified_detached_cache=(
+                                    self._verified_detached_installed_card_cache
+                                ),
                             )
                         ):
                             raise ModelNotInStoreError(
@@ -2189,13 +2231,18 @@ class ModelStoreDownloader(ShardDownloader):
                 requested_card=shard.model_card,
                 owner_card=installed_owner_card,
                 artifact_role=installed_artifact_role,
+                verified_detached_cache=self._verified_detached_installed_card_cache,
             )
         )
         if (
             dest_path.exists()
             and _staged_directory_looks_complete(dest_path)
             and not _staged_pinned_gguf_missing(shard, dest_path)
-            and not await _staged_vision_projector_missing_async(shard, dest_path)
+            and not await _staged_vision_projector_missing_async(
+                shard,
+                dest_path,
+                self._verified_detached_installed_card_cache,
+            )
             and not _staged_same_repo_draft_missing(shard, dest_path)
             and _staged_generation_matches(
                 dest_path,
@@ -2203,6 +2250,7 @@ class ModelStoreDownloader(ShardDownloader):
                 requested_card=shard.model_card,
                 owner_card=installed_owner_card,
                 artifact_role=installed_artifact_role,
+                verified_detached_cache=self._verified_detached_installed_card_cache,
             )
         ):
             logger.info(

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -106,6 +106,7 @@ from skulk.store.installed_cards import (
     installed_companion_matches,
     read_installed_card_with_fallback,
     require_registry_installed_artifact,
+    verify_installed_file,
     write_installed_card_with_fallback,
 )
 from skulk.store.staging_eviction import touch_last_used
@@ -474,7 +475,7 @@ def _staged_directory_looks_complete(directory: Path) -> bool:
 
 
 def _staged_vision_projector_missing(shard: ShardMetadata, directory: Path) -> bool:
-    """True when a GGUF vision model's staged dir is missing its ``mmproj``.
+    """True when a GGUF vision model's staged dir lacks its authenticated ``mmproj``.
 
     The generic completeness probe (``_staged_directory_looks_complete``)
     excludes ``mmproj`` files, so a GGUF vision model staged without its
@@ -492,16 +493,46 @@ def _staged_vision_projector_missing(shard: ShardMetadata, directory: Path) -> b
     if card.vision is None or not card.gguf_file:
         return False
     if card.vision.projector_file is not None:
-        projector = directory.joinpath(*Path(card.vision.projector_file).parts)
-        return (
-            not projector.is_file()
-            or projector.stat().st_size != card.vision.projector_size
+        assert card.vision.projector_size is not None
+        try:
+            record = read_installed_card_with_fallback(directory)
+        except (OSError, ValueError):
+            return True
+        return record is None or not verify_installed_file(
+            directory,
+            record,
+            card.vision.projector_file,
+            expected_size=card.vision.projector_size,
         )
     from skulk.store.model_store import has_gguf_projector
 
     return not has_gguf_projector(
         path.name for path in directory.rglob("*") if path.is_file()
     )
+
+
+def _remove_invalid_staged_projector(
+    shard: ShardMetadata,
+    directory: Path,
+) -> None:
+    """Remove only a corrupt pinned projector so normal staging replaces it."""
+
+    card = shard.model_card
+    vision = card.vision
+    if (
+        vision is None
+        or vision.projector_file is None
+        or not _staged_vision_projector_missing(shard, directory)
+    ):
+        return
+    root = directory.resolve()
+    projector = (root / vision.projector_file).resolve()
+    if projector.is_relative_to(root) and projector.is_file():
+        projector.unlink()
+        logger.warning(
+            f"ModelStoreDownloader: removed invalid staged projector "
+            f"{vision.projector_file!r} for {card.model_id} before recovery"
+        )
 
 
 def _staged_pinned_gguf_missing(shard: ShardMetadata, directory: Path) -> bool:
@@ -1806,6 +1837,12 @@ class ModelStoreDownloader(ShardDownloader):
             )
 
         async with self._staging_transfer_lock:
+            if not replace_existing_generation and destination.exists():
+                await asyncio.to_thread(
+                    _remove_invalid_staged_projector,
+                    shard,
+                    destination,
+                )
             staged_path = await self._store_client.stage_shard(
                 model_id,
                 transfer_root,

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -2101,19 +2101,22 @@ class ModelStoreDownloader(ShardDownloader):
                     direct_path is not None
                     and _staged_directory_looks_complete(direct_path)
                     and not _staged_pinned_gguf_missing(shard, direct_path)
-                    and not await _staged_vision_projector_missing_async(
-                        shard,
-                        direct_path,
-                    )
                     and not _staged_same_repo_draft_missing(shard, direct_path)
                 ):
-                    if not _staged_generation_matches(
+                    projector_requires_recovery = (
+                        await _staged_vision_projector_missing_async(
+                            shard,
+                            direct_path,
+                        )
+                    )
+                    generation_requires_recovery = not _staged_generation_matches(
                         direct_path,
                         artifact_model_id=model_id,
                         requested_card=shard.model_card,
                         owner_card=installed_owner_card,
                         artifact_role=installed_artifact_role,
-                    ):
+                    )
+                    if projector_requires_recovery or generation_requires_recovery:
                         await self._store_client.request_and_wait_for_download(
                             model_id,
                             pinned_gguf=shard.model_card.gguf_file,

--- a/src/skulk/store/tests/test_entry_missing_files.py
+++ b/src/skulk/store/tests/test_entry_missing_files.py
@@ -116,6 +116,28 @@ def test_invalid_projector_is_removed_before_recovery_download(tmp_path: Path) -
     assert not projector.exists()
 
 
+def test_invalid_canonical_projector_symlink_preserves_target(tmp_path: Path) -> None:
+    """Canonical recovery unlinks an escaping projector symlink, not its target."""
+
+    store = ModelStore(tmp_path / "store")
+    model_dir, _card = _register_pinned_projector(store)
+    projector = model_dir / "mmproj-F16.gguf"
+    projector.unlink()
+    external = tmp_path / "external-projector.gguf"
+    external.write_bytes(b"x")
+    projector.symlink_to(external)
+
+    store._remove_invalid_registered_file_for_recovery(  # pyright: ignore[reportPrivateUsage]
+        "org/vision",
+        "mmproj-F16.gguf",
+        1,
+        model_dir,
+    )
+
+    assert not projector.exists()
+    assert external.read_bytes() == b"x"
+
+
 async def test_cached_complete_entry_redownloads_when_companion_missing(
     tmp_path: Path,
 ) -> None:

--- a/src/skulk/store/tests/test_staged_pinned_gguf.py
+++ b/src/skulk/store/tests/test_staged_pinned_gguf.py
@@ -10,7 +10,12 @@ import pytest
 
 from skulk.download.download_utils import RepoDownloadProgress
 from skulk.download.shard_downloader import ShardDownloader
-from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from skulk.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    ModelTask,
+    VisionCardConfig,
+)
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
 from skulk.store.config import StagingNodeConfig
@@ -458,6 +463,75 @@ async def test_store_host_reloads_canonical_path_after_generation_replacement(
 
     assert path == new_path
     assert (path / "model-IQ3_XXS.gguf").read_bytes() == b"new"
+
+
+@pytest.mark.anyio
+async def test_store_host_repairs_corrupt_canonical_projector(
+    tmp_path: Path,
+) -> None:
+    """A direct-store load must repair invalid projector bytes before serving."""
+
+    card = _aliased_shard().model_card.model_copy(
+        update={
+            "registry_provenance": "foxlight",
+            "vision": VisionCardConfig(
+                projector_file="mmproj-F16.gguf",
+                projector_size=1,
+            )
+        }
+    )
+    shard = _aliased_shard().model_copy(update={"model_card": card})
+    direct_path = tmp_path / "canonical"
+    direct_path.mkdir()
+    (direct_path / "model-IQ3_XXS.gguf").write_bytes(b"weights")
+    (direct_path / "mmproj-F16.gguf").write_bytes(b"x")
+    (direct_path / ".skulk-source-revision").write_text(f"{card.source_revision}\n")
+    write_installed_card(
+        direct_path,
+        build_installed_card_record(direct_path, card),
+    )
+    (direct_path / "mmproj-F16.gguf").write_bytes(b"y")
+
+    class RepairingCanonicalStoreClient(_RecordingStoreClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.local_store_path = tmp_path
+            self.repaired = False
+
+        async def local_model_path(
+            self,
+            model_id: str,
+            source_revision: str | None = None,
+        ) -> Path:
+            del model_id, source_revision
+            return direct_path
+
+        async def request_and_wait_for_download(
+            self,
+            model_id: str,
+            **kwargs: object,
+        ) -> bool:
+            del model_id, kwargs
+            (direct_path / "mmproj-F16.gguf").write_bytes(b"x")
+            write_installed_card(
+                direct_path,
+                build_installed_card_record(direct_path, card),
+            )
+            self.repaired = True
+            return True
+
+    store_client = RepairingCanonicalStoreClient()
+    downloader = ModelStoreDownloader(
+        inner=_UnusedInnerDownloader(),
+        store_client=cast(ModelStoreClient, cast(object, store_client)),
+        staging_config=StagingNodeConfig(enabled=False),
+    )
+
+    path = await downloader.ensure_shard(shard)
+
+    assert path == direct_path
+    assert store_client.repaired is True
+    assert (path / "mmproj-F16.gguf").read_bytes() == b"x"
 
 
 @pytest.mark.anyio

--- a/src/skulk/store/tests/test_staged_vision_projector.py
+++ b/src/skulk/store/tests/test_staged_vision_projector.py
@@ -22,11 +22,13 @@ from skulk.shared.models.model_cards import (
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.worker.shards import PipelineShardMetadata
 from skulk.store.installed_cards import (
+    VerifiedDetachedInstalledCardCache,
     build_installed_card_record,
     write_installed_card,
 )
 from skulk.store.model_store_client import (
     _remove_invalid_staged_projector,
+    _staged_generation_matches,
     _staged_vision_projector_missing,
     _staged_vision_projector_missing_async,
 )
@@ -194,6 +196,52 @@ async def test_async_projector_check_hashes_off_event_loop(
 
     assert await _staged_vision_projector_missing_async(shard, staged) is False
     assert delegated == [_staged_vision_projector_missing]
+
+
+def test_projector_and_generation_checks_share_detached_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One downloader cache is threaded through both installed-record reads."""
+
+    staged = _write(tmp_path, "model-Q4_K_M.gguf", "config.json")
+    shard = _shard(
+        vision=True,
+        gguf_file="model-Q4_K_M.gguf",
+        projector_file="mmproj-F16.gguf",
+        projector_size=1,
+    )
+    cache = VerifiedDetachedInstalledCardCache()
+    observed: list[VerifiedDetachedInstalledCardCache | None] = []
+
+    def _record_cache(
+        _directory: Path,
+        *,
+        fallback_root: Path | None = None,
+        verified_detached_cache: VerifiedDetachedInstalledCardCache | None = None,
+    ) -> None:
+        del fallback_root
+        observed.append(verified_detached_cache)
+        return None
+
+    monkeypatch.setattr(
+        "skulk.store.model_store_client.read_installed_card_with_fallback",
+        _record_cache,
+    )
+
+    assert _staged_vision_projector_missing(shard, staged, cache) is True
+    assert (
+        _staged_generation_matches(
+            staged,
+            artifact_model_id=str(shard.model_card.model_id),
+            requested_card=shard.model_card,
+            owner_card=None,
+            artifact_role="base",
+            verified_detached_cache=cache,
+        )
+        is False
+    )
+    assert observed == [cache, cache]
 
 
 def test_mlx_vision_without_projector_is_not_flagged(tmp_path: Path) -> None:

--- a/src/skulk/store/tests/test_staged_vision_projector.py
+++ b/src/skulk/store/tests/test_staged_vision_projector.py
@@ -8,7 +8,10 @@ projector, so it must NOT be flagged (doing so would disable the staged-cache
 fast path that keeps inference working when the store is unreachable).
 """
 
+from collections.abc import Callable
 from pathlib import Path
+
+import pytest
 
 from skulk.shared.models.model_cards import (
     ModelCard,
@@ -25,6 +28,7 @@ from skulk.store.installed_cards import (
 from skulk.store.model_store_client import (
     _remove_invalid_staged_projector,
     _staged_vision_projector_missing,
+    _staged_vision_projector_missing_async,
 )
 
 
@@ -134,6 +138,40 @@ def test_same_size_corrupt_projector_is_removed_for_recovery(tmp_path: Path) -> 
     _remove_invalid_staged_projector(shard, staged)
 
     assert not (staged / "mmproj-F16.gguf").exists()
+
+
+async def test_async_projector_check_hashes_off_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The worker's cache fast path delegates projector hashing to a thread."""
+
+    staged = _write(
+        tmp_path,
+        "model-Q4_K_M.gguf",
+        "mmproj-F16.gguf",
+        "config.json",
+    )
+    shard = _shard(
+        vision=True,
+        gguf_file="model-Q4_K_M.gguf",
+        projector_file="mmproj-F16.gguf",
+        projector_size=1,
+    )
+    write_installed_card(
+        staged,
+        build_installed_card_record(staged, shard.model_card),
+    )
+    delegated: list[Callable[..., bool]] = []
+
+    async def _to_thread(function: Callable[..., bool], *args: object) -> bool:
+        delegated.append(function)
+        return function(*args)
+
+    monkeypatch.setattr("skulk.store.model_store_client.asyncio.to_thread", _to_thread)
+
+    assert await _staged_vision_projector_missing_async(shard, staged) is False
+    assert delegated == [_staged_vision_projector_missing]
 
 
 def test_mlx_vision_without_projector_is_not_flagged(tmp_path: Path) -> None:

--- a/src/skulk/store/tests/test_staged_vision_projector.py
+++ b/src/skulk/store/tests/test_staged_vision_projector.py
@@ -140,6 +140,28 @@ def test_same_size_corrupt_projector_is_removed_for_recovery(tmp_path: Path) -> 
     assert not (staged / "mmproj-F16.gguf").exists()
 
 
+def test_corrupt_projector_symlink_is_unlinked_without_following(
+    tmp_path: Path,
+) -> None:
+    """Recovery removes the staged symlink entry and preserves its target."""
+
+    staged = _write(tmp_path / "staged", "model-Q4_K_M.gguf", "config.json")
+    external = tmp_path / "external-projector.gguf"
+    external.write_bytes(b"x")
+    (staged / "mmproj-F16.gguf").symlink_to(external)
+    shard = _shard(
+        vision=True,
+        gguf_file="model-Q4_K_M.gguf",
+        projector_file="mmproj-F16.gguf",
+        projector_size=1,
+    )
+
+    _remove_invalid_staged_projector(shard, staged)
+
+    assert not (staged / "mmproj-F16.gguf").exists()
+    assert external.read_bytes() == b"x"
+
+
 async def test_async_projector_check_hashes_off_event_loop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/src/skulk/store/tests/test_staged_vision_projector.py
+++ b/src/skulk/store/tests/test_staged_vision_projector.py
@@ -18,7 +18,14 @@ from skulk.shared.models.model_cards import (
 )
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.worker.shards import PipelineShardMetadata
-from skulk.store.model_store_client import _staged_vision_projector_missing
+from skulk.store.installed_cards import (
+    build_installed_card_record,
+    write_installed_card,
+)
+from skulk.store.model_store_client import (
+    _remove_invalid_staged_projector,
+    _staged_vision_projector_missing,
+)
 
 
 def _shard(
@@ -95,7 +102,38 @@ def test_pinned_projector_requires_exact_path_and_size(tmp_path: Path) -> None:
     (staged / "mmproj-F16.gguf").write_bytes(b"wrong")
     assert _staged_vision_projector_missing(shard, staged) is True
     (staged / "mmproj-F16.gguf").write_bytes(b"x")
+    write_installed_card(
+        staged,
+        build_installed_card_record(staged, shard.model_card),
+    )
     assert _staged_vision_projector_missing(shard, staged) is False
+
+
+def test_same_size_corrupt_projector_is_removed_for_recovery(tmp_path: Path) -> None:
+    """Manifest-invalid staged bytes cannot survive the store recovery path."""
+
+    staged = _write(
+        tmp_path,
+        "model-Q4_K_M.gguf",
+        "mmproj-F16.gguf",
+        "config.json",
+    )
+    shard = _shard(
+        vision=True,
+        gguf_file="model-Q4_K_M.gguf",
+        projector_file="mmproj-F16.gguf",
+        projector_size=1,
+    )
+    write_installed_card(
+        staged,
+        build_installed_card_record(staged, shard.model_card),
+    )
+    (staged / "mmproj-F16.gguf").write_bytes(b"y")
+
+    assert _staged_vision_projector_missing(shard, staged) is True
+    _remove_invalid_staged_projector(shard, staged)
+
+    assert not (staged / "mmproj-F16.gguf").exists()
 
 
 def test_mlx_vision_without_projector_is_not_flagged(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- authenticate pinned staged projectors against the installed-card manifest, not byte length alone
- remove only an invalid staged projector under the serialized staging lock so local or HTTP staging must replace it
- cover same-size digest corruption and recovery without disturbing the rest of the generation

## Root cause

The cache fast path accepted a pinned projector when its path and byte length matched. Same-size corruption therefore survived every staging retry even when the canonical store copy was healthy.

## Validation

- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (3,588 passed, 2 skipped)