### PR TITLE
fix(api): project cluster model install state

### DIFF
--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -5580,6 +5580,12 @@ class API:
         """
 
         self._skulk_config = skulk_config
+        if store_client is not self._store_client:
+            # Last-known installation truth belongs to one authoritative store.
+            # Carrying it across config convergence could manufacture installed
+            # state when the replacement store is unavailable.
+            self._model_list_store_records_cache = {}
+            self._model_list_store_records_cached_at = 0.0
         self._store_client = store_client
         self.refresh_config_dependent_capabilities()
 

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -311,6 +311,7 @@ from skulk.shared.backends import engine_of
 from skulk.shared.constants import (
     DASHBOARD_DIR,
     SKULK_CACHE_HOME,
+    SKULK_ENABLE_IMAGE_MODELS,
     SKULK_EVENT_LOG_DIR,
     SKULK_IMAGE_CACHE_DIR,
     SKULK_IMAGE_TRANSPORT_DEBUG,
@@ -521,6 +522,8 @@ from skulk.store.peer_exports import ArtifactExportManager
 
 JsonObject = dict[str, object]
 _DEFAULT_OPTIMIZER_CANDIDATE_BITS = [4, 8]
+_MODEL_LIST_STORE_CACHE_TTL_SECONDS = 5.0
+_MODEL_LIST_STORE_FETCH_TIMEOUT_SECONDS = 1.0
 
 #: Chunk type flowing through the performance-envelope tap (duck-typed on
 #: ``text`` / ``stats`` / ``finish_reason``, like the field-telemetry tap).
@@ -1621,6 +1624,9 @@ class API:
         # hanging the caller. Bounded FIFO; consumed at stream registration.
         self._pending_stream_failures: dict[CommandId, ErrorChunk] = {}
         self._store_client = store_client
+        self._model_list_store_records_cache: dict[ModelId, InstalledCardRecord] = {}
+        self._model_list_store_records_cached_at = 0.0
+        self._model_list_store_records_lock = asyncio.Lock()
         self._artifact_exports = ArtifactExportManager()
         reconciliation_config = (
             skulk_config.model_store.reconciliation
@@ -8137,6 +8143,10 @@ class API:
         Returns:
             The public catalog projection for ``card``.
         """
+        catalog_card = card
+        installed_record = installed_record or get_installed_card_record(card.model_id)
+        if installed_record is not None:
+            card = installed_record.model_card
         remote_code_approval_required = remote_code_execution_requires_approval(card)
         if remote_code_approval_required and approved_remote_code_card_ids is None:
             approved_remote_code_card_ids = approved_remote_code_identities()
@@ -8149,9 +8159,14 @@ class API:
             "request-specific options such as tools may change prompt rendering "
             "and related resolved capability values."
         )
