### PR TITLE
Fix signed card-only cache refresh before launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project records release notes here and mirrors public-facing notes in
 
 ## [Unreleased]
 
+### Fixed
+
+- Same-artifact signed card replacements now run the card-only installed-sidecar
+  refresh before a staged-cache fast path can report the model ready. This
+  prevents a newly approved replacement card from passing placement and then
+  failing runner startup against the prior installed identity, without
+  retransferring unchanged model bytes.
+
 ### Added
 
 - Served GGUF vision now uses one truthful model card for the base quant,

--- a/src/skulk/download/coordinator.py
+++ b/src/skulk/download/coordinator.py
@@ -579,7 +579,9 @@ class DownloadCoordinator:
         # review on the launch-smoke fix). Fall through to the download
         # path instead so the companion gets fetched.
         found_path = resolve_model_in_path(
-            model_id, shard.model_card.source_revision
+            model_id,
+            shard.model_card.source_revision,
+            expected_card=shard.model_card,
         )
         # In offline mode optional companions can never be fetched and the
         # runner degrades to run-without-speculation, so only load-bearing

--- a/src/skulk/download/coordinator.py
+++ b/src/skulk/download/coordinator.py
@@ -625,15 +625,32 @@ class DownloadCoordinator:
             await self.shard_downloader.get_shard_download_status_for_shard(shard)
         )
 
-        if initial_progress.status == "complete":
+        completed_path = (
+            resolve_model_in_path(
+                model_id,
+                shard.model_card.source_revision,
+                expected_card=shard.model_card,
+            )
+            if initial_progress.status == "complete"
+            else None
+        )
+        if initial_progress.status == "complete" and completed_path is not None:
             completed = DownloadCompleted(
                 shard_metadata=shard,
                 node_id=self.node_id,
                 total=initial_progress.total,
-                model_directory=self._model_dir(model_id),
+                model_directory=str(completed_path),
             )
             await self._emit_status(completed)
             return
+        if initial_progress.status == "complete":
+            # Byte-only direct-download probes cannot distinguish a signed
+            # same-artifact card replacement. Keep the transfer path active so
+            # the store can atomically refresh the installed-card identity
+            # without retransferring unchanged model bytes.
+            initial_progress = initial_progress.model_copy(
+                update={"status": "in_progress"}
+            )
 
         if self.offline:
             logger.warning(
@@ -858,7 +875,11 @@ class DownloadCoordinator:
                         (DownloadCompleted, DownloadOngoing, DownloadFailed),
                     ):
                         continue
-                    found = resolve_model_in_path(mid, card.source_revision)
+                    found = resolve_model_in_path(
+                        mid,
+                        card.source_revision,
+                        expected_card=card,
+                    )
                     if found is not None and not model_companions_present_on_disk(
                         card, required_only=self.offline
                     ):

--- a/src/skulk/download/coordinator.py
+++ b/src/skulk/download/coordinator.py
@@ -24,6 +24,7 @@ from skulk.shared.constants import SKULK_MODELS_DIR
 from skulk.shared.models.model_cards import (
     ModelId,
     get_model_cards,
+    register_installed_card_record,
     same_model_artifact,
     unregister_installed_card_record,
 )
@@ -52,6 +53,9 @@ from skulk.shared.types.worker.downloads import (
 )
 from skulk.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
 from skulk.store.config import resolve_config_path, update_skulk_config_atomic
+from skulk.store.installed_cards import (
+    refresh_registry_installed_card_if_same_artifact,
+)
 from skulk.utils.channels import Receiver, Sender
 from skulk.utils.task_group import TaskGroup
 
@@ -125,6 +129,66 @@ class DownloadCoordinator:
 
     def _model_dir(self, model_id: ModelId) -> str:
         return str(SKULK_MODELS_DIR / model_id.normalize())
