### PR TITLE
fix(tools): scrub dialect markers from no-tools responses on every engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- The no-tools marker protection now covers every engine. The scan below was
+  in-process MLX only: the served engines' servers never parse without tools
+  in the request, and the llama.cpp recovery branch is likewise skipped, so a
+  model that wrote a call anyway leaked its dialect markers to the caller as
+  content (observed live with a gemma card and `tool_choice: "none"`). The
+  `llama_server`, `vllm`, and `llama_cpp` runners now stream no-tools content
+  through a shared scaffolding scrub that removes the cross-dialect marker
+  vocabulary, holding partial markers across chunk boundaries.
+
 - A request offering no tools still has its markers stripped. Skipping the scan
   entirely when none were offered, which is what keeps `tool_choice: "none"`
   from producing a call, also meant nothing recognized a block the model wrote

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -64,6 +64,9 @@ from skulk.worker.runner.generation_stats import (
     resolve_stream_token_counts,
 )
 from skulk.worker.runner.llm_inference.harmony_text_parser import HarmonyTextParser
+from skulk.worker.runner.llm_inference.scaffolding_scrub import (
+    StreamingScaffoldingScrub,
+)
 from skulk.worker.runner.llm_inference.think_text_parser import ThinkTextParser
 from skulk.worker.runner.llm_inference.tool_parsers import declared_tool_calls
 from skulk.worker.runner.llm_inference.tool_text_parser import (
@@ -1039,6 +1042,17 @@ class Runner(ServedConcurrentDispatch):
                 )
 
             emitted_finish = False
+            # With no tools offered neither llama.cpp's native handler nor the
+            # text-recovery branch runs, so a model writing a call anyway would
+            # leak its dialect markers as content (#889); scrub them, the same
+            # invariant the MLX path enforces with emit_calls=False. Logprobs
+            # requests are exempt: rewriting a token chunk's text would detach
+            # it from the per-token logprob it carries.
+            scrub = (
+                StreamingScaffoldingScrub()
+                if not task.task_params.tools and not want_logprobs
+                else None
+            )
             for chunk in stream:
                 if self._is_cancelled(task.task_id):
                     logger.info(f"llama.cpp generation cancelled: {task.task_id}")
@@ -1057,17 +1071,29 @@ class Runner(ServedConcurrentDispatch):
 
                 if reasoning_parser is not None:
                     for clean_text, is_thinking in reasoning_parser.feed(text):
+                        if not is_thinking and scrub is not None:
+                            clean_text = scrub.feed(clean_text)
+                            if not clean_text:
+                                continue
                         self._send_token_chunk(
                             command_id, model_id, clean_text, is_thinking=is_thinking
                         )
                     if finish is not None:
                         for clean_text, is_thinking in reasoning_parser.flush():
+                            if not is_thinking and scrub is not None:
+                                clean_text = scrub.feed(clean_text)
+                                if not clean_text:
+                                    continue
                             self._send_token_chunk(
                                 command_id,
                                 model_id,
                                 clean_text,
                                 is_thinking=is_thinking,
                             )
+                        if scrub is not None:
+                            tail = scrub.flush()
+                            if tail:
+                                self._send_token_chunk(command_id, model_id, tail)
                         emitted_finish = True
                         self._send_token_chunk(
                             command_id,
@@ -1078,6 +1104,10 @@ class Runner(ServedConcurrentDispatch):
                         )
                     continue
 
+                if scrub is not None:
+                    text = scrub.feed(text)
+                    if finish is not None:
+                        text += scrub.flush()
                 if not text and finish is None and logprob is None:
                     continue
                 emitted_finish = emitted_finish or finish is not None
@@ -1104,9 +1134,17 @@ class Runner(ServedConcurrentDispatch):
                 # so a stream that ends without a finish_reason doesn't truncate.
                 if reasoning_parser is not None:
                     for clean_text, is_thinking in reasoning_parser.flush():
+                        if not is_thinking and scrub is not None:
+                            clean_text = scrub.feed(clean_text)
+                            if not clean_text:
+                                continue
                         self._send_token_chunk(
                             command_id, model_id, clean_text, is_thinking=is_thinking
                         )
