### PR TITLE
fix(api): streaming chat chunks carry the chunk object discriminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- Streaming chat completions now carry `"object": "chat.completion.chunk"`.
+  Every SSE frame previously carried `"chat.completion"`, the non-streaming
+  discriminator, because one response model served both paths. Clients that
+  read `choices[0].delta` directly were unaffected, which is why this went
+  unnoticed, but clients that validate the discriminator reject such a stream
+  outright, including the Vercel AI SDK's openai-compatible provider. The
+  streaming and non-streaming responses are now separate models so the two
+  cannot drift again. This changes bytes on the wire for streaming responses,
+  toward the documented OpenAI format rather than away from it.
+
+### Fixed
+
 - Pre-publication qualification cleanup now names the complete temporary card
   it owns, and the elected master compares that exact card before deleting the
   alias. An older or retried job can no longer remove a newer qualification

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from skulk.api.types import (
     ChatCompletionChoice,
+    ChatCompletionChunkResponse,
     ChatCompletionMessage,
     ChatCompletionMessageImageUrl,
     ChatCompletionMessageText,
@@ -279,8 +280,8 @@ def usage_from_stats(stats: GenerationStats | None) -> Usage | None:
 
 def chunk_to_response(
     chunk: TokenChunk, command_id: CommandId
-) -> ChatCompletionResponse:
-    """Convert a TokenChunk to a streaming ChatCompletionResponse."""
+) -> ChatCompletionChunkResponse:
+    """Convert a TokenChunk to one streaming chat-completion chunk."""
     # Build logprobs if available
     logprobs: Logprobs | None = None
     if chunk.logprob is not None:
@@ -307,7 +308,7 @@ def chunk_to_response(
             f"finish_reason={chunk.finish_reason!r}"
         )
 
