### PR TITLE
Keep local qualification records out of signed model listings

### DIFF
--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -8181,6 +8181,15 @@ class API:
         """
         catalog_card = card
         local_installed_record = get_installed_card_record(card.model_id)
+        if (
+            local_installed_record is not None
+            and local_installed_record.model_card.qualification_only
+            and not catalog_card.qualification_only
+        ):
+            # A retained local qualification artifact remains usable for a
+            # future signed-card refresh, but its temporary unsigned card is
+            # not installed truth for a normal catalog entry sharing the alias.
+            local_installed_record = None
         if catalog_card.is_custom:
             # A custom catalog entry is an operator-owned override. Prefer its
             # node-local custom generation, but do not hide the same custom

--- a/src/skulk/api/tests/test_model_installed_projection.py
+++ b/src/skulk/api/tests/test_model_installed_projection.py
@@ -434,6 +434,56 @@ async def test_store_qualification_card_cannot_override_signed_catalog_card(
     assert response.data[0].installed is False
 
 
+async def test_local_qualification_card_cannot_override_signed_catalog_card(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A retained node-local temporary record cannot replace signed truth."""
+
+    catalog_card = _card("a")
+    local_record = _qualification_installed_record(tmp_path)
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=catalog_card,
+        current_registry_card_value=catalog_card,
+        local_record=local_record,
+    )
+    api = _api_with_store(_RegistryStoreClient([]))
+
+    response = await api.get_models(status=None)
+
+    assert len(response.data) == 1
+    assert response.data[0].registry_card_id == catalog_card.registry_card_id
+    assert response.data[0].catalog_source == "registry"
+    assert response.data[0].installed is False
+
+
+async def test_active_qualification_card_uses_matching_local_record(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The service-owned card remains installed while its lifecycle is active."""
+
+    local_record = _qualification_installed_record(tmp_path)
+    qualification_card = local_record.model_card
+    _configure_model_list_test(
+        monkeypatch,
+        catalog_card=qualification_card,
+        current_registry_card_value=None,
+        local_record=local_record,
+    )
+    api = _api_with_store(_RegistryStoreClient([]))
+
+    response = await api.get_models(status=None)
+
+    assert len(response.data) == 1
+    assert response.data[0].catalog_source == "custom"
+    assert response.data[0].installed is True
+    assert response.data[0].active_installed_identity == (
+        local_record.installed_identity
+    )
+
+
 async def test_model_list_store_timeout_reuses_last_known_snapshot(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -1354,14 +1354,17 @@ curl http://localhost:52415/v1/models
 This returns known model cards, not just running instances. `GET /models`
 serves the same catalog through the same handler; prefer the `/v1/models` path
 for OpenAI-compatible clients. Complete installed cards load first so an
-air-gapped node keeps the exact generation it can actually launch. The current
-supported catalog comes from the external TUF-signed registry and refreshes at
-most every 60 seconds; a previously verified catalog may be used for up to 30
-days during an outage. That age limit does not apply to complete installed
-artifacts. Bundled cards fill non-installed catalog entries only when registry
-access and its acceptable cache are unavailable or disabled. Registry entries
-include immutable card and snapshot identities; local custom cards retain final
-override precedence.
+air-gapped node keeps the exact generation it can actually launch. Temporary
+`qualification_only` installed records are the exception: once a normal signed
+catalog card owns the same alias, `/v1/models` reports the signed card and does
+not use the retained qualification record to claim that signed generation is
+installed. The current supported catalog comes from the external TUF-signed
+registry and refreshes at most every 60 seconds; a previously verified catalog
+may be used for up to 30 days during an outage. That age limit does not apply to
+complete installed artifacts. Bundled cards fill non-installed catalog entries
+only when registry access and its acceptable cache are unavailable or disabled.
+Registry entries include immutable card and snapshot identities; local custom
+cards retain final override precedence.
 
 Each entry also separates discovery truth from runtime truth:
 


### PR DESCRIPTION
## Summary
- prevent retained node-local qualification records from overriding later signed catalog cards
- preserve installed projection while the service-owned qualification card is actively visible
- add regressions for both lifecycle states

## Validation
- `uv run basedpyright`
- `uv run ruff check`
- `nix --extra-experimental-features "nix-command flakes" fmt` (0 changes)
- `uv run pytest` (3660 passed, 2 skipped, 237 deselected)