+                if scrub is not None:
+                    tail = scrub.flush()
+                    if tail:
+                        self._send_token_chunk(command_id, model_id, tail)
                 self.event_sender.send(
                     ChunkGenerated(
                         command_id=command_id,

--- a/src/skulk/worker/runner/llama_server/runner.py
+++ b/src/skulk/worker/runner/llama_server/runner.py
@@ -92,6 +92,9 @@ from skulk.worker.runner.llama_cpp.runner import (
 from skulk.worker.runner.llama_server.channel_text_parser import (
     GemmaChannelTextParser,
 )
+from skulk.worker.runner.llm_inference.scaffolding_scrub import (
+    StreamingScaffoldingScrub,
+)
 from skulk.worker.runner.served_concurrency import ServedConcurrentDispatch
 
 
@@ -1282,6 +1285,16 @@ class Runner(ServedConcurrentDispatch):
         # Gemma 4 emits its reasoning as literal <|channel> markers in content;
         # reparse them here (llama-server can't) into reasoning/content chunks.
         parser = GemmaChannelTextParser() if self._uses_channel_parser else None
+        # With no tools offered the server's own tool parser never runs, so a
+        # model that writes a call anyway would leak its dialect markers to the
+        # caller as content (#889). Scrub them here, the same invariant the
+        # MLX path enforces in parse_tool_calls with emit_calls=False.
+        scrub = (
+            StreamingScaffoldingScrub() if not task.task_params.tools else None
+        )
+
+        def _content_pieces(text: str) -> str:
+            return scrub.feed(text) if scrub is not None else text
         # No read timeout: generation can pause between tokens on a busy GPU. The
         # connection is closed (aborting server generation) when we break out.
         timeout = httpx.Timeout(connect=15.0, read=None, write=30.0, pool=None)
@@ -1313,17 +1326,27 @@ class Runner(ServedConcurrentDispatch):
                 if delta.content:
                     if parser is not None:
                         for text, is_thinking in parser.feed(delta.content):
-                            self._send_token(
-                                command_id, model_id, text, is_thinking=is_thinking
-                            )
+                            emit = text if is_thinking else _content_pieces(text)
+                            if emit or is_thinking:
+                                self._send_token(
+                                    command_id, model_id, emit, is_thinking=is_thinking
+                                )
                     else:
-                        self._send_token(command_id, model_id, delta.content)
+                        emit = _content_pieces(delta.content)
+                        if emit:
+                            self._send_token(command_id, model_id, emit)
                 if delta.finish is not None:
                     if parser is not None:
                         for text, is_thinking in parser.flush():
-                            self._send_token(
-                                command_id, model_id, text, is_thinking=is_thinking
-                            )
+                            emit = text if is_thinking else _content_pieces(text)
+                            if emit or is_thinking:
+                                self._send_token(
+                                    command_id, model_id, emit, is_thinking=is_thinking
+                                )
+                    if scrub is not None:
+                        tail = scrub.flush()
+                        if tail:
+                            self._send_token(command_id, model_id, tail)
                     self._send_token(
                         command_id,
                         model_id,
@@ -1337,9 +1360,15 @@ class Runner(ServedConcurrentDispatch):
         if not emitted_finish and not self._is_cancelled(task.task_id):
             if parser is not None:
                 for text, is_thinking in parser.flush():
-                    self._send_token(
-                        command_id, model_id, text, is_thinking=is_thinking
-                    )
+                    emit = text if is_thinking else _content_pieces(text)
+                    if emit or is_thinking:
+                        self._send_token(
+                            command_id, model_id, emit, is_thinking=is_thinking
+                        )
+            if scrub is not None:
+                tail = scrub.flush()
+                if tail:
+                    self._send_token(command_id, model_id, tail)
             self._send_token(
                 command_id, model_id, "", finish_reason="stop", stats=final_stats()
             )

--- a/src/skulk/worker/runner/llm_inference/scaffolding_scrub.py
+++ b/src/skulk/worker/runner/llm_inference/scaffolding_scrub.py
@@ -53,6 +53,7 @@ SCAFFOLDING_MARKERS: Final[tuple[str, ...]] = (
     "<｜tool▁calls▁end｜>",
     "<｜tool▁call▁begin｜>",
     "<｜tool▁call▁end｜>",
+    "<｜tool▁sep｜>",
     # DeepSeek V3.2 DSML scaffolding (`dsml_encoding.py`). The containers and
     # closing tags are fixed strings; the invoke/parameter OPENING tags carry
     # attributes (`<｜DSML｜invoke name="...">`), which a fixed-string marker

--- a/src/skulk/worker/runner/llm_inference/scaffolding_scrub.py
+++ b/src/skulk/worker/runner/llm_inference/scaffolding_scrub.py
@@ -1,0 +1,119 @@
+"""Strip tool-dialect scaffolding from no-tools response streams (#889).
+
+The invariant, shared with the in-process MLX parser: a request that offered
+no tools never surfaces tool-call control markup as assistant content, however
+the stream was chunked. The MLX path enforces this inside ``parse_tool_calls``
+(the scan always runs and recognized blocks are delivered as marker-stripped
+content). The served engines have no equivalent seam: with no tools in the
+request the server's own parser does not run, so a model that writes a call
+anyway leaks its dialect markers to the caller verbatim. Observed live on
+`llama_server` with a gemma4 card and ``tool_choice: "none"``:
+``<|tool_call>_call:get_weather{...}<tool_call|>`` arrived as content.
+
+This module is that seam. It deliberately strips the marker vocabulary rather
+than recognizing whole blocks: on a no-tools request nothing may be executed,
+so the body of whatever the model wrote is ordinary content either way, and
+marker-stripping is the exact transformation the MLX path's
+``_block_as_content`` applies to a recognized block. Stripping unconditionally
+also covers a malformed or truncated block, which block recognition would
+hand back verbatim.
+
+Used by the served runners (`llama_server`, `vllm`) and the in-process
+`llama_cpp` runner on their no-tools paths only. A request that offered tools
+keeps the engine's own behavior: there the server-parsed calls are the
+product, and a block the server did not parse is evidence the caller may need
+to see.
+"""
+
+from __future__ import annotations
+
+from typing import Final, final
+
+# Every dialect's block scaffolding, as it leaks into plain text. Grouped by
+# the family that writes it; each entry either leaked from a live model during
+# tool validation or is the write-side marker of a dialect Skulk parses
+# (`tool_text_parser`). Sorted longest-first at strip time so no marker can
+# shadow a longer one that contains it.
+SCAFFOLDING_MARKERS: Final[tuple[str, ...]] = (
+    # Generic marker dialect (Qwen3 XML / Hermes JSON carriers).
+    "<tool_call>",
+    "</tool_call>",
+    # Llama 3.1+ built-in / tool handoff.
+    "<|python_tag|>",
+    # Mistral call arrays.
+    "[TOOL_CALLS]",
+    # Gemma 4 (`call:NAME{...}` blocks); response markers included because the
+    # family writes both sides with the same scaffolding.
+    "<|tool_call>",
+    "<tool_call|>",
+    "<|tool_response>",
+    "<tool_response|>",
+    # DeepSeek DSML block containers.
+    "<｜tool▁calls▁begin｜>",
+    "<｜tool▁calls▁end｜>",
+    "<｜tool▁call▁begin｜>",
+    "<｜tool▁call▁end｜>",
+)
+
+_MARKERS_LONGEST_FIRST: Final = tuple(
+    sorted(SCAFFOLDING_MARKERS, key=len, reverse=True)
+)
+_LONGEST_MARKER: Final = max(len(marker) for marker in SCAFFOLDING_MARKERS)
+
+
+def strip_scaffolding(text: str) -> str:
+    """Remove every complete scaffolding marker from ``text``.
+
+    For blocking (non-streamed) response paths, where the whole message is in
+    hand. Streaming paths must use :class:`StreamingScaffoldingScrub` instead,
+    because a marker split across two stream chunks is invisible to a
+    per-chunk replace.
+    """
+
+    for marker in _MARKERS_LONGEST_FIRST:
+        text = text.replace(marker, "")
+    return text
+
+
+def _partial_marker_suffix_length(text: str) -> int:
+    """Length of the trailing run of ``text`` that could still become a marker.
+
+    The same hold-back rule as the MLX streaming parser: bounded by the
+    longest marker, so at most a few characters of latency and never an
+    unbounded buffer.
+    """
+
+    for length in range(min(_LONGEST_MARKER - 1, len(text)), 0, -1):
+        tail = text[-length:]
+        if any(marker.startswith(tail) for marker in SCAFFOLDING_MARKERS):
+            return length
+    return 0
+
+
+@final
+class StreamingScaffoldingScrub:
+    """Marker-strip a text stream, holding back partial markers across chunks.
+
+    ``feed`` returns the text safe to emit now; ``flush`` returns whatever was
+    held once the stream ends (a trailing partial marker is then just text).
+    The interface mirrors ``GemmaChannelTextParser`` so the served runners
+    compose both the same way.
+    """
+
+    def __init__(self) -> None:
+        self._held = ""
+
+    def feed(self, text: str) -> str:
+        """Scrub ``text`` (plus any held tail) and return the emittable part."""
+
+        combined = strip_scaffolding(self._held + text)
+        keep = _partial_marker_suffix_length(combined)
+        self._held = combined[len(combined) - keep :] if keep else ""
+        return combined[: len(combined) - keep] if keep else combined
+
+    def flush(self) -> str:
+        """Return the held tail at end of stream; nothing more is coming."""
+
+        held = self._held
+        self._held = ""
+        return held

--- a/src/skulk/worker/runner/llm_inference/scaffolding_scrub.py
+++ b/src/skulk/worker/runner/llm_inference/scaffolding_scrub.py
@@ -48,11 +48,25 @@ SCAFFOLDING_MARKERS: Final[tuple[str, ...]] = (
     "<tool_call|>",
     "<|tool_response>",
     "<tool_response|>",
-    # DeepSeek DSML block containers.
+    # DeepSeek V3/R1 block containers (the pre-DSML wire format).
     "<｜tool▁calls▁begin｜>",
     "<｜tool▁calls▁end｜>",
     "<｜tool▁call▁begin｜>",
     "<｜tool▁call▁end｜>",
+    # DeepSeek V3.2 DSML scaffolding (`dsml_encoding.py`). The containers and
+    # closing tags are fixed strings; the invoke/parameter OPENING tags carry
+    # attributes (`<｜DSML｜invoke name="...">`), which a fixed-string marker
+    # cannot cover, so the namespace prefixes are stripped on their own. That
+    # leaves attribute debris (`invoke name="...">`) as plain text, which is
+    # the accepted trade: the control namespace never reaches the caller, and
+    # a bounded fixed-string vocabulary is what keeps the streaming hold-back
+    # bounded.
+    "<｜DSML｜function_calls>",
+    "</｜DSML｜function_calls>",
+    "</｜DSML｜invoke>",
+    "</｜DSML｜parameter>",
+    "<｜DSML｜",
+    "</｜DSML｜",
 )
 
 _MARKERS_LONGEST_FIRST: Final = tuple(
@@ -104,16 +118,30 @@ class StreamingScaffoldingScrub:
         self._held = ""
 
     def feed(self, text: str) -> str:
-        """Scrub ``text`` (plus any held tail) and return the emittable part."""
+        """Scrub ``text`` (plus any held tail) and return the emittable part.
 
-        combined = strip_scaffolding(self._held + text)
+        The hold-back is computed on the RAW combined text, before stripping:
+        some markers are strict prefixes of longer ones (the bare DSML
+        namespace inside its container tags), and stripping a completed short
+        marker eagerly would make the result depend on where the stream was
+        split, because the longer marker could never match across the
+        boundary its prefix was consumed at.
+        """
+
+        combined = self._held + text
         keep = _partial_marker_suffix_length(combined)
         self._held = combined[len(combined) - keep :] if keep else ""
-        return combined[: len(combined) - keep] if keep else combined
+        emittable = combined[: len(combined) - keep] if keep else combined
+        return strip_scaffolding(emittable)
 
     def flush(self) -> str:
-        """Return the held tail at end of stream; nothing more is coming."""
+        """Return the held tail at end of stream; nothing more is coming.
+
+        Stripped once more on the way out: the tail may be a complete short
+        marker held because a longer marker extends it. A genuine partial
+        lookalike survives the strip and is returned as ordinary text.
+        """
 
         held = self._held
         self._held = ""
-        return held
+        return strip_scaffolding(held)

--- a/src/skulk/worker/runner/llm_inference/tests/test_scaffolding_scrub.py
+++ b/src/skulk/worker/runner/llm_inference/tests/test_scaffolding_scrub.py
@@ -1,0 +1,92 @@
+"""Invariant sweep over the no-tools scaffolding scrub (#889).
+
+The scrub sits on streamed text, so the bugs it can have are split bugs: a
+marker divided across two chunks that a per-chunk replace would miss, or a
+held-back partial marker that never gets released. The invariants, checked
+across every single split point of each message plus character-by-character:
+
+1. No scaffolding marker survives to the output, wherever the split fell.
+2. Everything that is not a marker is preserved exactly: the streamed result
+   equals the blocking ``strip_scaffolding`` of the whole message.
+3. A message with no markers passes through byte-identical.
+4. ``flush`` releases a trailing partial marker as ordinary text, so a stream
+   that ends mid-lookalike does not truncate the answer.
+"""
+
+from __future__ import annotations
+
+from skulk.worker.runner.llm_inference.scaffolding_scrub import (
+    SCAFFOLDING_MARKERS,
+    StreamingScaffoldingScrub,
+    strip_scaffolding,
+)
+
+GEMMA_LEAK = '<|tool_call>_call:get_weather{location: "Denver"}<tool_call|>'
+
+MESSAGES: list[str] = [
+    "The weather is fine.",
+    GEMMA_LEAK,
+    f"I'll check. {GEMMA_LEAK} Done.",
+    '<tool_call>{"name": "get_weather", "arguments": {}}</tool_call>',
+    "<|python_tag|>print('hello')",
+    '[TOOL_CALLS] [{"name": "get_weather"}]',
+    "<｜tool▁calls▁begin｜>x<｜tool▁calls▁end｜>",
+    "Braces {like this} and <angles> are fine.",
+    "A lone < at the end",
+    "Ends with a partial marker <tool_ca",
+    "<tool_call><tool_call>doubled</tool_call></tool_call>",
+]
+
+
+def splits(message: str) -> list[list[str]]:
+    """Every single split point, plus whole and character-by-character."""
+
+    variants: list[list[str]] = [[message]]
+    variants.extend(
+        [message[:index], message[index:]] for index in range(1, len(message))
+    )
+    variants.append(list(message))
+    return variants
+
+
+def run_stream(pieces: list[str]) -> str:
+    scrub = StreamingScaffoldingScrub()
+    out = [scrub.feed(piece) for piece in pieces]
+    out.append(scrub.flush())
+    return "".join(out)
+
+
+class TestStreamingScrubInvariants:
+    def test_every_split_of_every_message(self) -> None:
+        for message in MESSAGES:
+            expected = strip_scaffolding(message)
+            for pieces in splits(message):
+                result = run_stream(pieces)
+                where = f"{message!r} split as {pieces!r}"
+                assert result == expected, f"stream differs from blocking for {where}"
+                for marker in SCAFFOLDING_MARKERS:
+                    assert marker not in result, f"{marker!r} leaked for {where}"
+
+    def test_marker_free_text_is_identity(self) -> None:
+        for message in MESSAGES:
+            if any(marker in message for marker in SCAFFOLDING_MARKERS):
+                continue
+            for pieces in splits(message):
+                assert run_stream(pieces) == message
+
+    def test_trailing_partial_marker_is_released_on_flush(self) -> None:
+        scrub = StreamingScaffoldingScrub()
+        emitted = scrub.feed("answer <tool_ca")
+        assert emitted == "answer "
+        assert scrub.flush() == "<tool_ca"
+
+
+class TestBlockingStrip:
+    def test_strips_the_observed_live_leak(self) -> None:
+        assert (
+            strip_scaffolding(GEMMA_LEAK) == '_call:get_weather{location: "Denver"}'
+        )
+
+    def test_every_marker_is_stripped(self) -> None:
+        for marker in SCAFFOLDING_MARKERS:
+            assert strip_scaffolding(f"a{marker}b") == "ab"

--- a/src/skulk/worker/runner/llm_inference/tests/test_scaffolding_scrub.py
+++ b/src/skulk/worker/runner/llm_inference/tests/test_scaffolding_scrub.py
@@ -31,6 +31,11 @@ MESSAGES: list[str] = [
     "<|python_tag|>print('hello')",
     '[TOOL_CALLS] [{"name": "get_weather"}]',
     "<｜tool▁calls▁begin｜>x<｜tool▁calls▁end｜>",
+    (
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_weather">'
+        '<｜DSML｜parameter name="location">Denver</｜DSML｜parameter>'
+        "</｜DSML｜invoke></｜DSML｜function_calls>"
+    ),
     "Braces {like this} and <angles> are fine.",
     "A lone < at the end",
     "Ends with a partial marker <tool_ca",
@@ -90,3 +95,13 @@ class TestBlockingStrip:
     def test_every_marker_is_stripped(self) -> None:
         for marker in SCAFFOLDING_MARKERS:
             assert strip_scaffolding(f"a{marker}b") == "ab"
+
+    def test_dsml_namespace_never_reaches_the_caller(self) -> None:
+        """DSML control tokens are stripped; attribute debris may remain."""
+        leak = (
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_weather">'
+            "</｜DSML｜invoke></｜DSML｜function_calls>"
+        )
+        result = strip_scaffolding(leak)
+        assert "｜DSML｜" not in result
+        assert result == 'invoke name="get_weather">'

--- a/src/skulk/worker/runner/vllm/runner.py
+++ b/src/skulk/worker/runner/vllm/runner.py
@@ -108,6 +108,9 @@ from skulk.worker.runner.llama_cpp.runner import (
     tool_calls_from_message,
     wants_logprobs,
 )
+from skulk.worker.runner.llm_inference.scaffolding_scrub import (
+    StreamingScaffoldingScrub,
+)
 from skulk.worker.runner.served_concurrency import ServedConcurrentDispatch
 from skulk.worker.runner.vllm.orphan_sweep import sweep_orphaned_vllm_engines
 
@@ -1038,6 +1041,12 @@ class Runner(ServedConcurrentDispatch):
             return self.stamp_runner_stats(base, admission_in_flight)
 
         finish_reason: Literal["stop", "length", "content_filter"] | None = None
+        # With no tools offered the server's tool parser never runs, so a model
+        # writing a call anyway would leak dialect markers as content (#889).
+        # Same invariant the MLX path enforces with emit_calls=False.
+        scrub = (
+            StreamingScaffoldingScrub() if not task.task_params.tools else None
+        )
         # No read timeout: generation can pause between tokens on a busy GPU. The
         # connection is closed (aborting server generation) when we break out.
         timeout = httpx.Timeout(connect=15.0, read=None, write=30.0, pool=None)
@@ -1067,7 +1076,13 @@ class Runner(ServedConcurrentDispatch):
                         command_id, model_id, delta.reasoning, is_thinking=True
                     )
                 if delta.content:
-                    self._send_token(command_id, model_id, delta.content)
+                    emit = (
+                        scrub.feed(delta.content)
+                        if scrub is not None
+                        else delta.content
+                    )
+                    if emit:
+                        self._send_token(command_id, model_id, emit)
                 if delta.finish is not None:
                     # The terminal chunk is deferred past the loop: the
                     # include_usage counts arrive AFTER the finish_reason
@@ -1077,6 +1092,10 @@ class Runner(ServedConcurrentDispatch):
         # fully drained, whether or not the server sent an explicit
         # finish_reason.
         if not self._is_cancelled(task.task_id):
+            if scrub is not None:
+                tail = scrub.flush()
+                if tail:
+                    self._send_token(command_id, model_id, tail)
             self._send_token(
                 command_id,
                 model_id,

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -879,7 +879,15 @@ recognized block is still converted to content with its markers stripped.
 That is what makes `tool_choice: "none"` hold on the in-process engines, at
 the cost that a no-tools response opening a block is buffered until the block
 resolves. The llama.cpp runner does skip its recovery branch with no tools
-offered, since its native handler only produces calls when tools are passed.
+offered, since its native handler only produces calls when tools are passed;
+what covers that engine, and the served engines whose server-side parsers
+also never run without tools, is `scaffolding_scrub.py`: on a no-tools
+request the `llama_cpp`, `llama_server`, and `vllm` runners stream content
+through `StreamingScaffoldingScrub`, which strips the cross-dialect marker
+vocabulary while holding back partial markers across chunk boundaries, so a
+model writing a call anyway cannot leak control markup to the caller.
+Logprobs requests on `llama_cpp` are exempt, because rewriting a token
+chunk's text would detach it from its per-token logprob.
 `declared_tool_calls` itself treats a `None` tools list as "no list to
 check against" rather than "nothing may be called", because the steward parses
 its own turns through the same dialects without passing one; whether a

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -643,6 +643,16 @@ built-ins (Llama answers some plain questions with a call to `print`, gpt-oss
 has `python` and `browser`), and a caller has no implementation for those, so
 those blocks come back as content too.
 
+A request that offered no tools gets the same protection on every engine. The
+MLX parser scans anyway and delivers recognized blocks as marker-stripped
+content, and the engines whose parsers never run without tools (the served
+`llama_server` and `vllm` runners, whose servers only parse when tools are in
+the request, and the llama.cpp runner's recovery branch) stream their content
+through a shared scaffolding scrub instead: the cross-dialect marker
+vocabulary is removed, with partial markers held across chunk boundaries, so
+a model that writes a call nobody asked for cannot leak control markup to the
+caller as answer text.
+
 The llama.cpp runner serves GGUF models single-node and matches the MLX runner
 on the capabilities llama.cpp supports natively: per-token logprobs (with the
 top alternatives) and tool calling. A tool-enabled request runs unstreamed so

--- a/website/docs/release-notes/next.md
+++ b/website/docs/release-notes/next.md
@@ -23,6 +23,13 @@ call. Sending `"none"` now guarantees no call, and naming a single function
 guarantees the model cannot call a different one.
 
 
+A request that offers no tools can no longer receive tool-call control markup
+as answer text, whichever engine serves the model. Models sometimes write a
+call nobody asked for; on the engines whose tool parsing only runs when tools
+are in the request, that markup previously passed straight through to the
+caller. The markers are now removed from the answer on every engine.
+
+
 Tool calls are now recognized when a model's opening marker arrives split
 across several streamed pieces, which is the normal case rather than the
 exception, and when the model writes a sentence before calling ("I'll check


### PR DESCRIPTION
## What this fixes

The no-tools marker protection added in #879 covered the in-process MLX path only: its parser always scans and delivers recognized blocks as marker-stripped content. The other three engines had no equivalent seam. The served engines (`llama_server`, `vllm`) only run their server-side tool parsers when tools are in the request, and the in-process `llama_cpp` runner skips its text-recovery branch the same way, so a model that wrote a call nobody asked for leaked its dialect markers to the caller as answer content. Observed live during the post-#879 validation battery: a gemma4 GGUF card under `tool_choice: "none"` returned `<|tool_call>_call:get_weather{location: "Denver"}<tool_call|>` as message content.

## The fix

A shared `StreamingScaffoldingScrub` (`worker/runner/llm_inference/scaffolding_scrub.py`) now sits on the no-tools content streams of all three runners. It strips the cross-dialect marker vocabulary (generic `<tool_call>` pair, Llama `<|python_tag|>`, Mistral `[TOOL_CALLS]`, gemma4 call/response markers, DSML block containers), holding back partial markers across chunk boundaries exactly the way the MLX streaming parser holds its own, and releasing a trailing lookalike on flush so a stream ending mid-lookalike is not truncated. Marker-stripping rather than block recognition is deliberate: on a no-tools request nothing may execute, so the body is content either way, and stripping also covers malformed or truncated blocks.

Scope choices, stated: requests that offered tools keep each engine's existing behavior (there the server-parsed calls are the product, and an unparsed block is evidence the caller may need). Logprobs requests on `llama_cpp` bypass the scrub, because rewriting a token chunk's text would detach it from the per-token logprob it carries.

## Validation

- New invariant sweep `test_scaffolding_scrub.py`: every single split point of every message, plus character-by-character, asserting stream-equals-blocking, no marker survives, marker-free text is byte-identical, and flush releases a held tail.
- Full battery: `basedpyright` 0 errors, `ruff check` clean, format clean, 3806 tests pass.
- Live validation on the den segment follows on this branch: re-running the exact tool-contract case that surfaced the leak (gemma4 GGUF via `llama_server`, `tool_choice: "none"`).

Both architecture documents, the changelog, and the next release notes describe the new seam.

Fixes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)