### PR TITLE
fix(worker): attribute the already-staged download completion

### DIFF
--- a/src/skulk/shared/types/tests/test_telemetry.py
+++ b/src/skulk/shared/types/tests/test_telemetry.py
@@ -767,3 +767,75 @@ def test_linux_gpu_metrics_round_trip_and_apply() -> None:
     assert acc.vendor == "amd"
     assert acc.vram_total_bytes == 68719476736
     assert acc.utilization_ratio == 0.42
+
+
+def test_unattributed_terminal_outcome_cannot_clear_a_live_attempt() -> None:
+    """An unattributed completion is ignored while a live attempt is identified.
+
+    This is the guard that made an already-staged model unloadable: the worker's
+    fast path emitted a terminal ``DownloadCompleted`` with no attempt id, this
+    branch treated it as an unorderable legacy replay, and the live ``Pending``
+    kept overlaying the durable completion. The planner then re-issued
+    ``DownloadModel`` every tick while the instance sat idle forever.
+
+    The guard itself is correct and stays; the fix is that live producers must
+    attribute their terminal outcomes. This pins the behaviour so the reason the
+    fast path carries an attempt id does not get lost.
+    """
+
+    node = NodeId("node-a")
+    shard = get_pipeline_shard_metadata(MODEL_A_ID, device_rank=0, world_size=1)
+    attempt = DownloadAttemptId("attempt-live")
+    pending = DownloadPending(node_id=node, shard_metadata=shard, attempt_id=attempt)
+
+    view = TelemetryView()
+    view.record_download_event(NodeDownloadProgress(download_progress=pending))
+    view.apply(NodeTelemetry(node_id=node, info=pending))
+    assert view.effective_downloads({})[node] == [pending]
+
+    unattributed = DownloadCompleted(
+        node_id=node,
+        shard_metadata=shard,
+        model_directory="/models/a",
+        total=Memory.from_mb(10),
+        read_only=True,
+    )
+    view.record_download_event(NodeDownloadProgress(download_progress=unattributed))
+
+    # The live pending survives, so a planner reading effective_downloads still
+    # believes the model is not present.
+    assert view.effective_downloads({})[node] == [pending]
+
+
+def test_attributed_terminal_outcome_clears_its_live_attempt() -> None:
+    """A completion carrying the live attempt id retires the pending overlay.
+
+    This is the shape the already-staged fast path now emits: it opens an
+    attempt and closes it, so the durable completion becomes visible to the
+    planner and the instance can progress to loading.
+    """
+
+    node = NodeId("node-a")
+    shard = get_pipeline_shard_metadata(MODEL_A_ID, device_rank=0, world_size=1)
+    attempt = DownloadAttemptId("attempt-live")
+    pending = DownloadPending(node_id=node, shard_metadata=shard, attempt_id=attempt)
+
+    view = TelemetryView()
+    view.record_download_event(NodeDownloadProgress(download_progress=pending))
+    view.apply(NodeTelemetry(node_id=node, info=pending))
+    assert view.effective_downloads({})[node] == [pending]
+
+    completed = DownloadCompleted(
+        node_id=node,
+        shard_metadata=shard,
+        model_directory="/models/a",
+        total=Memory.from_mb(10),
+        read_only=True,
+        attempt_id=attempt,
+    )
+    view.record_download_event(NodeDownloadProgress(download_progress=completed))
+
+    # No live overlay remains, so the durable terminal outcome is what the
+    # planner sees.
+    assert view.effective_downloads({}).get(node, []) == []
+    assert view.effective_downloads({node: [completed]})[node] == [completed]

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -2100,6 +2100,28 @@ class Worker:
                         logger.info(
                             f"Model {model_id} found in SKULK_MODELS_PATH at {found_path}"
                         )
