### PR TITLE
fix(api): never answer a chat request with an empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ This project records release notes here and mirrors public-facing notes in
   generator; because the status is committed before the body streams, callers
   received HTTP 200 with zero bytes and every OpenAI-compatible client failed
   while parsing rather than reporting the real problem. The non-streaming path
-  now returns the standard error object, and the streaming path emits an error
-  frame followed by `data: [DONE]` instead of closing without a terminator,
-  which a client cannot distinguish from a dropped connection.
+  now returns a real 4xx or 5xx status with the standard error object, since
+  nothing forces it to commit a status before the outcome is known, and the
+  streaming path, whose status is committed with its first byte, emits an
+  error frame followed by `data: [DONE]` instead of closing without a
+  terminator, which a client cannot distinguish from a dropped connection. A
+  turn that produced text but never reported a finish reason is also treated
+  as a failure rather than returned as a silently truncated completion.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- Chat completions never return an empty body, and streaming responses always
+  terminate. A task that ended without producing any output, for example after
+  being cancelled, previously tripped an assertion inside the response
+  generator; because the status is committed before the body streams, callers
+  received HTTP 200 with zero bytes and every OpenAI-compatible client failed
+  while parsing rather than reporting the real problem. The non-streaming path
+  now returns the standard error object, and the streaming path emits an error
+  frame followed by `data: [DONE]` instead of closing without a terminator,
+  which a client cannot distinguish from a dropped connection.
+
+### Fixed
+
 - Streaming chat completions now carry `"object": "chat.completion.chunk"`.
   Every SSE frame previously carried `"chat.completion"`, the non-streaming
   discriminator, because one response model served both paths. Clients that

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -498,18 +498,31 @@ async def collect_chat_response(
     combined_text = "".join(text_parts)
     combined_thinking = "".join(thinking_parts) if thinking_parts else None
 
-    if model is None:
-        # The stream ended without a single token or tool call and without an
-        # error chunk, which happens when the task is cancelled or times out
-        # having produced nothing. This used to assert, and because the status
-        # is already committed the assertion surfaced to the caller as HTTP 200
-        # with a zero-byte body: the worst possible answer, since every client
-        # treats 2xx as success and then fails parsing far from the cause.
-        # Emit the same structured envelope the error path uses so the caller
-        # gets something it can read and report (#872).
-        yield error_chunk_response(
+    if model is None or finish_reason is None:
+        # The producer stopped without reaching a terminal chunk. Two shapes
+        # land here and both must be failures rather than successes:
+        #
+        # - Nothing at all was produced (`model is None`). This used to assert,
+        #   and because the status is committed before the body streams the
+        #   assertion reached callers as HTTP 200 with zero bytes, which every
+        #   client treats as success and then fails to parse (#872).
+        # - Some text arrived but no finish reason did, which is what
+        #   cancellation mid-generation looks like. Returning that as a normal
+        #   completion would hand the caller a silently truncated answer, which
+        #   is worse than an empty body because nothing marks it as incomplete.
+        #
+        # A finish reason is the producer's only signal that a turn ended; the
+        # streaming path already refuses to send `[DONE]` without one.
+        produced = len(combined_text)
+        detail = (
             "Generation produced no output before the task ended"
-        ).model_dump_json()
+            if model is None
+            else (
+                "Generation ended without a finish reason after "
+                f"{produced} characters, so the response is incomplete"
+            )
+        )
+        yield error_chunk_response(detail).model_dump_json()
         return
 
     yield ChatCompletionResponse(

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -408,6 +408,20 @@ async def generate_chat_stream(
                     yield "data: [DONE]\n\n"
                     return
 
+    # Falling out of the loop means the producer stopped without a finish
+    # reason and without an error: a cancelled or timed-out task that never
+    # reached a terminal chunk. Returning here would close the connection with
+    # no `data: [DONE]`, which a client reads as a truncated stream rather than
+    # as a failure, so say what happened and terminate properly (#872).
+    yield (
+        "data: "
+        + error_chunk_response(
+            "Generation ended without completing before the task finished"
+        ).model_dump_json()
+        + "\n\n"
+    )
+    yield "data: [DONE]\n\n"
+
 
 async def collect_chat_response(
     command_id: CommandId,
@@ -483,7 +497,20 @@ async def collect_chat_response(
 
     combined_text = "".join(text_parts)
     combined_thinking = "".join(thinking_parts) if thinking_parts else None
-    assert model is not None
+
+    if model is None:
+        # The stream ended without a single token or tool call and without an
+        # error chunk, which happens when the task is cancelled or times out
+        # having produced nothing. This used to assert, and because the status
+        # is already committed the assertion surfaced to the caller as HTTP 200
+        # with a zero-byte body: the worst possible answer, since every client
+        # treats 2xx as success and then fails parsing far from the cause.
+        # Emit the same structured envelope the error path uses so the caller
+        # gets something it can read and report (#872).
+        yield error_chunk_response(
+            "Generation produced no output before the task ended"
+        ).model_dump_json()
+        return
 
     yield ChatCompletionResponse(
         id=command_id,

--- a/src/skulk/api/adapters/chat_completions.py
+++ b/src/skulk/api/adapters/chat_completions.py
@@ -1,10 +1,12 @@
 """OpenAI Chat Completions API adapter for converting requests/responses."""
 
 import base64
+import json
 import re
 import time
 from collections.abc import AsyncGenerator
-from typing import Any
+from http import HTTPStatus
+from typing import Any, cast
 
 from loguru import logger
 
@@ -421,6 +423,47 @@ async def generate_chat_stream(
         + "\n\n"
     )
     yield "data: [DONE]\n\n"
+
+
+async def collect_chat_response_body(
+    command_id: CommandId,
+    chunk_stream: AsyncGenerator[
+        ErrorChunk | ToolCallChunk | TokenChunk | PrefillProgressChunk, None
+    ],
+) -> tuple[int, str]:
+    """Collect a non-streaming chat response and its HTTP status.
+
+    A non-streaming request has no reason to commit a status before the
+    outcome is known: the body is one complete object, produced once. Awaiting
+    it here lets a failure answer with a real status code, so a client that
+    branches on status, which is every OpenAI client, sees a failure as a
+    failure rather than discovering it later through missing `choices`.
+
+    The streaming path cannot do this and does not try: its status is committed
+    with the first byte, so it reports post-commit failures in band.
+
+    Returns:
+        The HTTP status to send and the serialized JSON body.
+    """
+
+    body = "".join([part async for part in collect_chat_response(command_id, chunk_stream)])
+    try:
+        parsed = cast("object", json.loads(body))
+    except ValueError:
+        # collect_chat_response always serializes a model, so this is
+        # unreachable in practice; answering 500 keeps an impossible state from
+        # masquerading as success.
+        return (HTTPStatus.INTERNAL_SERVER_ERROR.value, body)
+    if not isinstance(parsed, dict):
+        return (HTTPStatus.INTERNAL_SERVER_ERROR.value, body)
+    payload = cast("dict[str, object]", parsed)
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return (HTTPStatus.OK.value, body)
+    code = cast("dict[str, object]", error).get("code")
+    if isinstance(code, int) and not isinstance(code, bool) and 400 <= code <= 599:
+        return (code, body)
+    return (HTTPStatus.INTERNAL_SERVER_ERROR.value, body)
 
 
 async def collect_chat_response(

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -65,7 +65,7 @@ from starlette.datastructures import UploadFile as StarletteUploadFile
 import skulk.shared.types.tasks as task_types
 from skulk.api.adapters.chat_completions import (
     chat_request_to_text_generation,
-    collect_chat_response,
+    collect_chat_response_body,
     fetch_image_url,
     generate_chat_stream,
 )
@@ -3519,7 +3519,7 @@ class API:
 
     async def _steward_chat_completions(
         self, payload: ChatCompletionRequest
-    ) -> StreamingResponse:
+    ) -> StreamingResponse | Response:
         """Serve the steward through the standard chat-completions surface.
 
         The steward's tool surface belongs to the server, so client tool
@@ -3631,8 +3631,15 @@ class API:
                     "X-Accel-Buffering": "no",
                 },
             )
-        return StreamingResponse(
-            collect_chat_response(command_id, chunk_stream),
+        # A non-streaming request commits no status until the outcome is
+        # known, so a failure answers with a real status code rather than a
+        # 200 whose body happens to carry an error (#872).
+        status_code, body = await collect_chat_response_body(
+            command_id, chunk_stream
+        )
+        return Response(
+            content=body,
+            status_code=status_code,
             media_type="application/json",
         )
 
@@ -5080,7 +5087,7 @@ class API:
 
     async def chat_completions(
         self, payload: ChatCompletionRequest
-    ) -> ChatCompletionResponse | StreamingResponse:
+    ) -> ChatCompletionResponse | StreamingResponse | Response:
         """OpenAI Chat Completions API - adapter."""
         if str(payload.model) == STEWARD_VIRTUAL_MODEL_ID:
             # The reserved steward id selects model-plus-harness: the
@@ -5131,11 +5138,15 @@ class API:
                 },
             )
         else:
-            return StreamingResponse(
-                collect_chat_response(
-                    command.command_id,
-                    chunk_stream,
-                ),
+            # Same contract as the ordinary chat route: no status is committed
+            # until the outcome is known (#872).
+            status_code, body = await collect_chat_response_body(
+                command.command_id,
+                chunk_stream,
+            )
+            return Response(
+                content=body,
+                status_code=status_code,
                 media_type="application/json",
             )
 

--- a/src/skulk/api/main.py
+++ b/src/skulk/api/main.py
@@ -1336,6 +1336,62 @@ def _coerce_json_object(value: object) -> JsonObject:
     return {str(key): item for key, item in raw_dict.items()}
 
 
+DISCONNECT_POLL_INTERVAL_S = 0.5
+"""How often a non-streaming request checks whether its caller is still there."""
+
+CLIENT_DISCONNECTED_STATUS = 499
+"""Nginx's client-closed-request code. Nothing receives it; it exists so the
+handler returns a value rather than raising into the server's error path."""
+
+
+async def _wait_for_client_disconnect(request: Request) -> None:
+    """Resolve once the caller has gone away."""
+
+    while not await request.is_disconnected():
+        await asyncio.sleep(DISCONNECT_POLL_INTERVAL_S)
+
+
+async def collect_response_watching_disconnect(
+    request: Request,
+    collect: Awaitable[tuple[int, str]],
+) -> tuple[int, str]:
+    """Collect a non-streaming body without losing disconnect cancellation.
+
+    A `StreamingResponse` gets disconnect handling for free: Starlette cancels
+    the body generator when the caller goes away, the `CancelledError`
+    propagates into the chunk stream, and the API sends `TaskCancelled` so the
+    runner stops work nobody is waiting for. Awaiting the body directly, which
+    is what lets a non-streaming failure answer with a real status code, would
+    silently give that up and leave runners generating for callers that left;
+    repeated abandoned requests would then consume cluster capacity until they
+    finished naturally.
+
+    So watch for the disconnect explicitly and cancel the collection, which
+    reaches the same `CancelledError` handler by the same path.
+
+    Returns:
+        The status and body to send, or a client-disconnected status whose
+        response nobody will receive.
+    """
+
+    collect_task = asyncio.ensure_future(collect)
+    watcher = asyncio.ensure_future(_wait_for_client_disconnect(request))
+    try:
+        done, _ = await asyncio.wait(
+            {collect_task, watcher}, return_when=asyncio.FIRST_COMPLETED
+        )
+        if collect_task in done:
+            return collect_task.result()
+        collect_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await collect_task
+        return (CLIENT_DISCONNECTED_STATUS, "")
+    finally:
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watcher
+
+
 async def _read_request_json_object(request: Request) -> JsonObject:
     """Parse one request body into a string-keyed JSON object."""
     payload = cast(object, await request.json())
@@ -3518,7 +3574,7 @@ class API:
         return self.state.instances[instance_id]
 
     async def _steward_chat_completions(
-        self, payload: ChatCompletionRequest
+        self, payload: ChatCompletionRequest, request: Request
     ) -> StreamingResponse | Response:
         """Serve the steward through the standard chat-completions surface.
 
@@ -3633,9 +3689,13 @@ class API:
             )
         # A non-streaming request commits no status until the outcome is
         # known, so a failure answers with a real status code rather than a
-        # 200 whose body happens to carry an error (#872).
-        status_code, body = await collect_chat_response_body(
-            command_id, chunk_stream
+        # 200 whose body happens to carry an error (#872). Collecting the body
+        # gives up the disconnect handling a StreamingResponse gets for free,
+        # so watch for it explicitly and cancel, which reaches the same
+        # TaskCancelled path and stops the runner working for a caller that
+        # has gone.
+        status_code, body = await collect_response_watching_disconnect(
+            request, collect_chat_response_body(command_id, chunk_stream)
         )
         return Response(
             content=body,
@@ -5086,7 +5146,7 @@ class API:
         return command
 
     async def chat_completions(
-        self, payload: ChatCompletionRequest
+        self, payload: ChatCompletionRequest, request: Request
     ) -> ChatCompletionResponse | StreamingResponse | Response:
         """OpenAI Chat Completions API - adapter."""
         if str(payload.model) == STEWARD_VIRTUAL_MODEL_ID:
@@ -5094,7 +5154,7 @@ class API:
             # server-side investigation loop answers, with its tool trace
             # streamed as reasoning content. Checked before card resolution
             # so no repository of the same name can shadow it.
-            return await self._steward_chat_completions(payload)
+            return await self._steward_chat_completions(payload, request)
         resolved_model = await self._resolve_and_validate_text_model(payload.model)
         model_card = await self._get_running_model_card(resolved_model)
         task_params = await chat_request_to_text_generation(
@@ -5138,11 +5198,11 @@ class API:
                 },
             )
         else:
-            # Same contract as the ordinary chat route: no status is committed
-            # until the outcome is known (#872).
-            status_code, body = await collect_chat_response_body(
-                command.command_id,
-                chunk_stream,
+            # Same contract as the ordinary chat route, disconnect handling
+            # included (#872).
+            status_code, body = await collect_response_watching_disconnect(
+                request,
+                collect_chat_response_body(command.command_id, chunk_stream),
             )
             return Response(
                 content=body,

--- a/src/skulk/api/tests/test_chat_completions_streaming.py
+++ b/src/skulk/api/tests/test_chat_completions_streaming.py
@@ -337,3 +337,36 @@ async def test_truncated_generation_is_reported_rather_than_returned() -> None:
     message = error["message"]
     assert isinstance(message, str)
     assert "finish reason" in message
+
+
+@pytest.mark.anyio
+async def test_non_streaming_failure_carries_a_real_status_code() -> None:
+    """A non-streaming failure answers with a status, not a 200 plus an error.
+
+    Nothing forces a non-streaming request to commit its status before the
+    outcome is known: the body is one complete object produced once. Every
+    OpenAI client branches on status first, so reporting a failure only in the
+    body means the client treats it as success and discovers the problem later
+    through missing ``choices``.
+    """
+    from skulk.api.adapters.chat_completions import collect_chat_response_body
+
+    status, body = await collect_chat_response_body(
+        CommandId("cmd-empty"), _empty_stream()
+    )
+
+    assert status >= 400, "a failed generation must not answer 2xx"
+    assert body.strip()
+
+
+@pytest.mark.anyio
+async def test_non_streaming_success_still_answers_200() -> None:
+    """The status derivation must not turn ordinary completions into errors."""
+    from skulk.api.adapters.chat_completions import collect_chat_response_body
+
+    status, body = await collect_chat_response_body(
+        CommandId("cmd-ok"), _single_token_stream()
+    )
+
+    assert status == 200
+    assert '"chat.completion"' in body

--- a/src/skulk/api/tests/test_chat_completions_streaming.py
+++ b/src/skulk/api/tests/test_chat_completions_streaming.py
@@ -231,3 +231,62 @@ async def test_non_streaming_response_keeps_the_completion_discriminator() -> No
 
     assert payload["object"] == "chat.completion"
     assert "message" in _first_choice(payload)
+
+
+async def _empty_stream():
+    """A producer that ends without a token, a tool call or an error.
+
+    This is what a cancelled or timed-out task looks like from the adapter's
+    side: the chunk stream simply finishes having produced nothing.
+    """
+    return
+    yield  # pragma: no cover - unreachable, makes this an async generator
+
+
+@pytest.mark.anyio
+async def test_collected_response_never_returns_an_empty_body() -> None:
+    """A task that produced nothing must still yield a readable body.
+
+    This previously asserted, and because the status is committed before the
+    body streams, the assertion reached callers as HTTP 200 with zero bytes.
+    Every OpenAI client treats 2xx as success and then fails parsing, so the
+    real failure surfaced far from its cause.
+    """
+    import json
+
+    from skulk.api.adapters.chat_completions import collect_chat_response
+
+    body = "".join(
+        [part async for part in collect_chat_response(CommandId("cmd-empty"), _empty_stream())]
+    )
+
+    assert body.strip(), "a committed response must never have an empty body"
+    parsed = cast("object", json.loads(body))
+    assert isinstance(parsed, dict)
+    payload = cast("dict[str, object]", parsed)
+    error = cast("dict[str, object]", payload["error"])
+    message = error["message"]
+    assert isinstance(message, str)
+    assert message
+
+
+@pytest.mark.anyio
+async def test_stream_terminates_even_when_the_producer_stops_early() -> None:
+    """A stream that ends without a finish reason must still send [DONE].
+
+    Without a terminator a client cannot tell a finished turn from a dropped
+    connection, so it either hangs or reports a transport error instead of the
+    server's actual problem.
+    """
+    chunks = [
+        chunk
+        async for chunk in generate_chat_stream(CommandId("cmd-empty"), _empty_stream())
+    ]
+
+    assert chunks[-1] == "data: [DONE]\n\n"
+    payloads = _sse_payloads(chunks)
+    assert payloads, "expected an explanatory frame before the terminator"
+    error = cast("dict[str, object]", payloads[-1]["error"])
+    message = error["message"]
+    assert isinstance(message, str)
+    assert message

--- a/src/skulk/api/tests/test_chat_completions_streaming.py
+++ b/src/skulk/api/tests/test_chat_completions_streaming.py
@@ -290,3 +290,50 @@ async def test_stream_terminates_even_when_the_producer_stops_early() -> None:
     message = error["message"]
     assert isinstance(message, str)
     assert message
+
+
+async def _truncated_stream():
+    """A producer that emits text and then stops without a finish reason.
+
+    This is what cancellation mid-generation looks like: real output arrived,
+    but nothing ever marked the turn as ended.
+    """
+    yield TokenChunk(
+        model=ModelId("mlx-community/gemma-4-26b-a4b-it-4bit"),
+        text="partial answer",
+        token_id=1,
+        usage=None,
+        finish_reason=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_truncated_generation_is_reported_rather_than_returned() -> None:
+    """Partial output with no finish reason must not look like a completion.
+
+    Returning it as a normal `chat.completion` hands the caller a silently
+    truncated answer, which is worse than an empty body because nothing marks
+    it incomplete. A finish reason is the producer's only end-of-turn signal;
+    the streaming path already refuses to send `[DONE]` without one.
+    """
+    import json
+
+    from skulk.api.adapters.chat_completions import collect_chat_response
+
+    body = "".join(
+        [
+            part
+            async for part in collect_chat_response(
+                CommandId("cmd-trunc"), _truncated_stream()
+            )
+        ]
+    )
+    parsed = cast("object", json.loads(body))
+    assert isinstance(parsed, dict)
+    payload = cast("dict[str, object]", parsed)
+
+    assert "choices" not in payload, "a truncated turn must not look successful"
+    error = cast("dict[str, object]", payload["error"])
+    message = error["message"]
+    assert isinstance(message, str)
+    assert "finish reason" in message

--- a/src/skulk/api/tests/test_disconnect_collection.py
+++ b/src/skulk/api/tests/test_disconnect_collection.py
@@ -1,0 +1,73 @@
+"""Disconnect handling for non-streaming chat responses.
+
+A `StreamingResponse` gets disconnect handling for free: Starlette cancels the
+body generator when the caller leaves, which reaches the chunk stream's
+cancellation handler and stops the runner. Collecting the body to choose a real
+status code gives that up unless it is replaced deliberately, and losing it is
+expensive: an abandoned request would keep a runner generating for a caller
+that is gone.
+"""
+
+import asyncio
+
+import pytest
+from starlette.requests import Request
+
+from skulk.api.main import (
+    CLIENT_DISCONNECTED_STATUS,
+    collect_response_watching_disconnect,
+)
+
+
+def _request(*, disconnected: bool) -> Request:
+    """Build a request whose receive channel reports the given liveness."""
+
+    async def receive() -> dict[str, object]:
+        if disconnected:
+            return {"type": "http.disconnect"}
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(
+        {"type": "http", "method": "POST", "path": "/v1/chat/completions", "headers": []},
+        receive=receive,
+    )
+
+
+@pytest.mark.anyio
+async def test_returns_the_collected_response_when_the_caller_stays() -> None:
+    """The ordinary path must be unaffected by the disconnect watch."""
+
+    async def collect() -> tuple[int, str]:
+        return (200, '{"object":"chat.completion"}')
+
+    status, body = await collect_response_watching_disconnect(
+        _request(disconnected=False), collect()
+    )
+
+    assert status == 200
+    assert body == '{"object":"chat.completion"}'
+
+
+@pytest.mark.anyio
+async def test_cancels_the_collection_when_the_caller_disconnects() -> None:
+    """The point of the watch: work stops rather than running on unattended.
+
+    Asserts the cancellation actually reached the collection, which is what
+    propagates into the chunk stream and sends TaskCancelled to the runner.
+    """
+    cancelled = asyncio.Event()
+
+    async def collect() -> tuple[int, str]:
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return (200, "never reached")
+
+    status, _ = await collect_response_watching_disconnect(
+        _request(disconnected=True), collect()
+    )
+
+    assert status == CLIENT_DISCONNECTED_STATUS
+    assert cancelled.is_set(), "the collection must be cancelled, not abandoned"

--- a/src/skulk/api/tests/test_model_validation_order.py
+++ b/src/skulk/api/tests/test_model_validation_order.py
@@ -38,6 +38,30 @@ from skulk.shared.types.worker.runners import RunnerId, RunnerReady, ShardAssign
 from skulk.shared.types.worker.shards import PipelineShardMetadata
 
 
+def _http_request() -> Request:
+    """A minimal connected HTTP request for direct handler calls.
+
+    The handler watches for client disconnect while collecting a
+    non-streaming body, so it needs a request whose receive channel reports a
+    live connection rather than a disconnect.
+    """
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [],
+        },
+        receive=receive,
+    )
+
+
+
+
 def _get_running_model_card_fn(api: API) -> Callable[[ModelId], Awaitable[ModelCard]]:
     """Return the protected running-card helper with an explicit callable type."""
     return cast(
@@ -111,7 +135,7 @@ async def test_chat_completions_validates_model_before_adapter(monkeypatch: pyte
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await api.chat_completions(payload)
+        await api.chat_completions(payload, _http_request())
 
     assert exc_info.value.status_code == 404
 
@@ -228,7 +252,7 @@ async def test_chat_rejects_speech_only_models_before_dispatch(
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        await api.chat_completions(payload)
+        await api.chat_completions(payload, _http_request())
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == (

--- a/src/skulk/api/tests/test_steward_status_state.py
+++ b/src/skulk/api/tests/test_steward_status_state.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 from fastapi import HTTPException
+from starlette.requests import Request
 
 from skulk.api.main import (
     API,
@@ -25,6 +26,30 @@ from skulk.shared.types.telemetry import TelemetryView
 from skulk.shared.types.worker.downloads import DownloadOngoing, DownloadProgressData
 from skulk.shared.types.worker.instances import InstanceId
 from skulk.shared.types.worker.shards import PipelineShardMetadata
+
+
+def _http_request() -> Request:
+    """A minimal connected HTTP request for direct handler calls.
+
+    The handler watches for client disconnect while collecting a
+    non-streaming body, so it needs a request whose receive channel reports a
+    live connection rather than a disconnect.
+    """
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [],
+        },
+        receive=receive,
+    )
+
+
 
 if TYPE_CHECKING:
     from skulk.api.steward import StewardState
@@ -192,7 +217,7 @@ async def test_not_ready_steward_answers_503_with_the_status_payload(
     status = _status(state)
     with pytest.raises(HTTPException) as raised:
         await API._steward_chat_completions(  # pyright: ignore[reportPrivateUsage]
-            _stub_api(status), _request()
+            _stub_api(status), _request(), _http_request()
         )
     error = raised.value
     assert error.status_code == 503
@@ -210,7 +235,7 @@ async def test_disabled_mode_still_answers_404_not_503() -> None:
     """The disabled contract predates this preflight and does not change."""
     with pytest.raises(HTTPException) as raised:
         await API._steward_chat_completions(  # pyright: ignore[reportPrivateUsage]
-            _stub_api(_status("disabled", enabled=False)), _request()
+            _stub_api(_status("disabled", enabled=False)), _request(), _http_request()
         )
     assert raised.value.status_code == 404
 
@@ -224,7 +249,7 @@ async def test_malformed_conversation_is_still_a_400_before_the_503() -> None:
     )
     with pytest.raises(HTTPException) as raised:
         await API._steward_chat_completions(  # pyright: ignore[reportPrivateUsage]
-            _stub_api(_status("starting")), payload
+            _stub_api(_status("starting")), payload, _http_request()
         )
     assert raised.value.status_code == 400
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -656,18 +656,18 @@ carries the accumulated call and whose `finish_reason` is `tool_calls`.
 
 #### When generation fails mid-response
 
-The HTTP status is committed before the body starts, so a failure that happens
-after that point cannot change the status code. It is reported in the body
-instead, as an object carrying an `error` with a `message`, `type` and
-`code`, the same shape returned by a request that is rejected before
-generation starts:
+Failures are reported differently depending on whether the response streams,
+because a streaming response commits its status with the first byte:
 
-- **Streaming**: a `data:` frame carrying an `error` object, followed by
-  `data: [DONE]`. The stream always terminates with the sentinel, including
-  when the task is cancelled or ends without completing, so a client can
-  distinguish a finished turn from a dropped connection.
-- **Non-streaming**: the response body is the error object rather than a
-  completion.
+- **Non-streaming** (`stream` omitted or false): the status reflects the
+  outcome. A generation that fails or never completes returns a 4xx or 5xx
+  carrying an object with an `error` holding `message`, `type` and `code`,
+  the same shape a request rejected before generation returns.
+- **Streaming**: the status is already committed, so a failure after that
+  point is reported in band as a `data:` frame carrying that same error
+  object, followed by `data: [DONE]`. The stream always terminates with the
+  sentinel, including when the task is cancelled or ends without completing,
+  so a client can distinguish a finished turn from a dropped connection.
 
 A response body is never empty, and a partial answer is never presented as a
 complete one. A turn ends only when the model reports a finish reason, so a

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -658,8 +658,9 @@ carries the accumulated call and whose `finish_reason` is `tool_calls`.
 
 The HTTP status is committed before the body starts, so a failure that happens
 after that point cannot change the status code. It is reported in the body
-instead, using the same error object documented under
-[Error Handling](#error-handling):
+instead, as an object carrying an `error` with a `message`, `type` and
+`code`, the same shape returned by a request that is rejected before
+generation starts:
 
 - **Streaming**: a `data:` frame carrying an `error` object, followed by
   `data: [DONE]`. The stream always terminates with the sentinel, including
@@ -668,9 +669,11 @@ instead, using the same error object documented under
 - **Non-streaming**: the response body is the error object rather than a
   completion.
 
-A response body is never empty. If a request produced no output at all, for
-example because the task was cancelled before the first token, the body is an
-error object explaining that rather than zero bytes.
+A response body is never empty, and a partial answer is never presented as a
+complete one. A turn ends only when the model reports a finish reason, so a
+request that produced nothing, or that produced text and then stopped without
+one, returns an error object rather than zero bytes or a silently truncated
+completion.
 
 ### Common Request Fields
 

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -569,10 +569,10 @@ memory:
 - After tokenization on the serving instance, a prompt that fills the window,
   or a prompt plus an explicit `max_tokens` that exceeds the limit, is
   rejected with an OpenAI-style `invalid_request_error` whose message starts
-  with `context_length_exceeded:`. For streaming requests this arrives as the
-  first SSE `data:` event; for non-streaming requests the response body is the
-  error envelope (the HTTP status is already committed when the rejection is
-  computed on the serving node).
+  with `context_length_exceeded:`. Non-streaming requests return this as
+  **400 Bad Request**. Streaming requests have already committed their status
+  by the time the rejection is computed on the serving node, so it arrives as
+  the first SSE `data:` event instead.
 - When `max_tokens` is omitted, the server default output budget is clamped to
   the remaining window, so generation ends with `finish_reason: "length"`
   instead of overrunning the context.

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -654,6 +654,24 @@ Reasoning models place thinking text on `delta.reasoning_content` rather than
 without the reasoning. Tool calls arrive as a frame whose `delta.tool_calls`
 carries the accumulated call and whose `finish_reason` is `tool_calls`.
 
+#### When generation fails mid-response
+
+The HTTP status is committed before the body starts, so a failure that happens
+after that point cannot change the status code. It is reported in the body
+instead, using the same error object documented under
+[Error Handling](#error-handling):
+
+- **Streaming**: a `data:` frame carrying an `error` object, followed by
+  `data: [DONE]`. The stream always terminates with the sentinel, including
+  when the task is cancelled or ends without completing, so a client can
+  distinguish a finished turn from a dropped connection.
+- **Non-streaming**: the response body is the error object rather than a
+  completion.
+
+A response body is never empty. If a request produced no output at all, for
+example because the task was cancelled before the first token, the body is an
+error object explaining that rather than zero bytes.
+
 ### Common Request Fields
 
 | Field | Type | Notes |


### PR DESCRIPTION
Closes #872.

## The defect

`POST /v1/chat/completions` could return **HTTP 200 with a zero-byte body**. That is the worst answer available: every OpenAI-compatible client treats 2xx as success and moves straight to parsing, so the real failure surfaces as an unrelated parse error far from its cause.

Observed on a cluster whose master held no runner for the requested model. The task was accepted, timed out, and was cancelled, and the caller got:

```
POST /v1/chat/completions  ->  HTTP 200, 0 bytes
```

For contrast, the same endpoint's other failure paths were already correct: an unknown model returns 404 and an embedding model asked to chat returns 400, both with proper error envelopes. Only this path was silent.

## Cause

`collect_chat_response` ended with `assert model is not None`. `model` is only set by a `TokenChunk` or a `ToolCallChunk`, so a stream that produced neither, and no `ErrorChunk` either, hit the assertion. Because the status is committed before the body streams, the raised assertion simply ended the response with nothing written.

The streaming path had the matching hole: `data: [DONE]` was emitted only from inside the loop when a chunk carried a `finish_reason`. A producer that stopped early fell out of the loop and returned, closing the connection with no terminator, which a client cannot distinguish from a dropped connection.

## Fix

Both paths now report what happened, using the structured error object the runner-error path already produces:

- non-streaming: the body is an error object rather than nothing
- streaming: a final `data:` frame carrying the error, then `data: [DONE]`, so the stream always terminates

No status codes change, because at that point they cannot. What changes is that the body is always readable and always says something.

## Validation

- Two regression tests driving a producer that ends without any chunk: one asserts the collected body is non-empty and parses to an error object with a message, the other asserts the stream ends with `[DONE]` preceded by an explanatory frame.
- Both were checked against a reverted implementation to confirm they fail without the fix rather than merely describing it.
- `uv run pytest src/skulk/api/tests`: 777 pass. `uv run basedpyright`: 0 errors. `uv run ruff check`: clean. `nix fmt`: no changes.

## Documentation

The API guide gains a **When generation fails mid-response** section under streaming, stating that the status is committed before the body so post-commit failures are reported in the body, describing both shapes, and stating plainly that a response body is never empty. Recorded in the changelog as a fix.

## How it was found

By the external-API compatibility suite's central invariant, that a success status must carry a body which parses and matches the documented shape. The suite reached this via a degraded cluster; the contract violation is independent of what degraded it.