### PR TITLE
feat(cards): enable Qwen3.6 FP8 tool calling on vLLM with qwen3_xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- The Qwen3.6 FP8 cards now enable tool calling on the vLLM engine. Qwen3.6
+  emits the XML function format, which vLLM's `qwen3_xml` parser reads; the
+  parser name was validated live on an A100-class GPU with the full served
+  tool suite on both cards, which is what the cards' own deferral note asked
+  for before pinning.
+
 - The no-tools marker protection now covers every engine. The scan below was
   in-process MLX only: the served engines' servers never parse without tools
   in the request, and the llama.cpp recovery branch is likewise skipped, so a

--- a/resources/inference_model_cards/Qwen--Qwen3.6-27B-FP8.toml
+++ b/resources/inference_model_cards/Qwen--Qwen3.6-27B-FP8.toml
@@ -10,10 +10,11 @@
 #   ({mlx, llama_cpp} in shared/backends.py) would make a vision-declaring
 #   vllm-only card unplaceable, so this card claims text serving only.
 #   Restore the vision declaration when the vllm runner gains image input.
-# - Tool calling stays off on this engine for now: Qwen3.6 emits the XML
-#   function format (not Hermes JSON), so it needs the matching vLLM
-#   parser pinned via runtime.vllm_tool_call_parser once that parser name
-#   is validated on a pod; a wrong parser fails at request time.
+# - Tool calling is on: Qwen3.6 emits the XML function format (not Hermes
+#   JSON), read by vLLM's qwen3_xml parser. Validated live on an A100-80GB
+#   pod (2026-08-28): full tool-served suite pass on this card and its
+#   sibling, structured dispatchable calls, tool_choice "none" enforcement,
+#   and the tool-result round trip.
 # Architecture facts from the repo's config.json; context_length is the
 # config max_position_embeddings. storage_size is the full staging set.
 # `supports_tensor = false`: vLLM runs single-node in Skulk.
@@ -31,6 +32,7 @@ context_length = 262144
 trust_remote_code = false
 
 [runtime]
+vllm_tool_call_parser = "qwen3_xml"
 # Native MTP through vLLM's unified "mtp" method: the checkpoint's own
 # prediction head (mtp_num_hidden_layers=1) drafts, no separate model.
 # Probe-measured on A100-80GB, 512-token greedy decode: 27B-FP8 2.01x
@@ -41,7 +43,7 @@ vllm_spec_method = "mtp"
 vllm_spec_num_tokens = 2
 
 [tooling]
-supports_tool_calling = false
+supports_tool_calling = true
 
 [placement]
 compatible_backends = ["vllm-cuda", "vllm-rocm"]

--- a/resources/inference_model_cards/Qwen--Qwen3.6-35B-A3B-FP8.toml
+++ b/resources/inference_model_cards/Qwen--Qwen3.6-35B-A3B-FP8.toml
@@ -10,10 +10,11 @@
 #   ({mlx, llama_cpp} in shared/backends.py) would make a vision-declaring
 #   vllm-only card unplaceable, so this card claims text serving only.
 #   Restore the vision declaration when the vllm runner gains image input.
-# - Tool calling stays off on this engine for now: Qwen3.6 emits the XML
-#   function format (not Hermes JSON), so it needs the matching vLLM
-#   parser pinned via runtime.vllm_tool_call_parser once that parser name
-#   is validated on a pod; a wrong parser fails at request time.
+# - Tool calling is on: Qwen3.6 emits the XML function format (not Hermes
+#   JSON), read by vLLM's qwen3_xml parser. Validated live on an A100-80GB
+#   pod (2026-08-28): full tool-served suite pass on this card and its
+#   sibling, structured dispatchable calls, tool_choice "none" enforcement,
+#   and the tool-result round trip.
 # Architecture facts from the repo's config.json; context_length is the
 # config max_position_embeddings. storage_size is the full staging set.
 # `supports_tensor = false`: vLLM runs single-node in Skulk.
