### PR TITLE
Keep qualification sidecars out of the live catalog

### DIFF
--- a/src/skulk/shared/models/model_cards.py
+++ b/src/skulk/shared/models/model_cards.py
@@ -533,6 +533,12 @@ def register_installed_card_record(record: "InstalledCardRecord") -> None:
     _installed_current_registry_ids[model_id] = (
         current_card.registry_card_id if current_card is not None else None
     )
+    if record.model_card.qualification_only:
+        # The lifecycle-owned custom TOML is the sole authority that makes an
+        # unsigned qualification card visible.  Retain its installed sidecar
+        # for offline artifact truth, but never let the live download path make
+        # that temporary card independently durable in the model catalog.
+        return
     existing = _card_cache.get(model_id)
     if existing is None or not existing.is_custom or record.verification == "custom":
         _card_cache[model_id] = record.model_card

--- a/src/skulk/shared/models/tests/test_registry.py
+++ b/src/skulk/shared/models/tests/test_registry.py
@@ -1306,13 +1306,6 @@ def test_installed_qualification_card_does_not_survive_lifecycle_cleanup(
     model_cards_module._installed_current_registry_ids.clear()
     model_cards_module._card_cache[card.model_id] = card
     try:
-        model_cards_module.register_installed_card_record(record)
-
-        assert model_cards_module.get_card(card.model_id) == card
-        model_cards_module._card_cache.pop(card.model_id)
-        assert model_cards_module.get_card(card.model_id) is None
-        assert model_cards_module.get_installed_card_record(card.model_id) == record
-
         model_cards_module._apply_installed_card_snapshot([record], 0)
 
         assert card.model_id not in model_cards_module._card_cache
@@ -1324,6 +1317,56 @@ def test_installed_qualification_card_does_not_survive_lifecycle_cleanup(
         model_cards_module._installed_card_cache.update(original_installed)
         model_cards_module._installed_current_registry_ids.clear()
         model_cards_module._installed_current_registry_ids.update(original_current)
+
+
+def test_late_qualification_install_registration_cannot_restore_deleted_card(
+    tmp_path: Path,
+) -> None:
+    """A late staging callback cannot outlive qualification-card cleanup."""
+    card = ModelCard(
+        model_id=ModelId("org/qualification-late-install"),
+        source_revision="b" * 40,
+        storage_size=Memory.from_bytes(1),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        is_custom=True,
+        qualification_only=True,
+    )
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "model.safetensors").write_bytes(b"weights")
+    record = build_installed_card_record(artifact, card)
+    original_cache = dict(model_cards_module._card_cache)
+    original_installed = dict(model_cards_module._installed_card_cache)
+    original_current = dict(model_cards_module._installed_current_registry_ids)
+    original_mutations = dict(model_cards_module._installed_card_mutation_versions)
+    original_version = cast(
+        "int", model_cards_module._installed_card_cache_version
+    )
+    model_cards_module._card_cache.clear()
+    model_cards_module._installed_card_cache.clear()
+    model_cards_module._installed_current_registry_ids.clear()
+    model_cards_module._installed_card_mutation_versions.clear()
+    try:
+        model_cards_module._card_cache[card.model_id] = card
+        model_cards_module._card_cache.pop(card.model_id)
+
+        model_cards_module.register_installed_card_record(record)
+
+        assert model_cards_module.get_card(card.model_id) is None
+        assert model_cards_module.get_installed_card_record(card.model_id) == record
+    finally:
+        model_cards_module._card_cache.clear()
+        model_cards_module._card_cache.update(original_cache)
+        model_cards_module._installed_card_cache.clear()
+        model_cards_module._installed_card_cache.update(original_installed)
+        model_cards_module._installed_current_registry_ids.clear()
+        model_cards_module._installed_current_registry_ids.update(original_current)
+        model_cards_module._installed_card_mutation_versions.clear()
+        model_cards_module._installed_card_mutation_versions.update(original_mutations)
+        model_cards_module._installed_card_cache_version = original_version
 
 
 @pytest.mark.asyncio

--- a/src/skulk/shared/models/tests/test_registry.py
+++ b/src/skulk/shared/models/tests/test_registry.py
@@ -1306,6 +1306,13 @@ def test_installed_qualification_card_does_not_survive_lifecycle_cleanup(
     model_cards_module._installed_current_registry_ids.clear()
     model_cards_module._card_cache[card.model_id] = card
     try:
+        model_cards_module.register_installed_card_record(record)
+
+        assert model_cards_module.get_card(card.model_id) == card
+        model_cards_module._card_cache.pop(card.model_id)
+        assert model_cards_module.get_card(card.model_id) is None
+        assert model_cards_module.get_installed_card_record(card.model_id) == record
+
         model_cards_module._apply_installed_card_snapshot([record], 0)
 
         assert card.model_id not in model_cards_module._card_cache


### PR DESCRIPTION
## Summary
- retain downloaded qualification artifacts and their installed sidecars
- prevent the live installed-card registration path from independently exposing the temporary unsigned card
- cover live registration, lifecycle cleanup, and startup rescan in one regression

## Validation
- uv run basedpyright
- uv run ruff check
- nix fmt (0 files changed)
- uv run pytest (3655 passed, 2 skipped)