+
+    async def _resolve_or_refresh_complete_artifact(
+        self,
+        shard: ShardMetadata,
+        candidate: Path | None = None,
+    ) -> Path | None:
+        """Resolve exact installed truth or refresh a proven card-only update.
+
+        Args:
+            shard: Exact card generation requested by the coordinator.
+            candidate: Optional byte-complete directory reported by the direct
+                downloader's status probe.
+
+        Returns:
+            A directory carrying the exact requested installed-card identity,
+            or ``None`` when bytes must still be downloaded or staged.
+
+        Side effects:
+            May atomically refresh only installed-card metadata when an older
+            sidecar proves the same repository, revision, and selected files.
+        """
+
+        card = shard.model_card
+        exact = resolve_model_in_path(
+            card.model_id,
+            card.source_revision,
+            expected_card=card,
+        )
+        if exact is not None:
+            return exact
+
+        candidates: list[Path] = []
+        if candidate is not None:
+            candidates.append(candidate.parent if candidate.is_file() else candidate)
+        retained_path = resolve_model_in_path(card.model_id, card.source_revision)
+        if retained_path is not None:
+            candidates.append(retained_path)
+        if card.registry_card_id is not None:
+            candidates.append(Path(self._model_dir(card.model_id)))
+        seen: set[Path] = set()
+        for artifact_directory in candidates:
+            resolved = artifact_directory.resolve()
+            if resolved in seen or not artifact_directory.is_dir():
+                continue
+            seen.add(resolved)
+            if card.registry_card_id is None:
+                return artifact_directory
+            refreshed = await asyncio.to_thread(
+                refresh_registry_installed_card_if_same_artifact,
+                artifact_directory,
+                card,
+            )
+            if refreshed is not None:
+                register_installed_card_record(refreshed)
+                logger.info(
+                    "DownloadCoordinator: refreshed installed-card identity for "
+                    f"{card.model_id} without transferring model bytes"
+                )
+                return artifact_directory
+        return None
 
     def _reset_progress_throttle(self, model_id: ModelId) -> None:
         """Start a fresh progress high-water mark for one download attempt."""
@@ -578,11 +642,7 @@ class DownloadCoordinator:
         # models with speculative decoding silently unavailable (codex
         # review on the launch-smoke fix). Fall through to the download
         # path instead so the companion gets fetched.
-        found_path = resolve_model_in_path(
-            model_id,
-            shard.model_card.source_revision,
-            expected_card=shard.model_card,
-        )
+        found_path = await self._resolve_or_refresh_complete_artifact(shard)
         # In offline mode optional companions can never be fetched and the
         # runner degrades to run-without-speculation, so only load-bearing
         # companions (split vision weights) block the shortcut there —
