### PR TITLE
fix(tools): close the four deferred parser findings from the #879 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@ This project records release notes here and mirrors public-facing notes in
 - Visible text a model writes around its call is delivered as content
   alongside the tool calls, instead of being swallowed with the markup, for
   the dialects that know where their markup ends: the unmarked call object
-  (MLX streaming and llama.cpp text recovery) and the Mistral `[TOOL_CALLS]`
-  array (llama.cpp text recovery).
+  and the Mistral `[TOOL_CALLS]` array, on both the MLX streaming path and
+  the llama.cpp text-recovery path. Mistral's displaced upstream
+  `NAME[ARGS]` form keeps parsing through the inner parser, with no
+  remainder.
 
 - Gemma 4 models can now call tools on the in-process llama.cpp engine. The
   engine's bundled chat handler does not parse Gemma 4's call format, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ This project records release notes here and mirrors public-facing notes in
 
 ### Fixed
 
+- A plain JSON answer from an unmarked-dialect model (Llama on MLX) streams
+  incrementally again. The message-opening brace provisionally opens a
+  tool-call block whose closing token is a generation stop that never arrives
+  as text, so the whole answer was held until the terminal chunk and
+  time-to-first-token grew to the full generation time. The open is now
+  provisional: the buffered prefix is released the moment it can no longer be
+  a call, bounded by the first decisive key, and a real call still parses
+  exactly as before.
+
+- A quoted argument containing the dialect's own closing marker (an
+  HTML-writing tool passing `"</tool_call>"`) no longer truncates the block
+  and errors the generation, on the streaming paths whose block interior is
+  known: Gemma 4's quoting and templates that render arguments as JSON.
+  Interiors with other quoting rules (Qwen3 XML) keep the previous scan.
+
+- Chained Llama `<|python_tag|>` calls are no longer split inside a quoted
+  argument: a semicolon in a shell command, SQL, or prose is data, and the
+  chained objects are now read as successive balanced JSON spans.
+
+- Visible text a model writes around its call is delivered as content
+  alongside the tool calls, instead of being swallowed with the markup, for
+  the dialects that know where their markup ends: the unmarked call object
+  (MLX streaming and llama.cpp text recovery) and the Mistral `[TOOL_CALLS]`
+  array (llama.cpp text recovery).
+
 - Gemma 4 models can now call tools on the in-process llama.cpp engine. The
   engine's bundled chat handler does not parse Gemma 4's call format, and the
   text-recovery path had no dialect for it, so well-formed calls streamed to

