### PR TITLE
Fix exact qualification cleanup acknowledgement race

### DIFF
--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -9003,7 +9003,11 @@ class API:
             mutation_applied = custom_card_mutation_applied(mutation_command_id)
             if mutation_applied and current != expected_card:
                 return
-            if expected_card is not None and current != expected_card:
+            if (
+                expected_card is not None
+                and current is not None
+                and current != expected_card
+            ):
                 raise HTTPException(
                     status_code=409,
                     detail=(

--- a/src/skulk/api/tests/test_remote_code_approval_catalog.py
+++ b/src/skulk/api/tests/test_remote_code_approval_catalog.py
@@ -661,6 +661,17 @@ async def test_qualification_cleanup_requires_this_command_acknowledgement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An absent cached card cannot acknowledge a new cleanup command."""
+    expected = ModelCard(
+        model_id=ModelId("org/preexisting"),
+        source_revision="b" * 40,
+        storage_size=Memory.from_bytes(1),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        is_custom=True,
+        qualification_only=True,
+    )
 
     def missing_card(_model_id: ModelId) -> None:
         return None
@@ -676,5 +687,6 @@ async def test_qualification_cleanup_requires_this_command_acknowledgement(
         await API._wait_for_qualification_card_deletion(
             ModelId("org/preexisting"),
             CommandId(),
+            expected_card=expected,
             timeout_seconds=0.0,
         )


### PR DESCRIPTION
## Summary
- wait for the exact delete acknowledgement when the temporary card disappears before its command acknowledgement reaches the API cache
- retain `409` only for a different non-null card that actually won ownership
- cover the absent-before-ack race with a focused regression test

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt`
- `uv run pytest src/skulk/api/tests/test_remote_code_approval_catalog.py -q` (16 passed)
- `uv run pytest -q` (3655 passed, 2 skipped, 237 deselected)