@@ -626,10 +686,9 @@ class DownloadCoordinator:
         )
 
         completed_path = (
-            resolve_model_in_path(
-                model_id,
-                shard.model_card.source_revision,
-                expected_card=shard.model_card,
+            await self._resolve_or_refresh_complete_artifact(
+                shard,
+                Path(self._model_dir(model_id)),
             )
             if initial_progress.status == "complete"
             else None
@@ -644,10 +703,9 @@ class DownloadCoordinator:
             await self._emit_status(completed)
             return
         if initial_progress.status == "complete":
-            # Byte-only direct-download probes cannot distinguish a signed
-            # same-artifact card replacement. Keep the transfer path active so
-            # the store can atomically refresh the installed-card identity
-            # without retransferring unchanged model bytes.
+            # Byte-only direct-download probes cannot distinguish a genuinely
+            # different generation from a replacement card whose newly
+            # selected files are absent. Keep those cases on the transfer path.
             initial_progress = initial_progress.model_copy(
                 update={"status": "in_progress"}
             )
@@ -802,7 +860,7 @@ class DownloadCoordinator:
                         "DownloadCoordinator: One-time scan for existing HF download progress..."
                     )
                     async for (
-                        _,
+                        discovered_path,
                         progress,
                     ) in self.shard_downloader.get_shard_download_status():
                         model_id = progress.shard.model_card.model_id
@@ -821,14 +879,31 @@ class DownloadCoordinator:
                             continue
 
                         if progress.status == "complete":
-                            status: DownloadProgress = DownloadCompleted(
-                                node_id=self.node_id,
-                                shard_metadata=progress.shard,
-                                total=progress.total,
-                                model_directory=self._model_dir(
-                                    progress.shard.model_card.model_id
-                                ),
+                            completed_path = (
+                                await self._resolve_or_refresh_complete_artifact(
+                                    progress.shard,
+                                    discovered_path,
+                                )
                             )
+                            companions_present = model_companions_present_on_disk(
+                                progress.shard.model_card,
+                                required_only=self.offline,
+                            )
+                            if completed_path is not None and companions_present:
+                                status: DownloadProgress = DownloadCompleted(
+                                    node_id=self.node_id,
+                                    shard_metadata=progress.shard,
+                                    total=progress.total,
+                                    model_directory=str(completed_path),
+                                )
+                            else:
+                                status = DownloadPending(
+                                    node_id=self.node_id,
+                                    shard_metadata=progress.shard,
+                                    model_directory=self._model_dir(model_id),
+                                    downloaded=progress.downloaded,
+                                    total=progress.total,
+                                )
                         elif progress.status in ["in_progress", "not_started"]:
                             if progress.downloaded_this_session.in_bytes == 0:
                                 status = DownloadPending(

--- a/src/skulk/download/download_utils.py
+++ b/src/skulk/download/download_utils.py
@@ -247,19 +247,27 @@ def _commit_replacement_model_dir(replacement_dir: Path, target_dir: Path) -> No
 
 
 def resolve_model_in_path(
-    model_id: ModelId, source_revision: str | None = None
+    model_id: ModelId,
+    source_revision: str | None = None,
+    *,
+    expected_card: ModelCard | None = None,
 ) -> Path | None:
     """Search SKULK_MODELS_PATH directories for a pre-existing model.
 
     Checks each directory for the normalized name (org--model) and, for pinned
     artifacts, the store's revision-qualified sibling name. A candidate is only
     returned if ``is_model_directory_complete`` confirms all weight files are
-    present and its revision marker matches.
+    present and its revision marker matches. When ``expected_card`` is a signed
+    registry card, the installed-card sidecar must also prove that exact card
+    identity. This prevents a same-revision card replacement from bypassing the
+    normal card-only refresh transaction and then failing at runner load.
 
     Args:
         model_id: Model repository identifier to resolve.
         source_revision: Full immutable Hugging Face commit required by the
             card. When set, the directory must carry a matching revision marker.
+        expected_card: Optional complete card whose signed installed identity
+            must match the resolved directory.
 
     Returns:
         The first complete matching model directory, or ``None``.
@@ -282,6 +290,18 @@ def resolve_model_in_path(
                 and is_model_directory_complete(candidate)
                 and _source_revision_matches(candidate, source_revision)
             ):
+                if (
+                    expected_card is not None
+                    and expected_card.registry_card_id is not None
+                ):
+                    from skulk.store.installed_cards import (
+                        require_registry_installed_artifact,
+                    )
+
+                    try:
+                        require_registry_installed_artifact(candidate, expected_card)
+                    except PermissionError:
+                        continue
                 return candidate
     return None
 

--- a/src/skulk/download/tests/test_re_download.py
+++ b/src/skulk/download/tests/test_re_download.py
@@ -32,6 +32,7 @@ from skulk.shared.types.worker.downloads import DownloadCompleted, DownloadFaile
 from skulk.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
 from skulk.store.installed_cards import (
     build_installed_card_record,
+    require_registry_installed_artifact,
     write_installed_card,
 )
 from skulk.utils.channels import Receiver, Sender, channel
@@ -289,11 +290,13 @@ async def test_registry_identity_change_restarts_same_revision_status() -> None:
     assert status.shard_metadata.model_card.gguf_file == "model-q5.gguf"
 
 
-async def test_complete_byte_probe_cannot_bypass_signed_card_refresh(
+@pytest.mark.parametrize("offline", [False, True])
+async def test_complete_byte_probe_refreshes_signed_card_without_transfer(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    offline: bool,
 ) -> None:
-    """A stale sidecar keeps a byte-complete probe on the refresh path."""
+    """A stale same-artifact sidecar refreshes locally, including offline."""
 
     import skulk.shared.constants as constants
 
@@ -307,6 +310,7 @@ async def test_complete_byte_probe_cannot_bypass_signed_card_refresh(
         download_command_receiver=command_receive,
         event_sender=event_send,
         telemetry_sender=telemetry_send,
+        offline=offline,
     )
     revision = "a" * 40
     old_shard = _make_shard(
@@ -367,9 +371,88 @@ async def test_complete_byte_probe_cannot_bypass_signed_card_refresh(
 
     await coordinator._start_download(requested_shard)
 
-    assert len(started) == 1
-    assert started[0].status == "in_progress"
-    assert not isinstance(coordinator.download_status[MODEL_ID], DownloadCompleted)
+    assert started == []
+    status = coordinator.download_status[MODEL_ID]
+    assert isinstance(status, DownloadCompleted)
+    assert status.model_directory == str(model_directory)
+    require_registry_installed_artifact(model_directory, requested_shard.model_card)
+
+
+async def test_startup_complete_probe_refreshes_signed_card_before_terminal_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restart discovery cannot retain a stale signed completion identity."""
+
+    _command_send, command_receive = channel[ForwarderDownloadCommand]()
+    event_send, _event_receive = channel[Event]()
+    telemetry_send, _telemetry_receive = channel[NodeTelemetry]()
+    downloader = FakeShardDownloader()
+    coordinator = DownloadCoordinator(
+        node_id=NODE_ID,
+        shard_downloader=downloader,
+        download_command_receiver=command_receive,
+        event_sender=event_send,
+        telemetry_sender=telemetry_send,
+        offline=True,
+    )
+    revision = "a" * 40
+    old_shard = _make_shard(
+        source_revision=revision,
+        gguf_file="model.gguf",
+        registry_card_id=f"card_{'a' * 52}",
+    )
+    requested_shard = _make_shard(
+        source_revision=revision,
+        gguf_file="model.gguf",
+        registry_card_id=f"card_{'b' * 52}",
+    )
+    model_directory = tmp_path / MODEL_ID.normalize()
+    model_directory.mkdir()
+    (model_directory / "model.gguf").write_bytes(b"weights")
+    (model_directory / ".skulk-source-revision").write_text(f"{revision}\n")
+    write_installed_card(
+        model_directory,
+        build_installed_card_record(model_directory, old_shard.model_card),
+    )
+    progress = RepoDownloadProgress(
+        repo_id=str(MODEL_ID),
+        repo_revision=revision,
+        shard=requested_shard,
+        completed_files=1,
+        total_files=1,
+        downloaded=Memory.from_mb(100),
+        downloaded_this_session=Memory.from_bytes(0),
+        total=Memory.from_mb(100),
+        overall_speed=0,
+        overall_eta=timedelta(seconds=0),
+        status="complete",
+    )
+
+    async def startup_status() -> AsyncIterator[tuple[Path, RepoDownloadProgress]]:
+        yield model_directory, progress
+
+    async def no_catalog_cards() -> list[ModelCard]:
+        return []
+
+    monkeypatch.setattr(downloader, "get_shard_download_status", startup_status)
+    monkeypatch.setattr(coordinator_module, "get_model_cards", no_catalog_cards)
+    monkeypatch.setattr(coordinator_module, "SKULK_MODELS_DIR", tmp_path)
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(coordinator._emit_existing_download_progress)
+        with anyio.fail_after(1):
+            while not isinstance(
+                coordinator.download_status.get(MODEL_ID),
+                DownloadCompleted,
+            ):
+                await anyio.sleep(0)
+        task_group.cancel_scope.cancel()
+
+    status = coordinator.download_status[MODEL_ID]
+    assert isinstance(status, DownloadCompleted)
+    assert status.model_directory == str(model_directory)
+    require_registry_installed_artifact(model_directory, requested_shard.model_card)
 
 
 async def test_revision_change_replaces_active_download_after_cleanup() -> None:

--- a/src/skulk/download/tests/test_re_download.py
+++ b/src/skulk/download/tests/test_re_download.py
@@ -289,6 +289,89 @@ async def test_registry_identity_change_restarts_same_revision_status() -> None:
     assert status.shard_metadata.model_card.gguf_file == "model-q5.gguf"
 
 
+async def test_complete_byte_probe_cannot_bypass_signed_card_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale sidecar keeps a byte-complete probe on the refresh path."""
+
+    import skulk.shared.constants as constants
+
+    _command_send, command_receive = channel[ForwarderDownloadCommand]()
+    event_send, _event_receive = channel[Event]()
+    telemetry_send, _telemetry_receive = channel[NodeTelemetry]()
+    downloader = FakeShardDownloader()
+    coordinator = DownloadCoordinator(
+        node_id=NODE_ID,
+        shard_downloader=downloader,
+        download_command_receiver=command_receive,
+        event_sender=event_send,
+        telemetry_sender=telemetry_send,
+    )
+    revision = "a" * 40
+    old_shard = _make_shard(
+        source_revision=revision,
+        gguf_file="model.gguf",
+        registry_card_id=f"card_{'a' * 52}",
+    )
+    requested_shard = _make_shard(
+        source_revision=revision,
+        gguf_file="model.gguf",
+        registry_card_id=f"card_{'b' * 52}",
+    )
+    model_directory = tmp_path / MODEL_ID.normalize()
+    model_directory.mkdir()
+    (model_directory / "model.gguf").write_bytes(b"weights")
+    (model_directory / ".skulk-source-revision").write_text(f"{revision}\n")
+    write_installed_card(
+        model_directory,
+        build_installed_card_record(model_directory, old_shard.model_card),
+    )
+    monkeypatch.setattr(constants, "SKULK_MODELS_PATH", (tmp_path,))
+
+    async def byte_complete_status(
+        shard: ShardMetadata,
+    ) -> RepoDownloadProgress:
+        return RepoDownloadProgress(
+            repo_id=str(shard.model_card.model_id),
+            repo_revision=revision,
+            shard=shard,
+            completed_files=1,
+            total_files=1,
+            downloaded=Memory.from_mb(100),
+            downloaded_this_session=Memory.from_bytes(0),
+            total=Memory.from_mb(100),
+            overall_speed=0,
+            overall_eta=timedelta(seconds=0),
+            status="complete",
+        )
+
+    started: list[RepoDownloadProgress] = []
+    monkeypatch.setattr(
+        downloader,
+        "get_shard_download_status_for_shard",
+        byte_complete_status,
+    )
+
+    def record_download_start(
+        _shard: ShardMetadata,
+        progress: RepoDownloadProgress,
+    ) -> None:
+        started.append(progress)
+
+    monkeypatch.setattr(
+        coordinator,
+        "_start_download_task",
+        record_download_start,
+    )
+
+    await coordinator._start_download(requested_shard)
+
+    assert len(started) == 1
+    assert started[0].status == "in_progress"
+    assert not isinstance(coordinator.download_status[MODEL_ID], DownloadCompleted)
+
+
 async def test_revision_change_replaces_active_download_after_cleanup() -> None:
     """A corrected pin must cancel and replace an active old-pin download."""
 

--- a/src/skulk/download/tests/test_source_revision.py
+++ b/src/skulk/download/tests/test_source_revision.py
@@ -17,6 +17,10 @@ from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
 from skulk.shared.types.memory import Memory
 from skulk.shared.types.worker.downloads import FileListEntry, RepoDownloadProgress
 from skulk.shared.types.worker.shards import PipelineShardMetadata, ShardMetadata
+from skulk.store.installed_cards import (
+    build_installed_card_record,
+    write_installed_card,
+)
 
 _OLD_REVISION = "0" * 40
 _NEW_REVISION = "1" * 40
@@ -196,6 +200,54 @@ def test_pinned_store_revision_directory_is_discoverable(
 
     assert resolve_model_in_path(model_id, _NEW_REVISION) == model_dir
     assert build_model_path(model_id, _NEW_REVISION) == model_dir
+
+
+def test_signed_card_replacement_does_not_reuse_stale_installed_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Same artifact bytes still require the requested card-only refresh."""
+
+    model_id = ModelId("org/model")
+    model_dir = tmp_path / model_id.normalize()
+    model_dir.mkdir()
+    (model_dir / "model.gguf").write_bytes(b"weights")
+    (model_dir / ".skulk-source-revision").write_text(f"{_NEW_REVISION}\n")
+    old_card = _shard(_NEW_REVISION).model_card.model_copy(
+        update={
+            "registry_card_id": f"card_{'a' * 52}",
+            "registry_snapshot_id": "snapshot_1_old",
+            "registry_provenance": "agent",
+        }
+    )
+    requested_card = old_card.model_copy(
+        update={
+            "registry_card_id": f"card_{'b' * 52}",
+            "registry_snapshot_id": "snapshot_2_current",
+        }
+    )
+    write_installed_card(
+        model_dir,
+        build_installed_card_record(model_dir, old_card),
+    )
+    monkeypatch.setattr(constants, "SKULK_MODELS_PATH", (tmp_path,))
+
+    assert (
+        resolve_model_in_path(
+            model_id,
+            _NEW_REVISION,
+            expected_card=old_card,
+        )
+        == model_dir
+    )
+    assert (
+        resolve_model_in_path(
+            model_id,
+            _NEW_REVISION,
+            expected_card=requested_card,
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio

--- a/src/skulk/store/installed_cards.py
+++ b/src/skulk/store/installed_cards.py
@@ -845,6 +845,90 @@ def verify_installed_card(
     return bool(record.files)
 
 
+def refresh_registry_installed_card_if_same_artifact(
+    model_directory: Path,
+    model_card: ModelCard,
+) -> InstalledCardRecord | None:
+    """Atomically adopt a replacement signed card for unchanged local bytes.
+
+    The refresh is deliberately narrower than repository/revision equality. It
+    also requires the same selected base artifact and proves that every newly
+    selected same-repository file is already covered by the verified installed
+    manifest. A card that changes bytes, adds an absent projector, or selects a
+    different draft therefore stays on the normal download/staging path.
+
+    Args:
+        model_directory: Complete canonical or staged base-artifact directory.
+        model_card: Replacement signed registry card requested for launch.
+
+    Returns:
+        The newly written installed record, or ``None`` when local evidence is
+        insufficient for a metadata-only refresh.
+
+    Side effects:
+        Atomically replaces the adjacent installed-card sidecar, falling back
+        to Skulk's data directory for a read-only artifact root.
+    """
+
+    if model_card.registry_card_id is None or model_card.source_revision is None:
+        return None
+    try:
+        retained = read_installed_card_with_fallback(model_directory)
+    except (OSError, ValueError):
+        return None
+    if (
+        retained is None
+        or retained.artifact_role != "base"
+        or retained.artifact_model_id != str(model_card.model_id)
+        or retained.artifact_repository != str(model_card.artifact_repository)
+        or retained.artifact_revision != model_card.source_revision
+        or retained.artifact_file != model_card.gguf_file
+        or _revision_marker(model_directory) != model_card.source_revision
+        or not verify_installed_card(model_directory, retained)
+    ):
+        return None
+    if (
+        retained.verification == "registry_verified"
+        and retained.installed_identity == model_card.registry_card_id
+        and retained.model_card.registry_card_id == model_card.registry_card_id
+    ):
+        return retained
+
+    manifest_by_path = {entry.path: entry for entry in retained.files}
+    required_files: list[tuple[str, int | None]] = []
+    if model_card.gguf_file is not None:
+        required_files.append((model_card.gguf_file, None))
+    if model_card.vision is not None and model_card.vision.projector_file is not None:
+        required_files.append(
+            (model_card.vision.projector_file, model_card.vision.projector_size)
+        )
+    runtime = model_card.runtime
+    if (
+        runtime is not None
+        and runtime.served_spec_draft_repo
+        == str(model_card.artifact_repository)
+        and runtime.served_spec_draft_file is not None
+    ):
+        required_files.append((runtime.served_spec_draft_file, None))
+    for relative_path, expected_size in required_files:
+        entry = manifest_by_path.get(relative_path)
+        if entry is None or (
+            expected_size is not None and entry.size_bytes != expected_size
+        ):
+            return None
+
+    refreshed = build_installed_card_record(
+        model_directory,
+        model_card,
+        artifact_repository=str(model_card.artifact_repository),
+        artifact_revision=model_card.source_revision,
+        artifact_file=model_card.gguf_file,
+        file_manifest=retained.files,
+    )
+    write_installed_card_with_fallback(model_directory, refreshed)
+    return refreshed
+
+
 def verify_installed_file(
     model_directory: Path,
     record: InstalledCardRecord,

--- a/src/skulk/store/tests/test_installed_cards.py
+++ b/src/skulk/store/tests/test_installed_cards.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import pytest
 
 import skulk.store.installed_cards as installed_cards
-from skulk.shared.models.model_cards import ModelCard, ModelId, ModelTask
+from skulk.shared.models.model_cards import (
+    ModelCard,
+    ModelId,
+    ModelTask,
+    VisionCardConfig,
+)
 from skulk.shared.types.memory import Memory
 from skulk.store.installed_cards import (
     InstalledCardRecord,
@@ -17,6 +22,7 @@ from skulk.store.installed_cards import (
     installed_card_matches,
     read_installed_card,
     read_installed_card_with_fallback,
+    refresh_registry_installed_card_if_same_artifact,
     require_registry_installed_artifact,
     verify_installed_file,
     write_installed_card,
@@ -94,6 +100,76 @@ def test_pinned_companion_verification_detects_corruption(tmp_path: Path) -> Non
         "mmproj-F16.gguf",
         expected_size=len(b"projector"),
     )
+
+
+def test_signed_same_artifact_card_refresh_reuses_verified_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metadata-only refresh neither transfers nor re-hashes unchanged bytes."""
+
+    artifact = _artifact(tmp_path)
+    old_card = _card()
+    old_record = build_installed_card_record(artifact, old_card)
+    write_installed_card(artifact, old_record)
+    requested = old_card.model_copy(
+        update={"registry_card_id": f"card_{'b' * 52}"}
+    )
+
+    def reject_rehash(_directory: Path) -> object:
+        raise AssertionError("card-only refresh rehashed artifact bytes")
+
+    monkeypatch.setattr(installed_cards, "build_file_manifest", reject_rehash)
+
+    refreshed = refresh_registry_installed_card_if_same_artifact(
+        artifact,
+        requested,
+    )
+
+    assert refreshed is not None
+    assert refreshed.files == old_record.files
+    require_registry_installed_artifact(artifact, requested)
+
+
+def test_signed_card_refresh_upgrades_same_card_from_legacy_marker_state(
+    tmp_path: Path,
+) -> None:
+    """A later immutable revision marker upgrades, rather than reuses, legacy truth."""
+
+    artifact = _artifact(tmp_path, revision_marker=False)
+    card = _card()
+    legacy = build_installed_card_record(artifact, card)
+    write_installed_card(artifact, legacy)
+    (artifact / ".skulk-source-revision").write_text(f"{card.source_revision}\n")
+
+    refreshed = refresh_registry_installed_card_if_same_artifact(artifact, card)
+
+    assert refreshed is not None
+    assert refreshed.verification == "registry_verified"
+    require_registry_installed_artifact(artifact, card)
+
+
+def test_signed_card_refresh_rejects_absent_new_projector(tmp_path: Path) -> None:
+    """A card selecting new bytes stays on the normal artifact transfer path."""
+
+    artifact = _artifact(tmp_path)
+    old_card = _card()
+    old_record = build_installed_card_record(artifact, old_card)
+    write_installed_card(artifact, old_record)
+    requested = old_card.model_copy(
+        update={
+            "registry_card_id": f"card_{'b' * 52}",
+            "vision": VisionCardConfig(
+                projector_file="mmproj-F16.gguf",
+                projector_size=9,
+            ),
+        }
+    )
+
+    assert (
+        refresh_registry_installed_card_if_same_artifact(artifact, requested) is None
+    )
+    assert read_installed_card(artifact) == old_record
 
 
 def test_unmarked_registry_bytes_remain_local_legacy(tmp_path: Path) -> None:

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -2078,7 +2078,9 @@ class Worker:
                     self._download_backoff.record_attempt(model_id)
 
                     found_path = resolve_model_in_path(
-                        model_id, shard.model_card.source_revision
+                        model_id,
+                        shard.model_card.source_revision,
+                        expected_card=shard.model_card,
                     )
                     if found_path is not None:
                         logger.info(

--- a/website/docs/release-notes/next.md
+++ b/website/docs/release-notes/next.md
@@ -14,6 +14,11 @@ the projector and image input owned by the driver. Vision and native MTP work
 together with serial serving as the initial compatibility mode; legacy cards
 without a projector pin continue through the in-process runner.
 
+When a signed replacement changes only card metadata for the same immutable
+artifact, Skulk now refreshes the installed-card sidecar before treating a
+staged cache hit as launchable. The unchanged model bytes remain in place while
+runner trust sees the newly approved exact card identity.
+
 ## Native CUDA serving on Linux ARM64
 
 The managed CUDA llama-server wheel now ships for Linux aarch64 as well as


### PR DESCRIPTION
## Summary
- require an exact signed installed-card identity before the pre-existing-model shortcut can report a cache hit
- route same-artifact card replacements through the existing card-only refresh transaction on both worker and download-coordinator paths
- add focused regression coverage and next-release notes

## Why
A newly approved signed replacement card could pass placement while a staged cache still retained the prior card identity. The shortcut then reported download completion without refreshing the sidecar, and runner load correctly failed closed. Unchanged model bytes should remain reusable, but the exact installed-card identity must be refreshed first.

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (3595 passed, 2 skipped, 237 deselected)
- live configured-fleet reproduction confirmed the failure was terminal and identity-specific before this fix; no private environment details or payloads retained