--- a/src/skulk/worker/runner/llama_cpp/runner.py
+++ b/src/skulk/worker/runner/llama_cpp/runner.py
@@ -73,7 +73,7 @@ from skulk.worker.runner.llm_inference.scaffolding_scrub import (
 from skulk.worker.runner.llm_inference.think_text_parser import ThinkTextParser
 from skulk.worker.runner.llm_inference.tool_parsers import declared_tool_calls
 from skulk.worker.runner.llm_inference.tool_text_parser import (
-    parse_tool_calls_from_text,
+    parse_tool_calls_with_remainder,
 )
 from skulk.worker.runner.served_concurrency import ServedConcurrentDispatch
 
@@ -1391,11 +1391,17 @@ class Runner(ServedConcurrentDispatch):
             # Card truth scopes the recovery dialect (#897 review): a model's
             # resolved format decides how its output is read, so a foreign
             # dialect echoed in prose can never be minted as a call.
-            tool_calls = parse_tool_calls_from_text(
+            tool_calls, trailing_text = parse_tool_calls_with_remainder(
                 tool_source,
                 task.task_params.tools,
                 tool_call_format=resolved_format,
             )
+            if tool_calls and trailing_text:
+                # The model kept writing after its call ("{...} Done."). That
+                # is the assistant's content, delivered alongside the calls
+                # rather than swallowed with the markup; the tool response
+                # stays the terminal chunk.
+                self._send_token_chunk(command_id, model_id, trailing_text)
         if tool_calls:
             self.event_sender.send(
                 ChunkGenerated(

--- a/src/skulk/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/skulk/worker/runner/llm_inference/model_output_parsers.py
@@ -893,9 +893,10 @@ def _classify_anchored_prefix(text: str) -> str:
     call once a top-level ``"name"`` string and an ``"arguments"`` or
     ``"parameters"`` value are both distinguishable, and content the moment
     it can no longer be one: a top-level key outside the call shape, a
-    non-string name, a non-object argument value, malformed JSON, or the
-    object closing without the signature. The hold is therefore bounded by
-    the first decisive key rather than by the message.
+    non-string name, an argument value that is neither an object nor the
+    string-encoded form the OpenAI wire shape allows, malformed JSON, or
+    the object closing without the signature. The hold is therefore bounded
+    by the first decisive key rather than by the message.
     """
 
     length = len(text)

--- a/src/skulk/worker/runner/llm_inference/model_output_parsers.py
+++ b/src/skulk/worker/runner/llm_inference/model_output_parsers.py
@@ -36,6 +36,7 @@ from skulk.worker.runner.bootstrap import logger
 from skulk.worker.runner.llm_inference.tool_parsers import (
     ToolParser,
     declared_tool_calls,
+    find_close_marker,
 )
 
 _GEMMA4_THINK_START = "<|channel>thought\n"
@@ -787,14 +788,19 @@ def _block_as_content(text: str, tool_parser: ToolParser) -> str:
 
 def _block_start_index(
     text: str, tool_parser: ToolParser, *, at_message_start: bool
-) -> int | None:
-    """Index in ``text`` where a tool-call block begins, or ``None``.
+) -> tuple[int, bool] | None:
+    """Where a tool-call block begins in ``text``, or ``None``.
 
     Distinctive markers open a block wherever they appear, because models
     routinely write a sentence before calling ("I'll check that." then the
     call). The unmarked dialect's opening marker is ``{``, which appears in
     ordinary prose and JSON answers, so it opens a block only at the start of
     the message, which is the only place the families using it write a call.
+
+    Returns the index plus whether the anchored primary marker is what opens
+    there: that opening is provisional (the tentative classification in
+    :func:`parse_tool_calls` decides whether it is a call or a JSON answer),
+    while a distinctive marker commits the block immediately.
     """
 
     earliest: int | None = None
@@ -803,6 +809,7 @@ def _block_start_index(
         if found != -1 and (earliest is None or found < earliest):
             earliest = found
 
+    anchored_open = False
     if not tool_parser.anchored:
         found = text.find(tool_parser.start_parsing)
         if found != -1 and (earliest is None or found < earliest):
@@ -813,7 +820,153 @@ def _block_start_index(
             found = len(text) - len(stripped)
             if earliest is None or found < earliest:
                 earliest = found
-    return earliest
+                anchored_open = True
+    if earliest is None:
+        return None
+    return earliest, anchored_open
+
+
+_ANCHORED_CALL_KEYS = frozenset({"name", "arguments", "parameters"})
+# Keys some Llama variants add around the call signature without changing
+# what the object is; they neither make the object a call nor rule it out.
+_ANCHORED_NEUTRAL_KEYS = frozenset({"type", "id"})
+
+
+def _skip_json_value(text: str, index: int) -> int | None:
+    """Position just past the JSON value starting at ``index``, or ``None``.
+
+    ``None`` means the value is still incomplete in the buffered prefix. A
+    scalar running to the end of the buffer is also incomplete, because more
+    of it may still arrive.
+    """
+
+    length = len(text)
+    char = text[index]
+    if char == '"':
+        escaped = False
+        for position in range(index + 1, length):
+            current = text[position]
+            if escaped:
+                escaped = False
+            elif current == "\\":
+                escaped = True
+            elif current == '"':
+                return position + 1
+        return None
+    if char in "{[":
+        depth = 0
+        in_string = False
+        escaped = False
+        for position in range(index, length):
+            current = text[position]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif current == "\\":
+                    escaped = True
+                elif current == '"':
+                    in_string = False
+                continue
+            if current == '"':
+                in_string = True
+            elif current in "{[":
+                depth += 1
+            elif current in "}]":
+                depth -= 1
+                if depth == 0:
+                    return position + 1
+        return None
+    for position in range(index, length):
+        if text[position] in ",}]" or text[position].isspace():
+            return position
+    return None
+
+
+def _classify_anchored_prefix(text: str) -> str:
+    """Decide whether a message-opening ``{`` prefix is a call or an answer.
+
+    Returns ``"call"``, ``"content"``, or ``"undecided"``. The unmarked
+    dialect's block opens on ``{``, which a model asked for JSON also emits,
+    and its closing token is a generation stop that never arrives as text, so
+    without this the whole message was held until the terminal chunk and a
+    plain JSON answer lost incremental streaming entirely. The prefix is a
+    call once a top-level ``"name"`` string and an ``"arguments"`` or
+    ``"parameters"`` value are both distinguishable, and content the moment
+    it can no longer be one: a top-level key outside the call shape, a
+    non-string name, a non-object argument value, malformed JSON, or the
+    object closing without the signature. The hold is therefore bounded by
+    the first decisive key rather than by the message.
+    """
+
+    length = len(text)
+    index = 0
+    while index < length and text[index].isspace():
+        index += 1
+    if index >= length:
+        return "undecided"
+    if text[index] != "{":
+        return "content"
+    index += 1
+    has_name = False
+    has_args = False
+    while True:
+        while index < length and text[index].isspace():
+            index += 1
+        if index >= length:
+            return "undecided"
+        char = text[index]
+        if char == "}":
+            return "call" if has_name and has_args else "content"
+        if char != '"':
+            return "content"
+        key_end = _skip_json_value(text, index)
+        if key_end is None:
+            return "undecided"
+        key = text[index + 1 : key_end - 1]
+        if (
+            key not in _ANCHORED_CALL_KEYS
+            and key not in _ANCHORED_NEUTRAL_KEYS
+        ):
+            return "content"
+        index = key_end
+        while index < length and text[index].isspace():
+            index += 1
+        if index >= length:
+            return "undecided"
+        if text[index] != ":":
+            return "content"
+        index += 1
+        while index < length and text[index].isspace():
+            index += 1
+        if index >= length:
+            return "undecided"
+        value_start = text[index]
+        if key == "name":
+            if value_start != '"':
+                return "content"
+            has_name = True
+        elif key in _ANCHORED_CALL_KEYS:
+            # Arguments must be an object, or the JSON-encoded string form
+            # the OpenAI wire shape allows; anything else is not a call.
+            if value_start not in '{"':
+                return "content"
+            has_args = True
+        if has_name and has_args:
+            return "call"
+        value_end = _skip_json_value(text, index)
+        if value_end is None:
+            return "undecided"
+        index = value_end
+        while index < length and text[index].isspace():
+            index += 1
+        if index >= length:
+            return "undecided"
+        if text[index] == ",":
+            index += 1
+            continue
+        if text[index] == "}":
+            return "call" if has_name and has_args else "content"
+        return "content"
 
 
 def _partial_marker_suffix_length(text: str, markers: tuple[str, ...]) -> int:
@@ -861,11 +1014,14 @@ def _scan_remaining_blocks(
     leftover: list[str] = []
     remaining = text
     while remaining:
-        start = _block_start_index(remaining, tool_parser, at_message_start=False)
-        if start is None:
+        found = _block_start_index(remaining, tool_parser, at_message_start=False)
+        if found is None:
             leftover.append(remaining)
             break
-        end = remaining.find(tool_parser.end_parsing, start)
+        start, _ = found
+        end = find_close_marker(
+            remaining, tool_parser.end_parsing, tool_parser.close_scan, start=start
+        )
         if end == -1:
             leftover.append(remaining)
             break
@@ -927,6 +1083,78 @@ def parse_tool_calls(
     # message that turns out not to contain a call.
     held_text = ""
     at_message_start = True
+    # An anchored open (the unmarked dialect's message-opening "{") is
+    # provisional: the block is held only until the buffered prefix is
+    # distinguishably a call or distinguishably not one, so a plain JSON
+    # answer streams incrementally instead of losing all output to a hold
+    # that could only resolve at the terminal chunk.
+    tentative = False
+
+    def _scan_outside_block(
+        scanned: str, response: GenerationResponse
+    ) -> Generator[ParserChunk]:
+        """Scan text while no block is open; may open one (possibly tentative).
+
+        Also the re-entry point for a tentative block that turned out to be
+        content: the released text goes back through this same scan, so a
+        distinctive marker later in it still opens a real block and the rest
+        streams out under the usual partial-marker holding.
+        """
+
+        nonlocal in_tool_call, tentative, held_text, at_message_start
+        nonlocal accumulated_calls
+        found = _block_start_index(
+            scanned, tool_parser, at_message_start=at_message_start
+        )
+        if found is not None:
+            start, anchored_open = found
+            preamble = scanned[:start]
+            if preamble:
+                yield response.model_copy(
+                    update={
+                        "text": preamble,
+                        "token": 0,
+                        "finish_reason": None,
+                    }
+                )
+            in_tool_call = True
+            tentative = anchored_open
+            held_text = ""
+            at_message_start = False
+            tool_call_text_parts.append(scanned[start:])
+            return
+        keep = _partial_marker_suffix_length(scanned, tool_parser.start_markers)
+        if response.finish_reason is not None:
+            # Nothing more is coming, so a partial marker is just text.
+            keep = 0
+        emitted = scanned[: len(scanned) - keep]
+        held_text = scanned[len(scanned) - keep :]
+        if emitted.strip():
+            at_message_start = False
+        if response.finish_reason is not None and accumulated_calls:
+            # A call was found earlier in this message and the tool
+            # response has to be the terminal chunk, so this trailing
+            # text is released without the finish reason.
+            if emitted:
+                yield response.model_copy(
+                    update={
+                        "text": emitted,
+                        "token": 0,
+                        "finish_reason": None,
+                    }
+                )
+            yield ToolCallResponse(
+                tool_calls=accumulated_calls,
+                usage=response.usage,
+                stats=response.stats,
+            )
+            accumulated_calls = []
+            return
+        if emitted == response.text and not held_text:
+            yield response
+        elif emitted or response.finish_reason is not None:
+            yield response.model_copy(update={"text": emitted, "token": 0})
+
     def _finish_message(
         response: GenerationResponse,
     ) -> Generator[ParserChunk]:
@@ -1025,76 +1253,48 @@ def parse_tool_calls(
             continue
 
         last_response = response
-        just_opened = False
-        if not in_tool_call:
-            scanned = held_text + response.text
-            start = _block_start_index(
-                scanned, tool_parser, at_message_start=at_message_start
-            )
-            if start is not None:
-                preamble = scanned[:start]
-                if preamble:
-                    yield response.model_copy(
-                        update={
-                            "text": preamble,
-                            "token": 0,
-                            "finish_reason": None,
-                        }
-                    )
-                in_tool_call = True
-                just_opened = True
-                held_text = ""
-                at_message_start = False
-                tool_call_text_parts.append(scanned[start:])
-            else:
-                keep = _partial_marker_suffix_length(
-                    scanned, tool_parser.start_markers
-                )
-                if response.finish_reason is not None:
-                    # Nothing more is coming, so a partial marker is just text.
-                    keep = 0
-                emitted = scanned[: len(scanned) - keep]
-                held_text = scanned[len(scanned) - keep :]
-                if emitted.strip():
-                    at_message_start = False
-                if response.finish_reason is not None and accumulated_calls:
-                    # A call was found earlier in this message and the tool
-                    # response has to be the terminal chunk, so this trailing
-                    # text is released without the finish reason.
-                    if emitted:
-                        yield response.model_copy(
-                            update={
-                                "text": emitted,
-                                "token": 0,
-                                "finish_reason": None,
-                            }
-                        )
-                    yield ToolCallResponse(
-                        tool_calls=accumulated_calls,
-                        usage=response.usage,
-                        stats=response.stats,
-                    )
-                    accumulated_calls = []
-                    continue
-                if emitted == response.text and not held_text:
-                    yield response
-                elif emitted or response.finish_reason is not None:
-                    yield response.model_copy(
-                        update={"text": emitted, "token": 0}
-                    )
-                continue
-
-        if not just_opened:
+        if in_tool_call:
             tool_call_text_parts.append(response.text)
+        else:
+            yield from _scan_outside_block(held_text + response.text, response)
+            if not in_tool_call:
+                continue
+        if tentative:
+            verdict = _classify_anchored_prefix("".join(tool_call_text_parts))
+            if verdict == "call":
+                tentative = False
+            elif verdict == "content":
+                released = "".join(tool_call_text_parts)
+                tentative = False
+                in_tool_call = False
+                tool_call_text_parts = []
+                yield from _scan_outside_block(released, response)
+                if not in_tool_call:
+                    continue
+                # A distinctive marker inside the released text opened a
+                # real block; it cannot be tentative again (the anchored
+                # marker only opens at message start), so fall through to
+                # the closing scan.
+            elif response.finish_reason is None:
+                # Still consistent with both readings: keep holding. The
+                # hold is bounded by the first decisive key, not by the
+                # message.
+                continue
+            # Undecided on the terminal chunk falls through: the
+            # end-of-generation parse decides what the block was, exactly
+            # as it did before the tentative open existed.
         # The closing marker splits across chunks for the same reason the
         # opening one does, so it is located in the accumulated block rather
         # than tested against one chunk. Locating rather than matching the end
         # also matters because a model may keep writing after the call ("...
         # </tool_call> Done."): everything past the marker is ordinary text and
         # goes back to the opening scan, where a second call in the same
-        # message is still found.
+        # message is still found. The quote-aware modes keep a closing marker
+        # inside a quoted argument value from truncating the block.
         block_so_far = "".join(tool_call_text_parts)
-        end_index = block_so_far.find(tool_parser.end_parsing)
+        end_index = find_close_marker(
+            block_so_far, tool_parser.end_parsing, tool_parser.close_scan
+        )
         if end_index != -1:
             end_of_block = end_index + len(tool_parser.end_parsing)
             combined = block_so_far[:end_of_block]
@@ -1200,10 +1400,13 @@ def parse_tool_calls(
             # read as a call. A marker dialect's inner parser only strips the
             # closing marker if it is there, so a call cut off at max_tokens
             # would otherwise parse and be handed to the caller to execute.
-            parsed = (
-                None
+            # The split parse also reports visible text the model wrote after
+            # its call, which only the dialect itself can find here: there is
+            # no closing marker in the text to split at.
+            parsed, trailing_text = (
+                (None, "")
                 if response.finish_reason == "length"
-                else tool_parser.parse(combined.strip(), tools=tools)
+                else tool_parser.parse_split(combined.strip(), tools=tools)
             )
             if parsed is not None and (
                 not emit_calls or not declared_tool_calls(parsed, tools)
@@ -1223,6 +1426,11 @@ def parse_tool_calls(
                 break
             if parsed and emit_calls:
                 parsed = declared_tool_calls(parsed, tools)
+                # Trailing prose after the call rejoins the message-finishing
+                # scan, the same path text after a closing marker takes, so it
+                # reaches the caller as content and the tool response stays
+                # the terminal chunk.
+                held_text = trailing_text
                 logger.info(
                     "Parsed tool-call block closed by end of generation "
                     f"(generated_chars={len(combined)}, parsed_calls={len(parsed)})"

--- a/src/skulk/worker/runner/llm_inference/runner.py
+++ b/src/skulk/worker/runner/llm_inference/runner.py
@@ -90,6 +90,7 @@ from skulk.worker.runner.llm_inference.batch_generator import (
 from .batch_generator import Cancelled, Finished
 from .tool_parsers import (
     UNMARKED_TOOL_DIALECT,
+    infer_close_scan,
     make_mlx_parser,
     make_text_dialect_parser,
 )
@@ -806,10 +807,21 @@ class Builder:
                     self.tokenizer.tool_call_end,
                 )
             else:
+                chat_template = (
+                    getattr(self.tokenizer, "chat_template", None) or ""
+                )
                 tool_parser = make_mlx_parser(
                     self.tokenizer.tool_call_start,
                     self.tokenizer.tool_call_end,
                     self.tokenizer.tool_parser,  # type: ignore
+                    # Template truth at the wiring seam decides whether the
+                    # closer scan may skip quoted argument content; the
+                    # markers alone cannot (Qwen3 XML and Hermes JSON share
+                    # <tool_call>, with different quoting rules).
+                    close_scan=infer_close_scan(
+                        self.tokenizer.tool_call_start,
+                        chat_template if isinstance(chat_template, str) else "",
+                    ),
                 )
 
         kv_prefix_cache = KVPrefixCache(self.group)

--- a/src/skulk/worker/runner/llm_inference/tests/test_split_tool_markers.py
+++ b/src/skulk/worker/runner/llm_inference/tests/test_split_tool_markers.py
@@ -826,3 +826,48 @@ class TestClosingMarkerInsideArguments:
             parser,
         )
         assert calls_of(chunks) == ["get_weather"]
+
+
+class TestTextAroundAMistralArray:
+    """Mistral trailing text on the MLX streaming path.
+
+    Mistral closes its call by ending the message (the wired end marker is an
+    impossible sentinel), so the block resolves on the end-of-generation path
+    and only the split-aware text parser knows where the array ends. The
+    split reading is an overlay: the displaced upstream ``NAME[ARGS]`` form
+    still parses through the inner parser, with no remainder.
+    """
+
+    _SENTINEL = "\x00test:mistral:end\x00"
+
+    def _mistral_parser(self) -> ToolParser:
+        def inner(text: str) -> list[dict[str, object]]:
+            # Stands in for the displaced upstream parser: reads the
+            # NAME[ARGS] form only.
+            stripped = text.strip()
+            if not stripped.startswith("upstream_form"):
+                raise ValueError("not the upstream form")
+            return [{"name": "get_weather", "arguments": "{}"}]
+
+        return make_mlx_parser("[TOOL_CALLS]", self._SENTINEL, inner)
+
+    def test_trailing_text_after_the_array_is_delivered(self) -> None:
+        chunks = feed(
+            [
+                "[TOOL_CALLS] ",
+                '[{"name": "get_weather", "arguments": {"location": "Paris"}}]',
+                " I will check that.",
+            ],
+            self._mistral_parser(),
+        )
+        assert calls_of(chunks) == ["get_weather"]
+        assert "I will check that." in text_of(chunks)
+        last = [item for item in chunks if item is not None][-1]
+        assert isinstance(last, ToolCallResponse)
+
+    def test_the_displaced_upstream_form_still_parses(self) -> None:
+        chunks = feed(
+            ["[TOOL_CALLS]", "upstream_form"],
+            self._mistral_parser(),
+        )
+        assert calls_of(chunks) == ["get_weather"]

--- a/src/skulk/worker/runner/llm_inference/tests/test_split_tool_markers.py
+++ b/src/skulk/worker/runner/llm_inference/tests/test_split_tool_markers.py
@@ -11,6 +11,7 @@ detokenizer actually splits them.
 from __future__ import annotations
 
 from collections.abc import Generator
+from typing import cast
 
 from skulk.api.types import FinishReason, ToolCallItem
 from skulk.shared.types.worker.runner_response import (
@@ -640,5 +641,188 @@ class TestRejectedBlockDoesNotLeakMarkers:
         chunks = feed(
             ["<tool_call><function=get_weather></function></tool_call>"],
             generic_parser(),
+        )
+        assert calls_of(chunks) == ["get_weather"]
+
+
+class TestAJsonAnswerStreamsIncrementally:
+    """A message-opening brace no longer holds the whole answer.
+
+    The unmarked dialect's closing token is a generation stop that never
+    arrives as text, so an anchored open used to hold every chunk until the
+    terminal one: a plain JSON answer lost all incremental output and
+    time-to-first-token grew to the full generation time (deferred #879
+    review finding). The open is now provisional, and the buffered prefix is
+    released the moment it can no longer be a call.
+    """
+
+    def test_a_json_answer_is_released_at_the_first_decisive_key(self) -> None:
+        chunks = feed(
+            ['{"result": ', '{"answer": 42', ', "unit": "mm"}}'],
+            make_text_dialect_parser("{", "<|eom_id|>"),
+        )
+        assert calls_of(chunks) == []
+        assert text_of(chunks) == '{"result": {"answer": 42, "unit": "mm"}}'
+        streamed_early = [
+            item
+            for item in chunks
+            if isinstance(item, GenerationResponse)
+            and item.text
+            and item.finish_reason is None
+        ]
+        # Held-to-terminal behavior would produce one terminal blob; the
+        # released answer streams across several non-terminal chunks.
+        assert len(streamed_early) >= 2
+
+    def test_a_name_first_answer_is_released_at_the_second_key(self) -> None:
+        chunks = feed(
+            ['{"name": "John"', ', "age": 30}'],
+            make_text_dialect_parser("{", "<|eom_id|>"),
+        )
+        assert calls_of(chunks) == []
+        assert text_of(chunks) == '{"name": "John", "age": 30}'
+
+    def test_a_brace_that_is_not_json_is_released_immediately(self) -> None:
+        chunks = feed(
+            ["{oops, this is prose", " that keeps going"],
+            make_text_dialect_parser("{", "<|eom_id|>"),
+        )
+        assert calls_of(chunks) == []
+        assert text_of(chunks) == "{oops, this is prose that keeps going"
+        # Released as content, never reported as a parse failure.
+        assert all(
+            item.finish_reason != "error"
+            for item in chunks
+            if isinstance(item, GenerationResponse)
+        )
+
+    def test_a_reversed_key_order_call_still_parses(self) -> None:
+        chunks = feed(
+            [
+                '{"parameters": {"location": "Denver"}',
+                ', "name": "get_weather"}',
+            ],
+            make_text_dialect_parser("{", "<|eom_id|>"),
+        )
+        assert calls_of(chunks) == ["get_weather"]
+
+    def test_a_llama_type_wrapper_key_still_parses(self) -> None:
+        # Some Llama variants wrap the signature with a "type" key; it
+        # neither makes the object a call nor rules one out.
+        chunks = feed(
+            [
+                '{"type": "function", "name": "get_weather", ',
+                '"parameters": {"location": "Denver"}}',
+            ],
+            make_text_dialect_parser("{", "<|eom_id|>"),
+        )
+        assert calls_of(chunks) == ["get_weather"]
+
+    def test_a_released_answer_still_yields_a_later_marker_call(self) -> None:
+        chunks = feed(
+            [
+                '{"a": 1} ',
+                '<|python_tag|>{"name": "get_weather", "parameters": {}}',
+            ],
+            make_text_dialect_parser("{", "<|eom_id|>"),
+        )
+        assert calls_of(chunks) == ["get_weather"]
+        assert '{"a": 1}' in text_of(chunks)
+
+    def test_release_and_marker_call_in_one_terminal_chunk(self) -> None:
+        chunks = feed(
+            [
+                '{"a": 1} <|python_tag|>'
+                '{"name": "get_weather", "parameters": {}}'
+            ],
+            make_text_dialect_parser("{", "<|eom_id|>"),
+        )
+        assert calls_of(chunks) == ["get_weather"]
+        assert '{"a": 1}' in text_of(chunks)
+
+
+class TestTextAfterAnUnmarkedCall:
+    """Trailing prose after an anchored call reaches the caller as content."""
+
+    def test_a_remark_after_the_call_is_delivered(self) -> None:
+        chunks = feed(
+            ['{"name": "get_weather", "parameters": {}}', " Done."],
+            make_text_dialect_parser("{", "<|eom_id|>"),
+        )
+        assert calls_of(chunks) == ["get_weather"]
+        assert "Done." in text_of(chunks)
+
+    def test_the_tool_response_stays_the_terminal_chunk(self) -> None:
+        chunks = feed(
+            ['{"name": "get_weather", "parameters": {}} All set.'],
+            make_text_dialect_parser("{", "<|eom_id|>"),
+        )
+        assert calls_of(chunks) == ["get_weather"]
+        assert "All set." in text_of(chunks)
+        last = [item for item in chunks if item is not None][-1]
+        assert isinstance(last, ToolCallResponse)
+
+
+class TestClosingMarkerInsideArguments:
+    """A quoted argument may contain the dialect's own closing marker.
+
+    An HTML-writing tool passing "</tool_call>" used to end the block at the
+    quoted marker: the truncated block failed parsing and the caller received
+    a generation error instead of the call (deferred #879 review finding).
+    The scan mode comes from the wiring, which is the only place the block
+    interior's quoting rules are known.
+    """
+
+    @staticmethod
+    def _hermes_json_parser() -> ToolParser:
+        import json as json_module
+
+        def inner(text: str) -> dict[str, object]:
+            payload = cast("dict[str, object]", json_module.loads(text))
+            return {
+                "name": payload["name"],
+                "arguments": json_module.dumps(payload["arguments"]),
+            }
+
+        return make_mlx_parser(
+            "<tool_call>", "</tool_call>", inner, close_scan="json_strings"
+        )
+
+    def test_a_quoted_closer_does_not_truncate_a_json_block(self) -> None:
+        chunks = feed(
+            [
+                '<tool_call>{"name": "get_weather", ',
+                '"arguments": {"location": "</tool_call>"}}',
+                "</tool_call> after",
+            ],
+            self._hermes_json_parser(),
+        )
+        assert calls_of(chunks) == ["get_weather"]
+        assert "after" in text_of(chunks)
+
+    def test_a_gemma_quoted_closer_does_not_truncate(self) -> None:
+        from skulk.worker.runner.llm_inference.tool_text_parser import (
+            gemma4_calls,
+        )
+
+        def inner(text: str) -> list[dict[str, object]]:
+            items = gemma4_calls(text)
+            if not items:
+                raise ValueError("no tool calls")
+            return [
+                {"name": item.name, "arguments": item.arguments}
+                for item in items
+            ]
+
+        parser = make_mlx_parser(
+            "<|tool_call>", "<tool_call|>", inner, close_scan="gemma_quotes"
+        )
+        chunks = feed(
+            [
+                "<|tool_call>call:get_weather{location:",
+                '<|"|>a<tool_call|>b<|"|>}',
+                "<tool_call|>",
+            ],
+            parser,
         )
         assert calls_of(chunks) == ["get_weather"]

--- a/src/skulk/worker/runner/llm_inference/tests/test_tool_text_parser_dialects.py
+++ b/src/skulk/worker/runner/llm_inference/tests/test_tool_text_parser_dialects.py
@@ -11,6 +11,7 @@ import json
 
 from skulk.worker.runner.llm_inference.tool_text_parser import (
     parse_tool_calls_from_text,
+    parse_tool_calls_with_remainder,
 )
 
 
@@ -490,3 +491,125 @@ class TestGemma4Dialect:
                 )
                 is None
             )
+
+
+class TestSemicolonsInsideArguments:
+    """Chained Llama calls must not be split inside a quoted argument.
+
+    Several calls in one ``<|python_tag|>`` body are separated by ``;``, but a
+    semicolon is also ordinary data in shell commands, SQL, and prose. The old
+    ``split(";")`` divided the JSON string itself, both fragments failed the
+    balanced-object parse, and the valid call disappeared into content
+    (deferred #879 review finding).
+    """
+
+    SHELL = [
+        {
+            "type": "function",
+            "function": {
+                "name": "run_shell",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"cmd": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    def test_a_semicolon_inside_a_quoted_argument_survives(self) -> None:
+        text = (
+            '<|python_tag|>{"name": "run_shell", '
+            '"parameters": {"cmd": "echo a; echo b"}}<|eom_id|>'
+        )
+        calls = parse_tool_calls_from_text(text, self.SHELL)
+        assert calls is not None
+        assert [call.name for call in calls] == ["run_shell"]
+        assert json.loads(calls[0].arguments) == {"cmd": "echo a; echo b"}
+
+    def test_chained_calls_with_semicolons_in_both_strings_survive(self) -> None:
+        text = (
+            '<|python_tag|>{"name": "a", "parameters": {"x": "1;2"}};'
+            '{"name": "b", "parameters": {"y": ";"}}<|eom_id|>'
+        )
+        calls = parse_tool_calls_from_text(text)
+        assert calls is not None
+        assert [call.name for call in calls] == ["a", "b"]
+        assert json.loads(calls[0].arguments) == {"x": "1;2"}
+        assert json.loads(calls[1].arguments) == {"y": ";"}
+
+    def test_an_escaped_quote_does_not_derail_the_object_scan(self) -> None:
+        text = (
+            '<|python_tag|>{"name": "run_shell", '
+            '"parameters": {"cmd": "say \\"hi; bye\\""}}<|eom_id|>'
+        )
+        calls = parse_tool_calls_from_text(text, self.SHELL)
+        assert calls is not None
+        assert json.loads(calls[0].arguments) == {"cmd": 'say "hi; bye"'}
+
+
+class TestRemainderPreservation:
+    """The remainder-preserving variant reports visible text around a call.
+
+    A model may keep writing after its call, and only the dialect knows where
+    the markup ends. The remainder is meaningful only when calls are returned:
+    with no call, or every call dropped by the offered-tools rule, the caller
+    falls back to emitting the whole content, so the remainder must be empty.
+    """
+
+    WEATHER = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    def test_text_after_an_unmarked_call_is_the_remainder(self) -> None:
+        calls, remainder = parse_tool_calls_with_remainder(
+            '{"name": "get_weather", "parameters": {"location": "Denver"}} Done.',
+            self.WEATHER,
+        )
+        assert calls is not None
+        assert [call.name for call in calls] == ["get_weather"]
+        assert remainder == "Done."
+
+    def test_a_call_that_is_the_whole_message_has_no_remainder(self) -> None:
+        calls, remainder = parse_tool_calls_with_remainder(
+            '{"name": "get_weather", "parameters": {}}', self.WEATHER
+        )
+        assert calls is not None
+        assert remainder == ""
+
+    def test_text_around_a_mistral_array_is_the_remainder(self) -> None:
+        calls, remainder = parse_tool_calls_with_remainder(
+            "Sure. [TOOL_CALLS] "
+            '[{"name": "get_weather", "arguments": {"location": "Paris"}}] '
+            "I will check that.",
+            self.WEATHER,
+        )
+        assert calls is not None
+        assert [call.name for call in calls] == ["get_weather"]
+        assert "Sure." in remainder
+        assert "I will check that." in remainder
+        assert "[TOOL_CALLS]" not in remainder
+
+    def test_a_dropped_call_reports_no_remainder(self) -> None:
+        # The whole message is content when the offered-tools rule drops the
+        # call, so a remainder that excludes the markup would be wrong.
+        calls, remainder = parse_tool_calls_with_remainder(
+            '{"name": "report", "parameters": {}} trailing', self.WEATHER
+        )
+        assert calls is None
+        assert remainder == ""
+
+    def test_prose_reports_no_remainder(self) -> None:
+        calls, remainder = parse_tool_calls_with_remainder(
+            "There is no call here.", self.WEATHER
+        )
+        assert calls is None
+        assert remainder == ""

--- a/src/skulk/worker/runner/llm_inference/tool_parsers.py
+++ b/src/skulk/worker/runner/llm_inference/tool_parsers.py
@@ -99,15 +99,20 @@ class ToolParser:
         dialect itself is the only thing that knows where the call ends. The
         remainder is meaningful only when calls were parsed; a dialect without
         a split-aware parser returns the whole-block result and no remainder.
+
+        A split parser that finds no call defers to the whole-block parser
+        rather than answering ``None`` itself: the split reading is an
+        overlay, and forms only the inner parser reads (Mistral's displaced
+        upstream ``NAME[ARGS]`` fallback) must keep parsing exactly as they
+        did before a split parser existed.
         """
-        if self._split_parser is None:
-            return self.parse(text, tools), ""
-        parsed, remainder = self._split_parser(text)
-        if parsed is None:
-            return None, ""
-        if tools is not None:
-            parsed = coerce_tool_calls_to_schema(parsed, tools)
-        return parsed, remainder
+        if self._split_parser is not None:
+            parsed, remainder = self._split_parser(text)
+            if parsed is not None:
+                if tools is not None:
+                    parsed = coerce_tool_calls_to_schema(parsed, tools)
+                return parsed, remainder
+        return self.parse(text, tools), ""
 
 
 def _json_type_matches(value: Any, expected_type: str) -> bool:  # pyright: ignore[reportAny]
@@ -373,11 +378,29 @@ def make_mlx_parser(
         except Exception:
             return None
 
+    split_parser: (
+        Callable[[str], tuple[list[ToolCallItem] | None, str]] | None
+    ) = None
+    if tool_call_start == "[TOOL_CALLS]":
+        # The marker uniquely identifies the whole-block Mistral dialect at
+        # this seam, and the shared text parser knows where its array ends,
+        # so trailing assistant text after the array can be reported rather
+        # than swallowed. A miss (the displaced upstream NAME[ARGS] form)
+        # defers to the inner parser through parse_split's fallback.
+        # Imported at call time: tool_text_parser imports the schema
+        # coercion from this module, so a module-level import is circular.
+        from skulk.worker.runner.llm_inference.tool_text_parser import (
+            parse_tool_calls_with_remainder,
+        )
+
+        split_parser = lambda text: parse_tool_calls_with_remainder(text)  # noqa: E731
+
     return ToolParser(
         start_parsing=tool_call_start,
         end_parsing=tool_call_end,
         _inner_parser=parse_tool_calls,
         close_scan=close_scan,
+        _split_parser=split_parser,
     )
 
 

--- a/src/skulk/worker/runner/llm_inference/tool_parsers.py
+++ b/src/skulk/worker/runner/llm_inference/tool_parsers.py
@@ -1,9 +1,18 @@
 import json
 import math
 from dataclasses import dataclass
-from typing import Any, Callable, cast
+from typing import Any, Callable, Literal, cast
 
 from skulk.api.types import ToolCallItem
+
+CloseScan = Literal["plain", "json_strings", "gemma_quotes"]
+"""How the streaming scanner locates a block's closing marker.
+
+``plain`` matches the first occurrence. ``json_strings`` matches only outside
+JSON string values, so an argument like ``{"html": "</tool_call>"}`` does not
+truncate the block at the quoted marker. ``gemma_quotes`` skips Gemma 4's
+``<|"|>``-delimited string spans the same way.
+"""
 
 UNMARKED_TOOL_DIALECT = "skulk:unmarked-tool-dialect"
 """Sentinel tool parser meaning "read the whole block with the text dialects".
@@ -46,6 +55,23 @@ class ToolParser:
     of an unparsable block is that the model simply answered in JSON and the
     text should be delivered as content.
     """
+    close_scan: CloseScan = "plain"
+    """How the streaming scanner locates this dialect's closing marker.
+
+    Set only where the block interior's quoting rules are actually known (see
+    :func:`infer_close_scan`); the plain scan is the safe default because
+    tracking JSON strings over a non-JSON interior hides a real closer behind
+    an odd quote count, which is worse than the truncation it prevents.
+    """
+    _split_parser: (
+        Callable[[str], tuple[list[ToolCallItem] | None, str]] | None
+    ) = None
+    """Optional variant of the inner parser that also reports trailing text.
+
+    Only a dialect that knows where its markup ends can report a remainder;
+    parsers without one read the whole block as the call, which matches the
+    previous behavior everywhere.
+    """
 
     @property
     def start_markers(self) -> tuple[str, ...]:
@@ -62,6 +88,26 @@ class ToolParser:
         if tools is not None:
             parsed = coerce_tool_calls_to_schema(parsed, tools)
         return parsed
+
+    def parse_split(
+        self, text: str, tools: list[dict[str, Any]] | None
+    ) -> tuple[list[ToolCallItem] | None, str]:
+        """Parse ``text``, also returning any visible text after the calls.
+
+        A model may keep writing after its call (``{"name": ...} Done.``), and
+        an end-of-generation block has no closing marker to split at, so the
+        dialect itself is the only thing that knows where the call ends. The
+        remainder is meaningful only when calls were parsed; a dialect without
+        a split-aware parser returns the whole-block result and no remainder.
+        """
+        if self._split_parser is None:
+            return self.parse(text, tools), ""
+        parsed, remainder = self._split_parser(text)
+        if parsed is None:
+            return None, ""
+        if tools is not None:
+            parsed = coerce_tool_calls_to_schema(parsed, tools)
+        return parsed, remainder
 
 
 def _json_type_matches(value: Any, expected_type: str) -> bool:  # pyright: ignore[reportAny]
@@ -235,10 +281,84 @@ def coerce_tool_calls_to_schema(
     return coerced_calls
 
 
+def find_close_marker(
+    text: str, marker: str, close_scan: CloseScan, *, start: int = 0
+) -> int:
+    """Index of the block-closing ``marker`` in ``text``, or ``-1``.
+
+    ``close_scan`` decides what counts as an occurrence: the quote-aware modes
+    skip the dialect's quoted string spans, because a quoted argument may
+    legitimately contain the closing marker (an HTML-writing tool passing
+    ``"</tool_call>"``), and matching it there truncates the block and turns a
+    valid call into a parse error. An unterminated string span means the
+    block is still incomplete, so no closer is reported and the block closes
+    at end of generation instead, where the whole message is in hand.
+    """
+
+    if close_scan == "plain":
+        return text.find(marker, start)
+    if close_scan == "gemma_quotes":
+        index = start
+        while True:
+            closer = text.find(marker, index)
+            if closer == -1:
+                return -1
+            quote = text.find('<|"|>', index)
+            if quote == -1 or closer < quote:
+                return closer
+            closing_quote = text.find('<|"|>', quote + 5)
+            if closing_quote == -1:
+                return -1
+            index = closing_quote + 5
+    in_string = False
+    escaped = False
+    index = start
+    while index < len(text):
+        if not in_string and text.startswith(marker, index):
+            return index
+        char = text[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        index += 1
+    return -1
+
+
+def infer_close_scan(tool_call_start: str, chat_template: str) -> CloseScan:
+    """Choose the close-marker scan mode from what the wiring actually knows.
+
+    Quoting rules are dialect-specific, and the interior dialect of a
+    ``<tool_call>`` block is not knowable from the markers alone (Qwen3 XML
+    and Hermes JSON share them), so the mode comes from template truth at the
+    wiring seam: the Gemma opener identifies its dialect outright, a template
+    carrying the Qwen3 XML form keeps the plain scan (XML parameter values
+    carry unbalanced ``"`` characters freely, and tracking JSON strings over
+    them would hide a real closer), and a template that renders arguments as
+    JSON gets the JSON-string-aware scan. Unknown interiors keep the plain
+    scan, which is the previous behavior.
+    """
+
+    if tool_call_start == "<|tool_call>":
+        return "gemma_quotes"
+    if "<function=" in chat_template:
+        return "plain"
+    if "tool_call.arguments" in chat_template or "tojson" in chat_template:
+        return "json_strings"
+    return "plain"
+
+
 def make_mlx_parser(
     tool_call_start: str,
     tool_call_end: str,
     tool_parser: Callable[[str], dict[str, Any] | list[dict[str, Any]]],
+    *,
+    close_scan: CloseScan = "plain",
 ) -> ToolParser:
     def parse_tool_calls(text: str) -> list[ToolCallItem] | None:
         try:
@@ -257,6 +377,7 @@ def make_mlx_parser(
         start_parsing=tool_call_start,
         end_parsing=tool_call_end,
         _inner_parser=parse_tool_calls,
+        close_scan=close_scan,
     )
 
 
@@ -286,6 +407,9 @@ def make_json_parser() -> ToolParser:
         start_parsing="<tool_call>",
         end_parsing="</tool_call>",
         _inner_parser=_parse_json_calls,
+        # The interior is JSON by construction here, so the closer scan may
+        # safely skip its string values.
+        close_scan="json_strings",
     )
 
 
@@ -303,6 +427,7 @@ def make_text_dialect_parser(tool_call_start: str, tool_call_end: str) -> ToolPa
     # this module, so a module-level import here would be circular.
     from skulk.worker.runner.llm_inference.tool_text_parser import (
         parse_tool_calls_from_text,
+        parse_tool_calls_with_remainder,
     )
 
     return ToolParser(
@@ -312,6 +437,11 @@ def make_text_dialect_parser(tool_call_start: str, tool_call_end: str) -> ToolPa
         extra_start_parsing=("<|python_tag|>",),
         anchored=True,
         unparsed_is_text=True,
+        # The anchored block is a JSON object by construction, and the text
+        # dialects know where their markup ends, so trailing prose after the
+        # call ("{...} Done.") can be reported rather than swallowed.
+        close_scan="json_strings",
+        _split_parser=lambda text: parse_tool_calls_with_remainder(text),
     )
 
 

--- a/src/skulk/worker/runner/llm_inference/tool_text_parser.py
+++ b/src/skulk/worker/runner/llm_inference/tool_text_parser.py
@@ -161,47 +161,113 @@ def _call_from_json_object(obj: object) -> ToolCallItem | None:
     return ToolCallItem(name=str(payload["name"]), arguments=args_str)
 
 
+def _successive_json_objects(text: str) -> list[dict[str, Any]]:
+    """Every top-level balanced JSON object in ``text``, in order.
+
+    Llama chains several ``<|python_tag|>`` calls in one body separated by
+    ``;``, but a semicolon is also ordinary data inside a quoted argument
+    (shell commands, SQL, prose), so splitting on the separator divided the
+    JSON string itself and lost the call. The objects are instead read as
+    successive balanced spans, string-aware, and whatever separates them is
+    skipped rather than interpreted. A balanced span that is not valid JSON
+    is skipped whole rather than rescanned from inside, so its interior
+    braces cannot mint an object; an unterminated span is truncated
+    generation, and nothing after it can be complete either.
+    """
+
+    objects: list[dict[str, Any]] = []
+    position = 0
+    while True:
+        start = text.find("{", position)
+        if start == -1:
+            return objects
+        depth = 0
+        in_string = False
+        escaped = False
+        end = -1
+        for index in range(start, len(text)):
+            char = text[index]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    end = index
+                    break
+        if end == -1:
+            return objects
+        try:
+            decoded = json.loads(text[start : end + 1])
+        except ValueError:
+            decoded = None
+        if isinstance(decoded, dict):
+            objects.append(cast("dict[str, Any]", decoded))
+        position = end + 1
+
+
 def _python_tag_calls(text: str) -> list[ToolCallItem]:
     """Parse Llama 3.1+ ``<|python_tag|>`` calls."""
 
     calls: list[ToolCallItem] = []
     for match in _PYTHON_TAG_RE.finditer(text):
-        for chunk in match.group(1).split(";"):
-            call = _call_from_json_object(_first_json_object(chunk))
+        for obj in _successive_json_objects(match.group(1)):
+            call = _call_from_json_object(obj)
             if call is not None:
                 calls.append(call)
     return calls
 
 
-def _mistral_calls(text: str) -> list[ToolCallItem]:
-    """Parse Mistral ``[TOOL_CALLS] [...]`` arrays."""
+def _mistral_calls(text: str) -> tuple[list[ToolCallItem], str]:
+    """Parse Mistral ``[TOOL_CALLS] [...]`` arrays.
+
+    Returns the calls plus the visible text around the array: the model may
+    write a preamble before the marker and keep writing after the array
+    (``[TOOL_CALLS] [...] I will check that.``), and both are the assistant's
+    content rather than markup. The remainder is empty when nothing parsed,
+    so a message that is not a call is left whole for the caller.
+    """
 
     match = _MISTRAL_RE.search(text)
     if match is None:
-        return []
+        return [], ""
     decoder = json.JSONDecoder()
+    body = match.group(1).strip()
     try:
-        array, _ = decoder.raw_decode(match.group(1).strip())
+        array, consumed = decoder.raw_decode(body)
     except ValueError:
-        return []
+        return [], ""
     if not isinstance(array, list):
-        return []
+        return [], ""
     calls: list[ToolCallItem] = []
     for entry in array:
         call = _call_from_json_object(entry)
         if call is not None:
             calls.append(call)
-    return calls
+    if not calls:
+        return [], ""
+    remainder = (text[: match.start()] + " " + body[consumed:]).strip()
+    return calls, remainder
 
 
-def _bare_json_call(text: str) -> list[ToolCallItem]:
+def _bare_json_call(text: str) -> tuple[list[ToolCallItem], str]:
     """Parse an unmarked call that opens the message.
 
     Llama omits ``<|python_tag|>`` in some templates and simply emits the call
     object. The message must *begin* with that object, so prose containing JSON
     is never read as a call, but the model may keep writing after it: a call
-    followed by a closing remark is still a call, and requiring the object to
-    be the entire message lost it.
+    followed by a closing remark is still a call, and the remark is returned
+    as the remainder so it reaches the caller as content rather than being
+    swallowed with the markup.
 
     Two things keep this from mistaking a JSON answer for a call. The object
     must carry a ``name`` alongside an ``arguments`` or ``parameters`` value,
@@ -212,21 +278,23 @@ def _bare_json_call(text: str) -> list[ToolCallItem]:
 
     stripped = text.strip()
     if not stripped.startswith("{"):
-        return []
+        return [], ""
     decoder = json.JSONDecoder()
     try:
-        obj, _ = decoder.raw_decode(stripped)
+        obj, consumed = decoder.raw_decode(stripped)
     except ValueError:
-        return []
+        return [], ""
     if not isinstance(obj, dict):
-        return []
+        return [], ""
     payload = cast("dict[str, Any]", obj)
     if "name" not in payload:
-        return []
+        return [], ""
     if not isinstance(payload.get("arguments", payload.get("parameters")), (dict, str)):
-        return []
+        return [], ""
     call = _call_from_json_object(payload)
-    return [call] if call is not None else []
+    if call is None:
+        return [], ""
+    return [call], stripped[consumed:].strip()
 
 
 def _harmony_tool_calls(text: str) -> list[ToolCallItem]:
@@ -437,6 +505,25 @@ def parse_tool_calls_from_text(
 ) -> list[ToolCallItem] | None:
     """Recover tool calls a reasoning model emitted as text (llama.cpp engine).
 
+    The whole-block form of :func:`parse_tool_calls_with_remainder`: same
+    dispatch and same result, with any trailing visible text discarded.
+    Callers that can deliver content alongside calls should use the
+    remainder-preserving variant instead.
+    """
+
+    calls, _ = parse_tool_calls_with_remainder(
+        text, tools, tool_call_format=tool_call_format
+    )
+    return calls
+
+
+def parse_tool_calls_with_remainder(
+    text: str,
+    tools: list[dict[str, Any]] | None = None,
+    tool_call_format: "ToolCallFormat | None" = None,
+) -> tuple[list[ToolCallItem] | None, str]:
+    """Recover tool calls a reasoning model emitted as text (llama.cpp engine).
+
     Detects the dialect from the markers present and parses the calls, then
     coerces argument types to the tool schema. Recognized dialects:
 
@@ -454,11 +541,15 @@ def parse_tool_calls_from_text(
     dropped, because a model reaching for one of its own built-ins has not
     called anything the caller can run.
 
-    Returns ``None`` when no tool call is present (the model answered in prose),
-    so the caller can fall back to emitting the content.
+    Returns the calls plus the visible text around the call markup for the
+    dialects that know where their markup ends (the unmarked object and the
+    Mistral array); other dialects report no remainder. The remainder is
+    meaningful only when calls were returned: with no call (or every call
+    dropped by the offered-tools rule) the result is ``(None, "")`` and the
+    caller falls back to emitting the whole content, exactly as before.
     """
     if not text:
-        return None
+        return None, ""
     # When the caller knows the model's resolved format, dialect selection is
     # card truth rather than text inference: a Gemma-format model parses only
     # its own dialect, and any OTHER format can never have Gemma or harmony
@@ -477,14 +568,14 @@ def parse_tool_calls_from_text(
             gemma_calls: list[ToolCallItem] = []
             for block in _gemma_blocks(text):
                 gemma_calls.extend(gemma4_calls(block))
-            return _finish(gemma_calls, tools)
+            return _finish(gemma_calls, tools), ""
         if tool_call_format == _Format.GptOss:
-            return _finish(_harmony_tool_calls(text), tools)
+            return _finish(_harmony_tool_calls(text), tools), ""
         if tool_call_format != _Format.Generic:
             # A specialized format with no text dialect here (DSML parses at
             # the token level elsewhere) gets NO text inference at all:
             # foreign markers or a bare object in its prose are content.
-            return None
+            return None, ""
 
     # A message that OPENS with a valid JSON object is the unmarked dialect,
     # selected first and exclusively: the outermost structure is JSON, so a
@@ -500,7 +591,8 @@ def parse_tool_calls_from_text(
         except ValueError:
             pass
         else:
-            return _finish(_bare_json_call(text), tools)
+            leading_calls, leading_remainder = _bare_json_call(text)
+            return _finish_with_remainder(leading_calls, leading_remainder, tools)
     # The dialect is SELECTED by the earliest recognized marker in the text
     # and parsed exclusively. Marker presence anywhere is not enough: a
     # quoted argument may legitimately carry text shaped like ANY other
@@ -556,16 +648,16 @@ def parse_tool_calls_from_text(
         elif dialect == "python_tag":
             calls = _python_tag_calls(text)
         else:
-            calls = _mistral_calls(text)
-        return _finish(calls, tools)
-    if not calls:
-        # Last resort, and deliberately narrow: the message must begin with the
-        # call object. Unmarked dialects are otherwise indistinguishable from a
-        # model answering in JSON, so anything looser invents tool calls from
-        # prose. The object must also carry a name alongside arguments, and the
-        # caller's tools are checked afterwards.
-        calls = _bare_json_call(text)
-    return _finish(calls, tools)
+            mistral_calls, mistral_remainder = _mistral_calls(text)
+            return _finish_with_remainder(mistral_calls, mistral_remainder, tools)
+        return _finish(calls, tools), ""
+    # Last resort, and deliberately narrow: the message must begin with the
+    # call object. Unmarked dialects are otherwise indistinguishable from a
+    # model answering in JSON, so anything looser invents tool calls from
+    # prose. The object must also carry a name alongside arguments, and the
+    # caller's tools are checked afterwards.
+    bare_calls, bare_remainder = _bare_json_call(text)
+    return _finish_with_remainder(bare_calls, bare_remainder, tools)
 
 
 def _finish(
@@ -586,3 +678,21 @@ def _finish(
             return None
         calls = coerce_tool_calls_to_schema(calls, tools)
     return calls
+
+
+def _finish_with_remainder(
+    calls: list[ToolCallItem],
+    remainder: str,
+    tools: list[dict[str, Any]] | None,
+) -> tuple[list[ToolCallItem] | None, str]:
+    """Apply :func:`_finish`, keeping the remainder only when calls survive.
+
+    When the offered-tools rule drops every call the whole message is content,
+    so the caller must fall back to the full original text rather than a
+    remainder that excludes the rejected markup.
+    """
+
+    finished = _finish(calls, tools)
+    if finished is None:
+        return None, ""
+    return finished, remainder

--- a/website/docs/api-guide.md
+++ b/website/docs/api-guide.md
@@ -819,9 +819,11 @@ a guarantee, because forcing a call there would need constrained decoding.
 **A JSON answer stays an answer.** Several model families write a tool call as
 a bare JSON object, so a request that both offers tools and asks for JSON output
 is ambiguous on the wire. Skulk resolves it in favor of the answer: text that
-does not parse as a call to one of your tools is returned as content. Expect
-that content to arrive in one piece rather than streamed token by token, since
-it can only be classified once the message is complete.
+does not parse as a call to one of your tools is returned as content. A short
+prefix of such a message is buffered while it could still be either reading,
+and released the moment it is distinguishable, so a JSON answer streams
+incrementally after a delay bounded by its first decisive key rather than
+arriving in one piece.
 
 ## Thinking / Reasoning
 

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -829,9 +829,18 @@ dialects: harmony `to=functions.NAME` channels (gpt-oss); Gemma 4
 marker-delimited blocks parse, shared with the MLX family parser so both
 engines read one implementation); `<tool_call>` blocks carrying Hermes JSON, Qwen3 XML, or GLM
 `<arg_key>`/`<arg_value>` pairs; Llama `<|python_tag|>` calls (which use
-`parameters` rather than `arguments` and may chain several with `;`); Mistral
+`parameters` rather than `arguments` and may chain several with `;`; the
+chained objects are read as successive balanced JSON spans, string-aware, so
+a semicolon inside a quoted argument is data rather than a split point);
+Mistral
 `[TOOL_CALLS]` arrays; and an unmarked call object opening the message, which
-the model may keep writing after. The unmarked rule is deliberately narrow,
+the model may keep writing after. For the two dialects that know where their
+markup ends (the unmarked object and the Mistral array),
+`parse_tool_calls_with_remainder` also reports the visible text around the
+call, which the llama.cpp recovery path delivers as content alongside the
+`ToolCallChunk`; the remainder is empty whenever no call survives, so a
+non-call message still falls back to the whole content. The unmarked rule is
+deliberately narrow,
 since it is otherwise indistinguishable from a model answering in JSON: the
 message must begin with the object, the object must carry a `name` alongside an
 `arguments` or `parameters` value, and the offered-tools filter below removes
@@ -847,10 +856,28 @@ therefore searches the accumulated text rather than each chunk, and
 `_partial_marker_suffix_length` carries forward only the trailing run that
 could still become a marker. That run is shorter than the longest marker, so
 ordinary answers stream with at most a few characters of latency and nothing
-is held for a message containing no call. The scan does not stop once ordinary
+is held for a message containing no call. The one longer hold is the anchored
+dialect's message-opening `{`, which opens a block only provisionally:
+`_classify_anchored_prefix` releases the buffered prefix the moment it can no
+longer be a call (a top-level key outside the call signature, a non-string
+name, malformed JSON, or the object closing without the signature) and commits
+the block once a `"name"` plus `"arguments"`/`"parameters"` signature is
+distinguishable, so a plain JSON answer streams after a delay bounded by its
+first decisive key rather than losing all incremental output to a hold that
+could only resolve at the terminal chunk (the unmarked dialect's closing token
+is a generation stop that never arrives as text). Released text rejoins the
+ordinary scan, so a distinctive marker later in it still opens a real block.
+The scan does not stop once ordinary
 text has been released, so a model that writes a sentence before calling still
-has its call found. A block closes at the first `end_parsing` found in the accumulated block, or at
-the end of generation. The calls of every block in one message are coalesced
+has its call found. A block closes at the first `end_parsing` found in the
+accumulated block (`find_close_marker`, whose `ToolParser.close_scan` mode
+skips the dialect's quoted string spans where the wiring knows the interior's
+quoting rules: `infer_close_scan` selects Gemma-quote awareness from the Gemma
+opener and JSON-string awareness from a template that renders arguments as
+JSON, keeping the plain scan for Qwen3 XML and unknown interiors, whose values
+carry unbalanced quote characters freely), or at
+the end of generation, where `ToolParser.parse_split` also reports visible
+text the model wrote after its call so it reaches the caller as content. The calls of every block in one message are coalesced
 into a single `ToolCallResponse`, which is the OpenAI shape and is what makes
 parallel calls survive: several families write each call in its own block, and
 `API._token_chunk_stream` stops at the first chunk carrying a finish reason, so

--- a/website/docs/architecture-reference.md
+++ b/website/docs/architecture-reference.md
@@ -837,10 +837,14 @@ Mistral
 the model may keep writing after. For the two dialects that know where their
 markup ends (the unmarked object and the Mistral array),
 `parse_tool_calls_with_remainder` also reports the visible text around the
-call, which the llama.cpp recovery path delivers as content alongside the
-`ToolCallChunk`; the remainder is empty whenever no call survives, so a
-non-call message still falls back to the whole content. The unmarked rule is
-deliberately narrow,
+call: the llama.cpp recovery path delivers it as content alongside the
+`ToolCallChunk`, and the MLX terminal path routes it through the
+message-finishing scan via `ToolParser.parse_split` (`make_mlx_parser`
+attaches the split overlay for the `[TOOL_CALLS]` opener; a split miss
+defers to the inner parser, so Mistral's displaced upstream `NAME[ARGS]`
+form keeps parsing whole-block). The remainder is empty whenever no call
+survives, so a non-call message still falls back to the whole content. The
+unmarked rule is deliberately narrow,
 since it is otherwise indistinguishable from a model answering in JSON: the
 message must begin with the object, the object must carry a `name` alongside an
 `arguments` or `parameters` value, and the offered-tools filter below removes


### PR DESCRIPTION
## What

The four parser-side findings deferred at severity 3 during the #879 review, now closed as the recorded follow-up: the anchored-brace streaming hold, the closing marker inside quoted arguments, the Llama semicolon split, and trailing text around a call.

## Changes

**1. A JSON answer streams incrementally again** (`model_output_parsers.py`). The unmarked dialect's message-opening `{` used to open a block whose closing token (`<|eom_id|>`) is a generation stop that never arrives as text, so every chunk was held until the terminal one and a plain JSON answer lost all incremental output, with time-to-first-token growing to the full generation time. The open is now provisional: `_classify_anchored_prefix` walks the buffered prefix as JSON and releases it the moment it can no longer be a call (a top-level key outside the call signature, a non-string name, a non-object argument value, malformed JSON, or the object closing without the signature), committing the block once a `"name"` plus `"arguments"`/`"parameters"` signature is distinguishable. The hold is bounded by the first decisive key, not by the message. Released text rejoins the ordinary scan (via the extracted `_scan_outside_block`, which is the previous outside-block logic verbatim), so a distinctive marker later in it still opens a real block; a real call, including reversed key order and Llama's `"type"` wrapper key, parses exactly as before through the unchanged terminal path.

**2. A quoted closing marker no longer truncates the block** (`find_close_marker` + `ToolParser.close_scan`). An argument like `{"html": "</tool_call>"}` used to end the block at the quoted marker; the truncated block failed parsing and the caller received a generation error. The closer is now located outside quoted content, but only where the wiring actually knows the interior's quoting rules, because the markers alone cannot tell Qwen3 XML from Hermes JSON and tracking JSON strings over an XML interior (whose values carry unbalanced `"` freely) would hide a real closer, which is worse than the truncation it prevents. `infer_close_scan` decides from template truth at the wiring seam: the Gemma opener selects Gemma-quote awareness (skipping `<|"|>` spans, the streaming twin of #897's recovery-side scan), a template rendering arguments as JSON selects JSON-string awareness, and everything else keeps the previous plain scan.

**3. Chained Llama calls survive semicolons in arguments** (`tool_text_parser.py`). `<|python_tag|>` bodies were split on `;` before parsing, so a semicolon inside a quoted argument (shell commands, SQL, prose) divided the JSON string itself and the valid call disappeared into content. The body is now read as successive balanced JSON spans, string-aware; whatever separates them is skipped rather than interpreted.

**4. Text around a call reaches the caller** (`parse_tool_calls_with_remainder` + `ToolParser.parse_split`). A model that keeps writing after its call (`{"name": ...} Done.`, `[TOOL_CALLS] [...] I will check that.`) had the remark silently swallowed with the markup. The two dialects that know where their markup ends (the unmarked object and the Mistral array) now report the surrounding visible text: the llama.cpp recovery path emits it as a content chunk beside the `ToolCallChunk`, and the MLX terminal path routes it through the existing message-finishing scan, so the tool response stays the terminal chunk. `parse_tool_calls_from_text` keeps its signature (the steward and every other caller are untouched); the remainder is empty whenever no call survives, so a non-call message still falls back to the whole content.

## Invariants preserved

- Exactly one chunk carries the finish reason per message; a tool response is always the terminal chunk.
- Marker dialects behave identically except where a quote-aware close mode is explicitly selected.
- The anchored dialect's *results* are unchanged (a real call parses via the same terminal path); only the timing of content release changes.
- No text is lost or duplicated: the tentative buffer is either committed to the block or re-scanned exactly once.
- Reasoning chunks still bypass the scan entirely.

## Docs

`website/docs/api-guide.md` ("A JSON answer stays an answer" now describes the bounded release), `website/docs/architecture-reference.md` (rolling-scan section documents the provisional open, the close-scan modes, and the remainder path), CHANGELOG entries under [Unreleased].

## Validation

- Full suite: 3862 passed, 2 skipped.
- Focused: 55 dialect tests + 50 streaming tests, roughly 30 of them new, pinning every shape above including release-and-reopen in a single terminal chunk, reversed key order, the `"type"` wrapper key, escaped quotes, quoted closers in both Gemma and JSON dialects, and remainder semantics (dropped calls report none).
- `uv run basedpyright`: 0 errors; `uv run ruff check`: clean; `nix fmt`: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
