### PR TITLE
Keep retained qualification cards out of model listings

### DIFF
--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -8438,8 +8438,10 @@ class API:
         store_installed_records = await self._cached_store_installed_records()
         cards_by_id = {card.model_id: card for card in cards}
         for model_id, record in store_installed_records.items():
-            if model_id in cards_by_id or not self._model_list_card_visible(
-                record.model_card
+            if (
+                model_id in cards_by_id
+                or record.model_card.qualification_only
+                or not self._model_list_card_visible(record.model_card)
             ):
                 continue
             cards.append(record.model_card)

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -8359,6 +8359,11 @@ class API:
                     model_id_raw,
                 )
                 continue
+            if record.model_card.qualification_only:
+                # Qualification keeps exact bytes in the central store, but the
+                # temporary unsigned card is not installed catalog truth.  It
+                # must not override a later signed card sharing the same alias.
+                continue
             records[model_id] = record
         return records
 
@@ -8438,10 +8443,8 @@ class API:
         store_installed_records = await self._cached_store_installed_records()
         cards_by_id = {card.model_id: card for card in cards}
         for model_id, record in store_installed_records.items():
-            if (
-                model_id in cards_by_id
-                or record.model_card.qualification_only
-                or not self._model_list_card_visible(record.model_card)
+            if model_id in cards_by_id or not self._model_list_card_visible(
+                record.model_card
             ):
                 continue
             cards.append(record.model_card)

--- a/src/skulk/api/tests/test_model_installed_projection.py
+++ b/src/skulk/api/tests/test_model_installed_projection.py
@@ -402,6 +402,38 @@ async def test_store_only_qualification_card_stays_out_of_model_list(
     assert response.data == []
 
 
+async def test_store_qualification_card_cannot_override_signed_catalog_card(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A retained temporary record cannot replace a same-alias signed card."""
+
+    catalog_card = _card("a")
+    store_record = _qualification_installed_record(tmp_path)
+    store_client = _RegistryStoreClient(
+        [
+            {
+                "model_id": str(store_record.artifact_model_id),
+                "installed_card": store_record.model_dump(mode="json"),
+            }
+        ]
+    )
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=catalog_card,
+        current_registry_card_value=catalog_card,
+        local_record=None,
+    )
+    api = _api_with_store(store_client)
+
+    response = await api.get_models(status=None)
+
+    assert len(response.data) == 1
+    assert response.data[0].registry_card_id == catalog_card.registry_card_id
+    assert response.data[0].catalog_source == "registry"
+    assert response.data[0].installed is False
+
+
 async def test_model_list_store_timeout_reuses_last_known_snapshot(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/src/skulk/api/tests/test_model_installed_projection.py
+++ b/src/skulk/api/tests/test_model_installed_projection.py
@@ -95,6 +95,26 @@ def _custom_installed_record(tmp_path: Path) -> InstalledCardRecord:
     return build_installed_card_record(artifact, card, artifact_format="custom")
 
 
+def _qualification_installed_record(tmp_path: Path) -> InstalledCardRecord:
+    """Build a retained artifact whose temporary card is service-owned."""
+
+    card = ModelCard(
+        model_id=ModelId("example/model@q4"),
+        storage_size=Memory.from_mb(1),
+        n_layers=1,
+        hidden_size=1,
+        supports_tensor=False,
+        tasks=[ModelTask.TextGeneration],
+        is_custom=True,
+        qualification_only=True,
+        quantization="Q4_K_M",
+    )
+    artifact = tmp_path / "qualification"
+    artifact.mkdir()
+    (artifact / "model.gguf").write_bytes(b"weights")
+    return build_installed_card_record(artifact, card, artifact_format="gguf")
+
+
 def _configure_model_list_test(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -352,6 +372,34 @@ async def test_store_only_installed_card_remains_in_model_list(
     assert response.data[0].installed is True
     assert response.data[0].current_registry_identity is None
     assert response.data[0].update_available is False
+
+
+async def test_store_only_qualification_card_stays_out_of_model_list(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Retained qualification bytes must not expose their temporary card."""
+
+    store_record = _qualification_installed_record(tmp_path)
+    store_client = _RegistryStoreClient(
+        [
+            {
+                "model_id": str(store_record.artifact_model_id),
+                "installed_card": store_record.model_dump(mode="json"),
+            }
+        ]
+    )
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=None,
+        current_registry_card_value=None,
+        local_record=None,
+    )
+    api = _api_with_store(store_client)
+
+    response = await api.get_models(status=None)
+
+    assert response.data == []
 
 
 async def test_model_list_store_timeout_reuses_last_known_snapshot(


### PR DESCRIPTION
## Summary
- prevent central-store projection from exposing service-owned prepublication qualification cards
- retain ordinary store-only installed cards for offline and registry-removal behavior
- add a regression test for the exact retained-artifact case

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt` (0 changes)
- `uv run pytest` (3657 passed, 2 skipped, 237 deselected)