-    return ChatCompletionResponse(
+    return ChatCompletionChunkResponse(
         id=command_id,
         created=int(time.time()),
         model=chunk.model,
@@ -358,7 +359,7 @@ async def generate_chat_stream(
                     )
                     for i, tool in enumerate(chunk.tool_calls)
                 ]
-                tool_response = ChatCompletionResponse(
+                tool_response = ChatCompletionChunkResponse(
                     id=command_id,
                     created=int(time.time()),
                     model=chunk.model,

--- a/src/skulk/api/tests/test_chat_completions_streaming.py
+++ b/src/skulk/api/tests/test_chat_completions_streaming.py
@@ -1,5 +1,7 @@
 """Tests for streaming chat-completions adapter behavior."""
 
+from typing import cast
+
 import pytest
 
 from skulk.api.adapters.chat_completions import generate_chat_stream
@@ -132,3 +134,100 @@ async def test_streaming_tool_call_terminal_synthesizes_usage_from_stats() -> No
     assert '"prompt_tokens":43' in final_data
     assert '"completion_tokens":30' in final_data
     assert '"total_tokens":73' in final_data
+
+
+async def _tool_call_stream():
+    from skulk.api.types import ToolCallItem
+    from skulk.shared.types.chunks import ToolCallChunk
+
+    yield ToolCallChunk(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        tool_calls=[ToolCallItem(id="call_1", name="get_weather", arguments="{}")],
+        usage=None,
+        stats=None,
+    )
+
+
+def _sse_payloads(chunks: list[str]) -> list[dict[str, object]]:
+    """Parse the JSON payload out of every non-sentinel SSE data line."""
+    import json
+
+    payloads: list[dict[str, object]] = []
+    for chunk in chunks:
+        if not chunk.startswith("data: ") or "[DONE]" in chunk:
+            continue
+        parsed = cast("object", json.loads(chunk.removeprefix("data: ").strip()))
+        assert isinstance(parsed, dict)
+        payloads.append(cast("dict[str, object]", parsed))
+    return payloads
+
+
+def _first_choice(payload: dict[str, object]) -> dict[str, object]:
+    """Return the first choice of a completion payload."""
+    choices = payload["choices"]
+    assert isinstance(choices, list)
+    first = cast("object", choices[0])
+    assert isinstance(first, dict)
+    return cast("dict[str, object]", first)
+
+
+@pytest.mark.anyio
+async def test_streaming_chunks_use_the_chunk_object_discriminator() -> None:
+    """Streaming frames must not carry the non-streaming ``object`` value.
+
+    OpenAI's streaming format requires ``chat.completion.chunk``. Lenient
+    clients read ``choices[0].delta`` and never notice a wrong discriminator,
+    but strict ones reject the stream outright, so this is pinned rather than
+    left to a response model shared with the non-streaming path.
+    """
+    chunks = [
+        chunk
+        async for chunk in generate_chat_stream(
+            CommandId("cmd-123"), _single_token_stream()
+        )
+    ]
+    payloads = _sse_payloads(chunks)
+
+    assert payloads, "expected at least one streamed frame"
+    for payload in payloads:
+        assert payload["object"] == "chat.completion.chunk"
+        choice = _first_choice(payload)
+        assert "delta" in choice
+        assert "message" not in choice
+
+
+@pytest.mark.anyio
+async def test_streaming_tool_call_frames_use_the_chunk_discriminator() -> None:
+    """The tool-call frame takes a separate construction path from token frames."""
+    chunks = [
+        chunk
+        async for chunk in generate_chat_stream(
+            CommandId("cmd-tool"), _tool_call_stream()
+        )
+    ]
+    payloads = _sse_payloads(chunks)
+
+    assert payloads, "expected a tool-call frame"
+    for payload in payloads:
+        assert payload["object"] == "chat.completion.chunk"
+
+
+@pytest.mark.anyio
+async def test_non_streaming_response_keeps_the_completion_discriminator() -> None:
+    """The collected response is not a chunk and must keep ``chat.completion``."""
+    import json
+
+    from skulk.api.adapters.chat_completions import collect_chat_response
+
+    parts = [
+        part
+        async for part in collect_chat_response(
+            CommandId("cmd-456"), _single_token_stream()
+        )
+    ]
+    parsed = cast("object", json.loads("".join(parts)))
+    assert isinstance(parsed, dict)
+    payload = cast("dict[str, object]", parsed)
+
+    assert payload["object"] == "chat.completion"
+    assert "message" in _first_choice(payload)

--- a/src/skulk/api/types/__init__.py
+++ b/src/skulk/api/types/__init__.py
@@ -23,6 +23,7 @@ from .api import CachedArtifactLocation as CachedArtifactLocation
 from .api import CacheInventoryStatus as CacheInventoryStatus
 from .api import CancelCommandResponse as CancelCommandResponse
 from .api import ChatCompletionChoice as ChatCompletionChoice
+from .api import ChatCompletionChunkResponse as ChatCompletionChunkResponse
 from .api import ChatCompletionContentPart as ChatCompletionContentPart
 from .api import ChatCompletionMessage as ChatCompletionMessage
 from .api import ChatCompletionMessageImageUrl as ChatCompletionMessageImageUrl

--- a/src/skulk/api/types/api.py
+++ b/src/skulk/api/types/api.py
@@ -892,7 +892,7 @@ class ChatCompletionResponse(BaseModel):
     object: Literal["chat.completion"] = "chat.completion"
     created: int
     model: str
-    choices: list[ChatCompletionChoice | StreamingChoiceResponse]
+    choices: list[ChatCompletionChoice]
     usage: Usage | None = None
     service_tier: str | None = None
 
@@ -910,6 +910,8 @@ class ChatCompletionChunkResponse(BaseModel):
     read `choices[0].delta` and never noticed; strict ones, including the
     Vercel AI SDK's openai-compatible provider, reject the stream outright.
     """
+
+    model_config = ConfigDict(frozen=True, strict=True)
 
     id: str
     object: Literal["chat.completion.chunk"] = "chat.completion.chunk"

--- a/src/skulk/api/types/api.py
+++ b/src/skulk/api/types/api.py
@@ -882,11 +882,40 @@ class ChatCompletionChoice(BaseModel):
 
 
 class ChatCompletionResponse(BaseModel):
+    """One complete, non-streaming chat completion.
+
+    The `object` discriminator is the first field strict OpenAI clients check,
+    so streaming must not reuse this model: see `ChatCompletionChunkResponse`.
+    """
+
     id: str
     object: Literal["chat.completion"] = "chat.completion"
     created: int
     model: str
     choices: list[ChatCompletionChoice | StreamingChoiceResponse]
+    usage: Usage | None = None
+    service_tier: str | None = None
+
+
+class ChatCompletionChunkResponse(BaseModel):
+    """One frame of a streaming chat completion.
+
+    Identical to `ChatCompletionResponse` except for the two things the OpenAI
+    streaming format requires to differ: the `object` discriminator is
+    `chat.completion.chunk`, and every choice carries a `delta` rather than a
+    complete `message`.
+
+    These were one model until the external-API compatibility suite caught the
+    streaming path emitting the non-streaming discriminator. Lenient clients
+    read `choices[0].delta` and never noticed; strict ones, including the
+    Vercel AI SDK's openai-compatible provider, reject the stream outright.
+    """
+
+    id: str
+    object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: list[StreamingChoiceResponse]
     usage: Usage | None = None
     service_tier: str | None = None
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -618,6 +618,42 @@ for chunk in stream:
         print(chunk.choices[0].delta.content, end="")
 ```
 
+#### Streaming response shape
+
+Streaming responses are Server-Sent Events. Each event is a `data:` line
+carrying one chunk object, and the stream ends with a literal `data: [DONE]`
+sentinel:
+
+```
+data: {"id":"...","object":"chat.completion.chunk","created":1787328699,
+       "model":"mlx-community/Llama-3.2-1B-Instruct-4bit",
+       "choices":[{"index":0,"delta":{"role":"assistant","content":"Once"},
+                   "finish_reason":null}],"usage":null}
+
+data: {"id":"...","object":"chat.completion.chunk", ... ,
+       "choices":[{"index":0,"delta":{"content":" upon"},"finish_reason":null}]}
+
+data: [DONE]
+```
+
+Two differences from the non-streaming response matter to clients:
+
+- `object` is `chat.completion.chunk`, not `chat.completion`. Strict clients
+  validate this discriminator and reject a stream that carries the
+  non-streaming value.
+- Each choice carries a `delta` holding only what is new, rather than a
+  complete `message`.
+
+Skulk also emits SSE comment lines, which begin with `:` and which a
+compliant client ignores. These carry the command id at the start of the
+stream, and generation statistics at the end when available. A client that
+treats every non-blank line as data will need to skip them.
+
+Reasoning models place thinking text on `delta.reasoning_content` rather than
+`delta.content`, so a client that reads only `content` shows the answer
+without the reasoning. Tool calls arrive as a frame whose `delta.tool_calls`
+carries the accumulated call and whose `finish_reason` is `tool_calls`.
+
 ### Common Request Fields
 
 | Field | Type | Notes |

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -79,6 +79,8 @@ This file is intentionally dense. If you find a stale fact, fix it inline rather
 - **Default port:** 52415
 - **Mounts:** dashboard at `/` (skipped when the built assets are absent, e.g. a headless/non-Mac worker node with no `dashboard-react/dist`; `DASHBOARD_DIR` is then `None` and the API serves without the UI, #333); OpenAPI at `/api/openapi.json`
 - **Background tasks:** `_apply_state` (consumes `GLOBAL_EVENTS` and persists merged traces), `_pause_on_new_election`, `_cleanup_expired_images` (image-store TTL), `_prune_old_traces` (hourly trace janitor backed by `prune_old_trace_files`; retention via `tracing.retention_days`)
+- **Chat-completion response models:** non-streaming responses use `ChatCompletionResponse` (`object: "chat.completion"`, choices carry a complete `message`); streaming frames use `ChatCompletionChunkResponse` (`object: "chat.completion.chunk"`, choices carry a `delta`), both in `api/types/api.py`. These were one model until the harness's external-API compatibility suite caught streaming emitting the non-streaming discriminator; strict OpenAI clients validate it and reject the stream, while lenient ones read `choices[0].delta` and never notice. Keep them separate: the shared model is what allowed the drift.
+- **Third-party surface coverage:** the OpenAI, Anthropic and Ollama wire formats are contract-tested by the `external-api-compat` suite in the test harness, and a real client application is driven against them by `client-app-compat`. Wire-shape changes to these surfaces belong with a suite update.
 
 ### Intelligent fabric (internal steward role)
 


### PR DESCRIPTION
Closes #873.

## The defect

Every SSE frame from `POST /v1/chat/completions` carried `"object": "chat.completion"`. The OpenAI streaming format requires `"chat.completion.chunk"`, and that discriminator is one of the first fields a strict client checks.

Observed on a live cluster, MLX engine:

```
data: {"id":"9c073a74-...","object":"chat.completion","created":1787328699,
       "model":"mlx-community/Qwen3.5-4B-MLX-4bit",
       "choices":[{"index":0,"delta":{"role":"assistant","content":"Ready"},
                   "finish_reason":null}]}
```

Identical from `google/gemma-4-31B-it-qat-q4_0-gguf` on the served llama.cpp engine, so this was the adapter rather than a runner.

## Cause

One response model served both paths. `ChatCompletionResponse.choices` already accepted either a complete `message` or a `delta`, but `object` was pinned to the non-streaming literal, so the streaming path inherited the wrong value.

Split into two models so they cannot drift again:

- `ChatCompletionResponse`: `object: "chat.completion"`, choices carry a complete `message`
- `ChatCompletionChunkResponse`: `object: "chat.completion.chunk"`, choices carry a `delta`

Both streaming construction sites now use the chunk model: the token frame and the tool-call frame, which take separate paths through the adapter. The collected non-streaming response is unchanged.

## Impact

Clients that read `choices[0].delta` directly were unaffected, which is why this survived so long. Clients that validate the discriminator reject the stream outright, including the Vercel AI SDK's `openai-compatible` provider. That is the provider the dashboard's new Integrations page generates an OpenCode configuration for, so Skulk was shipping a recommended configuration against a stream some clients would refuse.

This changes bytes on the wire for streaming responses, toward the documented OpenAI format rather than away from it. Lenient clients keep working and strict clients start working.

## How it was found

The external-API compatibility suite added to the test harness, on its first run against a live two-node cluster. It failed identically for both models and both engines:

```
FAIL openai-surface-contract | google/gemma-4-31B-it-qat-q4_0-gguf
FAIL openai-surface-contract | mlx-community/Qwen3.5-4B-MLX-4bit
ERROR: openai compatibility: POST /v1/chat/completions (stream)
       chunk[0].object must be 'chat.completion.chunk', got 'chat.completion'
```

Confirmed independently with raw curl before changing anything.

## Documentation

This is a public wire change, so it is documented rather than just fixed:

- `website/docs/api-guide.md` gains a **Streaming response shape** section under the streaming example, showing the actual SSE frames, the `[DONE]` sentinel, and the two ways a streaming frame differs from a non-streaming response. It also documents two things that were previously undocumented and that clients trip over: the SSE comment lines Skulk emits (command id and generation statistics), and that reasoning models put thinking text on `delta.reasoning_content` rather than `delta.content`.
- `website/docs/architecture-reference.md` records the two response models, why they are separate, and that these surfaces are contract-tested by the harness so wire-shape changes travel with a suite update.
- `CHANGELOG.md` under Fixed, stating plainly that this changes streaming bytes on the wire.

## Validation

- Three new regression tests pin the discriminator on the token frame, on the tool-call frame, and pin `chat.completion` on the collected non-streaming response.
- `uv run pytest src/skulk/api/tests`: 773 pass.
- `uv run basedpyright`: 0 errors. `uv run ruff check`: clean. `nix fmt`: no changes. OpenAPI export regenerates cleanly.
- Will be re-verified against the live segment after merge by re-running the compatibility suite, which is the boundary the testing stopped at.