@@ -31,6 +32,7 @@ context_length = 262144
 trust_remote_code = false
 
 [runtime]
+vllm_tool_call_parser = "qwen3_xml"
 # Native MTP through vLLM's unified "mtp" method: the checkpoint's own
 # prediction head (mtp_num_hidden_layers=1) drafts, no separate model.
 # Probe-measured on A100-80GB, 512-token greedy decode: 27B-FP8 2.01x
@@ -41,7 +43,7 @@ vllm_spec_method = "mtp"
 vllm_spec_num_tokens = 2
 
 [tooling]
-supports_tool_calling = false
+supports_tool_calling = true
 
 [placement]
 compatible_backends = ["vllm-cuda", "vllm-rocm"]

--- a/src/skulk/shared/models/tests/test_bundled_card_tooling_agreement.py
+++ b/src/skulk/shared/models/tests/test_bundled_card_tooling_agreement.py
@@ -26,18 +26,14 @@ CARD_DIRECTORY = (
 )
 
 # Contradictions that exist today and are tracked for the signed registry
-# rather than fixed here. The vLLM-only cards under-declare: those models do
-# call tools, but the vLLM runner resolves a parser only from an explicit
-# `runtime.vllm_tool_call_parser` pin and rejects a tools request without one,
-# so flipping the flag alone would advertise a capability that fails at request
-# time. Pinning a parser has to be validated on GPU hardware first. Anything
-# NOT listed here is a new contradiction and fails.
-KNOWN_CONTRADICTIONS: frozenset[str] = frozenset(
-    {
-        "Qwen3.6 27B",
-        "Qwen3.6 35B A3B",
-    }
-)
+# rather than fixed here. The vLLM-only cards under-declare when a model does
+# call tools but no `runtime.vllm_tool_call_parser` pin has been validated on
+# GPU hardware yet: the vLLM runner rejects a tools request without a pin, so
+# flipping the flag alone would advertise a capability that fails at request
+# time. Anything NOT listed here is a new contradiction and fails. The Qwen3.6
+# FP8 entries left this list when their `qwen3_xml` pin was validated live on
+# an A100-class pod.
+KNOWN_CONTRADICTIONS: frozenset[str] = frozenset()
 
 
 def load_cards() -> dict[str, dict[str, Any]]:


### PR DESCRIPTION
## What this changes

The two vLLM FP8 cards (`Qwen/Qwen3.6-27B-FP8`, `Qwen/Qwen3.6-35B-A3B-FP8`) deliberately kept `supports_tool_calling = false`: Qwen3.6 emits the XML function format rather than Hermes JSON, the vLLM runner resolves a parser only from an explicit `runtime.vllm_tool_call_parser` pin, and the cards' own comments deferred the pin until the parser name was validated on GPU hardware, since a wrong pin fails at request time.

That validation has now run. On an A100-80GB pod (dev at the #891 merge), with `qwen3_xml` pinned, **both cards pass the full served tool suite: 6/6, zero issues** — structured dispatchable calls, `tool_choice: "none"` enforcement, and the tool-result round trip, on the 27B and the 35B-A3B. (`qwen3_xml` is the registered vLLM parser name mapping to its Qwen3 engine tool adapter.)

The pins land inside each card's existing `[runtime]` section (both cards already carry one for MTP speculative fields), `supports_tool_calling` flips on, and the two entries leave the tooling-agreement test's known-contradictions list, which is now empty.

Operational scoping: with the current catalog architecture these bundled corrections reach registry-connected fleets only via a registry publish (#878/#890 track that propagation); the A100 validation ran with bundled cards authoritative.

Also observed during validation, for the record: both FP8 models OOM a 48GB A40 at vLLM engine init on the validated 0.25.1 stack even at `--gpu-memory-utilization 0.80` (identical ~43.5GiB allocation signature) — these cards are A100-class-and-up on Ampere.

## Validation

- Live A100 served tool suite: 6/6 across both cards, zero issues.
- `basedpyright` 0 errors, `ruff check` clean, 3807 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)