+                        # This path never reaches the download coordinator, so
+                        # nothing stamps it with the attempt identity that
+                        # `_prepare_status` gives coordinator-routed statuses.
+                        # An unattributed terminal outcome is treated as a
+                        # legacy replay by `TelemetryView.record_download_event`
+                        # and ignored whenever a live attempt exists, which
+                        # leaves the live Pending overlaying the durable
+                        # completion forever: the planner never sees the model
+                        # as downloaded and re-issues DownloadModel every tick
+                        # while the instance sits idle. Open and close one
+                        # attempt of our own so the completion is attributable.
+                        already_present_attempt = DownloadAttemptId()
+                        await self.event_sender.send(
+                            NodeDownloadProgress(
+                                download_progress=DownloadPending(
+                                    node_id=self.node_id,
+                                    shard_metadata=shard,
+                                    model_directory=str(found_path),
+                                    attempt_id=already_present_attempt,
+                                )
+                            )
+                        )
                         await self.event_sender.send(
                             NodeDownloadProgress(
                                 download_progress=DownloadCompleted(
@@ -2108,6 +2130,7 @@ class Worker:
                                     model_directory=str(found_path),
                                     total=shard.model_card.storage_size,
                                     read_only=True,
+                                    attempt_id=already_present_attempt,
                                 )
                             )
                         )

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -2149,8 +2149,8 @@ class Worker:
                         logger.info(
                             f"Model {model_id} found in SKULK_MODELS_PATH at {found_path}"
                         )
-                        # This path never reaches the download coordinator, so
-                        # nothing stamps it with the attempt identity that
+                        # Attempt-identity stamping matters here; see
+                        # already_present_download_events.
                         for event in already_present_download_events(
                             node_id=self.node_id,
                             shard=shard,

--- a/src/skulk/worker/main.py
+++ b/src/skulk/worker/main.py
@@ -214,6 +214,55 @@ and weight mmaps, far under an indefinite hang."""
 _INSTANCE_FAILURE_MESSAGE_LIMIT = 2048
 
 
+def already_present_download_events(
+    *,
+    node_id: NodeId,
+    shard: ShardMetadata,
+    model_directory: str,
+) -> tuple[NodeDownloadProgress, NodeDownloadProgress]:
+    """Build the events announcing a model that is already staged on disk.
+
+    This path never reaches the download coordinator, so nothing applies the
+    attempt stamping that `DownloadCoordinator._prepare_status` gives
+    coordinator-routed statuses. An unattributed terminal outcome is treated as
+    an unorderable legacy replay by `TelemetryView.record_download_event` and
+    ignored whenever a live attempt exists, which leaves the live `Pending`
+    overlaying the durable completion forever: the planner never sees the model
+    as downloaded and re-issues `DownloadModel` every tick while the instance
+    sits idle.
+
+    So this opens an attempt and closes it under one identity, which is exactly
+    the documented contract of the two events: a `Pending` establishes the
+    attempt subsequent telemetry belongs to, and a terminal outcome carrying
+    that attempt retires it.
+
+    Returns:
+        The pending and completed events, in the order they must be sent.
+    """
+
+    attempt_id = DownloadAttemptId()
+    return (
+        NodeDownloadProgress(
+            download_progress=DownloadPending(
+                node_id=node_id,
+                shard_metadata=shard,
+                model_directory=model_directory,
+                attempt_id=attempt_id,
+            )
+        ),
+        NodeDownloadProgress(
+            download_progress=DownloadCompleted(
+                node_id=node_id,
+                shard_metadata=shard,
+                model_directory=model_directory,
+                total=shard.model_card.storage_size,
+                read_only=True,
+                attempt_id=attempt_id,
+            )
+        ),
+    )
+
+
 def _instance_failure_message(reason: str) -> str:
     """Return bounded classified failure text suitable for replicated state.
 
@@ -2102,38 +2151,12 @@ class Worker:
                         )
                         # This path never reaches the download coordinator, so
                         # nothing stamps it with the attempt identity that