-        installed_record = installed_record or get_installed_card_record(card.model_id)
-        current_registry_identity = get_current_registry_card_id(card.model_id)
-        current_registry_card = get_current_registry_card(card.model_id)
+        current_registry_card = get_current_registry_card(catalog_card.model_id)
+        current_registry_identity = get_current_registry_card_id(
+            catalog_card.model_id
+        ) or (
+            current_registry_card.registry_card_id
+            if current_registry_card is not None
+            else None
+        )
         advisories_by_id = {
             advisory.advisory_id: advisory
             for advisory in [
@@ -8294,6 +8309,65 @@ class API:
             records[model_id] = record
         return records
 
+    async def _cached_store_installed_records(
+        self,
+    ) -> dict[ModelId, InstalledCardRecord]:
+        """Return responsive last-known installed truth from the central store.
+
+        Model listing is a user-facing read path, so it cannot inherit the
+        metadata client's 30-second timeout. A successful response, including
+        an empty registry, replaces the short-lived cache. Failure or timeout
+        retains the previous snapshot and lets node-local sidecars cover aliases
+        that have never been observed centrally.
+
+        Returns:
+            Valid base installed-card records keyed by exact model alias.
+        """
+
+        if self._store_client is None:
+            return {}
+        now = time.monotonic()
+        if (
+            now - self._model_list_store_records_cached_at
+            < _MODEL_LIST_STORE_CACHE_TTL_SECONDS
+        ):
+            return self._model_list_store_records_cache
+        async with self._model_list_store_records_lock:
+            now = time.monotonic()
+            if (
+                now - self._model_list_store_records_cached_at
+                < _MODEL_LIST_STORE_CACHE_TTL_SECONDS
+            ):
+                return self._model_list_store_records_cache
+            try:
+                entries = await asyncio.wait_for(
+                    self._store_client.fetch_registry(raise_on_error=True),
+                    timeout=_MODEL_LIST_STORE_FETCH_TIMEOUT_SECONDS,
+                )
+            except Exception as error:
+                logger.debug(
+                    "Model-list store projection retained its last-known snapshot: {}",
+                    error,
+                )
+                # Back off the user-facing path after failure as well as success;
+                # otherwise every dashboard refresh would pay the timeout again.
+                self._model_list_store_records_cached_at = time.monotonic()
+                return self._model_list_store_records_cache
+            self._model_list_store_records_cache = self._store_installed_records(
+                entries
+            )
+            self._model_list_store_records_cached_at = time.monotonic()
+            return self._model_list_store_records_cache
+
+    @staticmethod
+    def _model_list_card_visible(card: ModelCard) -> bool:
+        """Apply the catalog's existing image-model visibility policy."""
+
+        return SKULK_ENABLE_IMAGE_MODELS or not any(
+            task in {ModelTask.TextToImage, ModelTask.ImageToImage}
+            for task in card.tasks
+        )
+
     async def get_models(self, status: str | None = Query(default=None)) -> ModelList:
         """Return available models with cluster-authoritative installed state.
 
@@ -8308,6 +8382,15 @@ class API:
             Available catalog models and their effective installed state.
         """
         cards = await get_model_cards()
+        store_installed_records = await self._cached_store_installed_records()
+        cards_by_id = {card.model_id: card for card in cards}
+        for model_id, record in store_installed_records.items():
+            if model_id in cards_by_id or not self._model_list_card_visible(
+                record.model_card
+            ):
+                continue
+            cards.append(record.model_card)
+            cards_by_id[model_id] = record.model_card
 
         if status == "downloaded":
             downloaded_model_ids: set[str] = set()
@@ -8315,14 +8398,14 @@ class API:
                 for dl in node_downloads:
                     if isinstance(dl, DownloadCompleted):
                         downloaded_model_ids.add(dl.shard_metadata.model_card.model_id)
-            cards = [c for c in cards if c.model_id in downloaded_model_ids]
+            cards = [
+                card
+                for card in cards
+                if card.model_id in downloaded_model_ids
+                or card.model_id in store_installed_records
+            ]
 
         approved_remote_code_card_ids = self._cluster_remote_code_approvals()
-        store_installed_records = (
-            self._store_installed_records(await self._store_client.fetch_registry())
-            if self._store_client is not None
-            else {}
-        )
         entries = [
             self._model_list_entry(
                 card,

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -8123,8 +8123,20 @@ class API:
     def _model_list_entry(
         card: "ModelCard",
         approved_remote_code_card_ids: frozenset[str] | None = None,
+        installed_record: InstalledCardRecord | None = None,
     ) -> ModelListModel:
-        """Build the public model-list representation for one model card."""
+        """Build the public model-list representation for one model card.
+
+        Args:
+            card: Effective catalog card exposed by the API.
+            approved_remote_code_card_ids: Cluster-wide remote-code approvals.
+            installed_record: Authoritative central-store generation when one
+                exists. When omitted, the node-local installed-card cache keeps
+                air-gapped and store-unreachable operation self-describing.
+
+        Returns:
+            The public catalog projection for ``card``.
+        """
         remote_code_approval_required = remote_code_execution_requires_approval(card)
         if remote_code_approval_required and approved_remote_code_card_ids is None:
             approved_remote_code_card_ids = approved_remote_code_identities()
@@ -8137,7 +8149,7 @@ class API:
             "request-specific options such as tools may change prompt rendering "
             "and related resolved capability values."
         )
-        installed_record = get_installed_card_record(card.model_id)
+        installed_record = installed_record or get_installed_card_record(card.model_id)
         current_registry_identity = get_current_registry_card_id(card.model_id)
         current_registry_card = get_current_registry_card(card.model_id)
         advisories_by_id = {
@@ -8230,8 +8242,71 @@ class API:
             ),
         )
 
+    @staticmethod
+    def _store_installed_records(
+        entries: Iterable[dict[str, object]],
+    ) -> dict[ModelId, InstalledCardRecord]:
+        """Validate central-store base records for the cluster model projection.
+
+        Companion entries do not represent independently launchable model-list
+        aliases. Malformed or internally mismatched records are ignored rather
+        than allowing store-index corruption to manufacture installed state.
+
+        Args:
+            entries: Raw entries returned by the authoritative store server.
+
+        Returns:
+            Valid base installed-card records keyed by their exact model alias.
+        """
+
+        records: dict[ModelId, InstalledCardRecord] = {}
+        for entry in entries:
+            model_id_raw = entry.get("model_id")
+            installed_raw = entry.get("installed_card")
+            if not isinstance(model_id_raw, str) or not isinstance(
+                installed_raw, dict
+            ):
+                continue
+            try:
+                model_id = ModelId(model_id_raw)
+                record = InstalledCardRecord.model_validate(
+                    installed_raw,
+                    strict=False,
+                )
+            except (ValidationError, ValueError):
+                logger.warning(
+                    "Ignoring malformed installed-card record from the model store "
+                    "for alias {}",
+                    model_id_raw,
+                )
+                continue
+            if (
+                record.artifact_role != "base"
+                or record.artifact_model_id != model_id_raw
+                or record.model_card.model_id != model_id
+            ):
+                logger.warning(
+                    "Ignoring mismatched installed-card record from the model store "
+                    "for alias {}",
+                    model_id_raw,
+                )
+                continue
+            records[model_id] = record
+        return records
+
     async def get_models(self, status: str | None = Query(default=None)) -> ModelList:
-        """Returns list of available models, optionally filtered by being downloaded."""
+        """Return available models with cluster-authoritative installed state.
+
+        The central store is the canonical source for active installed
+        generations. Node-local installed-card records remain the fallback when
+        the store is absent, unreachable, or does not own a particular alias.
+
+        Args:
+            status: Optional legacy ``downloaded`` filter.
+
+        Returns:
+            Available catalog models and their effective installed state.
+        """
         cards = await get_model_cards()
 
         if status == "downloaded":
@@ -8243,8 +8318,21 @@ class API:
             cards = [c for c in cards if c.model_id in downloaded_model_ids]
 
         approved_remote_code_card_ids = self._cluster_remote_code_approvals()
+        store_installed_records = (
+            self._store_installed_records(await self._store_client.fetch_registry())
+            if self._store_client is not None
+            else {}
+        )
         entries = [
-            self._model_list_entry(card, approved_remote_code_card_ids)
+            self._model_list_entry(
+                card,
+                approved_remote_code_card_ids,
+                (
+                    None
+                    if card.is_custom
+                    else store_installed_records.get(card.model_id)
+                ),
+            )
             for card in cards
         ]
         if self._intelligent_fabric_enabled():

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -8144,7 +8144,24 @@ class API:
             The public catalog projection for ``card``.
         """
         catalog_card = card
-        installed_record = installed_record or get_installed_card_record(card.model_id)
+        local_installed_record = get_installed_card_record(card.model_id)
+        if catalog_card.is_custom:
+            # A custom catalog entry is an operator-owned override. Prefer its
+            # node-local custom generation, but do not hide the same custom
+            # generation merely because it is canonical only in the store.
+            # Non-custom records sharing the alias cannot establish installed
+            # state for the custom card.
+            installed_record = (
+                local_installed_record
+                if local_installed_record is not None
+                and local_installed_record.model_card.is_custom
+                else installed_record
+                if installed_record is not None
+                and installed_record.model_card.is_custom
+                else None
+            )
+        else:
+            installed_record = installed_record or local_installed_record
         if installed_record is not None:
             card = installed_record.model_card
         remote_code_approval_required = remote_code_execution_requires_approval(card)
@@ -8410,11 +8427,7 @@ class API:
             self._model_list_entry(
                 card,
                 approved_remote_code_card_ids,
-                (
-                    None
-                    if card.is_custom
-                    else store_installed_records.get(card.model_id)
-                ),
+                store_installed_records.get(card.model_id),
             )
             for card in cards
         ]

--- a/src/skulk/api/tests/test_model_installed_projection.py
+++ b/src/skulk/api/tests/test_model_installed_projection.py
@@ -253,6 +253,40 @@ async def test_custom_card_keeps_local_installed_precedence(
     assert response.data[0].installed_verification == "custom"
 
 
+async def test_custom_card_uses_matching_cluster_store_installation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A store-backed custom generation must be installed across API nodes."""
+
+    store_record = _custom_installed_record(tmp_path)
+    custom_card = store_record.model_card
+    store_client = _RegistryStoreClient(
+        [
+            {
+                "model_id": str(custom_card.model_id),
+                "installed_card": store_record.model_dump(mode="json"),
+            }
+        ]
+    )
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=custom_card,
+        current_registry_card_value=None,
+        local_record=None,
+    )
+    api = _api_with_store(store_client)
+
+    response = await api.get_models(status=None)
+
+    assert len(response.data) == 1
+    assert response.data[0].installed is True
+    assert response.data[0].active_installed_identity == (
+        store_record.installed_identity
+    )
+    assert response.data[0].installed_verification == "custom"
+
+
 async def test_store_generation_supplies_active_metadata_and_current_update(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/src/skulk/api/tests/test_model_installed_projection.py
+++ b/src/skulk/api/tests/test_model_installed_projection.py
@@ -1,0 +1,248 @@
+# pyright: reportPrivateUsage=false
+"""Cluster model listings project authoritative installed-card state."""
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import skulk.api.main as api_main
+from skulk.api.main import API
+from skulk.shared.models.model_cards import ModelCard, ModelTask
+from skulk.shared.types.common import ModelId
+from skulk.shared.types.memory import Memory
+from skulk.store.installed_cards import (
+    InstalledCardRecord,
+    build_installed_card_record,
+)
+from skulk.store.model_store_client import ModelStoreClient
+
+
+class _RegistryStoreClient:
+    """Minimal store client returning a controlled registry snapshot."""
+
+    def __init__(self, entries: list[dict[str, object]]) -> None:
+        """Retain the entries returned by ``fetch_registry``."""
+
+        self.entries = entries
+        self.fetch_count = 0
+
+    async def fetch_registry(self) -> list[dict[str, object]]:
+        """Return one synthetic authoritative-store snapshot."""
+
+        self.fetch_count += 1
+        return self.entries
+
+
+def _card(identity_character: str) -> ModelCard:
+    """Create one immutable signed card for the projection tests."""
+
+    return ModelCard(
+        model_id=ModelId("example/model@q4"),
+        storage_size=Memory.from_mb(1),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        source_revision=identity_character * 40,
+        registry_card_id=f"card_{identity_character * 52}",
+        registry_snapshot_id="snapshot_test",
+        registry_provenance="foxlight",
+        quantization="Q4_K_M",
+    )
+
+
+def _installed_record(tmp_path: Path, card: ModelCard) -> InstalledCardRecord:
+    """Build a revision-verified installed record for ``card``."""
+
+    assert card.registry_card_id is not None
+    artifact = tmp_path / card.registry_card_id
+    artifact.mkdir()
+    (artifact / "model.gguf").write_bytes(b"weights")
+    assert card.source_revision is not None
+    (artifact / ".skulk-source-revision").write_text(
+        f"{card.source_revision}\n",
+        encoding="utf-8",
+    )
+    return build_installed_card_record(artifact, card, artifact_format="gguf")
+
+
+def _custom_installed_record(tmp_path: Path) -> InstalledCardRecord:
+    """Build a custom installed record sharing the registry test alias."""
+
+    card = ModelCard(
+        model_id=ModelId("example/model@q4"),
+        storage_size=Memory.from_mb(1),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        is_custom=True,
+        quantization="operator",
+    )
+    artifact = tmp_path / "custom"
+    artifact.mkdir()
+    (artifact / "config.json").write_text("{}", encoding="utf-8")
+    return build_installed_card_record(artifact, card, artifact_format="custom")
+
+
+def _configure_model_list_test(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    card: ModelCard,
+    local_record: InstalledCardRecord | None,
+) -> None:
+    """Install deterministic catalog and local-record effects for one test."""
+
+    async def model_cards() -> list[ModelCard]:
+        return [card]
+
+    def cluster_approvals(_api: API) -> frozenset[str]:
+        return frozenset()
+
+    def intelligent_fabric_enabled(_api: API) -> bool:
+        return False
+
+    def local_record_lookup(_model_id: ModelId) -> InstalledCardRecord | None:
+        return local_record
+
+    def current_registry_card_id(_model_id: ModelId) -> str | None:
+        return card.registry_card_id
+
+    def current_registry_card(_model_id: ModelId) -> ModelCard:
+        return card
+
+    def model_advisories(_card: ModelCard) -> tuple[()]:
+        return ()
+
+    monkeypatch.setattr(api_main, "get_model_cards", model_cards)
+    monkeypatch.setattr(api_main, "get_installed_card_record", local_record_lookup)
+    monkeypatch.setattr(
+        api_main,
+        "get_current_registry_card_id",
+        current_registry_card_id,
+    )
+    monkeypatch.setattr(
+        api_main,
+        "get_current_registry_card",
+        current_registry_card,
+    )
+    monkeypatch.setattr(api_main, "get_model_advisories", model_advisories)
+    monkeypatch.setattr(API, "_cluster_remote_code_approvals", cluster_approvals)
+    monkeypatch.setattr(
+        API,
+        "_intelligent_fabric_enabled",
+        intelligent_fabric_enabled,
+    )
+
+
+async def test_models_use_cluster_store_installed_record(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Every API node should expose the central store's active generation."""
+
+    card = _card("a")
+    record = _installed_record(tmp_path, card)
+    store_client = _RegistryStoreClient(
+        [
+            {
+                "model_id": str(card.model_id),
+                "installed_card": record.model_dump(mode="json"),
+            }
+        ]
+    )
+    _configure_model_list_test(monkeypatch, card=card, local_record=None)
+    api = object.__new__(API)
+    api._store_client = cast(ModelStoreClient, cast(object, store_client))
+
+    response = await api.get_models(status=None)
+
+    assert store_client.fetch_count == 1
+    assert len(response.data) == 1
+    assert response.data[0].installed is True
+    assert response.data[0].active_installed_identity == card.registry_card_id
+    assert response.data[0].installed_verification == "registry_verified"
+    assert response.data[0].update_available is False
+
+
+async def test_models_fall_back_to_local_installed_record(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A missing store record must not erase a usable local generation."""
+
+    installed_card = _card("a")
+    current_card = _card("b")
+    local_record = _installed_record(tmp_path, installed_card)
+    store_client = _RegistryStoreClient([])
+    _configure_model_list_test(
+        monkeypatch,
+        card=current_card,
+        local_record=local_record,
+    )
+    api = object.__new__(API)
+    api._store_client = cast(ModelStoreClient, cast(object, store_client))
+
+    response = await api.get_models(status=None)
+
+    assert store_client.fetch_count == 1
+    assert len(response.data) == 1
+    assert response.data[0].installed is True
+    assert response.data[0].active_installed_identity == installed_card.registry_card_id
+    assert response.data[0].installed_verification == "registry_verified"
+    assert response.data[0].current_registry_identity == current_card.registry_card_id
+    assert response.data[0].update_available is True
+
+
+async def test_custom_card_keeps_local_installed_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A same-alias store card must not override an operator's custom card."""
+
+    registry_card = _card("a")
+    store_record = _installed_record(tmp_path, registry_card)
+    local_record = _custom_installed_record(tmp_path)
+    custom_card = local_record.model_card
+    store_client = _RegistryStoreClient(
+        [
+            {
+                "model_id": str(registry_card.model_id),
+                "installed_card": store_record.model_dump(mode="json"),
+            }
+        ]
+    )
+    _configure_model_list_test(
+        monkeypatch,
+        card=custom_card,
+        local_record=local_record,
+    )
+    api = object.__new__(API)
+    api._store_client = cast(ModelStoreClient, cast(object, store_client))
+
+    response = await api.get_models(status=None)
+
+    assert response.data[0].installed is True
+    assert response.data[0].active_installed_identity == local_record.installed_identity
+    assert response.data[0].installed_verification == "custom"
+
+
+def test_store_projection_rejects_mismatched_alias(
+    tmp_path: Path,
+) -> None:
+    """An index key cannot assert installation for a different signed card alias."""
+
+    card = _card("a")
+    record = _installed_record(tmp_path, card)
+
+    records = API._store_installed_records(
+        [
+            {
+                "model_id": "example/other@q4",
+                "installed_card": record.model_dump(mode="json"),
+            }
+        ]
+    )
+
+    assert records == {}

--- a/src/skulk/api/tests/test_model_installed_projection.py
+++ b/src/skulk/api/tests/test_model_installed_projection.py
@@ -394,6 +394,53 @@ async def test_model_list_store_timeout_reuses_last_known_snapshot(
     )
 
 
+async def test_model_store_replacement_invalidates_installed_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Store convergence cannot retain another store's installed records."""
+
+    card = _card("a")
+    record = _installed_record(tmp_path, card)
+    first_store = _RegistryStoreClient(
+        [
+            {
+                "model_id": str(card.model_id),
+                "installed_card": record.model_dump(mode="json"),
+            }
+        ]
+    )
+    replacement_store = _RegistryStoreClient([])
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=card,
+        current_registry_card_value=card,
+        local_record=None,
+    )
+
+    def refresh_capabilities(_api: API) -> None:
+        """Keep the runtime convergence test independent of provider state."""
+
+    monkeypatch.setattr(
+        API,
+        "refresh_config_dependent_capabilities",
+        refresh_capabilities,
+    )
+    api = _api_with_store(first_store)
+
+    first = await api.get_models(status=None)
+    api.set_model_store_runtime(
+        None,
+        cast(ModelStoreClient, cast(object, replacement_store)),
+    )
+    second = await api.get_models(status=None)
+
+    assert first.data[0].installed is True
+    assert second.data[0].installed is False
+    assert first_store.fetch_count == 1
+    assert replacement_store.fetch_count == 1
+
+
 def test_store_projection_rejects_mismatched_alias(
     tmp_path: Path,
 ) -> None:

--- a/src/skulk/api/tests/test_model_installed_projection.py
+++ b/src/skulk/api/tests/test_model_installed_projection.py
@@ -1,6 +1,7 @@
 # pyright: reportPrivateUsage=false
 """Cluster model listings project authoritative installed-card state."""
 
+import asyncio
 from pathlib import Path
 from typing import cast
 
@@ -26,11 +27,19 @@ class _RegistryStoreClient:
 
         self.entries = entries
         self.fetch_count = 0
+        self.block = False
 
-    async def fetch_registry(self) -> list[dict[str, object]]:
+    async def fetch_registry(
+        self,
+        *,
+        raise_on_error: bool = False,
+    ) -> list[dict[str, object]]:
         """Return one synthetic authoritative-store snapshot."""
 
+        del raise_on_error
         self.fetch_count += 1
+        if self.block:
+            await asyncio.Event().wait()
         return self.entries
 
 
@@ -89,13 +98,14 @@ def _custom_installed_record(tmp_path: Path) -> InstalledCardRecord:
 def _configure_model_list_test(
     monkeypatch: pytest.MonkeyPatch,
     *,
-    card: ModelCard,
+    catalog_card: ModelCard | None,
+    current_registry_card_value: ModelCard | None,
     local_record: InstalledCardRecord | None,
 ) -> None:
     """Install deterministic catalog and local-record effects for one test."""
 
     async def model_cards() -> list[ModelCard]:
-        return [card]
+        return [catalog_card] if catalog_card is not None else []
 
     def cluster_approvals(_api: API) -> frozenset[str]:
         return frozenset()
@@ -107,10 +117,10 @@ def _configure_model_list_test(
         return local_record
 
     def current_registry_card_id(_model_id: ModelId) -> str | None:
-        return card.registry_card_id
+        return None
 
-    def current_registry_card(_model_id: ModelId) -> ModelCard:
-        return card
+    def current_registry_card(_model_id: ModelId) -> ModelCard | None:
+        return current_registry_card_value
 
     def model_advisories(_card: ModelCard) -> tuple[()]:
         return ()
@@ -136,6 +146,17 @@ def _configure_model_list_test(
     )
 
 
+def _api_with_store(store_client: _RegistryStoreClient) -> API:
+    """Create the minimal API state needed by the model-list projection."""
+
+    api = object.__new__(API)
+    api._store_client = cast(ModelStoreClient, cast(object, store_client))
+    api._model_list_store_records_cache = {}
+    api._model_list_store_records_cached_at = 0.0
+    api._model_list_store_records_lock = asyncio.Lock()
+    return api
+
+
 async def test_models_use_cluster_store_installed_record(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -152,9 +173,13 @@ async def test_models_use_cluster_store_installed_record(
             }
         ]
     )
-    _configure_model_list_test(monkeypatch, card=card, local_record=None)
-    api = object.__new__(API)
-    api._store_client = cast(ModelStoreClient, cast(object, store_client))
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=card,
+        current_registry_card_value=card,
+        local_record=None,
+    )
+    api = _api_with_store(store_client)
 
     response = await api.get_models(status=None)
 
@@ -178,11 +203,11 @@ async def test_models_fall_back_to_local_installed_record(
     store_client = _RegistryStoreClient([])
     _configure_model_list_test(
         monkeypatch,
-        card=current_card,
+        catalog_card=current_card,
+        current_registry_card_value=current_card,
         local_record=local_record,
     )
-    api = object.__new__(API)
-    api._store_client = cast(ModelStoreClient, cast(object, store_client))
+    api = _api_with_store(store_client)
 
     response = await api.get_models(status=None)
 
@@ -215,17 +240,124 @@ async def test_custom_card_keeps_local_installed_precedence(
     )
     _configure_model_list_test(
         monkeypatch,
-        card=custom_card,
+        catalog_card=custom_card,
+        current_registry_card_value=registry_card,
         local_record=local_record,
     )
-    api = object.__new__(API)
-    api._store_client = cast(ModelStoreClient, cast(object, store_client))
+    api = _api_with_store(store_client)
 
     response = await api.get_models(status=None)
 
     assert response.data[0].installed is True
     assert response.data[0].active_installed_identity == local_record.installed_identity
     assert response.data[0].installed_verification == "custom"
+
+
+async def test_store_generation_supplies_active_metadata_and_current_update(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Active fields describe installed A while update truth identifies current B."""
+
+    installed_card = _card("a")
+    current_card = _card("b")
+    store_record = _installed_record(tmp_path, installed_card)
+    store_client = _RegistryStoreClient(
+        [
+            {
+                "model_id": str(installed_card.model_id),
+                "installed_card": store_record.model_dump(mode="json"),
+            }
+        ]
+    )
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=current_card,
+        current_registry_card_value=current_card,
+        local_record=None,
+    )
+    api = _api_with_store(store_client)
+
+    response = await api.get_models(status=None)
+
+    entry = response.data[0]
+    assert entry.registry_card_id == installed_card.registry_card_id
+    assert entry.active_installed_identity == installed_card.registry_card_id
+    assert entry.current_registry_identity == current_card.registry_card_id
+    assert entry.update_available is True
+
+
+async def test_store_only_installed_card_remains_in_model_list(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Registry removal must not hide a complete installed generation."""
+
+    installed_card = _card("a")
+    store_record = _installed_record(tmp_path, installed_card)
+    store_client = _RegistryStoreClient(
+        [
+            {
+                "model_id": str(installed_card.model_id),
+                "installed_card": store_record.model_dump(mode="json"),
+            }
+        ]
+    )
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=None,
+        current_registry_card_value=None,
+        local_record=None,
+    )
+    api = _api_with_store(store_client)
+
+    response = await api.get_models(status=None)
+
+    assert len(response.data) == 1
+    assert response.data[0].id == str(installed_card.model_id)
+    assert response.data[0].installed is True
+    assert response.data[0].current_registry_identity is None
+    assert response.data[0].update_available is False
+
+
+async def test_model_list_store_timeout_reuses_last_known_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An unreachable store cannot stall or erase the last installed projection."""
+
+    card = _card("a")
+    record = _installed_record(tmp_path, card)
+    store_client = _RegistryStoreClient(
+        [
+            {
+                "model_id": str(card.model_id),
+                "installed_card": record.model_dump(mode="json"),
+            }
+        ]
+    )
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=card,
+        current_registry_card_value=card,
+        local_record=None,
+    )
+    api = _api_with_store(store_client)
+    first = await api.get_models(status=None)
+    store_client.block = True
+    api._model_list_store_records_cached_at = 0.0
+    monkeypatch.setattr(api_main, "_MODEL_LIST_STORE_FETCH_TIMEOUT_SECONDS", 0.01)
+
+    second = await asyncio.wait_for(api.get_models(status=None), timeout=0.1)
+    third = await asyncio.wait_for(api.get_models(status=None), timeout=0.1)
+
+    assert store_client.fetch_count == 2
+    assert second.data[0].active_installed_identity == (
+        first.data[0].active_installed_identity
+    )
+    assert third.data[0].active_installed_identity == (
+        first.data[0].active_installed_identity
+    )
 
 
 def test_store_projection_rejects_mismatched_alias(

--- a/src/skulk/api/types/api.py
+++ b/src/skulk/api/types/api.py
@@ -140,8 +140,9 @@ class ModelListModel(BaseModel):
     artifact_repository: str = Field(
         default="",
         description=(
-            "Upstream repository containing the exact artifact; distinct from id "
-            "when multiple registry cards select files from one repository."
+            "Upstream repository containing the active installed artifact when one "
+            "exists, otherwise the effective catalog artifact; distinct from id when "
+            "multiple registry cards select files from one repository."
         ),
     )
     artifact_file: str | None = Field(
@@ -151,7 +152,10 @@ class ModelListModel(BaseModel):
     registry_card_id: str | None = Field(
         default=None,
         pattern=r"^card_[a-z2-7]{52}$",
-        description="Immutable signed-registry card id, or null for local cards.",
+        description=(
+            "Immutable signed identity of the active installed card when one exists, "
+            "otherwise the effective catalog card; null for local cards."
+        ),
     )
     registry_snapshot_id: str | None = Field(
         default=None,

--- a/src/skulk/api/types/api.py
+++ b/src/skulk/api/types/api.py
@@ -177,11 +177,17 @@ class ModelListModel(BaseModel):
     )
     installed: bool = Field(
         default=False,
-        description="Whether this node has an active complete installed generation.",
+        description=(
+            "Whether the authoritative cluster store, or the local node when the "
+            "store has no record, has an active complete installed generation."
+        ),
     )
     active_installed_identity: str | None = Field(
         default=None,
-        description="Durable identity of the generation this node will launch.",
+        description=(
+            "Durable identity of the active cluster-store generation, falling back "
+            "to the node-local generation when necessary."
+        ),
     )
     installed_verification: (
         Literal["registry_verified", "local_legacy", "custom", "unresolved"] | None

--- a/src/skulk/store/model_store_client.py
+++ b/src/skulk/store/model_store_client.py
@@ -995,6 +995,7 @@ class ModelStoreClient:
         self,
         *,
         recover_installed_cards: bool = False,
+        raise_on_error: bool = False,
     ) -> list[dict[str, object]]:
         """Fetch the full store registry from the store server.
 
@@ -1002,6 +1003,9 @@ class ModelStoreClient:
             recover_installed_cards: Ask a local authoritative store to adopt
                 complete adjacent sidecars before returning its index. Used by
                 reconciliation after it inventories pre-upgrade canonical data.
+            raise_on_error: Propagate transport, HTTP, and shape failures so a
+                latency-sensitive caller can retain last-known state. The
+                default preserves the historical empty-list fallback.
 
         Returns a list of registry entry dicts, or an empty list on error.
         """
@@ -1014,12 +1018,20 @@ class ModelStoreClient:
                 session.get(url) as resp,
             ):
                 if resp.status != 200:
+                    if raise_on_error:
+                        raise RuntimeError(
+                            f"store registry returned HTTP {resp.status}"
+                        )
                     return []
                 data: object = await resp.json()
                 if not isinstance(data, list):
+                    if raise_on_error:
+                        raise ValueError("store registry response is not a list")
                     return []
                 return [entry for entry in data if isinstance(entry, dict)]
         except Exception as exc:
+            if raise_on_error:
+                raise
             logger.debug(f"ModelStoreClient: fetch_registry failed: {exc}")
             return []
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -2152,8 +2152,8 @@ Important fields:
 | `registry_card_id` | string or null | Immutable content-derived card identity from the signed registry |
 | `registry_snapshot_id` | string or null | Signed catalog snapshot that supplied the card |
 | `registry_provenance` | string or null | Audited signed-registry origin (`foxlight`, `agent`, or `community`); null for bundled/custom cards |
-| `installed` | boolean | Whether this node has a complete active installed generation |
-| `active_installed_identity` | string or null | Durable generation identity this node will launch |
+| `installed` | boolean | Whether the authoritative cluster store has a complete active generation, falling back to the API node's local sidecar when the store has no record |
+| `active_installed_identity` | string or null | Durable identity of that cluster-store generation, or the node-local fallback generation |
 | `installed_verification` | string or null | `registry_verified`, `local_legacy`, `custom`, or `unresolved` |
 | `current_registry_identity` | string or null | Current signed identity for the alias, which may differ from the active install |
 | `update_available` | boolean | A newer signed generation exists but is not active until transfer commits |

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -2137,6 +2137,11 @@ Returns the known model catalog, including downloaded models and catalog-backed
 entries. Each item includes nullable `source_revision` metadata identifying the
 qualified Hugging Face commit when its card pins immutable artifacts.
 
+When an alias has an active installed generation, artifact, capability, runtime,
+trust, and `registry_card_id` fields describe that retained full card. The
+separate `current_registry_identity` and `update_available` fields describe a
+newer signed catalog generation without pretending it is already active.
+
 Important fields:
 
 | Field | Type | Meaning |
@@ -2149,7 +2154,7 @@ Important fields:
 | `artifact_repository` | string | Upstream repository containing the artifact bytes; may differ from `id` when several exact files or quants share one repository |
 | `artifact_file` | string or null | Exact selected file for file-addressed artifacts such as GGUF |
 | `catalog_source` | string | `registry`, `bundled`, or `custom` |
-| `registry_card_id` | string or null | Immutable content-derived card identity from the signed registry |
+| `registry_card_id` | string or null | Immutable content-derived identity of the active installed card, or the effective catalog card when not installed |
 | `registry_snapshot_id` | string or null | Signed catalog snapshot that supplied the card |
 | `registry_provenance` | string or null | Audited signed-registry origin (`foxlight`, `agent`, or `community`); null for bundled/custom cards |
 | `installed` | boolean | Whether the authoritative cluster store has a complete active generation, falling back to the API node's local sidecar when the store has no record |


### PR DESCRIPTION
## Summary
- project `/v1/models` installed state from the authoritative central-store registry instead of only the serving API node's local sidecar cache
- retain node-local installed-card fallback for offline, unreachable-store, and custom-card operation
- reject malformed, companion, or alias-mismatched store records from the model-list projection
- document the corrected additive API semantics

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest` (3,622 passed, 2 skipped)
- `uv run python scripts/export_openapi.py`
- `uv run python scripts/build_docs.py`