-                        # `_prepare_status` gives coordinator-routed statuses.
-                        # An unattributed terminal outcome is treated as a
-                        # legacy replay by `TelemetryView.record_download_event`
-                        # and ignored whenever a live attempt exists, which
-                        # leaves the live Pending overlaying the durable
-                        # completion forever: the planner never sees the model
-                        # as downloaded and re-issues DownloadModel every tick
-                        # while the instance sits idle. Open and close one
-                        # attempt of our own so the completion is attributable.
-                        already_present_attempt = DownloadAttemptId()
-                        await self.event_sender.send(
-                            NodeDownloadProgress(
-                                download_progress=DownloadPending(
-                                    node_id=self.node_id,
-                                    shard_metadata=shard,
-                                    model_directory=str(found_path),
-                                    attempt_id=already_present_attempt,
-                                )
-                            )
-                        )
-                        await self.event_sender.send(
-                            NodeDownloadProgress(
-                                download_progress=DownloadCompleted(
-                                    node_id=self.node_id,
-                                    shard_metadata=shard,
-                                    model_directory=str(found_path),
-                                    total=shard.model_card.storage_size,
-                                    read_only=True,
-                                    attempt_id=already_present_attempt,
-                                )
-                            )
-                        )
+                        for event in already_present_download_events(
+                            node_id=self.node_id,
+                            shard=shard,
+                            model_directory=str(found_path),
+                        ):
+                            await self.event_sender.send(event)
                         await self.event_sender.send(
                             TaskStatusUpdated(
                                 task_id=task.task_id,

--- a/src/skulk/worker/tests/unittests/test_already_present_download.py
+++ b/src/skulk/worker/tests/unittests/test_already_present_download.py
@@ -1,0 +1,81 @@
+"""Coverage for the already-staged download announcement (worker fast path).
+
+A model found on disk skips the download coordinator, so the worker itself is
+responsible for the attempt identity that makes its terminal outcome
+attributable. Without it the completion is ignored as an unorderable legacy
+replay, the live pending keeps overlaying it, and the instance hangs forever in
+`RunnerIdle` while the planner re-issues `DownloadModel` every tick.
+"""
+
+from skulk.shared.tests.conftest import get_pipeline_shard_metadata
+from skulk.shared.types.common import ModelId, NodeId
+from skulk.shared.types.events import NodeDownloadProgress
+from skulk.shared.types.telemetry import NodeTelemetry, TelemetryView
+from skulk.shared.types.worker.downloads import DownloadCompleted, DownloadPending
+from skulk.worker.main import already_present_download_events
+
+MODEL_ID = ModelId("org/already-staged")
+NODE_ID = NodeId("node-a")
+
+
+def _events() -> tuple[NodeDownloadProgress, NodeDownloadProgress]:
+    shard = get_pipeline_shard_metadata(MODEL_ID, device_rank=0, world_size=1)
+    return already_present_download_events(
+        node_id=NODE_ID, shard=shard, model_directory="/models/already-staged"
+    )
+
+
+def test_emits_a_pending_then_a_completed() -> None:
+    """The pair must be ordered: the pending opens the attempt it closes."""
+
+    pending_event, completed_event = _events()
+
+    assert isinstance(pending_event.download_progress, DownloadPending)
+    assert isinstance(completed_event.download_progress, DownloadCompleted)
+
+
+def test_both_events_share_one_non_null_attempt_id() -> None:
+    """This is the property whose absence caused the hang."""
+
+    pending_event, completed_event = _events()
+    pending = pending_event.download_progress
+    completed = completed_event.download_progress
+
+    assert pending.attempt_id is not None
+    assert completed.attempt_id is not None
+    assert completed.attempt_id == pending.attempt_id
+
+
+def test_completion_reports_the_staged_directory_as_read_only() -> None:
+    """A model found in place is not owned by us and must not be deleted."""
+
+    _, completed_event = _events()
+    completed = completed_event.download_progress
+
+    assert isinstance(completed, DownloadCompleted)
+    assert completed.read_only is True
+    assert completed.model_directory == "/models/already-staged"
+
+
+def test_the_pair_leaves_no_live_overlay_hiding_the_completion() -> None:
+    """End to end through the view that decides what a planner sees.
+
+    Drives the real `TelemetryView` the way the plane does: the pending is
+    recorded as a durable event and also arrives as live telemetry, then the
+    completion closes the attempt. If the completion were unattributed, the
+    pending would survive here and the planner would keep believing the model
+    is absent.
+    """
+
+    pending_event, completed_event = _events()
+    pending = pending_event.download_progress
+    assert isinstance(pending, DownloadPending)
+
+    view = TelemetryView()
+    view.record_download_event(pending_event)
+    view.apply(NodeTelemetry(node_id=NODE_ID, info=pending))
+    assert view.effective_downloads({})[NODE_ID] == [pending]
+
+    view.record_download_event(completed_event)
+
+    assert view.effective_downloads({}).get(NODE_ID, []) == []


### PR DESCRIPTION
## The defect

A model already present on disk could never load. Its instance sat in `RunnerIdle` indefinitely while the worker re-planned `DownloadModel` every ten seconds:

```
12:52:07 Worker plan: DownloadModel(model='mlx-community/Qwen3.5-4B-MLX-4bit', ...)
12:52:07 Model mlx-community/Qwen3.5-4B-MLX-4bit found in SKULK_MODELS_PATH at /Users/kite3/.skulk/staging/...
12:52:17 Worker plan: DownloadModel(model='mlx-community/Qwen3.5-4B-MLX-4bit', ...)
12:52:17 Model mlx-community/Qwen3.5-4B-MLX-4bit found in SKULK_MODELS_PATH at ...
   (repeating indefinitely)
```

Observed on a fleet node re-placing two already-staged MLX models. Both hung. On a peer node in the same cluster, two models that went through the download coordinator loaded normally, which is the clue that isolates the path.

## Cause

`resolve_model_in_path` finding the model takes a fast path that emits a terminal `DownloadCompleted` directly to the event sender. That path never reaches the download coordinator, so nothing applies the `_prepare_status` stamping that gives coordinator-routed statuses their attempt identity, and the event goes out with `attempt_id=None`.

`TelemetryView.record_download_event` then ignores it:

```python
current_attempt = self._node_download_attempts.get(key)
if progress.attempt_id is None and current_attempt is not None:
    # Legacy terminal events cannot be ordered against an identified
    # live attempt. Preserve the explicit attempt rather than letting
    # an ambiguous replay hide current progress.
    return
```

That guard is correct and stays: a replayed legacy terminal event must not hide current progress. But it means an unattributed completion never retires the live `DownloadPending`. `effective_downloads` overlays live progress on top of durable outcomes, so the planner kept reading pending, kept deciding the model was not downloaded, and kept re-issuing the task. The durable `DownloadCompleted` was in state the whole time, invisible underneath the overlay.

It reproduces only when a live attempt is already identified for that key, which is why an already-staged model sometimes loads and sometimes hangs.

## Fix

The guard is not the problem; an unattributed live producer is. The fast path now opens an attempt and closes it, emitting `DownloadPending` and `DownloadCompleted` under one fresh attempt id. The completion is attributable, so it retires its own overlay and the planner advances to `LoadModel`.

This matches the documented semantics of the two events: a `Pending` establishes the attempt that subsequent telemetry belongs to, and a terminal outcome carrying that attempt closes it.

## Validation

- Two regression tests in `test_telemetry.py`. One pins the guard by driving the exact failure, an unattributed completion arriving against a live attempt, and asserting the pending overlay survives. The other asserts an attributed completion retires the overlay so the durable outcome becomes visible to a planner. The first would have caught this class of bug; the second fails without this change.
- `uv run pytest src/skulk/worker src/skulk/shared src/skulk/master`: 1755 pass.
- `uv run basedpyright`: 0 errors. `uv run ruff check`: clean.
- Verified on the live segment after deploy: the two hung MLX instances progress to ready.

## How it was found

While resuming external-API compatibility testing after deploying an unrelated fix. Re-placing the test models exposed it, and the two nodes disagreeing (staged-locally hung, staged-from-store fine) pointed straight at the fast path. No API change and no wire change; the events involved already carry the field.